### PR TITLE
fix(coding-agent): properly cleanup terminal on Ctrl+C in session selector

### DIFF
--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -28,6 +28,10 @@ export async function selectSession(sessionManager: SessionManager): Promise<str
 					resolve(null);
 				}
 			},
+			() => {
+				ui.stop();
+				process.exit(0);
+			},
 		);
 
 		ui.addChild(selector);

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -33,6 +33,7 @@ class SessionList implements Component {
 	private searchInput: Input;
 	public onSelect?: (sessionPath: string) => void;
 	public onCancel?: () => void;
+	public onExit: () => void = () => {};
 	private maxVisible: number = 5; // Max sessions visible (each session is 3 lines: msg + metadata + blank)
 
 	constructor(sessions: SessionItem[]) {
@@ -153,9 +154,9 @@ class SessionList implements Component {
 				this.onCancel();
 			}
 		}
-		// Ctrl+C - exit process
+		// Ctrl+C - exit
 		else if (isCtrlC(keyData)) {
-			process.exit(0);
+			this.onExit();
 		}
 		// Pass everything else to search input
 		else {
@@ -171,7 +172,12 @@ class SessionList implements Component {
 export class SessionSelectorComponent extends Container {
 	private sessionList: SessionList;
 
-	constructor(sessionManager: SessionManager, onSelect: (sessionPath: string) => void, onCancel: () => void) {
+	constructor(
+		sessionManager: SessionManager,
+		onSelect: (sessionPath: string) => void,
+		onCancel: () => void,
+		onExit: () => void,
+	) {
 		super();
 
 		// Load all sessions
@@ -188,6 +194,7 @@ export class SessionSelectorComponent extends Container {
 		this.sessionList = new SessionList(sessions);
 		this.sessionList.onSelect = onSelect;
 		this.sessionList.onCancel = onCancel;
+		this.sessionList.onExit = onExit;
 
 		this.addChild(this.sessionList);
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1435,6 +1435,10 @@ export class InteractiveMode {
 					done();
 					this.ui.requestRender();
 				},
+				() => {
+					this.stop();
+					process.exit(0);
+				},
 			);
 			return { component: selector, focus: selector.getSessionList() };
 		});


### PR DESCRIPTION
Another small one!

To be honest, on this one I didn't take particular time to look around to see if this is the best way to do it. I just saw that we have the two event handlers for select and cancel, and so I just added a required one for the exit. But please let me know if it should be done another way.  

---
Opus's summary:


Ctrl+C in the session selector (`/resume` command) was calling `process.exit(0)` directly without cleaning up the terminal, leaving it in a broken state (raw mode still enabled, Kitty keyboard protocol active, etc.).

Now Ctrl+C triggers an `onExit` callback that properly calls `stop()` before exiting, which restores terminal settings.