### PR TITLE
Add support for project-specific settings.json

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -117,9 +117,14 @@ export function getOAuthPath(): string {
 	return join(getAgentDir(), "oauth.json");
 }
 
-/** Get path to settings.json */
+/** Get path to global settings.json (~/.pi/agent/settings.json) */
 export function getSettingsPath(): string {
 	return join(getAgentDir(), "settings.json");
+}
+
+/** Get path to project-level settings.json (<cwd>/.pi/settings.json) */
+export function getProjectSettingsPath(cwd: string = process.cwd()): string {
+	return join(cwd, CONFIG_DIR_NAME, "settings.json");
 }
 
 /** Get path to tools directory */

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SettingsManager } from "../src/core/settings-manager.js";
+
+const testDir = join(__dirname, "fixtures/settings-test");
+const globalDir = join(testDir, "global");
+const projectDir = join(testDir, "project");
+const projectSettingsDir = join(projectDir, ".pi");
+
+describe("SettingsManager", () => {
+	beforeEach(() => {
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true });
+		}
+		mkdirSync(globalDir, { recursive: true });
+		mkdirSync(projectSettingsDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true });
+		}
+	});
+
+	describe("project settings merge", () => {
+		it("should deep merge nested objects (skills, retry, etc)", () => {
+			writeFileSync(
+				join(globalDir, "settings.json"),
+				JSON.stringify({
+					skills: { enabled: true, enableCodexUser: true, enableClaudeUser: true },
+				}),
+			);
+			writeFileSync(
+				join(projectSettingsDir, "settings.json"),
+				JSON.stringify({
+					skills: { enableCodexUser: false },
+				}),
+			);
+
+			const manager = new SettingsManager(globalDir, projectDir);
+			const skillsSettings = manager.getSkillsSettings();
+
+			// enableCodexUser overridden by project, others preserved from global
+			expect(skillsSettings.enabled).toBe(true);
+			expect(skillsSettings.enableCodexUser).toBe(false);
+			expect(skillsSettings.enableClaudeUser).toBe(true);
+		});
+
+		it("should replace arrays entirely (not merge)", () => {
+			writeFileSync(
+				join(globalDir, "settings.json"),
+				JSON.stringify({
+					hooks: ["/global/hook1.ts", "/global/hook2.ts"],
+				}),
+			);
+			writeFileSync(
+				join(projectSettingsDir, "settings.json"),
+				JSON.stringify({
+					hooks: ["/project/hook.ts"],
+				}),
+			);
+
+			const manager = new SettingsManager(globalDir, projectDir);
+
+			expect(manager.getHookPaths()).toEqual(["/project/hook.ts"]);
+		});
+
+		it("should save to global settings only, preserving project overrides", () => {
+			writeFileSync(join(globalDir, "settings.json"), JSON.stringify({ defaultModel: "claude-sonnet" }));
+			writeFileSync(join(projectSettingsDir, "settings.json"), JSON.stringify({ defaultModel: "gpt-4o" }));
+
+			const manager = new SettingsManager(globalDir, projectDir);
+			manager.setDefaultModel("new-model");
+
+			// Project file should be untouched
+			const projectContent = JSON.parse(readFileSync(join(projectSettingsDir, "settings.json"), "utf-8"));
+			expect(projectContent.defaultModel).toBe("gpt-4o");
+
+			// Global file should have the new value
+			const globalContent = JSON.parse(readFileSync(join(globalDir, "settings.json"), "utf-8"));
+			expect(globalContent.defaultModel).toBe("new-model");
+
+			// Getter returns project override (project takes precedence)
+			expect(manager.getDefaultModel()).toBe("gpt-4o");
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Adds support for project-level `settings.json` at `<cwd>/.pi/settings.json`
- Project settings override global settings (`~/.pi/agent/settings.json`) with deep merge for nested objects
- For nested objects (skills, retry, terminal, compaction), individual keys can be overridden without replacing the entire object
- Arrays and primitives are fully replaced by project settings
- Save operations only modify global settings, preserving project settings for version control

## Implementation
1. **`config.ts`**: Added `getProjectSettingsPath()` returning `<cwd>/.pi/settings.json`
2. **`settings-manager.ts`**:
   - Added `deepMergeSettings()` helper for recursive merge
   - Added `loadProjectSettings()` method
   - Modified constructor to accept `cwd` parameter and merge project settings
   - Updated all setters to modify `globalSettings` and re-merge after save
3. **Tests**: Added comprehensive test suite for merge behavior

## Example
```json
// Global: ~/.pi/agent/settings.json
{
  "skills": { "enabled": true, "enableCodexUser": true },
  "defaultModel": "claude-sonnet"
}

// Project: .pi/settings.json  
{
  "skills": { "enableCodexUser": false }
}

// Result
{
  "skills": { "enabled": true, "enableCodexUser": false },
  "defaultModel": "claude-sonnet"
}
```

Closes #270