### PR TITLE
fix(coding-agent): prevent global AGENTS.md from being loaded twice

### DIFF
--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -65,12 +65,14 @@ function loadContextFileFromDir(dir: string): { path: string; content: string } 
  */
 export function loadProjectContextFiles(): Array<{ path: string; content: string }> {
 	const contextFiles: Array<{ path: string; content: string }> = [];
+	const seenPaths = new Set<string>();
 
 	// 1. Load global context from ~/{CONFIG_DIR_NAME}/agent/
 	const globalContextDir = getAgentDir();
 	const globalContext = loadContextFileFromDir(globalContextDir);
 	if (globalContext) {
 		contextFiles.push(globalContext);
+		seenPaths.add(globalContext.path);
 	}
 
 	// 2. Walk up from cwd to root, collecting all context files
@@ -82,9 +84,10 @@ export function loadProjectContextFiles(): Array<{ path: string; content: string
 
 	while (true) {
 		const contextFile = loadContextFileFromDir(currentDir);
-		if (contextFile) {
+		if (contextFile && !seenPaths.has(contextFile.path)) {
 			// Add to beginning so we get top-most parent first
 			ancestorContextFiles.unshift(contextFile);
+			seenPaths.add(contextFile.path);
 		}
 
 		// Stop if we've reached root


### PR DESCRIPTION
Noticed this while tweaking custom tools. It's pretty minor but could eat some tokens depending on the size of the AGENTS.md.

When cwd is `~/.pi/agent/` or a subdirectory, the global AGENTS.md file was included twice in the system prompt.

`loadProjectContextFiles()` loads context files in two steps:
1. Explicitly loads from `getAgentDir()` (`~/.pi/agent/`)
2. Walks from cwd up to root, collecting all AGENTS.md/CLAUDE.md files

There was no deduplication. When cwd is at or below `~/.pi/agent/`, the ancestor walk includes that directory again.

Fix: track seen paths with a Set and skip duplicates.