### PR TITLE
Fix Ghostty detection inside tmux for inline images

### DIFF
--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -44,7 +44,7 @@ export function detectCapabilities(): TerminalCapabilities {
 		return { images: "kitty", trueColor: true, hyperlinks: true };
 	}
 
-	if (termProgram === "ghostty" || term.includes("ghostty")) {
+	if (termProgram === "ghostty" || term.includes("ghostty") || process.env.GHOSTTY_RESOURCES_DIR) {
 		return { images: "kitty", trueColor: true, hyperlinks: true };
 	}
 


### PR DESCRIPTION
Inline image previews weren't working when running inside tmux because the terminal detection was failing.

Inside tmux, Ghostty's usual env vars get overwritten:
- `TERM` becomes `tmux-256color`
- `TERM_PROGRAM` becomes `tmux`

Added `GHOSTTY_RESOURCES_DIR` as a fallback check since it persists inside tmux sessions. This follows the same pattern used for Kitty (`KITTY_WINDOW_ID`), WezTerm (`WEZTERM_PANE`), and iTerm2 (`ITERM_SESSION_ID`).
