### PR TITLE
Fix Ctrl+W to use standard readline word deletion behavior

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -26,11 +26,10 @@ import {
 	isTab,
 } from "../keys.js";
 import type { Component } from "../tui.js";
-import { visibleWidth } from "../utils.js";
+import { getSegmenter, isPunctuationChar, isWhitespaceChar, visibleWidth } from "../utils.js";
 import { SelectList, type SelectListTheme } from "./select-list.js";
 
-// Grapheme segmenter for proper Unicode iteration (handles emojis, etc.)
-const segmenter = new Intl.Segmenter();
+const segmenter = getSegmenter();
 
 interface EditorState {
 	lines: string[];
@@ -909,30 +908,10 @@ export class Editor implements Component {
 				this.state.cursorCol = previousLine.length;
 			}
 		} else {
-			const textBeforeCursor = currentLine.slice(0, this.state.cursorCol);
-
-			const isWhitespace = (char: string): boolean => /\s/.test(char);
-			const isPunctuation = (char: string): boolean => {
-				// Treat obvious code punctuation as boundaries
-				return /[(){}[\]<>.,;:'"!?+\-=*/\\|&%^$#@~`]/.test(char);
-			};
-
-			let deleteFrom = this.state.cursorCol;
-			const lastChar = textBeforeCursor[deleteFrom - 1] ?? "";
-
-			// If immediately on whitespace or punctuation, delete that single boundary char
-			if (isWhitespace(lastChar) || isPunctuation(lastChar)) {
-				deleteFrom -= 1;
-			} else {
-				// Otherwise, delete a run of non-boundary characters (the "word")
-				while (deleteFrom > 0) {
-					const ch = textBeforeCursor[deleteFrom - 1] ?? "";
-					if (isWhitespace(ch) || isPunctuation(ch)) {
-						break;
-					}
-					deleteFrom -= 1;
-				}
-			}
+			const oldCursorCol = this.state.cursorCol;
+			this.moveWordBackwards();
+			const deleteFrom = this.state.cursorCol;
+			this.state.cursorCol = oldCursorCol;
 
 			this.state.lines[this.state.cursorLine] =
 				currentLine.slice(0, deleteFrom) + currentLine.slice(this.state.cursorCol);
@@ -1129,10 +1108,6 @@ export class Editor implements Component {
 		}
 	}
 
-	private isWordBoundary(char: string): boolean {
-		return /\s/.test(char) || /[(){}[\]<>.,;:'"!?+\-=*/\\|&%^$#@~`]/.test(char);
-	}
-
 	private moveWordBackwards(): void {
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
 
@@ -1147,21 +1122,31 @@ export class Editor implements Component {
 		}
 
 		const textBeforeCursor = currentLine.slice(0, this.state.cursorCol);
+		const graphemes = [...segmenter.segment(textBeforeCursor)];
 		let newCol = this.state.cursorCol;
-		const lastChar = textBeforeCursor[newCol - 1] ?? "";
 
-		// If immediately on whitespace or punctuation, skip that single boundary char
-		if (this.isWordBoundary(lastChar)) {
-			newCol -= 1;
+		// Skip trailing whitespace
+		while (graphemes.length > 0 && isWhitespaceChar(graphemes[graphemes.length - 1]?.segment || "")) {
+			newCol -= graphemes.pop()?.segment.length || 0;
 		}
 
-		// Now skip the "word" (non-boundary characters)
-		while (newCol > 0) {
-			const ch = textBeforeCursor[newCol - 1] ?? "";
-			if (this.isWordBoundary(ch)) {
-				break;
+		if (graphemes.length > 0) {
+			const lastGrapheme = graphemes[graphemes.length - 1]?.segment || "";
+			if (isPunctuationChar(lastGrapheme)) {
+				// Skip punctuation run
+				while (graphemes.length > 0 && isPunctuationChar(graphemes[graphemes.length - 1]?.segment || "")) {
+					newCol -= graphemes.pop()?.segment.length || 0;
+				}
+			} else {
+				// Skip word run
+				while (
+					graphemes.length > 0 &&
+					!isWhitespaceChar(graphemes[graphemes.length - 1]?.segment || "") &&
+					!isPunctuationChar(graphemes[graphemes.length - 1]?.segment || "")
+				) {
+					newCol -= graphemes.pop()?.segment.length || 0;
+				}
 			}
-			newCol -= 1;
 		}
 
 		this.state.cursorCol = newCol;
@@ -1179,24 +1164,33 @@ export class Editor implements Component {
 			return;
 		}
 
-		let newCol = this.state.cursorCol;
-		const charAtCursor = currentLine[newCol] ?? "";
+		const textAfterCursor = currentLine.slice(this.state.cursorCol);
+		const segments = segmenter.segment(textAfterCursor);
+		const iterator = segments[Symbol.iterator]();
+		let next = iterator.next();
 
-		// If on whitespace or punctuation, skip it
-		if (this.isWordBoundary(charAtCursor)) {
-			newCol += 1;
+		// Skip leading whitespace
+		while (!next.done && isWhitespaceChar(next.value.segment)) {
+			this.state.cursorCol += next.value.segment.length;
+			next = iterator.next();
 		}
 
-		// Skip the "word" (non-boundary characters)
-		while (newCol < currentLine.length) {
-			const ch = currentLine[newCol] ?? "";
-			if (this.isWordBoundary(ch)) {
-				break;
+		if (!next.done) {
+			const firstGrapheme = next.value.segment;
+			if (isPunctuationChar(firstGrapheme)) {
+				// Skip punctuation run
+				while (!next.done && isPunctuationChar(next.value.segment)) {
+					this.state.cursorCol += next.value.segment.length;
+					next = iterator.next();
+				}
+			} else {
+				// Skip word run
+				while (!next.done && !isWhitespaceChar(next.value.segment) && !isPunctuationChar(next.value.segment)) {
+					this.state.cursorCol += next.value.segment.length;
+					next = iterator.next();
+				}
 			}
-			newCol += 1;
 		}
-
-		this.state.cursorCol = newCol;
 	}
 
 	// Helper method to check if cursor is at start of message (for slash command detection)
@@ -1264,9 +1258,11 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 	private forceFileAutocomplete(): void {
 		if (!this.autocompleteProvider) return;
 
-		// Check if provider has the force method
-		const provider = this.autocompleteProvider as any;
-		if (!provider.getForceFileSuggestions) {
+		// Check if provider supports force file suggestions via runtime check
+		const provider = this.autocompleteProvider as {
+			getForceFileSuggestions?: CombinedAutocompleteProvider["getForceFileSuggestions"];
+		};
+		if (typeof provider.getForceFileSuggestions !== "function") {
 			this.tryTriggerAutocomplete(true);
 			return;
 		}
@@ -1288,7 +1284,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 
 	private cancelAutocomplete(): void {
 		this.isAutocompleting = false;
-		this.autocompleteList = undefined as any;
+		this.autocompleteList = undefined;
 		this.autocompletePrefix = "";
 	}
 

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -406,8 +406,30 @@ function wrapSingleLine(line: string, width: number): string[] {
 	return wrapped.length > 0 ? wrapped : [""];
 }
 
-// Grapheme segmenter for proper Unicode iteration (handles emojis, etc.)
-const segmenter = new Intl.Segmenter();
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+/**
+ * Get the shared grapheme segmenter instance.
+ */
+export function getSegmenter(): Intl.Segmenter {
+	return segmenter;
+}
+
+const PUNCTUATION_REGEX = /[(){}[\]<>.,;:'"!?+\-=*/\\|&%^$#@~`]/;
+
+/**
+ * Check if a character is whitespace.
+ */
+export function isWhitespaceChar(char: string): boolean {
+	return /\s/.test(char);
+}
+
+/**
+ * Check if a character is punctuation.
+ */
+export function isPunctuationChar(char: string): boolean {
+	return PUNCTUATION_REGEX.test(char);
+}
 
 function breakLongWord(word: string, width: number, tracker: AnsiCodeTracker): string[] {
 	const lines: string[] = [];


### PR DESCRIPTION
## Summary
Fixes Ctrl+W in TUI input components to match standard readline behavior: skip trailing whitespace before deleting the preceding word.

Previously, `foo bar |` (cursor after space) would only delete the space. Now it correctly deletes to `foo |`.

## Changes
- **Readline-style word deletion**: Ctrl+W now skips trailing whitespace, then deletes either a punctuation run or a word run
- **Grapheme-aware**: All word navigation and deletion uses `Intl.Segmenter` to safely handle emojis and multi-code-unit characters
- **Word navigation for Input**: Added Ctrl+Left/Right and Alt+Left/Right support to the single-line Input component
- **Full Unicode input**: Input component now accepts Unicode characters while rejecting control characters (C0/C1/DEL)
- **Shared utilities**: Extracted `getSegmenter()`, `isWhitespaceChar()`, `isPunctuationChar()` to `utils.ts`
- **Type safety**: Replaced unsafe `as any` cast in `Editor.forceFileAutocomplete` with runtime type check

## Testing
- Added comprehensive tests for Ctrl+W with trailing whitespace, punctuation runs, emojis, and line merging
- Added tests for Ctrl+Left/Right word navigation including forward movement over whitespace and punctuation
- All 75 TUI tests pass