### PR TITLE
Fix bash tool hanging on git editor prompts

### DIFF
--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -44,6 +44,11 @@ export function createBashTool(cwd: string): AgentTool<typeof bashSchema> {
 					cwd,
 					detached: true,
 					stdio: ["ignore", "pipe", "pipe"],
+					env: {
+						...process.env,
+						GIT_EDITOR: "true",
+						GIT_SEQUENCE_EDITOR: "true",
+					},
 				});
 
 				// We'll stream to a temp file if output gets large


### PR DESCRIPTION
Commands like `git rebase --continue` hang forever because they try to open an interactive editor, but stdin is ignored.

Sets `GIT_EDITOR=true` and `GIT_SEQUENCE_EDITOR=true` so git uses the `true` command (no-op, exits 0) instead of waiting for an editor that can never receive input.