### PR TITLE
feat(tui): add circular wrap-around navigation to all menus

### DIFF
--- a/packages/coding-agent/src/tui/model-selector.ts
+++ b/packages/coding-agent/src/tui/model-selector.ts
@@ -185,14 +185,14 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
-		// Up arrow
+		// Up arrow - wrap to bottom when at top
 		if (keyData === "\x1b[A") {
-			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+			this.selectedIndex = this.selectedIndex === 0 ? this.filteredModels.length - 1 : this.selectedIndex - 1;
 			this.updateList();
 		}
-		// Down arrow
+		// Down arrow - wrap to top when at bottom
 		else if (keyData === "\x1b[B") {
-			this.selectedIndex = Math.min(this.filteredModels.length - 1, this.selectedIndex + 1);
+			this.selectedIndex = this.selectedIndex === this.filteredModels.length - 1 ? 0 : this.selectedIndex + 1;
 			this.updateList();
 		}
 		// Enter

--- a/packages/coding-agent/src/tui/user-message-selector.ts
+++ b/packages/coding-agent/src/tui/user-message-selector.ts
@@ -78,13 +78,13 @@ class UserMessageList implements Component {
 	}
 
 	handleInput(keyData: string): void {
-		// Up arrow - go to previous (older) message
+		// Up arrow - go to previous (older) message, wrap to bottom when at top
 		if (keyData === "\x1b[A") {
-			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+			this.selectedIndex = this.selectedIndex === 0 ? this.messages.length - 1 : this.selectedIndex - 1;
 		}
-		// Down arrow - go to next (newer) message
+		// Down arrow - go to next (newer) message, wrap to top when at bottom
 		else if (keyData === "\x1b[B") {
-			this.selectedIndex = Math.min(this.messages.length - 1, this.selectedIndex + 1);
+			this.selectedIndex = this.selectedIndex === this.messages.length - 1 ? 0 : this.selectedIndex + 1;
 		}
 		// Enter - select message and branch
 		else if (keyData === "\r") {

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -145,14 +145,14 @@ export class SelectList implements Component {
 	}
 
 	handleInput(keyData: string): void {
-		// Up arrow
+		// Up arrow - wrap to bottom when at top
 		if (keyData === "\x1b[A") {
-			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+			this.selectedIndex = this.selectedIndex === 0 ? this.filteredItems.length - 1 : this.selectedIndex - 1;
 			this.notifySelectionChange();
 		}
-		// Down arrow
+		// Down arrow - wrap to top when at bottom
 		else if (keyData === "\x1b[B") {
-			this.selectedIndex = Math.min(this.filteredItems.length - 1, this.selectedIndex + 1);
+			this.selectedIndex = this.selectedIndex === this.filteredItems.length - 1 ? 0 : this.selectedIndex + 1;
 			this.notifySelectionChange();
 		}
 		// Enter


### PR DESCRIPTION
Adds circular navigation to all TUI menus. When reaching the bottom option and pressing down arrow, the selection wraps to the top. Similarly, pressing up arrow at the top wraps to the bottom.
