### PR TITLE
Add `enabledModels` to `settings.json`

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`enabledModels` setting**: Configure whitelisted models in `settings.json` (same format as `--models` CLI flag). CLI `--models` takes precedence over the setting.
+
 ## [0.30.2] - 2025-12-26
 
 ### Changed

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -699,6 +699,7 @@ Global `~/.pi/agent/settings.json` stores persistent preferences:
   "defaultProvider": "anthropic",
   "defaultModel": "claude-sonnet-4-20250514",
   "defaultThinkingLevel": "medium",
+  "enabledModels": ["claude-sonnet", "gpt-4o", "gemini-2.5-pro:high"],
   "queueMode": "one-at-a-time",
   "shellPath": "C:\\path\\to\\bash.exe",
   "hideThinkingBlock": false,
@@ -731,6 +732,7 @@ Global `~/.pi/agent/settings.json` stores persistent preferences:
 | `defaultProvider` | Default model provider | - |
 | `defaultModel` | Default model ID | - |
 | `defaultThinkingLevel` | Thinking level: `off`, `minimal`, `low`, `medium`, `high`, `xhigh` | - |
+| `enabledModels` | Model patterns for cycling (same as `--models` CLI flag) | - |
 | `queueMode` | Message queue mode: `all` or `one-at-a-time` | `one-at-a-time` |
 | `shellPath` | Custom bash path (Windows) | auto-detected |
 | `hideThinkingBlock` | Hide thinking blocks in output (Ctrl+T to toggle) | `false` |

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -47,6 +47,7 @@ export interface Settings {
 	customTools?: string[]; // Array of custom tool file paths
 	skills?: SkillsSettings;
 	terminal?: TerminalSettings;
+	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -364,5 +365,9 @@ export class SettingsManager {
 		}
 		this.globalSettings.terminal.showImages = show;
 		this.save();
+	}
+
+	getEnabledModels(): string[] | undefined {
+		return this.settings.enabledModels;
 	}
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -341,8 +341,9 @@ export async function main(args: string[]) {
 	time("initTheme");
 
 	let scopedModels: ScopedModel[] = [];
-	if (parsed.models && parsed.models.length > 0) {
-		scopedModels = await resolveModelScope(parsed.models, modelRegistry);
+	const modelPatterns = parsed.models ?? settingsManager.getEnabledModels();
+	if (modelPatterns && modelPatterns.length > 0) {
+		scopedModels = await resolveModelScope(modelPatterns, modelRegistry);
 		time("resolveModelScope");
 	}
 


### PR DESCRIPTION
Not sure about the naming, but personally I only use claude sonnet/opus 4.5 and glm-4.7 so this is useful to configure globally instead of having to pass it to `--models`.