### PR TITLE
Fix CI: Correct theme path in release workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -73,7 +73,7 @@ jobs:
             cp README.md binaries/$platform/
             cp CHANGELOG.md binaries/$platform/
             mkdir -p binaries/$platform/theme
-            cp dist/theme/*.json binaries/$platform/theme/
+            cp dist/modes/interactive/theme/*.json binaries/$platform/theme/
           done
 
           # Create archives


### PR DESCRIPTION
Build outputs to dist/modes/interactive/theme/*.json but workflow expected dist/theme/*.json. The copy-binary-assets script creates dist/theme/ but CI never invokes it.

Fixes v0.18.0 release failure:
https://github.com/badlogic/pi-mono/actions/runs/20082833642