### PR TITLE
fix(ai): pass baseUrl to Google GenAI SDK via httpOptions

### DIFF
--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -258,9 +258,18 @@ function createClient(model: Model<"google-generative-ai">, apiKey?: string): Go
 		}
 		apiKey = process.env.GEMINI_API_KEY;
 	}
+
+	const httpOptions: { baseUrl?: string; headers?: Record<string, string> } = {};
+	if (model.baseUrl) {
+		httpOptions.baseUrl = model.baseUrl;
+	}
+	if (model.headers) {
+		httpOptions.headers = model.headers;
+	}
+
 	return new GoogleGenAI({
 		apiKey,
-		httpOptions: model.headers ? { headers: model.headers } : undefined,
+		httpOptions: Object.keys(httpOptions).length > 0 ? httpOptions : undefined,
 	});
 }
 


### PR DESCRIPTION
## Summary

When using `google-generative-ai` API with a custom `baseUrl` in `models.json`, the `baseUrl` was previously ignored - requests always went to the default Google endpoint.

## Changes

Updated `createClient` function to pass `model.baseUrl` to the SDK's `httpOptions.baseUrl`, enabling use of custom endpoints or API proxies.

## Related Issue

Fixes #216