### PR TITLE
fix(mom): thread replies stay in thread with full context

### DIFF
--- a/packages/mom/src/store.ts
+++ b/packages/mom/src/store.ts
@@ -11,6 +11,7 @@ export interface Attachment {
 export interface LoggedMessage {
 	date: string; // ISO 8601 date (e.g., "2025-11-26T10:44:00.000Z") for easy grepping
 	ts: string; // slack timestamp or epoch ms
+	thread_ts?: string; // parent thread timestamp (present if message is in a thread)
 	user: string; // user ID (or "bot" for bot responses)
 	userName?: string; // handle (e.g., "mario")
 	displayName?: string; // display name (e.g., "Mario Zechner")


### PR DESCRIPTION
## Summary

When @mentioned in a thread, mom now:
1. **Responds in the same thread** (not as a new top-level message)
2. **Has access to thread conversation history** (not just channel messages)

## Changes

### `store.ts`
- Added `thread_ts?: string` to `LoggedMessage` interface

### `slack.ts`
- Added `thread_ts` to `SlackMessage` interface
- Added `fetchAndLogThread()` to fetch thread history via Slack API
- All `postMessage` calls now include `thread_ts` when replying in a thread

### `agent.ts`
- Extracted `formatMessages()` helper
- `getRecentMessages()` now handles thread context:
  - **In thread**: 20 recent channel messages + full thread conversation
  - **Not in thread**: 50 turns, excluding thread replies
- Added `isInThread` flag to prevent duplicate posts when already in thread

## Testing

1. @mention mom in a channel → she replies (top-level)
2. Reply in that thread and @mention her → she now replies **in the thread** with context of the conversation