### PR TITLE
fix: chalk v5 imports in tui tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3661,6 +3661,7 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.10.7.tgz",
 			"integrity": "sha512-icXIITfw/07Q88nLSkB9aiUrd8rYzSweK681Kjo/TSggaGbOX4RRyxxm71v+3PC8C/j+4rlxGeoTRxQDkaJkUw==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -4218,6 +4219,7 @@
 			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
 			"integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@lit/reactive-element": "^2.1.0",
 				"lit-element": "^4.2.0",
@@ -5282,6 +5284,7 @@
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
 			"integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -5310,7 +5313,8 @@
 			"version": "4.1.17",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
 			"integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -5518,6 +5522,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
 			"integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -5960,6 +5965,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -5978,8 +5984,8 @@
 			"version": "0.12.14",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/pi-ai": "^0.12.13",
-				"@mariozechner/pi-tui": "^0.12.13"
+				"@mariozechner/pi-ai": "^0.12.14",
+				"@mariozechner/pi-tui": "^0.12.14"
 			},
 			"devDependencies": {
 				"@types/node": "^24.3.0",
@@ -6053,9 +6059,9 @@
 			"version": "0.12.14",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/pi-agent-core": "^0.12.13",
-				"@mariozechner/pi-ai": "^0.12.13",
-				"@mariozechner/pi-tui": "^0.12.13",
+				"@mariozechner/pi-agent-core": "^0.12.14",
+				"@mariozechner/pi-ai": "^0.12.14",
+				"@mariozechner/pi-tui": "^0.12.14",
 				"chalk": "^5.5.0",
 				"diff": "^8.0.2",
 				"glob": "^11.0.3"
@@ -6096,8 +6102,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sandbox-runtime": "^0.0.16",
-				"@mariozechner/pi-agent-core": "^0.12.13",
-				"@mariozechner/pi-ai": "^0.12.13",
+				"@mariozechner/pi-agent-core": "^0.12.14",
+				"@mariozechner/pi-ai": "^0.12.14",
 				"@sinclair/typebox": "^0.34.0",
 				"@slack/socket-mode": "^2.0.0",
 				"@slack/web-api": "^7.0.0",
@@ -6138,7 +6144,7 @@
 			"version": "0.12.14",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/pi-agent-core": "^0.12.13",
+				"@mariozechner/pi-agent-core": "^0.12.14",
 				"chalk": "^5.5.0"
 			},
 			"bin": {
@@ -6215,8 +6221,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@lmstudio/sdk": "^1.5.0",
-				"@mariozechner/pi-ai": "^0.12.13",
-				"@mariozechner/pi-tui": "^0.12.13",
+				"@mariozechner/pi-ai": "^0.12.14",
+				"@mariozechner/pi-tui": "^0.12.14",
 				"docx-preview": "^0.3.7",
 				"jszip": "^3.10.1",
 				"lucide": "^0.544.0",


### PR DESCRIPTION
Chalk v5’s Chalk export is type-only; using it as a value triggers TS2693 (“only refers to a type”).
