### PR TITLE
Added support for command aliases

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -711,7 +711,11 @@ Global `~/.pi/agent/settings.json` stores persistent preferences:
   },
   "hooks": ["/path/to/hook.ts"],
   "hookTimeout": 30000,
-  "customTools": ["/path/to/tool.ts"]
+  "customTools": ["/path/to/tool.ts"],
+  "commandAliases": {
+    "new": "clear",
+    "b": "branch"
+  }
 }
 ```
 
@@ -736,6 +740,7 @@ Global `~/.pi/agent/settings.json` stores persistent preferences:
 | `hooks` | Additional hook file paths | `[]` |
 | `hookTimeout` | Timeout for hook operations (ms) | `30000` |
 | `customTools` | Additional custom tool file paths | `[]` |
+| `commandAliases` | Slash command aliases (e.g., `{"new": "clear"}`) | `{}` |
 
 ---
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -48,6 +48,7 @@ export interface Settings {
 	skills?: SkillsSettings;
 	terminal?: TerminalSettings;
 	apiKeys?: Record<string, string>; // provider -> API key (e.g., { "anthropic": "sk-..." })
+	commandAliases?: Record<string, string>; // alias -> original command (e.g., { "new": "clear" })
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -388,5 +389,9 @@ export class SettingsManager {
 
 	getApiKeys(): Record<string, string> {
 		return this.settings.apiKeys ?? {};
+	}
+
+	getCommandAliases(): Record<string, string> {
+		return this.settings.commandAliases ?? {};
 	}
 }


### PR DESCRIPTION
Feel free to reject this, but I'm getting confused between `/clear` and `/new` because it's inconsistent between agents.  All I wanted for Christmas was to hit `/new` too.  So this is a generic way in which that is possible :)

In the auto complete it shows up as alias:

<img width="497" height="173" alt="Screenshot 2025-12-24 at 23 27 07" src="https://github.com/user-attachments/assets/bc096393-32c8-4c72-8e9e-83c6f1c2abaf" />
