### PR TITLE
Added compat flags to model config example for ollama

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -205,7 +205,11 @@ You can add custom models and providers (like Ollama, vLLM, LM Studio, or any cu
           "input": ["text"],
           "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
           "contextWindow": 128000,
-          "maxTokens": 32000
+          "maxTokens": 32000,
+          "compat": {
+            "supportsDeveloperRole": false,
+            "supportsStore": false
+          }
         }
       ]
     },


### PR DESCRIPTION
The new compat flags are working great with ollama, so it would be important to update the example for model config in README.md