### PR TITLE
Fix thinking tag leakage by skipping unsigned blocks

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -57,6 +57,8 @@ export interface AgentOptions {
 	messageTransformer?: (messages: AppMessage[]) => Message[] | Promise<Message[]>;
 	// Queue mode: "all" = send all queued messages at once, "one-at-a-time" = send one queued message per turn
 	queueMode?: "all" | "one-at-a-time";
+	// Preserve unsigned thinking blocks as text (may cause tag leakage)
+	preserveUnsignedThinking?: boolean;
 }
 
 export class Agent {
@@ -77,6 +79,7 @@ export class Agent {
 	private messageTransformer: (messages: AppMessage[]) => Message[] | Promise<Message[]>;
 	private messageQueue: Array<QueuedMessage<AppMessage>> = [];
 	private queueMode: "all" | "one-at-a-time";
+	private preserveUnsignedThinking: boolean;
 	private runningPrompt?: Promise<void>;
 	private resolveRunningPrompt?: () => void;
 
@@ -85,6 +88,7 @@ export class Agent {
 		this.transport = opts.transport;
 		this.messageTransformer = opts.messageTransformer || defaultMessageTransformer;
 		this.queueMode = opts.queueMode || "one-at-a-time";
+		this.preserveUnsignedThinking = opts.preserveUnsignedThinking ?? false;
 	}
 
 	get state(): AgentState {
@@ -272,6 +276,7 @@ export class Agent {
 			tools: this._state.tools,
 			model,
 			reasoning,
+			preserveUnsignedThinking: this.preserveUnsignedThinking,
 			getQueuedMessages: async <T>() => {
 				if (this.queueMode === "one-at-a-time") {
 					if (this.messageQueue.length > 0) {

--- a/packages/agent/src/transports/AppTransport.ts
+++ b/packages/agent/src/transports/AppTransport.ts
@@ -361,6 +361,7 @@ export class AppTransport implements AgentTransport {
 		return {
 			model: cfg.model,
 			reasoning: cfg.reasoning,
+			preserveUnsignedThinking: cfg.preserveUnsignedThinking,
 			getQueuedMessages: cfg.getQueuedMessages,
 		};
 	}

--- a/packages/agent/src/transports/ProviderTransport.ts
+++ b/packages/agent/src/transports/ProviderTransport.ts
@@ -57,6 +57,7 @@ export class ProviderTransport implements AgentTransport {
 		return {
 			model,
 			reasoning: cfg.reasoning,
+			preserveUnsignedThinking: cfg.preserveUnsignedThinking,
 			// Resolve API key per assistant response (important for expiring OAuth tokens)
 			getApiKey: this.options.getApiKey,
 			getQueuedMessages: cfg.getQueuedMessages,

--- a/packages/agent/src/transports/types.ts
+++ b/packages/agent/src/transports/types.ts
@@ -8,6 +8,7 @@ export interface AgentRunConfig {
 	tools: AgentTool<any>[];
 	model: Model<any>;
 	reasoning?: ReasoningEffort;
+	preserveUnsignedThinking?: boolean;
 	getQueuedMessages?: <T>() => Promise<QueuedMessage<T>[]>;
 }
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -176,7 +176,11 @@ function mapOptionsForApi<TApi extends Api>(
 		case "anthropic-messages": {
 			// Explicitly disable thinking when reasoning is not specified
 			if (!options?.reasoning) {
-				return { ...base, thinkingEnabled: false } satisfies AnthropicOptions;
+				return {
+					...base,
+					thinkingEnabled: false,
+					preserveUnsignedThinking: options?.preserveUnsignedThinking,
+				} satisfies AnthropicOptions;
 			}
 
 			const anthropicBudgets = {
@@ -190,6 +194,7 @@ function mapOptionsForApi<TApi extends Api>(
 				...base,
 				thinkingEnabled: true,
 				thinkingBudgetTokens: anthropicBudgets[clampReasoning(options.reasoning)!],
+				preserveUnsignedThinking: options?.preserveUnsignedThinking,
 			} satisfies AnthropicOptions;
 		}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -61,6 +61,7 @@ export interface StreamOptions {
 // Unified options with reasoning passed to streamSimple() and completeSimple()
 export interface SimpleStreamOptions extends StreamOptions {
 	reasoning?: ReasoningEffort;
+	preserveUnsignedThinking?: boolean;
 }
 
 // Generic StreamFunction with typed options

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -651,6 +651,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		},
 		messageTransformer,
 		queueMode: settingsManager.getQueueMode(),
+		preserveUnsignedThinking: settingsManager.getPreserveUnsignedThinking(),
 		transport: new ProviderTransport({
 			getApiKey: async () => {
 				const currentModel = agent.state.model;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -47,6 +47,7 @@ export interface Settings {
 	customTools?: string[]; // Array of custom tool file paths
 	skills?: SkillsSettings;
 	terminal?: TerminalSettings;
+	preserveUnsignedThinking?: boolean; // default: false - when true, aborted thinking blocks are kept as <thinking> text (may cause tag leakage)
 	apiKeys?: Record<string, string>; // provider -> API key (e.g., { "anthropic": "sk-..." })
 }
 
@@ -388,5 +389,9 @@ export class SettingsManager {
 
 	getApiKeys(): Record<string, string> {
 		return this.settings.apiKeys ?? {};
+	}
+
+	getPreserveUnsignedThinking(): boolean {
+		return this.settings.preserveUnsignedThinking ?? false;
 	}
 }


### PR DESCRIPTION
Thinking block signatures arrive at the end of the block. If a stream gets interrupted (abort, network issues, timeout, etc.), the signature is missing. To avoid API rejection, the code was converting unsigned blocks to literal `<thinking>` tags:

```typescript
blocks.push({
    type: "text",
    text: `<thinking>\n${block.thinking}\n</thinking>`,
});
```

Claude sees these literal tags in conversation history and starts mimicking them in responses - outputting `</thinking>` as regular text.

### Solution

Reviewed how Vercel AI SDK handles this - they skip unsigned blocks with a warning ("unsupported reasoning metadata") rather than converting to text. Makes sense since the thinking was incomplete anyway.

Changes:
- Skip unsigned thinking blocks by default (with console warning)
- Added `preserveUnsignedThinking` option configurable via settings.json:
  ```json
  { "preserveUnsignedThinking": true }
  ```

Note: The settings plumbing adds some lines across packages. If we don't need the option to toggle this, the fix could be much smaller - just the change in `anthropic.ts`.