### PR TITLE
fix: Use bash instead of sh on Unix systems

### DIFF
--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -26,8 +26,9 @@ function findBashOnPath(): string | null {
  * Get shell configuration based on platform.
  * Resolution order:
  * 1. User-specified shellPath in settings.json
- * 2. On Windows: Git Bash in known locations
- * 3. Fallback: bash on PATH (Windows) or sh (Unix)
+ * 2. On Windows: Git Bash in known locations, then bash on PATH
+ * 3. On Unix: /bin/bash
+ * 4. Fallback: sh
  */
 export function getShellConfig(): { shell: string; args: string[] } {
 	if (cachedShellConfig) {
@@ -81,6 +82,12 @@ export function getShellConfig(): { shell: string; args: string[] } {
 				`  3. Set shellPath in ~/.pi/agent/settings.json\n\n` +
 				`Searched Git Bash in:\n${paths.map((p) => `  ${p}`).join("\n")}`,
 		);
+	}
+
+	// Unix: prefer bash over sh
+	if (existsSync("/bin/bash")) {
+		cachedShellConfig = { shell: "/bin/bash", args: ["-c"] };
+		return cachedShellConfig;
 	}
 
 	cachedShellConfig = { shell: "sh", args: ["-c"] };


### PR DESCRIPTION
The bash tool is named "bash" and described as executing bash commands, but was using sh on Unix. On many distros (Ubuntu, Debian, Alpine, etc.), /bin/sh is a POSIX-only shell that doesn't support bash syntax like [[ ]], arrays, or here-strings. This caused the LLM to write bash syntax that failed, wasting tokens on rewrites.

Now prefers /bin/bash on Unix, falling back to sh only if bash isn't found.