### PR TITLE
Wrap custom tools with hooks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hooks wrap custom tools**: Custom tools are now executed through the hook wrapper, so `tool_call`/`tool_result` hooks can observe, block, and modify custom tool executions (consistent with hook type docs).
+
 ## [0.24.0] - 2025-12-19
 
 ### Added

--- a/packages/coding-agent/docs/hooks.md
+++ b/packages/coding-agent/docs/hooks.md
@@ -645,7 +645,7 @@ main.ts
 
 ## Tool Wrapping
 
-Tools are wrapped with hook callbacks before the agent is created:
+Tools (built-in and custom) are wrapped with hook callbacks after tool discovery/selection, before the agent is created:
 
 ```
 main.ts

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -315,9 +315,6 @@ export async function main(args: string[]) {
 	if (hooks.length > 0) {
 		const timeout = settingsManager.getHookTimeout();
 		hookRunner = new HookRunner(hooks, cwd, timeout);
-
-		// Wrap tools with hook callbacks
-		selectedTools = wrapToolsWithHooks(selectedTools, hookRunner);
 	}
 
 	// Discover and load custom tools from:
@@ -342,6 +339,11 @@ export async function main(args: string[]) {
 	if (loadedCustomTools.length > 0) {
 		const customToolInstances = loadedCustomTools.map((lt) => lt.tool);
 		selectedTools = [...selectedTools, ...customToolInstances] as typeof selectedTools;
+	}
+
+	// Wrap tools with hook callbacks (built-in and custom)
+	if (hookRunner) {
+		selectedTools = wrapToolsWithHooks(selectedTools, hookRunner);
 	}
 
 	// Create agent


### PR DESCRIPTION
This is a behavior change if someone has hooks enabled and uses custom tools, since those hooks will start seeing custom tool events and may block them depending on hook logic.

Before this, custom tools were not going through the hook wrapper because we wrapped the built-in tool list first, then loaded and appended custom tools afterward. That meant `tool_call` and `tool_result` hooks never fired for custom tools, even though the hook types and docs already treat `toolName` as “built-in or custom”.

This change moves the wrapping step to happen after tool discovery and selection is complete, so when hooks are enabled both built-in tools and custom tools are executed through the same wrapper. As a result, hooks can now observe, block, and modify custom tool executions the same way they already can for built-ins.

This makes the runtime behavior match what the package exports and documents for hooks, where tool events are described as covering both built-in and custom tools.

### Before: Custom tools bypass hooks

```mermaid
flowchart TD
    subgraph init["Initialization (main.ts)"]
        A[Load built-in tools] --> B[Wrap with hooks]
        B --> C[Load custom tools]
        C --> D[Append to tool list]
        D --> E[Create Agent]
    end

    subgraph runtime["Runtime Execution"]
        E --> F{Tool called?}
        F --> G[Built-in tool]
        F --> H[Custom tool]
        G --> I[Hook wrapper]
        I --> J[tool_call hook fires]
        J --> K[Execute tool]
        K --> L[tool_result hook fires]
        H --> M[Execute directly]
        M --> N[No hooks fire]
    end

    style H fill:#f96,stroke:#333
    style M fill:#f96,stroke:#333
    style N fill:#f96,stroke:#333
```

### After: All tools go through hooks

```mermaid
flowchart TD
    subgraph init["Initialization (main.ts)"]
        A[Load built-in tools] --> B[Load custom tools]
        B --> C[Append to tool list]
        C --> D[Wrap ALL tools with hooks]
        D --> E[Create Agent]
    end

    subgraph runtime["Runtime Execution"]
        E --> F{Tool called?}
        F --> G[Built-in tool]
        F --> H[Custom tool]
        G --> I[Hook wrapper]
        H --> I
        I --> J[tool_call hook fires]
        J --> K[Execute tool]
        K --> L[tool_result hook fires]
    end

    style D fill:#6f9,stroke:#333
    style H fill:#6f9,stroke:#333
```