### PR TITLE
feat(coding-agent): show login status in OAuth provider selector

### DIFF
--- a/packages/coding-agent/src/tui/oauth-selector.ts
+++ b/packages/coding-agent/src/tui/oauth-selector.ts
@@ -1,5 +1,6 @@
 import { Container, Spacer, Text } from "@mariozechner/pi-tui";
 import { getOAuthProviders, type OAuthProviderInfo } from "../oauth/index.js";
+import { loadOAuthCredentials } from "../oauth/storage.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 
@@ -61,14 +62,19 @@ export class OAuthSelectorComponent extends Container {
 			const isSelected = i === this.selectedIndex;
 			const isAvailable = provider.available;
 
+			// Check if user is logged in for this provider
+			const credentials = loadOAuthCredentials(provider.id);
+			const isLoggedIn = credentials !== null;
+			const statusIndicator = isLoggedIn ? theme.fg("success", " ✓ logged in") : "";
+
 			let line = "";
 			if (isSelected) {
 				const prefix = theme.fg("accent", "→ ");
 				const text = isAvailable ? theme.fg("accent", provider.name) : theme.fg("dim", provider.name);
-				line = prefix + text;
+				line = prefix + text + statusIndicator;
 			} else {
 				const text = isAvailable ? `  ${provider.name}` : theme.fg("dim", `  ${provider.name}`);
-				line = text;
+				line = text + statusIndicator;
 			}
 
 			this.listContainer.addChild(new Text(line, 0, 0));


### PR DESCRIPTION
Display '✓ logged in' indicator next to providers where the user is already authenticated. This makes it clear at a glance whether you're using your Claude Pro/Max subscription.

This is vibed during a discussion how I can see if my sub is used. 

I'd like to add a follow-up PR that updates the cost indicator somewhat so it shows the price (sub) or similar - to make this visible without a /login - but wanted to bring this up as discussion first.