### PR TITLE
fix(coding-agent): support symlinked tools and hooks in discovery

### DIFF
--- a/packages/coding-agent/src/core/custom-tools/loader.ts
+++ b/packages/coding-agent/src/core/custom-tools/loader.ts
@@ -224,7 +224,7 @@ export async function loadCustomTools(
 
 /**
  * Discover tool files from a directory.
- * Returns all .ts files in the directory (non-recursive).
+ * Returns all .ts files (and symlinks to .ts files) in the directory (non-recursive).
  */
 function discoverToolsInDir(dir: string): string[] {
 	if (!fs.existsSync(dir)) {
@@ -233,7 +233,9 @@ function discoverToolsInDir(dir: string): string[] {
 
 	try {
 		const entries = fs.readdirSync(dir, { withFileTypes: true });
-		return entries.filter((e) => e.isFile() && e.name.endsWith(".ts")).map((e) => path.join(dir, e.name));
+		return entries
+			.filter((e) => (e.isFile() || e.isSymbolicLink()) && e.name.endsWith(".ts"))
+			.map((e) => path.join(dir, e.name));
 	} catch {
 		return [];
 	}

--- a/packages/coding-agent/src/core/hooks/loader.ts
+++ b/packages/coding-agent/src/core/hooks/loader.ts
@@ -198,7 +198,7 @@ export async function loadHooks(paths: string[], cwd: string): Promise<LoadHooks
 
 /**
  * Discover hook files from a directory.
- * Returns all .ts files in the directory (non-recursive).
+ * Returns all .ts files (and symlinks to .ts files) in the directory (non-recursive).
  */
 function discoverHooksInDir(dir: string): string[] {
 	if (!fs.existsSync(dir)) {
@@ -207,7 +207,9 @@ function discoverHooksInDir(dir: string): string[] {
 
 	try {
 		const entries = fs.readdirSync(dir, { withFileTypes: true });
-		return entries.filter((e) => e.isFile() && e.name.endsWith(".ts")).map((e) => path.join(dir, e.name));
+		return entries
+			.filter((e) => (e.isFile() || e.isSymbolicLink()) && e.name.endsWith(".ts"))
+			.map((e) => path.join(dir, e.name));
 	} catch {
 		return [];
 	}


### PR DESCRIPTION
## Problem

Users managing their configuration with Nix Flakes cannot use custom tools or hooks with Pi. Nix stores files in `/nix/store/` and symlinks them to user directories (e.g., `~/.pi/agent/tools/`). The discovery functions use `Dirent.isFile()` which returns `false` for symlinks, so symlinked tools/hooks are silently ignored.

## Solution

Update `discoverToolsInDir()` and `discoverHooksInDir()` to also check `isSymbolicLink()` when filtering entries. `jiti.import()` already resolves symlinks when loading, so only the discovery filter needed fixing.

## Changes

- `packages/coding-agent/src/core/custom-tools/loader.ts`: include symlinks in discovery
- `packages/coding-agent/src/core/hooks/loader.ts`: include symlinks in discovery
- Updated comments to reflect new behavior