### PR TITLE
feat(coding-agent): add build:binary script for Bun bytecode compilation

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -15,6 +15,7 @@
 	"scripts": {
 		"clean": "rm -rf dist",
 		"build": "tsgo -p tsconfig.build.json && chmod +x dist/cli.js && npm run copy-theme-assets",
+		"build:binary": "command -v bun >/dev/null 2>&1 || { echo 'Error: Bun is required for building the binary. Install it from https://bun.sh'; exit 1; } && npm run build && bun build --compile --bytecode ./dist/cli.js --outfile dist/pi",
 		"copy-theme-assets": "cp src/theme/*.json dist/theme/",
 		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
 		"check": "tsgo --noEmit",


### PR DESCRIPTION
## Summary

Adds a `build:binary` npm script that creates a standalone binary using Bun's bytecode compilation feature.

### Changes:
- Added `build:binary` script to package.json
- Script checks if Bun is installed and provides helpful error message if not
- Uses `bun build --compile --bytecode` for optimized binary output

### Benchmark Results (5 runs each, "What is 1+1?" prompt):

| CLI | Average Time | Correctness |
|-----|-------------|-------------|
| **Pi (Bun Bytecode)** | 2.63s | 5/5 ✓ |
| **Codex CLI** | 2.78s | 5/5 ✓ |
| **Pi (Node.js)** | 3.08s | 5/5 ✓ |
| **Claude CLI** | 6.49s | 5/5 ✓ |

The Bun bytecode binary is **~15% faster** than the Node.js version and competitive with Codex CLI.

### Startup Time Only (`--help`, 20 runs):
- Node.js: ~0.185s
- Bun: ~0.079s  
- Bun Bytecode: ~0.049s (3.8x faster than Node.js)

### Usage
```bash
npm run build:binary
./dist/pi -p "your prompt"
```

Requires Bun 1.3+ to be installed.

## Test plan
- [x] Verified binary builds successfully with `npm run build:binary`
- [x] Verified error message shows when Bun is not installed
- [x] Benchmarked against Node.js, Claude CLI, and Codex CLI