### PR TITLE
fix(coding-agent): support symlinked slash commands in discovery

### DIFF
--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -99,7 +99,7 @@ export function substituteArgs(content: string, args: string[]): string {
 }
 
 /**
- * Recursively scan a directory for .md files and load them as slash commands
+ * Recursively scan a directory for .md files (and symlinks to .md files) and load them as slash commands
  */
 function loadCommandsFromDir(dir: string, source: "user" | "project", subdir: string = ""): FileSlashCommand[] {
 	const commands: FileSlashCommand[] = [];
@@ -118,7 +118,7 @@ function loadCommandsFromDir(dir: string, source: "user" | "project", subdir: st
 				// Recurse into subdirectory
 				const newSubdir = subdir ? `${subdir}:${entry.name}` : entry.name;
 				commands.push(...loadCommandsFromDir(fullPath, source, newSubdir));
-			} else if (entry.isFile() && entry.name.endsWith(".md")) {
+			} else if ((entry.isFile() || entry.isSymbolicLink()) && entry.name.endsWith(".md")) {
 				try {
 					const rawContent = readFileSync(fullPath, "utf-8");
 					const { frontmatter, content } = parseFrontmatter(rawContent);


### PR DESCRIPTION
## Problem

Users managing their configuration with Nix Flakes cannot use custom slash commands with Pi. Nix stores files in `/nix/store/` and symlinks them to user directories (e.g., `~/.pi/agent/commands/`). The `loadCommandsFromDir()` function uses `Dirent.isFile()` which returns `false` for symlinks, so symlinked command files are silently ignored.

## Solution

Update `loadCommandsFromDir()` to also check `isSymbolicLink()` when filtering entries. `readFileSync()` already resolves symlinks when reading, so only the discovery filter needed fixing.

## Changes

- `packages/coding-agent/src/core/slash-commands.ts`: include symlinks in discovery
- Updated comment to reflect new behavior