### PR TITLE
fix: pass attachments to agent prompt from RPC interface

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -609,7 +609,7 @@ async function runRpcMode(agent: Agent, _sessionManager: SessionManager): Promis
 
 			// Handle different RPC commands
 			if (input.type === "prompt" && input.message) {
-				await agent.prompt(input.message);
+				await agent.prompt(input.message, input.attachments);
 			} else if (input.type === "abort") {
 				agent.abort();
 			}


### PR DESCRIPTION
This PR updates the call to `agent.prompt` with the `attachments` prop provided in the JSON input.
