### PR TITLE
Show invoked binary name in coding agent banner

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -4,7 +4,7 @@ import { ProcessTerminal, TUI } from "@mariozechner/pi-tui";
 import chalk from "chalk";
 import { existsSync, readFileSync, statSync } from "fs";
 import { homedir } from "os";
-import { extname, join, resolve } from "path";
+import { basename, extname, join, resolve } from "path";
 import { getChangelogPath, getNewEntries, parseChangelog } from "./changelog.js";
 import { exportFromFile } from "./export-html.js";
 import { findModel, getApiKeyForModel, getAvailableModels } from "./model-config.js";
@@ -20,7 +20,11 @@ import { TuiRenderer } from "./tui/tui-renderer.js";
 
 // Get version from package.json
 const packageJson = JSON.parse(readFileSync(getPackageJsonPath(), "utf-8"));
-const VERSION = packageJson.version;
+export const VERSION = packageJson.version;
+
+// Derive binary name from the invoked executable (pi, tau, etc.)
+const invokedBin = basename(process.argv[1] || "pi").replace(/\.(m?js)$/i, "");
+export const BIN_NAME = invokedBin || "pi";
 
 const defaultModelPerProvider: Record<KnownProvider, string> = {
 	anthropic: "claude-sonnet-4-5",

--- a/packages/coding-agent/src/tui/tui-renderer.ts
+++ b/packages/coding-agent/src/tui/tui-renderer.ts
@@ -20,6 +20,7 @@ import {
 import { exec } from "child_process";
 import { getChangelogPath, parseChangelog } from "../changelog.js";
 import { exportSessionToHtml } from "../export-html.js";
+import { BIN_NAME } from "../main.js";
 import { getApiKeyForModel, getAvailableModels, invalidateOAuthCache } from "../model-config.js";
 import { listOAuthProviders, login, logout } from "../oauth/index.js";
 import type { SessionManager } from "../session-manager.js";
@@ -221,7 +222,7 @@ export class TuiRenderer {
 		if (this.isInitialized) return;
 
 		// Add header with logo and instructions
-		const logo = theme.bold(theme.fg("accent", "pi")) + theme.fg("dim", ` v${this.version}`);
+		const logo = theme.bold(theme.fg("accent", BIN_NAME)) + theme.fg("dim", ` v${this.version}`);
 		const instructions =
 			theme.fg("dim", "esc") +
 			theme.fg("muted", " to interrupt") +


### PR DESCRIPTION
- Derive the CLI banner label from the invoked executable (pi, tau, etc.) instead of a hardcoded name.
 - Export BIN_NAME from packages/coding-agent/src/main.ts and use it in the TUI banner so the displayed
 name matches the command the user ran.

I was torn to compile this in, but using the bin name seems simplest and makes forks *cough tau* easier.

<img width="923" height="499" alt="Screenshot 2025-12-02 at 16 08 35" src="https://github.com/user-attachments/assets/0c8c7efb-13e8-4453-8116-6bd9c756871b" />
