### PR TITLE
Fix auto‑compaction trigger to use full session history

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - **Double-Escape Branch Shortcut**: Press Escape twice with an empty editor to quickly open the `/branch` selector for conversation branching.
 
+### Fixed
+
+- Auto-compaction now uses persisted session history to calculate context usage in both RPC and TUI modes, avoiding under-triggering and redundant session reloads during compaction.
+
 ## [0.12.13] - 2025-12-05
 
 ### Changed


### PR DESCRIPTION
- Auto‑compaction (RPC and TUI) now derives usage from persisted session history, falling back to the current turn only if needed.
- TUI compaction reuses preloaded session entries to avoid redundant disk reads when auto‑compaction fires.
- Keeps compaction trigger logic consistent across RPC and TUI modes; retains session reload after compaction.

