### PR TITLE
Fix expired OAuth tokens in long-running agent loops

### DIFF
--- a/packages/ai/src/agent/agent-loop.ts
+++ b/packages/ai/src/agent/agent-loop.ts
@@ -174,7 +174,12 @@ async function streamAssistantResponse(
 
 	// Use custom stream function if provided, otherwise use default streamSimple
 	const streamFunction = streamFn || streamSimple;
-	const response = await streamFunction(config.model, processedContext, { ...config, signal });
+
+	// Resolve API key for every assistant response (important for expiring tokens)
+	const resolvedApiKey =
+		(config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
+
+	const response = await streamFunction(config.model, processedContext, { ...config, apiKey: resolvedApiKey, signal });
 
 	let partialMessage: AssistantMessage | null = null;
 	let addedPartial = false;

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -85,6 +85,21 @@ export interface QueuedMessage<TApp = Message> {
 // Configuration for agent loop execution
 export interface AgentLoopConfig extends SimpleStreamOptions {
 	model: Model<any>;
+
+	/**
+	 * Optional hook to resolve an API key dynamically for each LLM call.
+	 *
+	 * This is useful for short-lived OAuth tokens (e.g. GitHub Copilot) that may
+	 * expire during long-running tool execution phases.
+	 *
+	 * The agent loop will call this before each assistant response and pass the
+	 * returned value as `apiKey` to `streamSimple()` (or a custom `streamFn`).
+	 *
+	 * If it returns `undefined`, the loop falls back to `config.apiKey`, and then
+	 * to `streamSimple()`'s own provider key lookup (setApiKey/env vars).
+	 */
+	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
+
 	preprocessor?: (messages: AgentContext["messages"], abortSignal?: AbortSignal) => Promise<AgentContext["messages"]>;
 	getQueuedMessages?: <T>() => Promise<QueuedMessage<T>[]>;
 }


### PR DESCRIPTION
## Problem

When an agent loop runs for an extended period, OAuth tokens can expire
between LLM calls. This particularly affects:

- GitHub Copilot tokens (~30 minute lifetime)
- Anthropic OAuth tokens (~60 minute lifetime)

Extended thinking at high reasoning levels (e.g., gpt-5.2 with `xhigh`
reasoning) can take long enough for tokens to expire before the next
LLM call.

Previously, the API key was resolved once when `ProviderTransport.run()`
was called and passed as a static string into the agent loop config. All
subsequent LLM calls reused this same token, even if it had expired.

## Solution

Add a `getApiKey` hook to `AgentLoopConfig` that is called before each
LLM call, allowing tokens to be refreshed dynamically:

```typescript
interface AgentLoopConfig {
  // ...existing fields...
  getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
}
```

The agent loop now resolves the API key fresh before each assistant
response, which triggers the existing OAuth refresh logic when tokens
are expired.

## Changes

- **packages/ai**: Add `getApiKey` hook to `AgentLoopConfig`, call it in
  `streamAssistantResponse()` before each LLM call
- **packages/agent**: Update `ProviderTransport` to pass `getApiKey`
  callback instead of static `apiKey` string
- **packages/web-ui**: Same pattern for web-ui's `ProviderTransport`

## Backward Compatibility

Fully backward compatible. The `getApiKey` hook is optional. Existing
code passing `apiKey` as a string continues to work unchanged.