### PR TITLE
Show context window size in tokens after percentage

### DIFF
--- a/packages/coding-agent/src/tui/footer.ts
+++ b/packages/coding-agent/src/tui/footer.ts
@@ -186,12 +186,13 @@ export class FooterComponent implements Component {
 		// Colorize context percentage based on usage
 		let contextPercentStr: string;
 		const autoIndicator = this.autoCompactEnabled ? " (auto)" : "";
+		const contextPercentDisplay = `${contextPercent}% of ${formatTokens(contextWindow)}${autoIndicator}`;
 		if (contextPercentValue > 90) {
-			contextPercentStr = theme.fg("error", `${contextPercent}%${autoIndicator}`);
+			contextPercentStr = theme.fg("error", contextPercentDisplay);
 		} else if (contextPercentValue > 70) {
-			contextPercentStr = theme.fg("warning", `${contextPercent}%${autoIndicator}`);
+			contextPercentStr = theme.fg("warning", contextPercentDisplay);
 		} else {
-			contextPercentStr = `${contextPercent}%${autoIndicator}`;
+			contextPercentStr = contextPercentDisplay;
 		}
 		statsParts.push(contextPercentStr);
 


### PR DESCRIPTION
It's useful to know roughly how many tokens are currently in the context window, as model performance degrades quite rapidly when the context window gets bloated. Also, just showing the percentage of context window used does not really help when there are so many different model variations (most Claude models have 200k, Gemini has 1M, and so on). To address this and allow for calculating the rough token count, this PR shows `3.4% of 200k` instead of just `3.4%` in the footer.