### PR TITLE
Add createSeededSession() API for session seeding

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`spawnSession()` API**: Create and switch to a new session without exiting pi. Optionally seed with initial messages and track lineage via `parentSession`. Old session stays accessible via `/resume`. Available via `AgentSession.spawnSession()`, `SessionManager.spawnSession()`, and RPC `spawn_session` command. ([#293](https://github.com/badlogic/pi-mono/pull/293) by [@nicobailon](https://github.com/nicobailon))
+- **Renamed `branchedFrom` to `parentSession`**: Session header field renamed for clarity. Applies to both branched sessions and spawned sessions. ([#293](https://github.com/badlogic/pi-mono/pull/293) by [@nicobailon](https://github.com/nicobailon))
+
 ### Fixed
 
 - **Duplicate skill warnings for symlinks**: Skills loaded via symlinks pointing to the same file are now silently deduplicated instead of showing name collision warnings. ([#304](https://github.com/badlogic/pi-mono/pull/304) by [@mitsuhiko](https://github.com/mitsuhiko))

--- a/packages/coding-agent/docs/hooks.md
+++ b/packages/coding-agent/docs/hooks.md
@@ -125,6 +125,11 @@ user switches session (/resume)
   ├─► session (reason: "before_switch", can cancel)
   └─► session (reason: "switch", AFTER switch)
 
+spawn new session (via SDK/RPC)
+  │
+  ├─► session (reason: "before_switch", can cancel)
+  └─► session (reason: "switch", AFTER spawn)
+
 user clears session (/clear)
   │
   ├─► session (reason: "before_clear", can cancel)

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -486,6 +486,45 @@ If a hook cancelled the switch:
 {"type": "response", "command": "switch_session", "success": true, "data": {"cancelled": true}}
 ```
 
+#### spawn_session
+
+Create a new session (optionally with initial messages) and switch to it. The old session remains accessible via `/resume`. Can be cancelled by a `before_switch` hook.
+
+```json
+{"type": "spawn_session", "options": {}}
+```
+
+With initial messages and source tracking:
+```json
+{
+  "type": "spawn_session",
+  "options": {
+    "initialMessages": [{"role": "user", "content": "Context...", "timestamp": 1234567890}],
+    "parentSession": "/path/to/source-session.jsonl"
+  }
+}
+```
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "spawn_session",
+  "success": true,
+  "data": {"cancelled": false, "sessionPath": "/path/to/new-session.jsonl"}
+}
+```
+
+If a hook cancelled the spawn:
+```json
+{
+  "type": "response",
+  "command": "spawn_session",
+  "success": true,
+  "data": {"cancelled": true, "sessionPath": null}
+}
+```
+
 #### branch
 
 Create a new branch from a previous user message. Can be cancelled by a `before_branch` hook. Returns the text of the message being branched from.

--- a/packages/coding-agent/docs/session.md
+++ b/packages/coding-agent/docs/session.md
@@ -29,7 +29,7 @@ First line of the file. Defines session metadata.
 For branched sessions, includes the source session path:
 
 ```json
-{"type":"session","id":"uuid","timestamp":"2024-12-03T14:00:00.000Z","cwd":"/path/to/project","provider":"anthropic","modelId":"claude-sonnet-4-5","thinkingLevel":"off","branchedFrom":"/path/to/original/session.jsonl"}
+{"type":"session","id":"uuid","timestamp":"2024-12-03T14:00:00.000Z","cwd":"/path/to/project","provider":"anthropic","modelId":"claude-sonnet-4-5","thinkingLevel":"off","parentSession":"/path/to/original/session.jsonl"}
 ```
 
 ### SessionMessageEntry

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -131,6 +131,7 @@ export {
 	type SessionInfo,
 	SessionManager,
 	type SessionMessageEntry,
+	type SpawnSessionOptions,
 	SUMMARY_PREFIX,
 	SUMMARY_SUFFIX,
 	type ThinkingLevelChangeEntry,

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -9,6 +9,7 @@ import * as readline from "node:readline";
 import type { AgentEvent, AppMessage, Attachment, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { CompactionResult, SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
+import type { SpawnSessionOptions } from "../../core/session-manager.js";
 import type { RpcCommand, RpcResponse, RpcSessionState } from "./rpc-types.js";
 
 // ============================================================================
@@ -317,6 +318,11 @@ export class RpcClient {
 	 */
 	async switchSession(sessionPath: string): Promise<{ cancelled: boolean }> {
 		const response = await this.send({ type: "switch_session", sessionPath });
+		return this.getData(response);
+	}
+
+	async spawnSession(options: SpawnSessionOptions): Promise<{ cancelled: boolean; sessionPath: string | null }> {
+		const response = await this.send({ type: "spawn_session", options });
 		return this.getData(response);
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -343,6 +343,11 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				return success(id, "switch_session", { cancelled });
 			}
 
+			case "spawn_session": {
+				const result = await session.spawnSession(command.options);
+				return success(id, "spawn_session", result);
+			}
+
 			case "branch": {
 				const result = await session.branch(command.entryIndex);
 				return success(id, "branch", { text: result.selectedText, cancelled: result.cancelled });

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -9,6 +9,7 @@ import type { AppMessage, Attachment, ThinkingLevel } from "@mariozechner/pi-age
 import type { Model } from "@mariozechner/pi-ai";
 import type { CompactionResult, SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
+import type { SpawnSessionOptions } from "../../core/session-manager.js";
 
 // ============================================================================
 // RPC Commands (stdin)
@@ -52,6 +53,7 @@ export type RpcCommand =
 	| { id?: string; type: "get_session_stats" }
 	| { id?: string; type: "export_html"; outputPath?: string }
 	| { id?: string; type: "switch_session"; sessionPath: string }
+	| { id?: string; type: "spawn_session"; options: SpawnSessionOptions }
 	| { id?: string; type: "branch"; entryIndex: number }
 	| { id?: string; type: "get_branch_messages" }
 	| { id?: string; type: "get_last_assistant_text" }
@@ -143,6 +145,13 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "get_session_stats"; success: true; data: SessionStats }
 	| { id?: string; type: "response"; command: "export_html"; success: true; data: { path: string } }
 	| { id?: string; type: "response"; command: "switch_session"; success: true; data: { cancelled: boolean } }
+	| {
+			id?: string;
+			type: "response";
+			command: "spawn_session";
+			success: true;
+			data: { cancelled: boolean; sessionPath: string | null };
+	  }
 	| { id?: string; type: "response"; command: "branch"; success: true; data: { text: string; cancelled: boolean } }
 	| {
 			id?: string;


### PR DESCRIPTION
Adds `createSeededSession()` to create and switch to a new session without exiting pi. Old session stays accessible via `/resume`. Optionally seed it with messages.

## Problem

The SDK doesn't expose a way to create a seeded session and switch to it within the current pi process. Custom tools, commands, and hooks can't implement workflows like handoff, templated sessions, or context import without forcing the user to exit and restart.

## Solution

New `createSeededSession(options)` method on both `SessionManager` and `AgentSession`:

```typescript
await session.createSeededSession({
  initialMessages: [{ role: "user", content: "...", timestamp: Date.now() }],
  linkedFrom: session.sessionFile,  // optional - tracks where this came from
});
```

This creates a fresh session with the provided messages and switches to it. The old session stays accessible via `/resume`.

## Use cases this enables

- **Handoff**: Summarize current session, start fresh with just the summary
- **Templates**: Start with predefined instructions/context
- **Import**: Bring in context from external sources
- **SDK**: Programmatic session creation with custom initial state

## Changes

- `SessionHeader` gets optional `linkedFrom` field (similar to existing `branchedFrom`)
- `SessionManager.createSeededSession()` - low-level, creates the session file
- `AgentSession.createSeededSession()` - high-level, handles hooks and switching
- RPC layer updated for headless mode support
