### PR TITLE
feat(coding-agent): Improve context window safety with per-turn context budget guard and overflow recovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6462,8 +6462,8 @@
 			"version": "0.13.2",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/pi-ai": "^0.13.1",
-				"@mariozechner/pi-tui": "^0.13.1"
+				"@mariozechner/pi-ai": "^0.13.2",
+				"@mariozechner/pi-tui": "^0.13.2"
 			},
 			"devDependencies": {
 				"@types/node": "^24.3.0",
@@ -6537,9 +6537,9 @@
 			"version": "0.13.2",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/pi-agent-core": "^0.13.1",
-				"@mariozechner/pi-ai": "^0.13.1",
-				"@mariozechner/pi-tui": "^0.13.1",
+				"@mariozechner/pi-agent-core": "^0.13.2",
+				"@mariozechner/pi-ai": "^0.13.2",
+				"@mariozechner/pi-tui": "^0.13.2",
 				"chalk": "^5.5.0",
 				"diff": "^8.0.2",
 				"glob": "^11.0.3"
@@ -6580,8 +6580,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sandbox-runtime": "^0.0.16",
-				"@mariozechner/pi-agent-core": "^0.13.1",
-				"@mariozechner/pi-ai": "^0.13.1",
+				"@mariozechner/pi-agent-core": "^0.13.2",
+				"@mariozechner/pi-ai": "^0.13.2",
 				"@sinclair/typebox": "^0.34.0",
 				"@slack/socket-mode": "^2.0.0",
 				"@slack/web-api": "^7.0.0",
@@ -6622,7 +6622,7 @@
 			"version": "0.13.2",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/pi-agent-core": "^0.13.1",
+				"@mariozechner/pi-agent-core": "^0.13.2",
 				"chalk": "^5.5.0"
 			},
 			"bin": {
@@ -6699,8 +6699,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@lmstudio/sdk": "^1.5.0",
-				"@mariozechner/pi-ai": "^0.13.1",
-				"@mariozechner/pi-tui": "^0.13.1",
+				"@mariozechner/pi-ai": "^0.13.2",
+				"@mariozechner/pi-tui": "^0.13.2",
 				"docx-preview": "^0.3.7",
 				"jszip": "^3.10.1",
 				"lucide": "^0.544.0",

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -260,11 +260,18 @@ contextTokens = usage.input + usage.output + usage.cacheRead + usage.cacheWrite
 This gives total context size across all providers. The `input` field represents non-cached input tokens, so adding `cacheRead` and `cacheWrite` gives the true total input.
 
 **Trigger condition:**
-```typescript
-if (contextTokens > model.contextWindow - settings.compaction.reserveTokens) {
-  await compact({ auto: true });
-}
-```
+
+- **Per-turn threshold (existing):** after each assistant message, auto-compaction runs when
+  ```typescript
+  if (contextTokens > model.contextWindow - settings.compaction.reserveTokens) {
+    await compact({ auto: true });
+  }
+  ```
+- **Post-tool projection (new):** after each tool finishes, we estimate how many tokens its
+  result will add and, if the projected total exceeds `contextWindow - reserveTokens`, we
+  mark the turn for compaction. When the turn ends, compaction runs *before* the next model
+  call.
+
 
 ### Turn Boundaries
 

--- a/packages/coding-agent/src/context-budget.ts
+++ b/packages/coding-agent/src/context-budget.ts
@@ -1,0 +1,110 @@
+import type { AppMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, Usage } from "@mariozechner/pi-ai";
+import { calculateContextTokens } from "./compaction.js";
+
+/**
+ * Extract total character length from a tool result.
+ *
+ * We only count text visible to the model (text content blocks or plain strings),
+ * ignoring images and opaque detail fields.
+ */
+function extractTextLength(result: unknown): number {
+	if (!result) return 0;
+
+	if (typeof result === "string") {
+		return result.length;
+	}
+
+	// Some tools may return just an array of content blocks
+	if (Array.isArray(result)) {
+		let total = 0;
+		for (const item of result) {
+			if (!item) continue;
+			if (typeof item === "string") {
+				total += item.length;
+			} else if (
+				typeof item === "object" &&
+				(item as any).type === "text" &&
+				typeof (item as any).text === "string"
+			) {
+				total += (item as any).text.length;
+			}
+		}
+		return total;
+	}
+
+	// Standard tool result shape: { content: [...], details?: ... }
+	if (typeof result === "object" && result !== null && Array.isArray((result as any).content)) {
+		const content = (result as any).content as unknown[];
+		let total = 0;
+		for (const item of content) {
+			if (!item) continue;
+			if (typeof item === "string") {
+				total += item.length;
+			} else if (
+				typeof item === "object" &&
+				(item as any).type === "text" &&
+				typeof (item as any).text === "string"
+			) {
+				total += (item as any).text.length;
+			}
+		}
+		return total;
+	}
+
+	return 0;
+}
+
+/**
+ * Estimate the number of tokens added to the context by a tool result.
+ *
+ * Uses a simple chars/4 heuristic which is sufficient for budget checks.
+ */
+export function estimateToolResultTokens(result: unknown): number {
+	const chars = extractTextLength(result);
+	if (chars <= 0) return 0;
+	return Math.ceil(chars / 4);
+}
+
+/**
+ * Find the last non-aborted assistant message usage from in-memory messages.
+ */
+export function getLastAssistantUsageFromMessages(messages: AppMessage[]): Usage | null {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (msg.role === "assistant") {
+			const assistant = msg as AssistantMessage;
+			if (assistant.stopReason !== "aborted") {
+				return assistant.usage;
+			}
+		}
+	}
+	return null;
+}
+
+export interface PostTurnCompactionParams {
+	lastUsage: Usage | null;
+	estimatedAddedTokens: number;
+	contextWindow: number;
+	reserveTokens: number;
+	enabled: boolean;
+}
+
+/**
+ * Decide whether we should trigger compaction *before* the next LLM call
+ * based on projected context usage after tool outputs.
+ */
+export function shouldTriggerCompactionAfterTurn(params: PostTurnCompactionParams): boolean {
+	const { lastUsage, estimatedAddedTokens, contextWindow, reserveTokens, enabled } = params;
+	if (!enabled) return false;
+	if (!lastUsage) return false;
+	if (estimatedAddedTokens <= 0) return false;
+	if (contextWindow <= 0) return false;
+
+	const current = calculateContextTokens(lastUsage);
+	const threshold = contextWindow - reserveTokens;
+	if (threshold <= 0) return false;
+
+	const projected = current + estimatedAddedTokens;
+	return projected > threshold;
+}

--- a/packages/coding-agent/test/context-budget.test.ts
+++ b/packages/coding-agent/test/context-budget.test.ts
@@ -1,0 +1,130 @@
+import type { AppMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, Usage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	estimateToolResultTokens,
+	getLastAssistantUsageFromMessages,
+	shouldTriggerCompactionAfterTurn,
+} from "../src/context-budget.js";
+
+function createUsage(totalTokens: number): Usage {
+	return {
+		input: totalTokens,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+describe("context-budget: estimateToolResultTokens", () => {
+	it("counts plain string results", () => {
+		const text = "abcd".repeat(10); // 40 chars
+		const tokens = estimateToolResultTokens(text);
+		expect(tokens).toBe(10); // ceil(40/4)
+	});
+
+	it("counts text blocks in content arrays and ignores images", () => {
+		const result = {
+			content: [
+				{ type: "text", text: "hello" },
+				{ type: "image", data: "xxx", mimeType: "image/png" },
+				{ type: "text", text: "world" },
+			],
+			details: { diff: "ignored" },
+		};
+
+		const totalChars = "hello".length + "world".length;
+		const tokens = estimateToolResultTokens(result);
+		expect(tokens).toBe(Math.ceil(totalChars / 4));
+	});
+
+	it("returns zero for empty or non-text results", () => {
+		expect(estimateToolResultTokens(undefined)).toBe(0);
+		expect(estimateToolResultTokens({})).toBe(0);
+	});
+});
+
+describe("context-budget: getLastAssistantUsageFromMessages", () => {
+	it("returns usage from last non-aborted assistant", () => {
+		const now = Date.now();
+		const messages: AppMessage[] = [
+			{ role: "user", content: "hi", timestamp: now },
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "first" }],
+				usage: createUsage(100),
+				stopReason: "stop",
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude",
+				timestamp: now,
+			} as AssistantMessage,
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "second" }],
+				usage: createUsage(200),
+				stopReason: "aborted",
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude",
+				timestamp: now,
+			} as AssistantMessage,
+		];
+
+		const usage = getLastAssistantUsageFromMessages(messages);
+		expect(usage).not.toBeNull();
+		expect(usage!.totalTokens).toBe(100);
+	});
+
+	it("returns null when no assistant messages", () => {
+		const messages: AppMessage[] = [{ role: "user", content: "only user", timestamp: Date.now() }];
+		expect(getLastAssistantUsageFromMessages(messages)).toBeNull();
+	});
+});
+
+describe("context-budget: shouldTriggerCompactionAfterTurn", () => {
+	it("returns true when projected usage exceeds threshold", () => {
+		const usage = createUsage(90_000);
+		const result = shouldTriggerCompactionAfterTurn({
+			lastUsage: usage,
+			estimatedAddedTokens: 15_000,
+			contextWindow: 100_000,
+			reserveTokens: 10_000,
+			enabled: true,
+		});
+		// threshold = 90k, projected = 105k
+		expect(result).toBe(true);
+	});
+
+	it("returns false when under threshold or disabled", () => {
+		const usage = createUsage(50_000);
+		const baseParams = {
+			lastUsage: usage,
+			estimatedAddedTokens: 10_000,
+			contextWindow: 100_000,
+			reserveTokens: 10_000,
+			enabled: true,
+		} as const;
+
+		// 50k + 10k = 60k, threshold = 90k
+		expect(shouldTriggerCompactionAfterTurn(baseParams)).toBe(false);
+
+		// Disabled
+		expect(
+			shouldTriggerCompactionAfterTurn({
+				...baseParams,
+				enabled: false,
+			}),
+		).toBe(false);
+
+		// No last usage
+		expect(
+			shouldTriggerCompactionAfterTurn({
+				...baseParams,
+				lastUsage: null,
+			}),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
This change enhances the coding agent’s context management to reduce context window overflows and make compaction behavior more predictable and explicit.

The implementation introduces a small, pure context budget helper that estimates additional tokens from tool outputs and projects them against the model’s context window with a configurable reserve. Both the TUI and RPC flows now track tool-induced growth per turn and trigger compaction before the next model call when the projected usage exceeds the safe threshold. Provider-reported context overflows are also detected and used as a signal to force compaction at the end of the turn.

Existing static truncation limits for tool outputs are preserved and integrated into this flow, providing a layered defense: first by bounding raw tool output size, then by proactively compacting when the projected context nears the configured limit.

Context compaction documentation has been updated to describe the new per-turn projection behavior alongside the existing post-assistant usage check, and tests have been added for the new context budget helper logic.

---

### Follow-up PRs (from code review)

These are non-blocking improvements identified in the code review and can be addressed in separate follow-up PRs:

1. **Improve token estimation for nested tool results**
   - Extend `estimateToolResultTokens` to walk nested `content` structures (e.g. paragraphs/blocks containing `{ type: "text" }` at deeper levels), still using a simple chars/4 heuristic but seeing all visible text.

2. **Clarify semantics of “last assistant usage”**
   - Decide whether `getLastAssistantUsageFromMessages` should also skip `stopReason === "error"` (not just `"aborted"`), and update both RPC + TUI call sites and tests accordingly.

3. **Tighten budgeting vs. amount of compaction**
   - Evaluate whether to pass projected tool tokens into the compaction logic (or adjust `reserveTokens`) so that the amount of compaction more closely targets `threshold - estimatedAddedTokens` rather than just “below threshold.”

4. **Deduplicate last-assistant scan logic**
   - Refactor TUI `checkAutoCompaction` to use `getLastAssistantUsageFromMessages` instead of its own backward scan, so that any future change in semantics (e.g. handling `"error"`) lives in one place.

5. **Improve TUI responsiveness around forced compaction**
   - Consider making forced compaction at `turn_end` fire-and-forget (plus clear UI feedback) instead of fully awaited inside the event handler, to avoid stalling the UI on very large sessions.

6. **Broaden tests for `estimateToolResultTokens`**
   - Add tests covering nested content structures (even if currently ignored), image-only content, and other edge cases to make current under-counting behavior explicit and documented.

7. **Align under-compaction design doc with actual limits**
   - Update `docs/undercompaction.md` Phase 1 examples to either:
     - Match the actual truncation limits implemented in `tools/truncate.ts`, or
     - Clearly label the numbers as illustrative and point to `truncate.ts` as the canonical source for the enforced limits.

8. **Model metadata documentation (optional)**
   - If external documentation or dashboards depend on model pricing/context metadata, ensure they are updated to reflect the new values in `models.generated.ts`, especially where context windows or `maxTokens` changed.