### PR TITLE
Add single-message model override with [model] syntax

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -973,6 +973,17 @@ export class InteractiveMode {
 				this.ui.requestRender();
 				break;
 			}
+
+			case "model_override_start": {
+				const thinkingInfo = event.thinkingLevel ? `:${event.thinkingLevel}` : "";
+				this.showStatus(`Using ${event.model.id}${thinkingInfo} for this message`);
+				break;
+			}
+
+			case "model_override_end": {
+				this.showStatus(`Restored model: ${event.restoredModel.id}`);
+				break;
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -430,7 +430,8 @@ export class RpcClient {
 	}
 
 	private async send(command: RpcCommandBody): Promise<RpcResponse> {
-		if (!this.process?.stdin) {
+		const stdin = this.process?.stdin;
+		if (!stdin) {
 			throw new Error("Client not started");
 		}
 
@@ -456,7 +457,7 @@ export class RpcClient {
 				},
 			});
 
-			this.process!.stdin!.write(JSON.stringify(fullCommand) + "\n");
+			stdin.write(JSON.stringify(fullCommand) + "\n");
 		});
 	}
 

--- a/packages/coding-agent/src/utils/model-override.ts
+++ b/packages/coding-agent/src/utils/model-override.ts
@@ -1,0 +1,77 @@
+/**
+ * Parse model override prefix from message text.
+ *
+ * Syntax: [model] or [model:thinking] at the start of the message
+ * Examples:
+ *   [haiku] quick question -> { pattern: "haiku", thinkingLevel: undefined, text: "quick question" }
+ *   [opus:high] analyze -> { pattern: "opus", thinkingLevel: "high", text: "analyze" }
+ *   [claude-sonnet-4-5] hi -> { pattern: "claude-sonnet-4-5", thinkingLevel: undefined, text: "hi" }
+ *   normal message -> null
+ */
+
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import { isValidThinkingLevel } from "../cli/args.js";
+
+export interface ModelOverride {
+	/** Model pattern (fuzzy matched against available models) */
+	pattern: string;
+	/** Optional thinking level override */
+	thinkingLevel: ThinkingLevel | undefined;
+	/** Remaining message text after the prefix */
+	text: string;
+}
+
+/**
+ * Parse a message for model override syntax.
+ * Returns null if no override syntax found.
+ */
+export function parseModelOverride(message: string): ModelOverride | null {
+	const trimmed = message.trimStart();
+
+	// Must start with [
+	if (!trimmed.startsWith("[")) {
+		return null;
+	}
+
+	// Find the closing bracket
+	const closeBracket = trimmed.indexOf("]");
+	if (closeBracket === -1) {
+		return null;
+	}
+
+	// Extract content inside brackets
+	const bracketContent = trimmed.slice(1, closeBracket).trim();
+	if (!bracketContent) {
+		return null;
+	}
+
+	// Parse pattern:level format
+	const colonIndex = bracketContent.indexOf(":");
+	let pattern: string;
+	let thinkingLevel: ThinkingLevel | undefined;
+
+	if (colonIndex !== -1) {
+		pattern = bracketContent.slice(0, colonIndex).trim();
+		const levelStr = bracketContent.slice(colonIndex + 1).trim();
+		if (levelStr && isValidThinkingLevel(levelStr)) {
+			thinkingLevel = levelStr;
+		} else if (levelStr) {
+			// Invalid thinking level - treat as part of pattern (e.g., [provider/model])
+			// Actually, colon might be in model name, so let's be more careful
+			// If it's not a valid thinking level, treat whole thing as pattern
+			pattern = bracketContent;
+			thinkingLevel = undefined;
+		}
+	} else {
+		pattern = bracketContent;
+	}
+
+	if (!pattern) {
+		return null;
+	}
+
+	// Extract remaining text
+	const text = trimmed.slice(closeBracket + 1).trim();
+
+	return { pattern, thinkingLevel, text };
+}


### PR DESCRIPTION
tl;dr: this is something I always wanted; because I have a keyboard macro that writes "/model X". This approach maybe is not the best for everyone; but I just wanted to contribute to see if others find it useful as well.

Mario feel free to just close it if it doesn't make sense; thanks. ( I ❤️ π )

## Summary

Add the ability to use a different model for a single message by prefixing with `[model]` or `[model:thinking]`.

## Features

- **Syntax**: `[pattern]` or `[pattern:thinking]` at the start of a message
- **Fuzzy matching**: Same matching as `/model` command (partial ID/name match)
- **Auto-restore**: Original model is restored after the response completes (including tool calls)
- **Native provider preference**: When resolving ambiguous patterns, prefer native providers over OpenRouter

## Examples

```
[haiku] Quick question: what's 2+2?
[opus:high] Analyze this complex architecture
[sonnet:medium] Review this code
[gpt-4o] How would OpenAI approach this?
```

## Changes

- `src/utils/model-override.ts` - New parser for `[model]` syntax
- `src/core/model-resolver.ts` - Add `resolveSingleModelPattern()` with native provider preference
- `src/core/agent-session.ts` - Add `modelOverride` option to `prompt()`, auto-restore on `agent_end`
- `src/main.ts` - Parse model override in interactive loop
- `src/modes/interactive/interactive-mode.ts` - Visual feedback for model override events
- `src/modes/rpc/rpc-client.ts` - Fix TS error (stdin null check)