### PR TITLE
Use only model ID for fuzzy filtering in model selector

### DIFF
--- a/packages/coding-agent/src/tui/model-selector.ts
+++ b/packages/coding-agent/src/tui/model-selector.ts
@@ -115,7 +115,7 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	private filterModels(query: string): void {
-		this.filteredModels = fuzzyFilter(this.allModels, query, ({ provider, id }) => `${provider} ${id}`);
+		this.filteredModels = fuzzyFilter(this.allModels, query, ({ id }) => id);
 		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredModels.length - 1));
 		this.updateList();
 	}


### PR DESCRIPTION
It was a mistake in my previous PR to include the provider in the fuzzy searchable string. For example, searching for `opus` lists Sonnet as the first match because all `o p u s` match in that order with the provider name: `anthropic claude-opus-4-5` -> `_____op__ ___u______s____`.