### PR TITLE
Add new `getCursor` and `getLines` methods to editor

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -595,6 +595,14 @@ export class Editor implements Component {
 		return this.state.lines.join("\n");
 	}
 
+	getLines(): string[] {
+		return [...this.state.lines];
+	}
+
+	getCursor(): { line: number; col: number } {
+		return { line: this.state.cursorLine, col: this.state.cursorCol };
+	}
+
 	setText(text: string): void {
 		this.historyIndex = -1; // Exit history browsing mode
 		this.setTextInternal(text);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -247,6 +247,34 @@ describe("Editor component", () => {
 		});
 	});
 
+	describe("public state accessors", () => {
+		it("returns cursor position", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 0 });
+
+			editor.handleInput("a");
+			editor.handleInput("b");
+			editor.handleInput("c");
+
+			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 3 });
+
+			editor.handleInput("\x1b[D"); // Left
+			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 2 });
+		});
+
+		it("returns lines as a defensive copy", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("a\nb");
+
+			const lines = editor.getLines();
+			assert.deepStrictEqual(lines, ["a", "b"]);
+
+			lines[0] = "mutated";
+			assert.deepStrictEqual(editor.getLines(), ["a", "b"]);
+		});
+	});
+
 	describe("Unicode text editing behavior", () => {
 		it("inserts mixed ASCII, umlauts, and emojis as literal text", () => {
 			const editor = new Editor(defaultEditorTheme);


### PR DESCRIPTION
Inspecting the lines or cursor is sometimes necessary when working with the editor. These methods expose the internal state as read-only.

Edit: I'm trying to use pi-tui in a project and would need these methods myself 😄 