### PR TITLE
Forward `onUpdate` callback through hook wrapper

### DIFF
--- a/packages/coding-agent/src/core/custom-tools/index.ts
+++ b/packages/coding-agent/src/core/custom-tools/index.ts
@@ -4,6 +4,7 @@
 
 export { discoverAndLoadCustomTools, loadCustomTools } from "./loader.js";
 export type {
+	AgentToolUpdateCallback,
 	CustomAgentTool,
 	CustomToolFactory,
 	CustomToolsLoadResult,

--- a/packages/coding-agent/src/core/hooks/tool-wrapper.ts
+++ b/packages/coding-agent/src/core/hooks/tool-wrapper.ts
@@ -2,7 +2,7 @@
  * Tool wrapper - wraps tools with hook callbacks for interception.
  */
 
-import type { AgentTool } from "@mariozechner/pi-ai";
+import type { AgentTool, AgentToolUpdateCallback } from "@mariozechner/pi-ai";
 import type { HookRunner } from "./runner.js";
 import type { ToolCallEventResult, ToolResultEventResult } from "./types.js";
 
@@ -10,11 +10,17 @@ import type { ToolCallEventResult, ToolResultEventResult } from "./types.js";
  * Wrap a tool with hook callbacks.
  * - Emits tool_call event before execution (can block)
  * - Emits tool_result event after execution (can modify result)
+ * - Forwards onUpdate callback to wrapped tool for progress streaming
  */
 export function wrapToolWithHooks<T>(tool: AgentTool<any, T>, hookRunner: HookRunner): AgentTool<any, T> {
 	return {
 		...tool,
-		execute: async (toolCallId: string, params: Record<string, unknown>, signal?: AbortSignal) => {
+		execute: async (
+			toolCallId: string,
+			params: Record<string, unknown>,
+			signal?: AbortSignal,
+			onUpdate?: AgentToolUpdateCallback<T>,
+		) => {
 			// Emit tool_call event - hooks can block execution
 			// If hook errors/times out, block by default (fail-safe)
 			if (hookRunner.hasHandlers("tool_call")) {
@@ -39,8 +45,8 @@ export function wrapToolWithHooks<T>(tool: AgentTool<any, T>, hookRunner: HookRu
 				}
 			}
 
-			// Execute the actual tool
-			const result = await tool.execute(toolCallId, params, signal);
+			// Execute the actual tool, forwarding onUpdate for progress streaming
+			const result = await tool.execute(toolCallId, params, signal, onUpdate);
 
 			// Emit tool_result event - hooks can modify the result
 			if (hookRunner.hasHandlers("tool_result")) {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -24,6 +24,7 @@ export {
 } from "./core/compaction.js";
 // Custom tools
 export type {
+	AgentToolUpdateCallback,
 	CustomAgentTool,
 	CustomToolFactory,
 	CustomToolsLoadResult,


### PR DESCRIPTION
Forward `onUpdate` callback through hook wrapper

The hook wrapper was dropping the `onUpdate` callback when wrapping tools. So if any hooks are loaded (which enables tool wrapping), tools that stream progress via `onUpdate` (like bash streaming stdout) emit no progress update events until the tool finishes.

Small fix, but it means the wrapper now preserves the full tool interface.

Also exported `AgentToolUpdateCallback` type for custom tools that want to use `onUpdate` in their execute signature.

### Before: wrapper drops onUpdate

User sees: tool starts, empty output area, then final result appears all at once

```mermaid
flowchart TD
    A[Agent loop] -->|"execute(..., onUpdate)"| B[Hook wrapper]
    B -->|"execute(...) ❌ onUpdate dropped"| C[Bash tool]
    C -->|"stdout chunk 1"| D["onUpdate?.() - undefined, ignored"]
    C -->|"stdout chunk 2"| D
    C -->|"stdout chunk N..."| D
    D --> E[No TUI updates]
    C -->|"tool finishes"| F["tool_execution_end"]
    F --> G[TUI shows final result all at once]
```

### After: wrapper forwards onUpdate

User sees: tool starts, output streams live as it runs

```mermaid
flowchart TD
    A[Agent loop] -->|"execute(..., onUpdate)"| B[Hook wrapper]
    B -->|"execute(..., onUpdate) ✓"| C[Bash tool]
    C -->|"stdout chunk 1"| D["onUpdate(partial)"]
    D -->|"tool_execution_update"| E[TUI updates live]
    C -->|"stdout chunk 2"| F["onUpdate(partial)"]
    F -->|"tool_execution_update"| E
    C -->|"stdout chunk N..."| G["onUpdate(partial)"]
    G -->|"tool_execution_update"| E
    C -->|"tool finishes"| H["tool_execution_end"]
    H --> I[TUI shows final result]
```

No breaking changes - only affects tools using `onUpdate` when hooks are enabled.
