### PR TITLE
feat(coding-agent): add cwd override for programmatic usage

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **AgentSession cwd override**: Added `cwd` to `AgentSessionConfig` so programmatic users can override the project root used for session paths and headers.
+
 ## [0.25.2] - 2025-12-21
 
 ### Fixed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -27,6 +27,7 @@ import { getApiKeyForModel, getAvailableModels } from "./model-config.js";
 import { loadSessionFromEntries, type SessionManager } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
 import { expandSlashCommand, type FileSlashCommand } from "./slash-commands.js";
+import { setToolCwd } from "./tools/index.js";
 
 /** Session-specific events that extend the core AgentEvent */
 export type AgentSessionEvent =
@@ -47,6 +48,8 @@ export interface AgentSessionConfig {
 	agent: Agent;
 	sessionManager: SessionManager;
 	settingsManager: SettingsManager;
+	/** Absolute project root override for session paths and headers */
+	cwd?: string;
 	/** Models to cycle through with Ctrl+P (from --models flag) */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel: ThinkingLevel }>;
 	/** File-based slash commands for expansion */
@@ -151,6 +154,11 @@ export class AgentSession {
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
+		if (config.cwd) {
+			this.sessionManager.setSessionCwd(config.cwd);
+			// Also set the tool context cwd so tools run in the right directory
+			setToolCwd(config.cwd);
+		}
 		this.settingsManager = config.settingsManager;
 		this._scopedModels = config.scopedModels ?? [];
 		this._fileCommands = config.fileCommands ?? [];

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -6,6 +6,7 @@ import type { AgentTool } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import { spawn } from "child_process";
 import { getShellConfig, killProcessTree } from "../../utils/shell.js";
+import { getToolCwd } from "./context.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateTail } from "./truncate.js";
 
 /**
@@ -40,6 +41,7 @@ export const bashTool: AgentTool<typeof bashSchema> = {
 		return new Promise((resolve, reject) => {
 			const { shell, args } = getShellConfig();
 			const child = spawn(shell, [...args, command], {
+				cwd: getToolCwd(),
 				detached: true,
 				stdio: ["ignore", "pipe", "pipe"],
 			});

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -1,4 +1,5 @@
 export { type BashToolDetails, bashTool } from "./bash.js";
+export { clearToolCwd, getToolCwd, setToolCwd } from "./context.js";
 export { editTool } from "./edit.js";
 export { type FindToolDetails, findTool } from "./find.js";
 export { type GrepToolDetails, grepTool } from "./grep.js";

--- a/packages/coding-agent/src/core/tools/path-utils.ts
+++ b/packages/coding-agent/src/core/tools/path-utils.ts
@@ -1,5 +1,7 @@
 import { accessSync, constants } from "node:fs";
 import * as os from "node:os";
+import { resolve } from "node:path";
+import { getToolCwd } from "./context.js";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const NARROW_NO_BREAK_SPACE = "\u202F";
@@ -29,7 +31,8 @@ export function expandPath(filePath: string): string {
 	if (normalized.startsWith("~/")) {
 		return os.homedir() + normalized.slice(1);
 	}
-	return normalized;
+	// Resolve relative paths against tool cwd
+	return resolve(getToolCwd(), normalized);
 }
 
 export function resolveReadPath(filePath: string): string {


### PR DESCRIPTION
Add `cwd` option to AgentSessionConfig to allow programmatic users to override the project root in AgentSession

- Add setSessionCwd to SessionManager for custom working directory
- Update bash tool to spawn processes in the configured cwd
- Resolve relative paths in path-utils against tool cwd
- Export tool context helpers (getToolCwd, setToolCwd, clearToolCwd)

Proposal for #271 