### PR TITLE
Pass non-truncated tool result in hook callback

### DIFF
--- a/packages/coding-agent/src/core/hooks/tool-wrapper.ts
+++ b/packages/coding-agent/src/core/hooks/tool-wrapper.ts
@@ -5,6 +5,7 @@
 import type { AgentTool } from "@mariozechner/pi-ai";
 import type { HookRunner } from "./runner.js";
 import type { ToolCallEventResult, ToolResultEventResult } from "./types.js";
+import * as fs from "node:fs/promises";
 
 /**
  * Wrap a tool with hook callbacks.
@@ -49,6 +50,16 @@ export function wrapToolWithHooks<T>(tool: AgentTool<any, T>, hookRunner: HookRu
 					.filter((c): c is { type: "text"; text: string } => c.type === "text")
 					.map((c) => c.text)
 					.join("\n");
+
+                                let fullResult: string | undefined;
+                                const details = result.details as any;
+                                if (details?.fullOutputPath) {
+                                    try {
+                                        fullResult = await fs.readFile(details.fullOutputPath, "utf-8");
+                                    } catch (err) {
+                                        console.error(`Hook system failed to read full output: ${err}`);
+                                    }
+                                }
 
 				const resultResult = (await hookRunner.emit({
 					type: "tool_result",

--- a/packages/coding-agent/src/core/hooks/types.ts
+++ b/packages/coding-agent/src/core/hooks/types.ts
@@ -153,6 +153,8 @@ export interface ToolResultEvent {
 	input: Record<string, unknown>;
 	/** Tool result content (text) */
 	result: string;
+        /** Tool non-truncated output */
+        fullResult?: string;
 	/** Whether the tool execution was an error */
 	isError: boolean;
 }


### PR DESCRIPTION
The "result" in hook "tool_result" event is truncated from the top (ring buffer?) so I have added "fullResult" in this PR to be able to work with very long outputs produced for example by an execution of "ls -R ." in project root directory (GPT-OSS models love to use this despite restictions in AGENTS.md).