### PR TITLE
Fix role in openai-completions for ollama provider

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -333,6 +333,7 @@ function convertMessages(model: Model<"openai-completions">, context: Context): 
 		// Cerebras/xAi/Mistral/Chutes don't like the "developer" role
 		const useDeveloperRole =
 			model.reasoning &&
+			!model.provider.includes("ollama") &&
 			!model.baseUrl.includes("cerebras.ai") &&
 			!model.baseUrl.includes("api.x.ai") &&
 			!model.baseUrl.includes("mistral.ai") &&


### PR DESCRIPTION
Fix missing system prompt on Ollama

The Ollama API ignores messages with "role": "developer". As a result, the system prompt (including AGENTS.md) was being left out of the inference context.

This fix forces the use of "role": "system" for model provider named "ollama" so the instructions are correctly applied.

Closes #133.