### PR TITLE
feat(coding-agent): add configurable skills directories

### DIFF
--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -145,6 +145,36 @@ Skills are discovered from these locations (later wins on name collision):
 4. `~/.pi/agent/skills/**/SKILL.md` (Pi user, recursive)
 5. `<cwd>/.pi/skills/**/SKILL.md` (Pi project, recursive)
 
+## Configuration
+
+Configure skill loading in `~/.pi/agent/settings.json`:
+
+```json
+{
+  "skills": {
+    "enabled": true,
+    "enableCodexUser": true,
+    "enableClaudeUser": true,
+    "enableClaudeProject": true,
+    "enablePiUser": true,
+    "enablePiProject": true,
+    "customDirectories": ["~/my-skills-repo"],
+    "ignoredSkills": ["deprecated-skill"]
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `true` | Master toggle for all skills |
+| `enableCodexUser` | `true` | Load from `~/.codex/skills/` |
+| `enableClaudeUser` | `true` | Load from `~/.claude/skills/` |
+| `enableClaudeProject` | `true` | Load from `<cwd>/.claude/skills/` |
+| `enablePiUser` | `true` | Load from `~/.pi/agent/skills/` |
+| `enablePiProject` | `true` | Load from `<cwd>/.pi/skills/` |
+| `customDirectories` | `[]` | Additional directories to scan (supports `~` expansion) |
+| `ignoredSkills` | `[]` | Skill names to exclude |
+
 ## How Skills Work
 
 1. At startup, pi scans skill locations and extracts names + descriptions
@@ -233,3 +263,5 @@ Settings (`~/.pi/agent/settings.json`):
   }
 }
 ```
+
+Use the granular `enable*` flags to disable individual sources (e.g., `enableClaudeUser: false` to skip `~/.claude/skills`).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -25,7 +25,7 @@ import type { BranchEventResult, HookRunner, TurnEndEvent, TurnStartEvent } from
 import type { BashExecutionMessage } from "./messages.js";
 import { getApiKeyForModel, getAvailableModels } from "./model-config.js";
 import { loadSessionFromEntries, type SessionManager } from "./session-manager.js";
-import type { SettingsManager } from "./settings-manager.js";
+import type { SettingsManager, SkillsSettings } from "./settings-manager.js";
 import { expandSlashCommand, type FileSlashCommand } from "./slash-commands.js";
 
 /** Session-specific events that extend the core AgentEvent */
@@ -55,6 +55,7 @@ export interface AgentSessionConfig {
 	hookRunner?: HookRunner | null;
 	/** Custom tools for session lifecycle events */
 	customTools?: LoadedCustomTool[];
+	skillsSettings?: Required<SkillsSettings>;
 }
 
 /** Options for AgentSession.prompt() */
@@ -148,6 +149,8 @@ export class AgentSession {
 	// Custom tools for session lifecycle
 	private _customTools: LoadedCustomTool[] = [];
 
+	private _skillsSettings: Required<SkillsSettings> | undefined;
+
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
@@ -156,6 +159,7 @@ export class AgentSession {
 		this._fileCommands = config.fileCommands ?? [];
 		this._hookRunner = config.hookRunner ?? null;
 		this._customTools = config.customTools ?? [];
+		this._skillsSettings = config.skillsSettings;
 	}
 
 	// =========================================================================
@@ -483,6 +487,10 @@ export class AgentSession {
 	/** Get queued messages (read-only) */
 	getQueuedMessages(): readonly string[] {
 		return this._queuedMessages;
+	}
+
+	get skillsSettings(): Required<SkillsSettings> | undefined {
+		return this._skillsSettings;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -16,6 +16,13 @@ export interface RetrySettings {
 
 export interface SkillsSettings {
 	enabled?: boolean; // default: true
+	enableCodexUser?: boolean; // default: true
+	enableClaudeUser?: boolean; // default: true
+	enableClaudeProject?: boolean; // default: true
+	enablePiUser?: boolean; // default: true
+	enablePiProject?: boolean; // default: true
+	customDirectories?: string[]; // default: []
+	ignoredSkills?: string[]; // default: []
 }
 
 export interface TerminalSettings {
@@ -251,6 +258,19 @@ export class SettingsManager {
 		}
 		this.settings.skills.enabled = enabled;
 		this.save();
+	}
+
+	getSkillsSettings(): Required<SkillsSettings> {
+		return {
+			enabled: this.settings.skills?.enabled ?? true,
+			enableCodexUser: this.settings.skills?.enableCodexUser ?? true,
+			enableClaudeUser: this.settings.skills?.enableClaudeUser ?? true,
+			enableClaudeProject: this.settings.skills?.enableClaudeProject ?? true,
+			enablePiUser: this.settings.skills?.enablePiUser ?? true,
+			enablePiProject: this.settings.skills?.enablePiProject ?? true,
+			customDirectories: this.settings.skills?.customDirectories ?? [],
+			ignoredSkills: this.settings.skills?.ignoredSkills ?? [],
+		};
 	}
 
 	getShowImages(): boolean {

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -6,6 +6,7 @@ import chalk from "chalk";
 import { existsSync, readFileSync } from "fs";
 import { join, resolve } from "path";
 import { getAgentDir, getDocsPath, getReadmePath } from "../config.js";
+import type { SkillsSettings } from "./settings-manager.js";
 import { formatSkillsForPrompt, loadSkills } from "./skills.js";
 import type { ToolName } from "./tools/index.js";
 
@@ -109,12 +110,12 @@ export interface BuildSystemPromptOptions {
 	customPrompt?: string;
 	selectedTools?: ToolName[];
 	appendSystemPrompt?: string;
-	skillsEnabled?: boolean;
+	skillsSettings?: SkillsSettings;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
 export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): string {
-	const { customPrompt, selectedTools, appendSystemPrompt, skillsEnabled = true } = options;
+	const { customPrompt, selectedTools, appendSystemPrompt, skillsSettings } = options;
 	const resolvedCustomPrompt = resolvePromptInput(customPrompt, "system prompt");
 	const resolvedAppendPrompt = resolvePromptInput(appendSystemPrompt, "append system prompt");
 
@@ -151,8 +152,8 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 
 		// Append skills section (only if read tool is available)
 		const customPromptHasRead = !selectedTools || selectedTools.includes("read");
-		if (skillsEnabled && customPromptHasRead) {
-			const { skills } = loadSkills();
+		if (skillsSettings?.enabled !== false && customPromptHasRead) {
+			const { skills } = loadSkills(skillsSettings ?? {});
 			prompt += formatSkillsForPrompt(skills);
 		}
 
@@ -257,8 +258,8 @@ Documentation:
 	}
 
 	// Append skills section (only if read tool is available)
-	if (skillsEnabled && hasRead) {
-		const { skills } = loadSkills();
+	if (skillsSettings?.enabled !== false && hasRead) {
+		const { skills } = loadSkills(skillsSettings ?? {});
 		prompt += formatSkillsForPrompt(skills);
 	}
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -104,6 +104,7 @@ export {
 	type RetrySettings,
 	type Settings,
 	SettingsManager,
+	type SkillsSettings,
 } from "./core/settings-manager.js";
 // Skills
 export {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -285,12 +285,15 @@ export async function main(args: string[]) {
 	}
 
 	// Build system prompt
-	const skillsEnabled = !parsed.noSkills && settingsManager.getSkillsEnabled();
+	const skillsSettings = settingsManager.getSkillsSettings();
+	if (parsed.noSkills) {
+		skillsSettings.enabled = false;
+	}
 	const systemPrompt = buildSystemPrompt({
 		customPrompt: parsed.systemPrompt,
 		selectedTools: parsed.tools,
 		appendSystemPrompt: parsed.appendSystemPrompt,
-		skillsEnabled,
+		skillsSettings,
 	});
 
 	// Handle session restoration
@@ -440,6 +443,7 @@ export async function main(args: string[]) {
 		fileCommands,
 		hookRunner,
 		customTools: loadedCustomTools,
+		skillsSettings,
 	});
 
 	// Route to appropriate mode

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -310,18 +310,23 @@ export class InteractiveMode {
 		}
 
 		// Show loaded skills
-		const { skills, warnings: skillWarnings } = loadSkills();
-		if (skills.length > 0) {
-			const skillList = skills.map((s) => theme.fg("dim", `  ${s.filePath}`)).join("\n");
-			this.chatContainer.addChild(new Text(theme.fg("muted", "Loaded skills:\n") + skillList, 0, 0));
-			this.chatContainer.addChild(new Spacer(1));
-		}
+		const skillsSettings = this.session.skillsSettings;
+		if (skillsSettings?.enabled !== false) {
+			const { skills, warnings: skillWarnings } = loadSkills(skillsSettings ?? {});
+			if (skills.length > 0) {
+				const skillList = skills.map((s) => theme.fg("dim", `  ${s.filePath}`)).join("\n");
+				this.chatContainer.addChild(new Text(theme.fg("muted", "Loaded skills:\n") + skillList, 0, 0));
+				this.chatContainer.addChild(new Spacer(1));
+			}
 
-		// Show skill warnings if any
-		if (skillWarnings.length > 0) {
-			const warningList = skillWarnings.map((w) => theme.fg("warning", `  ${w.skillPath}: ${w.message}`)).join("\n");
-			this.chatContainer.addChild(new Text(theme.fg("warning", "Skill warnings:\n") + warningList, 0, 0));
-			this.chatContainer.addChild(new Spacer(1));
+			// Show skill warnings if any
+			if (skillWarnings.length > 0) {
+				const warningList = skillWarnings
+					.map((w) => theme.fg("warning", `  ${w.skillPath}: ${w.message}`))
+					.join("\n");
+				this.chatContainer.addChild(new Text(theme.fg("warning", "Skill warnings:\n") + warningList, 0, 0));
+				this.chatContainer.addChild(new Spacer(1));
+			}
 		}
 
 		// Show loaded custom tools


### PR DESCRIPTION
Adds granular control over where skills are loaded from. You can now:

- Toggle individual built-in directories on/off (`enableCodexUser`, `enableClaudeUser`, etc.)
- Point to custom directories (like a personal git repo)
- Ignore specific skills by name

Pi already reads from Claude and Codex directories, but there was no way to disable sources you don't care about or add your own.

## Example config

```json
{
  "skills": {
    "enableCodexUser": false,
    "enableClaudeProject": false,
    "customDirectories": ["~/my-skills-repo"],
    "ignoredSkills": ["deprecated-skill"]
  }
}
```

This would skip Codex and Claude project directories, load from your git repo instead, and ignore any skill named "deprecated-skill".

**Changes**
- `settings-manager.ts` - expanded `SkillsSettings` interface + `getSkillsSettings()` method
- `skills.ts` - `loadSkills()` now accepts options for per-source toggles, custom dirs, ignored skills
- `system-prompt.ts` - passes settings through to `loadSkills()`
- `agent-session.ts` - stores `skillsSettings` so TUI can access it
- `main.ts` - computes merged settings (with `--no-skills` CLI override), passes everywhere
- `interactive-mode.ts` - respects settings when displaying loaded skills
- `index.ts` - exports `SkillsSettings` type
- `skills.md` - docs for new config options
- `skills.test.ts` - tests for custom dirs, ignored skills, tilde expansion