### PR TITLE
Add skipConversationRestore for before_branch hooks

### DIFF
--- a/packages/coding-agent/docs/hooks.md
+++ b/packages/coding-agent/docs/hooks.md
@@ -154,7 +154,12 @@ pi.on("session", async (event, ctx) => {
   if (event.reason === "before_clear") {
     return { cancel: true };
   }
-  // No return needed if not cancelling
+
+  // For before_branch only: create branch but skip conversation restore
+  // (useful for checkpoint hooks that restore files separately)
+  if (event.reason === "before_branch") {
+    return { skipConversationRestore: true };
+  }
 });
 ```
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1249,6 +1249,8 @@ export class AgentSession {
 
 		const selectedText = this._extractUserMessageText(selectedEntry.message.content);
 
+		let skipConversationRestore = false;
+
 		// Emit before_branch event (can be cancelled)
 		if (this._hookRunner?.hasHandlers("session")) {
 			const result = (await this._hookRunner.emit({
@@ -1263,6 +1265,7 @@ export class AgentSession {
 			if (result?.cancel) {
 				return { selectedText, cancelled: true };
 			}
+			skipConversationRestore = result?.skipConversationRestore ?? false;
 		}
 
 		// Create branched session (returns null in --no-session mode)
@@ -1293,7 +1296,9 @@ export class AgentSession {
 		// Emit session event to custom tools (with reason "branch")
 		await this._emitToolSessionEvent("branch", previousSessionFile);
 
-		this.agent.replaceMessages(loaded.messages);
+		if (!skipConversationRestore) {
+			this.agent.replaceMessages(loaded.messages);
+		}
 
 		return { selectedText, cancelled: false };
 	}

--- a/packages/coding-agent/src/core/hooks/types.ts
+++ b/packages/coding-agent/src/core/hooks/types.ts
@@ -323,6 +323,8 @@ export interface ToolResultEventResult {
 export interface SessionEventResult {
 	/** If true, cancel the pending action (switch, clear, or branch) */
 	cancel?: boolean;
+	/** If true (for before_branch only), skip restoring conversation to branch point while still creating the branched session file */
+	skipConversationRestore?: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
Hooks listening to `before_branch` can cancel the branch, but they can't restore files while keeping the conversation intact. This is needed for checkpoint/rewind hooks that want to:

1. Restore files to a previous state
2. Keep the current conversation intact

Currently the only options are:
- Let branch proceed (files + conversation both change)
- Cancel branch entirely (nothing changes)

**Use Case**

A rewind hook creates git checkpoints on each turn. When user branches to an earlier message, the hook offers:

| Option | Files | Conversation |
|--------|-------|--------------|
| Restore all | From checkpoint | Branched |
| Conversation only | Unchanged | Branched |
| **Files only** | From checkpoint | **Unchanged** |

The third option isn't possible today.

**Solution**

Adds `skipConversationRestore?: boolean` to `SessionEventResult`. When a `before_branch` hook returns this, the branch proceeds (session file is created) but `agent.replaceMessages()` is skipped, keeping the in-memory conversation intact.

```typescript
pi.on("session", async (event, ctx) => {
  if (event.reason !== "before_branch") return;
  
  // Restore files from checkpoint
  await ctx.exec("git", ["checkout", ref, "--", "."]);
  
  // Branch session file but keep current conversation
  return { skipConversationRestore: true };
});
```
