### PR TITLE
Extract thinking tags leaked in regular text content

### DIFF
--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -19,6 +19,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { ThinkingTagExtractor } from "../utils/thinking-tag-extractor.js";
 import { convertMessages, convertTools, mapStopReason, mapToolChoice } from "./google-shared.js";
 
 export interface GoogleOptions extends StreamOptions {
@@ -65,85 +66,96 @@ export const streamGoogle: StreamFunction<"google-generative-ai"> = (
 			const googleStream = await client.models.generateContentStream(params);
 
 			stream.push({ type: "start", partial: output });
-			let currentBlock: TextContent | ThinkingContent | null = null;
+			const state: { currentBlock: TextContent | ThinkingContent | null } = { currentBlock: null };
 			const blocks = output.content;
 			const blockIndex = () => blocks.length - 1;
+			const thinkingExtractor = new ThinkingTagExtractor();
+
+			// Helper to handle a text/thinking segment
+			const handleSegment = (content: string, isThinking: boolean, thoughtSignature?: string) => {
+				if (content.length === 0) return;
+
+				if (
+					!state.currentBlock ||
+					(isThinking && state.currentBlock.type !== "thinking") ||
+					(!isThinking && state.currentBlock.type !== "text")
+				) {
+					if (state.currentBlock) {
+						if (state.currentBlock.type === "text") {
+							stream.push({
+								type: "text_end",
+								contentIndex: blocks.length - 1,
+								content: state.currentBlock.text,
+								partial: output,
+							});
+						} else {
+							stream.push({
+								type: "thinking_end",
+								contentIndex: blockIndex(),
+								content: state.currentBlock.thinking,
+								partial: output,
+							});
+						}
+					}
+					if (isThinking) {
+						state.currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
+						output.content.push(state.currentBlock);
+						stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+					} else {
+						state.currentBlock = { type: "text", text: "" };
+						output.content.push(state.currentBlock);
+						stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+					}
+				}
+				if (state.currentBlock.type === "thinking") {
+					state.currentBlock.thinking += content;
+					state.currentBlock.thinkingSignature = thoughtSignature;
+					stream.push({
+						type: "thinking_delta",
+						contentIndex: blockIndex(),
+						delta: content,
+						partial: output,
+					});
+				} else {
+					state.currentBlock.text += content;
+					stream.push({
+						type: "text_delta",
+						contentIndex: blockIndex(),
+						delta: content,
+						partial: output,
+					});
+				}
+			};
+
 			for await (const chunk of googleStream) {
 				const candidate = chunk.candidates?.[0];
 				if (candidate?.content?.parts) {
 					for (const part of candidate.content.parts) {
 						if (part.text !== undefined) {
-							const isThinking = part.thought === true;
-							if (
-								!currentBlock ||
-								(isThinking && currentBlock.type !== "thinking") ||
-								(!isThinking && currentBlock.type !== "text")
-							) {
-								if (currentBlock) {
-									if (currentBlock.type === "text") {
-										stream.push({
-											type: "text_end",
-											contentIndex: blocks.length - 1,
-											content: currentBlock.text,
-											partial: output,
-										});
-									} else {
-										stream.push({
-											type: "thinking_end",
-											contentIndex: blockIndex(),
-											content: currentBlock.thinking,
-											partial: output,
-										});
-									}
-								}
-								if (isThinking) {
-									currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
-									output.content.push(currentBlock);
-									stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
-								} else {
-									currentBlock = { type: "text", text: "" };
-									output.content.push(currentBlock);
-									stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-								}
-							}
-							if (currentBlock.type === "thinking") {
-								currentBlock.thinking += part.text;
-								currentBlock.thinkingSignature = part.thoughtSignature;
-								stream.push({
-									type: "thinking_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							} else {
-								currentBlock.text += part.text;
-								stream.push({
-									type: "text_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							}
+							const extracted = thinkingExtractor.process(part.text, part.thought === true);
+							// Process thinking content first, then regular text
+							handleSegment(extracted.thinking, true, part.thoughtSignature);
+							handleSegment(extracted.text, false);
 						}
 
 						if (part.functionCall) {
-							if (currentBlock) {
-								if (currentBlock.type === "text") {
+							if (state.currentBlock) {
+								if (state.currentBlock.type === "text") {
 									stream.push({
 										type: "text_end",
 										contentIndex: blockIndex(),
-										content: currentBlock.text,
+										content: state.currentBlock.text,
 										partial: output,
 									});
 								} else {
 									stream.push({
 										type: "thinking_end",
 										contentIndex: blockIndex(),
-										content: currentBlock.thinking,
+										content: state.currentBlock.thinking,
 										partial: output,
 									});
 								}
-								currentBlock = null;
+								state.currentBlock = null;
 							}
 
 							// Generate unique ID if not provided or if it's a duplicate
@@ -202,19 +214,19 @@ export const streamGoogle: StreamFunction<"google-generative-ai"> = (
 				}
 			}
 
-			if (currentBlock) {
-				if (currentBlock.type === "text") {
+			if (state.currentBlock) {
+				if (state.currentBlock.type === "text") {
 					stream.push({
 						type: "text_end",
 						contentIndex: blockIndex(),
-						content: currentBlock.text,
+						content: state.currentBlock.text,
 						partial: output,
 					});
 				} else {
 					stream.push({
 						type: "thinking_end",
 						contentIndex: blockIndex(),
-						content: currentBlock.thinking,
+						content: state.currentBlock.thinking,
 						partial: output,
 					});
 				}

--- a/packages/ai/src/utils/thinking-tag-extractor.ts
+++ b/packages/ai/src/utils/thinking-tag-extractor.ts
@@ -1,0 +1,63 @@
+/**
+ * Extracts <thinking> tags from streaming text.
+ * Used when models leak thinking content as tags in regular text
+ * instead of using the API's native thinking mechanism.
+ */
+export class ThinkingTagExtractor {
+	private inThinkingMode = false;
+
+	/**
+	 * Process a text chunk. Returns separated thinking and regular text content.
+	 * Assumes tags are not split across chunks.
+	 */
+	process(
+		text: string,
+		isMarkedAsThinking: boolean,
+	): {
+		thinking: string;
+		text: string;
+	} {
+		// If already marked as thinking by API, pass through
+		if (isMarkedAsThinking) {
+			return { thinking: text, text: "" };
+		}
+
+		let thinking = "";
+		let regularText = "";
+		let remaining = text;
+
+		while (remaining.length > 0) {
+			if (!this.inThinkingMode) {
+				const trimmed = remaining.trimStart();
+				if (trimmed.startsWith("<thinking>")) {
+					this.inThinkingMode = true;
+					const tagIndex = remaining.indexOf("<thinking>");
+					const beforeTag = remaining.slice(0, tagIndex);
+					if (beforeTag.length > 0) {
+						regularText += beforeTag;
+					}
+					remaining = remaining.slice(tagIndex + "<thinking>".length);
+				} else {
+					regularText += remaining;
+					remaining = "";
+				}
+			} else {
+				const endTagIndex = remaining.indexOf("</thinking>");
+				if (endTagIndex !== -1) {
+					thinking += remaining.slice(0, endTagIndex);
+					remaining = remaining.slice(endTagIndex + "</thinking>".length);
+					this.inThinkingMode = false;
+				} else {
+					thinking += remaining;
+					remaining = "";
+				}
+			}
+		}
+
+		return { thinking, text: regularText };
+	}
+
+	isInThinkingMode(): boolean {
+		return this.inThinkingMode;
+	}
+}


### PR DESCRIPTION
[Add your context here]

------

<details><summary>Summary by Opus:</summary>
<p>

## Problem

Some AI models (Gemini 3 Pro, GLM 4.7) leak thinking content as `<thinking>`/`</thinking>` tags in regular text output instead of using their API's native thinking mechanism.

This causes:
- Thinking content appearing in user-visible text
- Malformed tool calls when thinking tags interrupt the output stream
- Broken agent behavior

Reference: https://github.com/badlogic/pi-mono/discussions/292

## Solution

Added a `ThinkingTagExtractor` utility class that detects and separates `<thinking>`/`</thinking>` tags from regular text content during streaming.

### Files changed

**New file:**
- `packages/ai/src/utils/thinking-tag-extractor.ts` - Utility class that tracks thinking mode state and extracts thinking content from regular text

**Modified providers:**
- `packages/ai/src/providers/google.ts` - Integrated extractor for Google Generative AI
- `packages/ai/src/providers/google-gemini-cli.ts` - Integrated extractor for Google Cloud Code Assist
- `packages/ai/src/providers/openai-completions.ts` - Integrated extractor for OpenAI-compatible endpoints

### Design decisions

1. **No split-tag handling**: Assumes tags are complete within a single chunk
2. **No nested tag handling**: Assumes tags are not nested
3. **Only process when not already marked**: If API already marks content as thinking, don't double-process
4. **Process thinking first, then text**: Ensures proper block ordering
5. **State object pattern**: Used `{ currentBlock: ... }` instead of plain variable to avoid TypeScript losing type narrowing through closures

</p>
</details>