### PR TITLE
Add safety-space before pasting

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -700,7 +700,7 @@ export class Editor implements Component {
 			const currentLine = this.state.lines[this.state.cursorLine] || "";
 			const charBeforeCursor = this.state.cursorCol > 0 ? currentLine[this.state.cursorCol - 1] : "";
 			if (charBeforeCursor && /\w/.test(charBeforeCursor)) {
-				filteredText = " " + filteredText;
+				filteredText = ` ${filteredText}`;
 			}
 		}
 


### PR DESCRIPTION
When pasting file paths in this now adds a leading space to separate out paths.  This is mostly useful when dragging screenshots from the macos UI.

<img width="912" height="680" alt="image" src="https://github.com/user-attachments/assets/fc644523-b742-418d-a8ff-ff89a83dfc16" />

After dropping:

<img width="912" height="680" alt="image" src="https://github.com/user-attachments/assets/a6416462-3d4a-48a9-9f1c-32f69d44e299" />

If the word on the left is not a word boundary (eg: already space, punctuation etc.) nothing changes.