### PR TITLE
fix(ai): prevent double API version path in Google provider URL

### DIFF
--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -266,9 +266,10 @@ function createClient(model: Model<"google-generative-ai">, apiKey?: string): Go
 		apiKey = process.env.GEMINI_API_KEY;
 	}
 
-	const httpOptions: { baseUrl?: string; headers?: Record<string, string> } = {};
+	const httpOptions: { baseUrl?: string; apiVersion?: string; headers?: Record<string, string> } = {};
 	if (model.baseUrl) {
 		httpOptions.baseUrl = model.baseUrl;
+		httpOptions.apiVersion = ""; // baseUrl already includes version path, don't append
 	}
 	if (model.headers) {
 		httpOptions.headers = model.headers;


### PR DESCRIPTION
## Problem

After #221 enabled `baseUrl` to be passed to the Google SDK, all Gemini API calls return 404.

Built-in models have `baseUrl: "https://generativelanguage.googleapis.com/v1beta"`. The SDK appends `apiVersion` (default `v1beta`) to this, resulting in `/v1beta/v1beta/models/...` which 404s.

## Fix

Set `apiVersion: ""` when `baseUrl` is provided, since `baseUrl` already includes the version path.

## Testing

- `gemini-2.0-flash`: works (was 404)
- `gemini-2.5-flash`: works
- `anthropic`: still works (no regression)

Fixes regression from #221.
