### PR TITLE
add discord transport for mom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,15 +47,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@anthropic-ai/sandbox-runtime/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
 		"node_modules/@anthropic-ai/sdk": {
 			"version": "0.71.2",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
@@ -246,6 +237,136 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@discordjs/builders": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+			"integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@discordjs/formatters": "^0.6.2",
+				"@discordjs/util": "^1.2.0",
+				"@sapphire/shapeshift": "^4.0.0",
+				"discord-api-types": "^0.38.33",
+				"fast-deep-equal": "^3.1.3",
+				"ts-mixer": "^6.0.4",
+				"tslib": "^2.6.3"
+			},
+			"engines": {
+				"node": ">=16.11.0"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
+			}
+		},
+		"node_modules/@discordjs/collection": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+			"integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=16.11.0"
+			}
+		},
+		"node_modules/@discordjs/formatters": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+			"integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"discord-api-types": "^0.38.33"
+			},
+			"engines": {
+				"node": ">=16.11.0"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
+			}
+		},
+		"node_modules/@discordjs/rest": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+			"integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@discordjs/collection": "^2.1.1",
+				"@discordjs/util": "^1.1.1",
+				"@sapphire/async-queue": "^1.5.3",
+				"@sapphire/snowflake": "^3.5.3",
+				"@vladfrangu/async_event_emitter": "^2.4.6",
+				"discord-api-types": "^0.38.16",
+				"magic-bytes.js": "^1.10.0",
+				"tslib": "^2.6.3",
+				"undici": "6.21.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
+			}
+		},
+		"node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+			"integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
+			}
+		},
+		"node_modules/@discordjs/util": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+			"integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"discord-api-types": "^0.38.33"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
+			}
+		},
+		"node_modules/@discordjs/ws": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+			"integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@discordjs/collection": "^2.1.0",
+				"@discordjs/rest": "^2.5.1",
+				"@discordjs/util": "^1.1.0",
+				"@sapphire/async-queue": "^1.5.2",
+				"@types/ws": "^8.5.10",
+				"@vladfrangu/async_event_emitter": "^2.2.4",
+				"discord-api-types": "^0.38.1",
+				"tslib": "^2.6.2",
+				"ws": "^8.17.0"
+			},
+			"engines": {
+				"node": ">=16.11.0"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
+			}
+		},
+		"node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+			"integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -909,15 +1030,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@lmstudio/sdk/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
 		"node_modules/@mariozechner/mini-lit": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/@mariozechner/mini-lit/-/mini-lit-0.2.1.tgz",
@@ -950,6 +1062,10 @@
 			"engines": {
 				"node": ">= 20"
 			}
+		},
+		"node_modules/@mariozechner/mom-discord": {
+			"resolved": "packages/mom-discord",
+			"link": true
 		},
 		"node_modules/@mariozechner/pi": {
 			"resolved": "packages/pods",
@@ -990,15 +1106,6 @@
 			"dependencies": {
 				"zod": "^3.20.0",
 				"zod-to-json-schema": "^3.24.1"
-			}
-		},
-		"node_modules/@mistralai/mistralai/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@napi-rs/canvas": {
@@ -1820,6 +1927,39 @@
 				"win32"
 			]
 		},
+		"node_modules/@sapphire/async-queue": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+			"integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/@sapphire/shapeshift": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+			"integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"lodash": "^4.17.21"
+			},
+			"engines": {
+				"node": ">=v16"
+			}
+		},
+		"node_modules/@sapphire/snowflake": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+			"integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.34.41",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
@@ -2481,6 +2621,16 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@vladfrangu/async_event_emitter": {
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+			"integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
 		"node_modules/@webreflection/alien-signals": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@webreflection/alien-signals/-/alien-signals-0.3.2.tgz",
@@ -3121,6 +3271,42 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/discord-api-types": {
+			"version": "0.38.37",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
+			"integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
+			"license": "MIT",
+			"workspaces": [
+				"scripts/actions/documentation"
+			]
+		},
+		"node_modules/discord.js": {
+			"version": "14.25.1",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+			"integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@discordjs/builders": "^1.13.0",
+				"@discordjs/collection": "1.5.3",
+				"@discordjs/formatters": "^0.6.2",
+				"@discordjs/rest": "^2.6.0",
+				"@discordjs/util": "^1.2.0",
+				"@discordjs/ws": "^1.2.3",
+				"@sapphire/snowflake": "3.5.3",
+				"discord-api-types": "^0.38.33",
+				"fast-deep-equal": "3.1.3",
+				"lodash.snakecase": "4.1.1",
+				"magic-bytes.js": "^1.10.0",
+				"tslib": "^2.6.3",
+				"undici": "6.21.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/docx-preview": {
@@ -4352,10 +4538,22 @@
 				"@types/trusted-types": "^2.0.2"
 			}
 		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"license": "MIT"
+		},
 		"node_modules/lodash-es": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
 			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.snakecase": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
 			"license": "MIT"
 		},
 		"node_modules/loupe": {
@@ -4379,6 +4577,12 @@
 			"resolved": "https://registry.npmjs.org/lucide/-/lucide-0.544.0.tgz",
 			"integrity": "sha512-U5ORwr5z9Sx7bNTDFaW55RbjVdQEnAcT3vws9uz3vRT1G4XXJUDAhRZdxhFoIyHEvjmTkzzlEhjSLYM5n4mb5w==",
 			"license": "ISC"
+		},
+		"node_modules/magic-bytes.js": {
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
+			"integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
+			"license": "MIT"
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
@@ -5552,11 +5756,16 @@
 			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
 			"license": "MIT"
 		},
+		"node_modules/ts-mixer": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+			"integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+			"license": "MIT"
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"devOptional": true,
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
@@ -5613,6 +5822,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"@webreflection/alien-signals": "^0.3.2"
+			}
+		},
+		"node_modules/undici": {
+			"version": "6.21.3",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+			"integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/undici-types": {
@@ -6527,11 +6745,10 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "4.1.13",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-			"integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -6678,7 +6895,8 @@
 				"@slack/web-api": "^7.0.0",
 				"chalk": "^5.6.2",
 				"croner": "^9.1.0",
-				"diff": "^8.0.2"
+				"diff": "^8.0.2",
+				"discord.js": "^14.16.3"
 			},
 			"bin": {
 				"mom": "dist/main.js"
@@ -6691,6 +6909,152 @@
 			"engines": {
 				"node": ">=20.0.0"
 			}
+		},
+		"packages/mom-discord": {
+			"name": "@mariozechner/mom-discord",
+			"version": "0.1.0",
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sandbox-runtime": "^0.0.16",
+				"@mariozechner/pi-agent-core": "^0.12.9",
+				"@mariozechner/pi-ai": "^0.12.9",
+				"@sinclair/typebox": "^0.34.0",
+				"chalk": "^5.6.2",
+				"diff": "^8.0.2",
+				"discord.js": "^14.16.3"
+			},
+			"bin": {
+				"mom-discord": "dist/main.js"
+			},
+			"devDependencies": {
+				"@types/diff": "^7.0.2",
+				"@types/node": "^24.3.0",
+				"typescript": "^5.7.3"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"packages/mom-discord/node_modules/@anthropic-ai/sdk": {
+			"version": "0.61.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.61.0.tgz",
+			"integrity": "sha512-GnlOXrPxow0uoaVB3DGNh9EJBU1MyagCBCLpU+bwDVlj/oOPYIwoiasMWlykkfYcQOrDP2x/zHnRD0xN7PeZPw==",
+			"license": "MIT",
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			}
+		},
+		"packages/mom-discord/node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.12.15",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.12.15.tgz",
+			"integrity": "sha512-xWUs67Mq/NO97areiIj19Def0t+hoWmaqUOLP70bzgiuor0GVkLIbazPmHMcFruZMRUpAjRKmURNg5cqnr4mLQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.12.15",
+				"@mariozechner/pi-tui": "^0.12.15"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"packages/mom-discord/node_modules/@mariozechner/pi-ai": {
+			"version": "0.12.15",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.12.15.tgz",
+			"integrity": "sha512-wKawXBKDJS+TaCjJsoxyrOCCgE0nVb1C1CYsMH+w1AsIGS/e72Cmhp1Htu9QFVj/96uoZoYnRBwvlCsbNhQ/Kg==",
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.61.0",
+				"@google/genai": "^1.30.0",
+				"@sinclair/typebox": "^0.34.41",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"chalk": "^5.6.2",
+				"openai": "5.21.0",
+				"partial-json": "^0.1.7",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"packages/mom-discord/node_modules/@mariozechner/pi-tui": {
+			"version": "0.12.15",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.12.15.tgz",
+			"integrity": "sha512-7os71i/J41qhg1KZqKViZVBECH5w8Er/zQB/08aLsjJSFdlNlRqLJuj29F8Mh6WYEEdtOLxwcDtdfTHUbJF2pQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1",
+				"string-width": "^8.1.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"packages/mom-discord/node_modules/@types/node": {
+			"version": "24.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
+			"integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
+		},
+		"packages/mom-discord/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"packages/mom-discord/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"packages/mom-discord/node_modules/openai": {
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-5.21.0.tgz",
+			"integrity": "sha512-E9LuV51vgvwbahPJaZu2x4V6SWMq9g3X6Bj2/wnFiNfV7lmAxYVxPxcQNZqCWbAVMaEoers9HzIxpOp6Vvgn8w==",
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.23.8"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"packages/mom-discord/node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"packages/mom/node_modules/@types/node": {
 			"version": "24.10.3",

--- a/packages/mom/README.md
+++ b/packages/mom/README.md
@@ -1,17 +1,17 @@
 # mom (Master Of Mischief)
 
-A Slack bot powered by an LLM that can execute bash commands, read/write files, and interact with your development environment. Mom is **self-managing**. She installs her own tools, programs [CLI tools (aka "skills")](https://mariozechner.at/posts/2025-11-02-what-if-you-dont-need-mcp/) she can use to help with your workflows and tasks, configures credentials, and maintains her workspace autonomously.
+A Slack/Discord bot powered by an LLM that can execute bash commands, read/write files, and interact with your development environment. Mom is **self-managing**. She installs her own tools, programs [CLI tools (aka "skills")](https://mariozechner.at/posts/2025-11-02-what-if-you-dont-need-mcp/) she can use to help with your workflows and tasks, configures credentials, and maintains her workspace autonomously.
 
 ## Features
 
 - **Minimal by Design**: Turn mom into whatever you need. She builds her own tools without pre-built assumptions
 - **Self-Managing**: Installs tools (apk, npm, etc.), writes scripts, configures credentials. Zero setup from you
-- **Slack Integration**: Responds to @mentions in channels and DMs
+- **Slack & Discord Integration**: Responds to @mentions in channels and DMs on both platforms
 - **Full Bash Access**: Execute any command, read/write files, automate workflows
 - **Docker Sandbox**: Isolate mom in a container (recommended for all use)
 - **Persistent Workspace**: All conversation history, files, and tools stored in one directory you control
 - **Working Memory & Custom Tools**: Mom remembers context across sessions and creates workflow-specific CLI tools ([aka "skills"](https://mariozechner.at/posts/2025-11-02-what-if-you-dont-need-mcp/)) for your tasks
-- **Thread-Based Details**: Clean main messages with verbose tool details in threads
+- **Thread-Based Details**: Clean main messages with verbose tool details in threads (Slack) or embeds (Discord)
 
 ## Installation
 
@@ -49,16 +49,29 @@ npm install @mariozechner/pi-mom
 7. Install the app to your workspace. Get the **Bot User OAuth Token**. This is `MOM_SLACK_BOT_TOKEN`
 8. Add mom to any channels where you want her to operate (she'll only see messages in channels she's added to)
 
+### Discord App Setup
+
+1. Create a new Discord application at https://discord.com/developers/applications
+2. Go to **Bot** in the left sidebar and click **Add Bot**
+3. Under **Privileged Gateway Intents**, enable:
+   - `MESSAGE CONTENT INTENT`
+   - `SERVER MEMBERS INTENT`
+4. Copy the **Bot Token**. This is `DISCORD_BOT_TOKEN`
+5. Go to **OAuth2 → URL Generator** and select:
+   - Scopes: `bot`, `applications.commands`
+   - Bot Permissions: `Send Messages`, `Read Message History`, `Attach Files`, `Embed Links`, `Use Slash Commands`, `Add Reactions`
+6. Copy the generated URL and open it to invite the bot to your server
+7. The bot will respond to @mentions and DMs, and register slash commands (`/mom`, `/mom-stop`, `/mom-memory`)
+
 ## Quick Start
+
+### Slack
 
 ```bash
 # Set environment variables
 export MOM_SLACK_APP_TOKEN=xapp-...
 export MOM_SLACK_BOT_TOKEN=xoxb-...
-# Option 1: Anthropic API key
-export ANTHROPIC_API_KEY=sk-ant-...
-# Option 2: Anthropic Pro/Max (use `claude setup-token`)
-export ANTHROPIC_OAUTH_TOKEN=sk-ant-...
+export ANTHROPIC_API_KEY=sk-ant-...  # or ANTHROPIC_OAUTH_TOKEN
 
 # Create Docker sandbox (recommended)
 docker run -d \
@@ -67,11 +80,29 @@ docker run -d \
   alpine:latest \
   tail -f /dev/null
 
-# Run mom in Docker mode
+# Run mom for Slack (default)
 mom --sandbox=docker:mom-sandbox ./data
-
-# Mom will install any tools she needs herself (git, jq, etc.)
 ```
+
+### Discord
+
+```bash
+# Set environment variables
+export DISCORD_BOT_TOKEN=...
+export ANTHROPIC_API_KEY=sk-ant-...  # or ANTHROPIC_OAUTH_TOKEN
+
+# Create Docker sandbox (recommended)
+docker run -d \
+  --name mom-sandbox \
+  -v $(pwd)/data:/workspace \
+  alpine:latest \
+  tail -f /dev/null
+
+# Run mom for Discord
+mom --transport=discord --sandbox=docker:mom-sandbox ./data
+```
+
+Mom will install any tools she needs herself (git, jq, etc.).
 
 ## CLI Options
 
@@ -79,6 +110,8 @@ mom --sandbox=docker:mom-sandbox ./data
 mom [options] <working-directory>
 
 Options:
+  --transport=slack           Use Slack transport (default)
+  --transport=discord         Use Discord transport
   --sandbox=host              Run tools on host (not recommended)
   --sandbox=docker:<name>     Run tools in Docker container (recommended)
 ```
@@ -87,14 +120,15 @@ Options:
 
 | Variable | Description |
 |----------|-------------|
-| `MOM_SLACK_APP_TOKEN` | Slack app-level token (xapp-...) |
-| `MOM_SLACK_BOT_TOKEN` | Slack bot token (xoxb-...) |
+| `MOM_SLACK_APP_TOKEN` | Slack app-level token (xapp-...) - required for Slack |
+| `MOM_SLACK_BOT_TOKEN` | Slack bot token (xoxb-...) - required for Slack |
+| `DISCORD_BOT_TOKEN` | Discord bot token - required for Discord |
 | `ANTHROPIC_API_KEY` | Anthropic API key |
 | `ANTHROPIC_OAUTH_TOKEN` | Alternative: Anthropic OAuth token |
 
 ## How Mom Works
 
-Mom is a Node.js app that runs on your host machine. She connects to Slack via Socket Mode, receives messages, and responds using an LLM-based agent that can create and use tools.
+Mom is a Node.js app that runs on your host machine. She connects to Slack (via Socket Mode) or Discord (via Gateway), receives messages, and responds using an LLM-based agent that can create and use tools.
 
 **For each channel you add mom to** (group channels or DMs), mom maintains a separate conversation history with its own context, memory, and files.
 
@@ -128,7 +162,7 @@ Mom has access to these tools:
 - **read**: Read file contents
 - **write**: Create or overwrite files
 - **edit**: Make surgical edits to existing files
-- **attach**: Share files back to Slack
+- **attach**: Share files back to the chat (Slack or Discord)
 
 ### Bash Execution Environment
 
@@ -158,8 +192,9 @@ You never need to manually install dependencies. Just ask mom and she'll set it 
 
 You provide mom with a **data directory** (e.g., `./data`) as her workspace. While mom can technically access any directory in her execution environment, she's instructed to store all her work here:
 
+**Slack:**
 ```
-./data/                         # Your host directory
+./data/
   ├── MEMORY.md                 # Global memory (shared across channels)
   ├── settings.json             # Global settings (compaction, retry, etc.)
   ├── skills/                   # Global custom CLI tools mom creates
@@ -172,6 +207,25 @@ You provide mom with a **data directory** (e.g., `./data`) as her workspace. Whi
   │   └── skills/               # Channel-specific CLI tools
   └── D456DEF/                  # DM channels also get directories
       └── ...
+```
+
+**Discord:**
+```
+./data/
+  ├── MEMORY.md                 # Global memory (shared across channels)
+  ├── settings.json             # Global settings
+  ├── skills/                   # Global custom CLI tools
+  └── discord/
+      ├── <guildId>/            # Each Discord server (guild)
+      │   └── <channelId>/      # Each channel within the server
+      │       ├── MEMORY.md
+      │       ├── log.jsonl
+      │       ├── context.jsonl
+      │       ├── attachments/
+      │       └── skills/
+      └── dm/                   # Discord DMs
+          └── <channelId>/
+              └── ...
 ```
 
 **What's stored here:**
@@ -290,9 +344,11 @@ esac
 
 Now, if you ask mom to "take a note: buy groceries", she'll use the note skill to add it. Ask her to "show me my notes" and she'll read them back to you.
 
-### Events (Scheduled Wake-ups)
+### Events (Scheduled Wake-ups) - Slack Only
 
 Mom can schedule events that wake her up at specific times or when external things happen. Events are JSON files in `data/events/`. The harness watches this directory and triggers mom when events are due.
+
+**Note:** Events are currently only supported with the Slack transport. Discord support may be added in the future.
 
 **Three event types:**
 
@@ -339,6 +395,23 @@ You can write event files directly to `data/events/` on the host machine. This l
 - Periodic events should debounce (e.g., check inbox every 15 minutes, not per-email)
 
 **Example workflow:** Ask mom to "remind me about the dentist tomorrow at 9am" and she'll create a one-shot event. Ask her to "check my inbox every morning at 9" and she'll create a periodic event with cron schedule `0 9 * * *`.
+
+### Discord-Specific Features
+
+When running with `--transport=discord`, mom provides these additional features:
+
+**Slash Commands:**
+- `/mom <message>` - Send a message to mom (alternative to @mentioning)
+- `/mom-stop` - Stop the current operation in this channel
+- `/mom-memory` - View or edit channel/global memory via a modal
+
+**Stop Button:**
+- While mom is working, a "Stop" button appears on her response message
+- Click it to abort the current operation
+
+**Tool Results:**
+- Tool execution results are shown as Discord embeds with color-coded status (green for success, red for error)
+- Embeds include the tool name, arguments, result, and duration
 
 ### Updating Mom
 
@@ -441,7 +514,7 @@ mom --sandbox=docker:mom-exec ./data-exec
 
 ### Code Structure
 
-- `src/main.ts`: Entry point, CLI arg parsing, handler setup, SlackContext adapter
+- `src/main.ts`: Entry point, CLI arg parsing, transport routing
 - `src/agent.ts`: Agent runner, event handling, tool execution, session management
 - `src/slack.ts`: Slack integration (Socket Mode), backfill, message logging
 - `src/context.ts`: Session manager (context.jsonl), log-to-context sync
@@ -449,6 +522,9 @@ mom --sandbox=docker:mom-exec ./data-exec
 - `src/log.ts`: Centralized logging (console output)
 - `src/sandbox.ts`: Docker/host sandbox execution
 - `src/tools/`: Tool implementations (bash, read, write, edit, attach)
+- `src/transport/types.ts`: Transport abstraction (TransportContext interface)
+- `src/transport/slack/`: Slack-specific context adapter
+- `src/transport/discord/`: Discord bot, store, and slash commands
 
 ### Running in Dev Mode
 

--- a/packages/mom/package.json
+++ b/packages/mom/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@mariozechner/pi-mom",
 	"version": "0.21.0",
-	"description": "Slack bot that delegates messages to the pi coding agent",
+	"description": "Chat bot (Slack/Discord) that delegates messages to the pi coding agent",
 	"type": "module",
 	"bin": {
 		"mom": "dist/main.js"
@@ -29,7 +29,8 @@
 		"@slack/web-api": "^7.0.0",
 		"chalk": "^5.6.2",
 		"croner": "^9.1.0",
-		"diff": "^8.0.2"
+		"diff": "^8.0.2",
+		"discord.js": "^14.16.3"
 	},
 	"devDependencies": {
 		"@types/diff": "^7.0.2",
@@ -38,6 +39,7 @@
 	},
 	"keywords": [
 		"slack",
+		"discord",
 		"bot",
 		"ai",
 		"agent"

--- a/packages/mom/src/tools/attach.ts
+++ b/packages/mom/src/tools/attach.ts
@@ -2,12 +2,7 @@ import type { AgentTool } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import { basename, resolve as resolvePath } from "path";
 
-// This will be set by the agent before running
-let uploadFn: ((filePath: string, title?: string) => Promise<void>) | null = null;
-
-export function setUploadFunction(fn: (filePath: string, title?: string) => Promise<void>): void {
-	uploadFn = fn;
-}
+export type UploadFunction = (filePath: string, title?: string) => Promise<void>;
 
 const attachSchema = Type.Object({
 	label: Type.String({ description: "Brief description of what you're sharing (shown to user)" }),
@@ -15,33 +10,36 @@ const attachSchema = Type.Object({
 	title: Type.Optional(Type.String({ description: "Title for the file (defaults to filename)" })),
 });
 
-export const attachTool: AgentTool<typeof attachSchema> = {
-	name: "attach",
-	label: "attach",
-	description:
-		"Attach a file to your response. Use this to share files, images, or documents with the user. Only files from /workspace/ can be attached.",
-	parameters: attachSchema,
-	execute: async (
-		_toolCallId: string,
-		{ path, title }: { label: string; path: string; title?: string },
-		signal?: AbortSignal,
-	) => {
-		if (!uploadFn) {
-			throw new Error("Upload function not configured");
-		}
+export function createAttachTool(getUploadFunction: () => UploadFunction | null): AgentTool<typeof attachSchema> {
+	return {
+		name: "attach",
+		label: "attach",
+		description:
+			"Attach a file to your response. Use this to share files, images, or documents with the user. Only files from /workspace/ can be attached.",
+		parameters: attachSchema,
+		execute: async (
+			_toolCallId: string,
+			{ path, title }: { label: string; path: string; title?: string },
+			signal?: AbortSignal,
+		) => {
+			const uploadFn = getUploadFunction();
+			if (!uploadFn) {
+				throw new Error("Upload function not configured");
+			}
 
-		if (signal?.aborted) {
-			throw new Error("Operation aborted");
-		}
+			if (signal?.aborted) {
+				throw new Error("Operation aborted");
+			}
 
-		const absolutePath = resolvePath(path);
-		const fileName = title || basename(absolutePath);
+			const absolutePath = resolvePath(path);
+			const fileName = title || basename(absolutePath);
 
-		await uploadFn(absolutePath, fileName);
+			await uploadFn(absolutePath, fileName);
 
-		return {
-			content: [{ type: "text" as const, text: `Attached file: ${fileName}` }],
-			details: undefined,
-		};
-	},
-};
+			return {
+				content: [{ type: "text" as const, text: `Attached file: ${fileName}` }],
+				details: undefined,
+			};
+		},
+	};
+}

--- a/packages/mom/src/tools/index.ts
+++ b/packages/mom/src/tools/index.ts
@@ -1,19 +1,17 @@
 import type { AgentTool } from "@mariozechner/pi-ai";
 import type { Executor } from "../sandbox.js";
-import { attachTool } from "./attach.js";
+import { createAttachTool, type UploadFunction } from "./attach.js";
 import { createBashTool } from "./bash.js";
 import { createEditTool } from "./edit.js";
 import { createReadTool } from "./read.js";
 import { createWriteTool } from "./write.js";
 
-export { setUploadFunction } from "./attach.js";
-
-export function createMomTools(executor: Executor): AgentTool<any>[] {
+export function createMomTools(executor: Executor, getUploadFunction: () => UploadFunction | null): AgentTool<any>[] {
 	return [
 		createReadTool(executor),
 		createBashTool(executor),
 		createEditTool(executor),
 		createWriteTool(executor),
-		attachTool,
+		createAttachTool(getUploadFunction),
 	];
 }

--- a/packages/mom/src/transport/discord/commands.ts
+++ b/packages/mom/src/transport/discord/commands.ts
@@ -1,0 +1,168 @@
+import {
+	ActionRowBuilder,
+	type ChatInputCommandInteraction,
+	type Client,
+	type ModalActionRowComponentBuilder,
+	ModalBuilder,
+	type ModalSubmitInteraction,
+	REST,
+	Routes,
+	SlashCommandBuilder,
+	TextInputBuilder,
+	TextInputStyle,
+} from "discord.js";
+import { existsSync, mkdirSync, readFileSync } from "fs";
+import { writeFile } from "fs/promises";
+import { dirname, join } from "path";
+import * as log from "../../log.js";
+
+export interface CommandHandler {
+	onMomCommand(interaction: ChatInputCommandInteraction): Promise<void>;
+	onStopCommand(interaction: ChatInputCommandInteraction): Promise<void>;
+	onMemoryCommand(interaction: ChatInputCommandInteraction): Promise<void>;
+	onMemoryEditSubmit(interaction: ModalSubmitInteraction): Promise<void>;
+}
+
+const momCommand = new SlashCommandBuilder()
+	.setName("mom")
+	.setDescription("Send a message to mom")
+	.addStringOption((option) => option.setName("message").setDescription("Your message to mom").setRequired(true));
+
+const momStopCommand = new SlashCommandBuilder()
+	.setName("mom-stop")
+	.setDescription("Stop the current mom operation in this channel");
+
+const momMemoryCommand = new SlashCommandBuilder()
+	.setName("mom-memory")
+	.setDescription("View or edit channel memory")
+	.addStringOption((option) =>
+		option
+			.setName("action")
+			.setDescription("What to do with memory")
+			.setRequired(true)
+			.addChoices({ name: "view", value: "view" }, { name: "edit", value: "edit" }),
+	)
+	.addStringOption((option) =>
+		option
+			.setName("scope")
+			.setDescription("Which memory to access")
+			.setRequired(false)
+			.addChoices({ name: "channel", value: "channel" }, { name: "global", value: "global" }),
+	);
+
+export const commands = [momCommand, momStopCommand, momMemoryCommand];
+
+export async function registerCommands(clientId: string, token: string, guildId?: string): Promise<void> {
+	const rest = new REST().setToken(token);
+
+	try {
+		log.logInfo("Registering Discord slash commands...");
+
+		const commandData = commands.map((cmd) => cmd.toJSON());
+
+		if (guildId) {
+			await rest.put(Routes.applicationGuildCommands(clientId, guildId), { body: commandData });
+			log.logInfo(`Registered ${commands.length} Discord commands to guild ${guildId}`);
+		} else {
+			await rest.put(Routes.applicationCommands(clientId), { body: commandData });
+			log.logInfo(`Registered ${commands.length} Discord commands globally`);
+		}
+	} catch (error) {
+		log.logWarning("Failed to register Discord commands", String(error));
+		throw error;
+	}
+}
+
+export function setupCommandHandlers(client: Client, handler: CommandHandler): void {
+	client.on("interactionCreate", async (interaction) => {
+		if (interaction.isChatInputCommand()) {
+			try {
+				switch (interaction.commandName) {
+					case "mom":
+						await handler.onMomCommand(interaction);
+						break;
+					case "mom-stop":
+						await handler.onStopCommand(interaction);
+						break;
+					case "mom-memory":
+						await handler.onMemoryCommand(interaction);
+						break;
+				}
+			} catch (error) {
+				const errMsg = error instanceof Error ? error.message : String(error);
+				log.logWarning(`Command error (${interaction.commandName})`, errMsg);
+
+				const reply = { content: `Error: ${errMsg}`, ephemeral: true };
+				if (interaction.replied || interaction.deferred) {
+					await interaction.followUp(reply);
+				} else {
+					await interaction.reply(reply);
+				}
+			}
+		}
+
+		if (interaction.isModalSubmit()) {
+			if (interaction.customId.startsWith("memory-edit-")) {
+				await handler.onMemoryEditSubmit(interaction);
+			}
+		}
+	});
+}
+
+export function getMemoryPath(
+	workingDir: string,
+	channelId: string,
+	guildId: string | undefined,
+	scope: "channel" | "global",
+): string {
+	if (scope === "global") {
+		return join(workingDir, "MEMORY.md");
+	}
+
+	if (guildId) {
+		return join(workingDir, "discord", guildId, channelId, "MEMORY.md");
+	}
+	return join(workingDir, "discord", "dm", channelId, "MEMORY.md");
+}
+
+export function readMemory(memoryPath: string): string {
+	if (!existsSync(memoryPath)) {
+		return "(no memory yet)";
+	}
+	try {
+		return readFileSync(memoryPath, "utf-8");
+	} catch {
+		return "(failed to read memory)";
+	}
+}
+
+export async function writeMemory(memoryPath: string, content: string): Promise<void> {
+	const dir = dirname(memoryPath);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+	await writeFile(memoryPath, content, "utf-8");
+}
+
+export function createMemoryEditModal(
+	scope: "channel" | "global",
+	currentContent: string,
+	channelId: string,
+): ModalBuilder {
+	const modal = new ModalBuilder()
+		.setCustomId(`memory-edit-${scope}-${channelId}`)
+		.setTitle(`Edit ${scope === "global" ? "Global" : "Channel"} Memory`);
+
+	const contentInput = new TextInputBuilder()
+		.setCustomId("memory-content")
+		.setLabel("Memory Content")
+		.setStyle(TextInputStyle.Paragraph)
+		.setValue(currentContent === "(no memory yet)" ? "" : currentContent)
+		.setRequired(false)
+		.setMaxLength(4000);
+
+	const actionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(contentInput);
+	modal.addComponents(actionRow);
+
+	return modal;
+}

--- a/packages/mom/src/transport/discord/discord.ts
+++ b/packages/mom/src/transport/discord/discord.ts
@@ -1,0 +1,606 @@
+import {
+	ActionRowBuilder,
+	AttachmentBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ChannelType,
+	type ChatInputCommandInteraction,
+	Client,
+	EmbedBuilder,
+	GatewayIntentBits,
+	type Guild,
+	type Message,
+	Partials,
+	type PartialTextBasedChannelFields,
+} from "discord.js";
+import { readFileSync } from "fs";
+import { basename } from "path";
+import * as log from "../../log.js";
+import type { ChannelInfo, ToolResultData, TransportContext, UserInfo } from "../types.js";
+import { DiscordChannelStore } from "./store.js";
+
+const DISCORD_PRIMARY_MAX_CHARS = 2000;
+const DISCORD_SECONDARY_MAX_CHARS = 2000;
+const DISCORD_EMBED_TITLE_MAX_CHARS = 256;
+const DISCORD_EMBED_ARGS_MAX_CHARS = 1000;
+const DISCORD_EMBED_DESCRIPTION_MAX_CHARS = 3900;
+
+export interface MomDiscordHandler {
+	onMention(ctx: TransportContext): Promise<void>;
+	onDirectMessage(ctx: TransportContext): Promise<void>;
+	onStopButton?(channelId: string): Promise<void>;
+}
+
+export interface MomDiscordConfig {
+	botToken: string;
+	workingDir: string;
+}
+
+export class MomDiscordBot {
+	private client: Client;
+	private handler: MomDiscordHandler;
+	public readonly store: DiscordChannelStore;
+	private botUserId: string | null = null;
+	private userCache = new Map<string, { userName: string; displayName: string }>();
+	private channelCache = new Map<string, string>();
+
+	constructor(handler: MomDiscordHandler, config: MomDiscordConfig) {
+		this.handler = handler;
+		this.client = new Client({
+			intents: [
+				GatewayIntentBits.Guilds,
+				GatewayIntentBits.GuildMessages,
+				GatewayIntentBits.MessageContent,
+				GatewayIntentBits.DirectMessages,
+				GatewayIntentBits.GuildMembers,
+			],
+			// Needed to reliably receive Direct Messages (DM channels aren't always cached).
+			partials: [Partials.Channel],
+		});
+		this.store = new DiscordChannelStore({ workingDir: config.workingDir });
+
+		this.setupEventHandlers(config);
+	}
+
+	private setupEventHandlers(config: MomDiscordConfig): void {
+		this.client.on("ready", async () => {
+			this.botUserId = this.client.user?.id || null;
+			log.logInfo(`Discord: logged in as ${this.client.user?.tag}`);
+
+			for (const [, guild] of this.client.guilds.cache) {
+				await this.fetchGuildData(guild);
+			}
+			log.logInfo(`Discord: loaded ${this.channelCache.size} channels, ${this.userCache.size} users`);
+		});
+
+		this.client.on("messageCreate", async (message: Message) => {
+			if (message.author.bot) return;
+			if (message.author.id === this.botUserId) return;
+			if (!message.channel.isTextBased()) return;
+			if (!this.isSendableTextChannel(message.channel)) return;
+
+			const isDM = message.guild === null;
+			const isMentioned = this.client.user ? message.mentions.has(this.client.user) : false;
+
+			// Cache channel names on-the-fly (important for threads, which aren't included in guild.channels.fetch()).
+			if (!isDM && "name" in message.channel) {
+				const name = (message.channel as { name?: string }).name;
+				if (name) {
+					this.channelCache.set(message.channel.id, String(name));
+				}
+			}
+
+			const attachments =
+				message.attachments.size > 0
+					? this.store.processAttachments(
+							message.channel.id,
+							Array.from(message.attachments.values()).flatMap((a) =>
+								a.name && a.url ? [{ name: a.name, url: a.url }] : [],
+							),
+							message.id,
+							message.guild?.id,
+						)
+					: [];
+
+			const { userName, displayName } = await this.getUserInfo(message.author.id, message.guild || undefined);
+
+			await this.store.logMessage(
+				message.channel.id,
+				{
+					date: message.createdAt.toISOString(),
+					ts: message.id,
+					user: message.author.id,
+					userName,
+					displayName,
+					text: message.content,
+					attachments,
+					isBot: false,
+				},
+				message.guild?.id,
+			);
+
+			if (isDM) {
+				const ctx = await this.createContextFromMessage(
+					message,
+					attachments,
+					userName,
+					displayName,
+					config.workingDir,
+				);
+				await this.handler.onDirectMessage(ctx);
+			} else if (isMentioned) {
+				const ctx = await this.createContextFromMessage(
+					message,
+					attachments,
+					userName,
+					displayName,
+					config.workingDir,
+				);
+				await this.handler.onMention(ctx);
+			}
+		});
+
+		this.client.on("guildCreate", async (guild: Guild) => {
+			log.logInfo(`Discord: joined guild ${guild.name}`);
+			await this.fetchGuildData(guild);
+		});
+
+		this.client.on("interactionCreate", async (interaction) => {
+			if (!interaction.isButton()) return;
+
+			if (interaction.customId.startsWith("mom-stop-")) {
+				const channelId = interaction.customId.replace("mom-stop-", "");
+				await interaction.deferUpdate();
+				if (this.handler.onStopButton) {
+					await this.handler.onStopButton(channelId);
+				}
+			}
+		});
+	}
+
+	private async fetchGuildData(guild: Guild): Promise<void> {
+		try {
+			const channels = await guild.channels.fetch();
+			for (const [id, channel] of channels) {
+				if (!channel) continue;
+				if (channel.type === ChannelType.GuildText || channel.type === ChannelType.GuildForum) {
+					this.channelCache.set(id, channel.name);
+				}
+			}
+
+			const members = await guild.members.fetch({ limit: 1000 });
+			for (const [id, member] of members) {
+				this.userCache.set(id, {
+					userName: member.user.username,
+					displayName: member.displayName || member.user.username,
+				});
+			}
+		} catch (error) {
+			log.logWarning("Discord: failed to fetch guild metadata", `${guild.name}: ${String(error)}`);
+		}
+	}
+
+	getChannels(): ChannelInfo[] {
+		return Array.from(this.channelCache.entries()).map(([id, name]) => ({ id, name }));
+	}
+
+	getUsers(): UserInfo[] {
+		return Array.from(this.userCache.entries()).map(([id, { userName, displayName }]) => ({
+			id,
+			userName,
+			displayName,
+		}));
+	}
+
+	private async getUserInfo(userId: string, guild?: Guild): Promise<{ userName: string; displayName: string }> {
+		const cached = this.userCache.get(userId);
+		if (cached) return cached;
+
+		try {
+			if (guild) {
+				const member = await guild.members.fetch(userId);
+				const info = {
+					userName: member.user.username,
+					displayName: member.displayName || member.user.username,
+				};
+				this.userCache.set(userId, info);
+				return info;
+			}
+
+			const user = await this.client.users.fetch(userId);
+			const info = {
+				userName: user.username,
+				displayName: user.displayName || user.username,
+			};
+			this.userCache.set(userId, info);
+			return info;
+		} catch {
+			const fallback = { userName: userId, displayName: userId };
+			this.userCache.set(userId, fallback);
+			return fallback;
+		}
+	}
+
+	private isSendableTextChannel(channel: unknown): channel is PartialTextBasedChannelFields<boolean> {
+		if (typeof channel !== "object" || channel === null) return false;
+		const maybeSend = (channel as { send?: unknown }).send;
+		if (typeof maybeSend !== "function") return false;
+		return true;
+	}
+
+	private splitMessage(text: string, maxLen: number): string[] {
+		if (text.length <= maxLen) return [text];
+
+		const parts: string[] = [];
+		let remaining = text;
+		while (remaining.length > 0) {
+			let cut = Math.min(maxLen, remaining.length);
+			const newlineCut = remaining.lastIndexOf("\n", cut);
+			if (newlineCut > Math.floor(maxLen * 0.6)) cut = newlineCut;
+			const head = remaining.slice(0, cut).trimEnd();
+			parts.push(head.length > 0 ? head : remaining.slice(0, Math.min(maxLen, remaining.length)));
+			remaining = remaining.slice(cut);
+			if (remaining.startsWith("\n")) remaining = remaining.slice(1);
+		}
+		return parts;
+	}
+
+	private createDiscordContext(params: {
+		workingDir: string;
+		channelDir: string;
+		channelName?: string;
+		guildId?: string;
+		guildName?: string;
+		message: TransportContext["message"];
+
+		sendTyping?: () => Promise<void>;
+		postPrimary: (payload: { content: string; components: ActionRowBuilder<ButtonBuilder>[] }) => Promise<Message>;
+		postText: (content: string) => Promise<Message>;
+		postEmbed: (embed: EmbedBuilder) => Promise<Message>;
+		uploadFile: (filePath: string, title?: string) => Promise<void>;
+	}): TransportContext {
+		let responseMessage: Message | null = null;
+		let primaryComponents: ActionRowBuilder<ButtonBuilder>[] = [];
+
+		// `overflowMessages` are used to hold overflow of the primary response (kept in sync via edits).
+		// `secondaryMessages` are "append-only" auxiliary messages (tool results, explicit secondary sends, etc).
+		const overflowMessages: Message[] = [];
+		const secondaryMessages: Message[] = [];
+
+		let accumulatedText = "";
+		let isWorking = true;
+		const workingIndicator = " ...";
+
+		const formatting = {
+			italic: (t: string) => `*${t}*`,
+			bold: (t: string) => `**${t}**`,
+			code: (t: string) => `\`${t}\``,
+			codeBlock: (t: string) => `\`\`\`\n${t}\n\`\`\``,
+		};
+
+		const syncOverflowMessages = async (overflowParts: string[]): Promise<void> => {
+			for (let i = 0; i < overflowParts.length; i++) {
+				const part = overflowParts[i];
+				const existing = overflowMessages[i];
+				if (existing) {
+					try {
+						await existing.edit(part);
+					} catch {
+						const posted = await params.postText(part);
+						try {
+							await existing.delete();
+						} catch {
+							// ignore
+						}
+						overflowMessages[i] = posted;
+					}
+				} else {
+					const posted = await params.postText(part);
+					overflowMessages.push(posted);
+				}
+			}
+
+			for (let i = overflowMessages.length - 1; i >= overflowParts.length; i--) {
+				const msg = overflowMessages[i];
+				try {
+					await msg.delete();
+				} catch {
+					// ignore
+				}
+				overflowMessages.pop();
+			}
+		};
+
+		const editOrSendPrimary = async (content: string): Promise<Message> => {
+			if (responseMessage) {
+				await responseMessage.edit({ content, components: primaryComponents });
+				return responseMessage;
+			}
+			const posted = await params.postPrimary({ content, components: primaryComponents });
+			responseMessage = posted;
+			return posted;
+		};
+
+		const sendSecondary = async (content: string): Promise<void> => {
+			const parts = this.splitMessage(content, DISCORD_SECONDARY_MAX_CHARS);
+			for (const part of parts) {
+				const msg = await params.postText(part);
+				secondaryMessages.push(msg);
+			}
+		};
+
+		const addStopButton = async (): Promise<void> => {
+			const stopButton = new ButtonBuilder()
+				.setCustomId(`mom-stop-${params.message.channelId}`)
+				.setLabel("Stop")
+				.setStyle(ButtonStyle.Danger);
+			const row = new ActionRowBuilder<ButtonBuilder>().addComponents(stopButton);
+			primaryComponents = [row];
+			if (!responseMessage) return;
+			await responseMessage.edit({ content: responseMessage.content, components: primaryComponents });
+		};
+
+		const removeStopButton = async (): Promise<void> => {
+			primaryComponents = [];
+			if (!responseMessage) return;
+			await responseMessage.edit({ content: responseMessage.content, components: primaryComponents });
+		};
+
+		const sendToolResult = async (data: ToolResultData): Promise<void> => {
+			const titlePrefix = data.isError ? "ERR" : "OK";
+			const rawTitle = `${titlePrefix} ${data.toolName}${data.label ? `: ${data.label}` : ""}`;
+			const title =
+				rawTitle.length > DISCORD_EMBED_TITLE_MAX_CHARS
+					? rawTitle.slice(0, DISCORD_EMBED_TITLE_MAX_CHARS - 3) + "..."
+					: rawTitle;
+
+			const embed = new EmbedBuilder()
+				.setTitle(title)
+				.setColor(data.isError ? 0xff0000 : 0x00ff00)
+				.setFooter({ text: `Duration: ${data.durationSecs}s` });
+
+			if (data.args?.trim()) {
+				const truncatedArgs =
+					data.args.length > DISCORD_EMBED_ARGS_MAX_CHARS
+						? data.args.slice(0, DISCORD_EMBED_ARGS_MAX_CHARS - 3) + "..."
+						: data.args;
+				embed.addFields({ name: "Arguments", value: "```\n" + truncatedArgs + "\n```", inline: false });
+			}
+
+			const truncatedResult =
+				data.result.length > DISCORD_EMBED_DESCRIPTION_MAX_CHARS
+					? data.result.slice(0, DISCORD_EMBED_DESCRIPTION_MAX_CHARS - 3) + "..."
+					: data.result;
+			embed.setDescription("```\n" + truncatedResult + "\n```");
+
+			const msg = await params.postEmbed(embed);
+			secondaryMessages.push(msg);
+		};
+
+		return {
+			transport: "discord",
+			workingDir: params.workingDir,
+			channelDir: params.channelDir,
+			channelName: params.channelName,
+			guildId: params.guildId,
+			guildName: params.guildName,
+			message: params.message,
+			channels: this.getChannels(),
+			users: this.getUsers(),
+			formatting,
+			limits: { primaryMaxChars: DISCORD_PRIMARY_MAX_CHARS, secondaryMaxChars: DISCORD_SECONDARY_MAX_CHARS },
+
+			send: async (target, content, opts) => {
+				const shouldLog = opts?.log ?? true;
+				if (target === "secondary") {
+					await sendSecondary(content);
+					return;
+				}
+
+				accumulatedText = accumulatedText ? accumulatedText + "\n" + content : content;
+				const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
+
+				const parts = this.splitMessage(displayText, DISCORD_PRIMARY_MAX_CHARS);
+				const primary = await editOrSendPrimary(parts[0]);
+
+				if (shouldLog) {
+					await this.store.logBotResponse(params.message.channelId, content, primary.id, params.guildId);
+				}
+
+				await syncOverflowMessages(parts.slice(1));
+			},
+
+			replacePrimary: async (content) => {
+				accumulatedText = content;
+				const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
+				const parts = this.splitMessage(displayText, DISCORD_PRIMARY_MAX_CHARS);
+				await editOrSendPrimary(parts[0]);
+				await syncOverflowMessages(parts.slice(1));
+			},
+
+			setTyping: async (isTyping) => {
+				if (!isTyping) return;
+				if (params.sendTyping) {
+					await params.sendTyping();
+				}
+				if (!responseMessage) {
+					accumulatedText = formatting.italic("Thinking...");
+					await editOrSendPrimary(accumulatedText + workingIndicator);
+				}
+			},
+
+			uploadFile: async (filePath, title) => {
+				await params.uploadFile(filePath, title);
+			},
+
+			setWorking: async (working) => {
+				isWorking = working;
+				if (responseMessage) {
+					const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
+					const parts = this.splitMessage(displayText, DISCORD_PRIMARY_MAX_CHARS);
+					await responseMessage.edit({ content: parts[0], components: primaryComponents });
+					await syncOverflowMessages(parts.slice(1));
+				}
+			},
+
+			deletePrimaryAndSecondary: async () => {
+				for (let i = secondaryMessages.length - 1; i >= 0; i--) {
+					try {
+						await secondaryMessages[i].delete();
+					} catch {
+						// ignore
+					}
+				}
+				secondaryMessages.length = 0;
+
+				for (let i = overflowMessages.length - 1; i >= 0; i--) {
+					try {
+						await overflowMessages[i].delete();
+					} catch {
+						// ignore
+					}
+				}
+				overflowMessages.length = 0;
+
+				if (responseMessage) {
+					try {
+						await responseMessage.delete();
+					} catch {
+						// ignore
+					}
+					responseMessage = null;
+					primaryComponents = [];
+				}
+			},
+
+			sendToolResult,
+			addStopControl: addStopButton,
+			removeStopControl: removeStopButton,
+		};
+	}
+
+	private async createContextFromMessage(
+		message: Message,
+		attachments: Array<{ local: string }>,
+		userName: string,
+		displayName: string,
+		workingDir: string,
+	): Promise<TransportContext> {
+		const rawText = message.content;
+		// Remove only the bot mention, keep other user mentions intact.
+		// Fallback to stripping all mentions if botUserId isn't available for some reason.
+		const mentionPattern = this.botUserId ? new RegExp(`<@!?${this.botUserId}>`, "g") : /<@!?\d+>/g;
+		const text = rawText.replace(mentionPattern, "").trim();
+
+		const channelName =
+			message.channel.type === ChannelType.DM
+				? undefined
+				: "name" in message.channel
+					? String((message.channel as { name?: string }).name)
+					: undefined;
+
+		const guildId = message.guild?.id;
+		const guildName = message.guild?.name;
+
+		const channelDir = this.store.getChannelDir(message.channel.id, guildId);
+
+		const channel = message.channel;
+		if (!this.isSendableTextChannel(channel)) {
+			throw new Error(`Unsupported Discord channel type for sending messages (channelId=${message.channel.id})`);
+		}
+
+		return this.createDiscordContext({
+			workingDir,
+			channelDir,
+			channelName,
+			guildId,
+			guildName,
+			message: {
+				text,
+				rawText,
+				userId: message.author.id,
+				userName,
+				displayName,
+				channelId: message.channel.id,
+				messageId: message.id,
+				attachments,
+			},
+			sendTyping: async () => {
+				const maybeSendTyping = (channel as { sendTyping?: unknown }).sendTyping;
+				if (typeof maybeSendTyping === "function") {
+					await (channel as { sendTyping: () => Promise<void> }).sendTyping();
+				}
+			},
+			postPrimary: async (payload) => channel.send(payload),
+			postText: async (content) => channel.send(content),
+			postEmbed: async (embed) => channel.send({ embeds: [embed] }),
+			uploadFile: async (filePath, title) => {
+				const fileName = title || basename(filePath);
+				const fileContent = readFileSync(filePath);
+				const attachment = new AttachmentBuilder(fileContent, { name: fileName });
+				await channel.send({ files: [attachment] });
+			},
+		});
+	}
+
+	async createContextFromInteraction(
+		interaction: ChatInputCommandInteraction,
+		messageText: string,
+		workingDir: string,
+	): Promise<TransportContext> {
+		const guildId = interaction.guildId || undefined;
+		const guildName = interaction.guild?.name;
+		const channelId = interaction.channelId;
+		const channelDir = this.store.getChannelDir(channelId, guildId);
+
+		const userName = interaction.user.username;
+		const displayName = interaction.user.displayName || interaction.user.username;
+
+		let channelName: string | undefined;
+		if (interaction.channel?.isTextBased() && !interaction.channel.isDMBased() && "name" in interaction.channel) {
+			channelName = String((interaction.channel as { name?: string }).name);
+		}
+		if (channelName) {
+			this.channelCache.set(channelId, channelName);
+		}
+
+		return this.createDiscordContext({
+			workingDir,
+			channelDir,
+			channelName,
+			guildId,
+			guildName,
+			message: {
+				text: messageText,
+				rawText: messageText,
+				userId: interaction.user.id,
+				userName,
+				displayName,
+				channelId,
+				messageId: interaction.id,
+				attachments: [],
+			},
+			postPrimary: async (payload) => (await interaction.editReply(payload)) as Message,
+			postText: async (content) => (await interaction.followUp(content)) as Message,
+			postEmbed: async (embed) => (await interaction.followUp({ embeds: [embed] })) as Message,
+			uploadFile: async (filePath, title) => {
+				const fileName = title || basename(filePath);
+				const fileContent = readFileSync(filePath);
+				const attachment = new AttachmentBuilder(fileContent, { name: fileName });
+				await interaction.followUp({ files: [attachment] });
+			},
+		});
+	}
+
+	getClient(): Client {
+		return this.client;
+	}
+
+	async start(botToken: string): Promise<void> {
+		await this.client.login(botToken);
+	}
+
+	async stop(): Promise<void> {
+		await this.client.destroy();
+	}
+}

--- a/packages/mom/src/transport/discord/index.ts
+++ b/packages/mom/src/transport/discord/index.ts
@@ -1,0 +1,11 @@
+export {
+	commands,
+	createMemoryEditModal,
+	getMemoryPath,
+	readMemory,
+	registerCommands,
+	setupCommandHandlers,
+	writeMemory,
+} from "./commands.js";
+export { MomDiscordBot, type MomDiscordConfig, type MomDiscordHandler } from "./discord.js";
+export { DiscordChannelStore } from "./store.js";

--- a/packages/mom/src/transport/discord/store.ts
+++ b/packages/mom/src/transport/discord/store.ts
@@ -1,0 +1,175 @@
+import { existsSync, mkdirSync, readFileSync } from "fs";
+import { appendFile, writeFile } from "fs/promises";
+import { dirname, join, relative } from "path";
+import * as log from "../../log.js";
+
+export interface DiscordAttachment {
+	original: string;
+	local: string; // path relative to working dir (e.g., "discord/<guildId>/<channelId>/attachments/<file>")
+}
+
+export interface DiscordLoggedMessage {
+	date: string; // ISO 8601 date
+	ts: string; // Discord message ID (snowflake) or epoch ms
+	user: string; // user ID (or "bot" for bot responses)
+	userName?: string;
+	displayName?: string;
+	text: string;
+	attachments: DiscordAttachment[];
+	isBot: boolean;
+}
+
+export interface DiscordChannelStoreConfig {
+	workingDir: string;
+}
+
+interface PendingDownload {
+	localPath: string; // relative to workingDir
+	url: string;
+}
+
+export class DiscordChannelStore {
+	private workingDir: string;
+	private pendingDownloads: PendingDownload[] = [];
+	private isDownloading = false;
+	private recentlyLogged = new Map<string, number>();
+
+	constructor(config: DiscordChannelStoreConfig) {
+		this.workingDir = config.workingDir;
+
+		if (!existsSync(this.workingDir)) {
+			mkdirSync(this.workingDir, { recursive: true });
+		}
+	}
+
+	getChannelDir(channelId: string, guildId?: string): string {
+		const dir = guildId
+			? join(this.workingDir, "discord", guildId, channelId)
+			: join(this.workingDir, "discord", "dm", channelId);
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true });
+		}
+		return dir;
+	}
+
+	generateLocalFilename(originalName: string, timestamp: string): string {
+		// Discord message IDs are snowflakes and can exceed JS safe integer range.
+		// Use the raw timestamp/id string when possible to preserve uniqueness and avoid precision loss.
+		const ts = /^[0-9]+$/.test(timestamp) ? timestamp : String(Date.now());
+		const sanitized = originalName.replace(/[^a-zA-Z0-9._-]/g, "_");
+		return `${ts}_${sanitized}`;
+	}
+
+	processAttachments(
+		channelId: string,
+		files: Array<{ name: string; url: string }>,
+		timestamp: string,
+		guildId?: string,
+	): DiscordAttachment[] {
+		const attachments: DiscordAttachment[] = [];
+		const channelDir = this.getChannelDir(channelId, guildId);
+
+		for (const file of files) {
+			if (!file.url || !file.name) continue;
+
+			const filename = this.generateLocalFilename(file.name, timestamp);
+			const localPath = join(channelDir, "attachments", filename);
+			const relativeLocalPath = relative(this.workingDir, localPath).replaceAll("\\", "/");
+
+			attachments.push({
+				original: file.name,
+				local: relativeLocalPath,
+			});
+
+			this.pendingDownloads.push({ localPath: relativeLocalPath, url: file.url });
+		}
+
+		this.processDownloadQueue();
+		return attachments;
+	}
+
+	async logMessage(channelId: string, message: DiscordLoggedMessage, guildId?: string): Promise<boolean> {
+		// Only dedupe user messages. For bot messages we intentionally allow repeated logs even if the message is edited
+		// (Discord "primary" output is typically an edited message, reusing the same messageId).
+		if (!message.isBot) {
+			const dedupeKey = `${guildId || "dm"}:${channelId}:${message.ts}`;
+			if (this.recentlyLogged.has(dedupeKey)) return false;
+
+			this.recentlyLogged.set(dedupeKey, Date.now());
+			setTimeout(() => this.recentlyLogged.delete(dedupeKey), 60000);
+		}
+
+		const logPath = join(this.getChannelDir(channelId, guildId), "log.jsonl");
+		const line = JSON.stringify(message) + "\n";
+		await appendFile(logPath, line, "utf-8");
+		return true;
+	}
+
+	async logBotResponse(channelId: string, text: string, ts: string, guildId?: string): Promise<void> {
+		await this.logMessage(
+			channelId,
+			{
+				date: new Date().toISOString(),
+				ts,
+				user: "bot",
+				text,
+				attachments: [],
+				isBot: true,
+			},
+			guildId,
+		);
+	}
+
+	getLastTimestamp(channelId: string, guildId?: string): string | null {
+		const logPath = join(this.getChannelDir(channelId, guildId), "log.jsonl");
+		if (!existsSync(logPath)) return null;
+
+		try {
+			const content = readFileSync(logPath, "utf-8");
+			const lines = content.trim().split("\n");
+			if (lines.length === 0 || lines[0] === "") return null;
+			const lastLine = lines[lines.length - 1];
+			const message = JSON.parse(lastLine) as DiscordLoggedMessage;
+			return message.ts;
+		} catch {
+			return null;
+		}
+	}
+
+	private async processDownloadQueue(): Promise<void> {
+		if (this.isDownloading || this.pendingDownloads.length === 0) return;
+
+		this.isDownloading = true;
+
+		while (this.pendingDownloads.length > 0) {
+			const item = this.pendingDownloads.shift();
+			if (!item) break;
+
+			try {
+				await this.downloadAttachment(item.localPath, item.url);
+			} catch (error) {
+				const errorMsg = error instanceof Error ? error.message : String(error);
+				log.logWarning("Failed to download Discord attachment", `${item.localPath}: ${errorMsg}`);
+			}
+		}
+
+		this.isDownloading = false;
+	}
+
+	private async downloadAttachment(relativeLocalPath: string, url: string): Promise<void> {
+		const filePath = join(this.workingDir, relativeLocalPath);
+		const dir = dirname(filePath);
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true });
+		}
+
+		// Discord attachments are public CDN URLs.
+		const response = await fetch(url);
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+		}
+
+		const buffer = await response.arrayBuffer();
+		await writeFile(filePath, Buffer.from(buffer));
+	}
+}

--- a/packages/mom/src/transport/slack/index.ts
+++ b/packages/mom/src/transport/slack/index.ts
@@ -1,0 +1,1 @@
+export { type CreateSlackContextArgs, createSlackContext } from "./slack.js";

--- a/packages/mom/src/transport/slack/slack.ts
+++ b/packages/mom/src/transport/slack/slack.ts
@@ -1,0 +1,201 @@
+import type { SlackBot, SlackEvent } from "../../slack.js";
+import type { TransportContext } from "../types.js";
+
+export interface CreateSlackContextArgs {
+	workingDir: string;
+	channelDir: string;
+	event: SlackEvent;
+	slack: SlackBot;
+	isEvent?: boolean;
+}
+
+export function createSlackContext({
+	workingDir,
+	channelDir,
+	event,
+	slack,
+	isEvent,
+}: CreateSlackContextArgs): TransportContext {
+	let messageTs: string | null = null;
+	const threadMessageTs: string[] = [];
+	let accumulatedText = "";
+	let isWorking = true;
+	const workingIndicator = " ...";
+	let updatePromise = Promise.resolve();
+	let primaryOverflowed = false;
+	const primaryMaxChars = 39000;
+	const secondaryMaxChars = 39000;
+	const overflowSuffix = "\n\n_(continued in thread)_";
+
+	const user = slack.getUser(event.user);
+	const eventFilename = isEvent ? event.text.match(/^\[EVENT:([^:]+):/)?.[1] : undefined;
+
+	function splitText(text: string, maxChars: number): string[] {
+		const parts: string[] = [];
+		let remaining = text;
+		while (remaining.length > maxChars) {
+			let cut = remaining.lastIndexOf("\n", maxChars);
+			if (cut < Math.floor(maxChars * 0.6)) cut = maxChars;
+			const head = remaining.slice(0, cut).trimEnd();
+			if (head) parts.push(head);
+			remaining = remaining.slice(cut);
+			if (remaining.startsWith("\n")) remaining = remaining.slice(1);
+		}
+		const tail = remaining.trimEnd();
+		if (tail) parts.push(tail);
+		return parts;
+	}
+
+	async function ensurePrimaryMessage(): Promise<void> {
+		if (messageTs) return;
+		accumulatedText = eventFilename ? `_Starting event: ${eventFilename}_` : "_Thinking_";
+		messageTs = await slack.postMessage(event.channel, accumulatedText + workingIndicator);
+	}
+
+	async function postToThread(text: string): Promise<void> {
+		if (!text.trim()) return;
+		await ensurePrimaryMessage();
+		if (!messageTs) return;
+		const parts = splitText(text, secondaryMaxChars);
+		for (const part of parts) {
+			const ts = await slack.postInThread(event.channel, messageTs, part);
+			threadMessageTs.push(ts);
+		}
+	}
+
+	async function updatePrimary(displayText: string, shouldLog: boolean, logText: string): Promise<void> {
+		await ensurePrimaryMessage();
+		if (messageTs) {
+			await slack.updateMessage(event.channel, messageTs, displayText);
+		} else {
+			messageTs = await slack.postMessage(event.channel, displayText);
+		}
+		if (shouldLog && messageTs && logText) {
+			slack.logBotResponse(event.channel, logText, messageTs);
+		}
+	}
+
+	return {
+		transport: "slack",
+		workingDir,
+		channelDir,
+		message: {
+			text: event.text,
+			rawText: event.text,
+			userId: event.user,
+			userName: user?.userName,
+			displayName: user?.displayName,
+			channelId: event.channel,
+			messageId: event.ts,
+			attachments: (event.attachments || []).map((a) => ({ local: a.local })),
+		},
+		channelName: slack.getChannel(event.channel)?.name,
+		channels: slack.getAllChannels().map((c) => ({ id: c.id, name: c.name })),
+		users: slack.getAllUsers().map((u) => ({ id: u.id, userName: u.userName, displayName: u.displayName })),
+		formatting: {
+			italic: (text: string) => `_${text}_`,
+			bold: (text: string) => `*${text}*`,
+			code: (text: string) => `\`${text}\``,
+			codeBlock: (text: string) => `\`\`\`\n${text}\n\`\`\``,
+		},
+		limits: {
+			primaryMaxChars,
+			secondaryMaxChars,
+		},
+		send: async (target, text, opts) => {
+			const shouldLog = opts?.log ?? true;
+			updatePromise = updatePromise.then(async () => {
+				if (target === "secondary") {
+					await postToThread(text);
+					return;
+				}
+
+				if (primaryOverflowed) {
+					await postToThread(text);
+					return;
+				}
+
+				const nextText = accumulatedText ? accumulatedText + "\n" + text : text;
+				const nextDisplayText = isWorking ? nextText + workingIndicator : nextText;
+
+				if (nextDisplayText.length <= primaryMaxChars) {
+					accumulatedText = nextText;
+					await updatePrimary(nextDisplayText, shouldLog, text);
+					return;
+				}
+
+				primaryOverflowed = true;
+
+				const maxWithoutIndicator = primaryMaxChars - (isWorking ? workingIndicator.length : 0);
+				const maxWithoutSuffix = maxWithoutIndicator - overflowSuffix.length;
+				const head = maxWithoutSuffix > 0 ? nextText.slice(0, maxWithoutSuffix) : "";
+				accumulatedText = head + overflowSuffix;
+				const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
+
+				await updatePrimary(displayText, shouldLog, text);
+
+				const overflow = nextText.slice(head.length);
+				await postToThread(overflow);
+			});
+			await updatePromise;
+		},
+		replacePrimary: async (text) => {
+			updatePromise = updatePromise.then(async () => {
+				accumulatedText = text;
+				primaryOverflowed = false;
+
+				const maxWithoutIndicator = primaryMaxChars - (isWorking ? workingIndicator.length : 0);
+				const maxWithoutSuffix = maxWithoutIndicator - overflowSuffix.length;
+				if (accumulatedText.length > maxWithoutIndicator) {
+					primaryOverflowed = true;
+					accumulatedText =
+						(maxWithoutSuffix > 0 ? accumulatedText.slice(0, maxWithoutSuffix) : "") + overflowSuffix;
+				}
+
+				const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
+				await updatePrimary(displayText, false, "");
+			});
+			await updatePromise;
+		},
+		setTyping: async (isTyping) => {
+			if (isTyping && !messageTs) {
+				updatePromise = updatePromise.then(async () => {
+					await ensurePrimaryMessage();
+				});
+				await updatePromise;
+			}
+		},
+		uploadFile: async (filePath, title) => {
+			await slack.uploadFile(event.channel, filePath, title);
+		},
+		setWorking: async (working) => {
+			updatePromise = updatePromise.then(async () => {
+				isWorking = working;
+				if (messageTs) {
+					const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
+					await slack.updateMessage(event.channel, messageTs, displayText);
+				}
+			});
+			await updatePromise;
+		},
+		deletePrimaryAndSecondary: async () => {
+			updatePromise = updatePromise.then(async () => {
+				for (let i = threadMessageTs.length - 1; i >= 0; i--) {
+					try {
+						await slack.deleteMessage(event.channel, threadMessageTs[i]);
+					} catch {
+						// ignore
+					}
+				}
+				threadMessageTs.length = 0;
+				if (messageTs) {
+					await slack.deleteMessage(event.channel, messageTs);
+					messageTs = null;
+				}
+				accumulatedText = "";
+				primaryOverflowed = false;
+			});
+			await updatePromise;
+		},
+	};
+}

--- a/packages/mom/src/transport/types.ts
+++ b/packages/mom/src/transport/types.ts
@@ -1,0 +1,81 @@
+export type TransportName = "slack" | "discord";
+
+export type ReplyTarget = "primary" | "secondary";
+
+export interface ChannelInfo {
+	id: string;
+	name: string;
+}
+
+export interface UserInfo {
+	id: string;
+	userName: string;
+	displayName: string;
+}
+
+export interface TransportFormatting {
+	italic(text: string): string;
+	bold(text: string): string;
+	code(text: string): string;
+	codeBlock(text: string): string;
+}
+
+export interface ToolResultData {
+	toolName: string;
+	label?: string;
+	args?: string;
+	result: string;
+	isError: boolean;
+	durationSecs: string;
+}
+
+export interface TransportContext {
+	transport: TransportName;
+
+	// Host filesystem layout (absolute paths)
+	workingDir: string;
+	channelDir: string;
+
+	// Optional display metadata
+	channelName?: string;
+	guildId?: string;
+	guildName?: string;
+
+	// The triggering message
+	message: {
+		text: string;
+		rawText: string;
+		userId: string;
+		userName?: string;
+		displayName?: string;
+		channelId: string;
+		messageId: string; // Slack: ts, Discord: snowflake
+		attachments: Array<{ local: string }>;
+	};
+
+	// Used for system prompt channel/user mapping
+	channels: ChannelInfo[];
+	users: UserInfo[];
+
+	// Formatting + splitting owned by transport
+	formatting: TransportFormatting;
+	limits: {
+		primaryMaxChars: number;
+		secondaryMaxChars: number;
+	};
+
+	// Messaging API
+	send(target: ReplyTarget, text: string, opts?: { log?: boolean }): Promise<void>;
+	replacePrimary(text: string): Promise<void>;
+
+	setTyping(isTyping: boolean): Promise<void>;
+	setWorking(working: boolean): Promise<void>;
+	deletePrimaryAndSecondary(): Promise<void>;
+
+	uploadFile(filePath: string, title?: string): Promise<void>;
+
+	// Optional transport-specific UX
+	sendToolResult?: (data: ToolResultData) => Promise<void>;
+	addStopControl?: () => Promise<void>;
+	removeStopControl?: () => Promise<void>;
+}


### PR DESCRIPTION
Here's my rough draft of #184 based on what we discussed.

Everything's under `mom/src/transport/slack|discord` as a single package. Main abstraction is `TransportContext` which handles the quirks. Timestamps for deduping (slack ts vs discord snowflake), message splitting (slack's 40k vs discord's 2k), formatting.

The Discord side has @mentions, DMs, slash commands (/mom, /mom-stop, /mom-memory), stop button, and tool results as embeds. Stores stuff under `workingDir/discord/<guildId>/<channelId>/` to avoid colliding with slack channel ids.

Slack behavior unchanged, just moved context creation into the transport folder for consistency. Events still slack-only for now.

Not quite ready for a review yet. I still need to give it a proper test, will pick up in the morning!