### PR TITLE
feat: Allow global custom tools to override built-in tools

### DIFF
--- a/packages/coding-agent/docs/custom-tools.md
+++ b/packages/coding-agent/docs/custom-tools.md
@@ -53,12 +53,12 @@ The tool is automatically discovered and available in your next pi session.
 
 Tools must be in a subdirectory with an `index.ts` entry point:
 
-| Location | Scope | Auto-discovered |
-|----------|-------|-----------------|
-| `~/.pi/agent/tools/*/index.ts` | Global (all projects) | Yes |
-| `.pi/tools/*/index.ts` | Project-local | Yes |
-| `settings.json` `customTools` array | Configured paths | Yes |
-| `--tool <path>` CLI flag | One-off/debugging | No |
+| Location | Scope | Auto-discovered | Can Override Built-ins |
+|----------|-------|-----------------|------------------------|
+| `~/.pi/agent/tools/*/index.ts` | Global (all projects) | Yes | Yes |
+| `.pi/tools/*/index.ts` | Project-local | Yes | No |
+| `settings.json` `customTools` array | Configured paths | Yes | Yes |
+| `--tool <path>` CLI flag | One-off/debugging | No | Yes |
 
 **Example structure:**
 ```
@@ -73,7 +73,16 @@ Tools must be in a subdirectory with an `index.ts` entry point:
 
 **Priority:** Later sources win on name conflicts. CLI `--tool` takes highest priority.
 
-**Reserved names:** Custom tools cannot use built-in tool names (`read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`).
+### Overriding Built-in Tools
+
+Global tools (`~/.pi/agent/tools/`) can override built-in tools like `bash`, `read`, `write`, etc. This allows you to:
+- Add features to existing tools (e.g., background process support for `bash`)
+- Customize tool behavior for your workflow
+- Prototype changes before contributing upstream
+
+Project-local tools (`.pi/tools/`) **cannot** override built-ins for security reasons - a malicious repository could otherwise hijack tool behavior.
+
+Overridden tools appear in the "Loaded custom tools" list at startup.
 
 ## Available Imports
 

--- a/packages/coding-agent/src/core/custom-tools/index.ts
+++ b/packages/coding-agent/src/core/custom-tools/index.ts
@@ -2,7 +2,7 @@
  * Custom tools module.
  */
 
-export { discoverAndLoadCustomTools, loadCustomTools } from "./loader.js";
+export { discoverAndLoadCustomTools, loadCustomTools, type ToolPathInfo } from "./loader.js";
 export type {
 	AgentToolUpdateCallback,
 	CustomAgentTool,

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -532,7 +532,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 	}
 
-	let allToolsArray: Tool[] = [...builtInTools, ...customToolsResult.tools.map((lt) => lt.tool as unknown as Tool)];
+	// Custom tools can override built-ins - filter out shadowed built-ins
+	const customToolNames = new Set(customToolsResult.tools.map((lt) => lt.tool.name));
+	const filteredBuiltIns = builtInTools.filter((t) => !customToolNames.has(t.name));
+	let allToolsArray: Tool[] = [
+		...filteredBuiltIns,
+		...customToolsResult.tools.map((lt) => lt.tool as unknown as Tool),
+	];
 	time("combineTools");
 	if (hookRunner) {
 		allToolsArray = wrapToolsWithHooks(allToolsArray, hookRunner) as Tool[];

--- a/packages/coding-agent/test/custom-tools-loader.test.ts
+++ b/packages/coding-agent/test/custom-tools-loader.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for custom tool loader override behavior.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("Custom Tools Loader - Override Logic", () => {
+	// Simulates the override logic from loader.ts
+	function checkOverrides(
+		tools: Array<{ name: string; canOverride: boolean }>,
+		builtInNames: string[],
+	): { loaded: string[]; errors: string[] } {
+		const builtInSet = new Set(builtInNames);
+		const seenNames = new Set<string>();
+		const loaded: string[] = [];
+		const errors: string[] = [];
+
+		for (const { name, canOverride } of tools) {
+			if (seenNames.has(name)) {
+				errors.push(`${name}: conflicts with another custom tool`);
+				continue;
+			}
+			if (builtInSet.has(name) && !canOverride) {
+				errors.push(`${name}: cannot override built-in`);
+				continue;
+			}
+			seenNames.add(name);
+			loaded.push(name);
+		}
+		return { loaded, errors };
+	}
+
+	it("should allow global tools to override built-ins", () => {
+		const result = checkOverrides([{ name: "bash", canOverride: true }], ["bash", "read"]);
+		expect(result.loaded).toContain("bash");
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it("should reject project-local tools overriding built-ins", () => {
+		const result = checkOverrides([{ name: "bash", canOverride: false }], ["bash", "read"]);
+		expect(result.loaded).not.toContain("bash");
+		expect(result.errors[0]).toContain("cannot override");
+	});
+
+	it("should allow non-conflicting tools from any source", () => {
+		const result = checkOverrides(
+			[
+				{ name: "my-tool", canOverride: false },
+				{ name: "other", canOverride: true },
+			],
+			["bash"],
+		);
+		expect(result.loaded).toEqual(["my-tool", "other"]);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it("should reject duplicate custom tool names", () => {
+		const result = checkOverrides(
+			[
+				{ name: "my-tool", canOverride: true },
+				{ name: "my-tool", canOverride: false },
+			],
+			[],
+		);
+		expect(result.loaded).toEqual(["my-tool"]);
+		expect(result.errors[0]).toContain("conflicts with another");
+	});
+});


### PR DESCRIPTION
Another stubborn PR ;-)

This enables users to customize built-in tool behavior (bash, read, write, etc.) by placing a custom tool with the same name in ~/.pi/agent/tools/.

Motivation: PR #327 proposed adding background process support to the bash tool, which was rejected.  The alternative is to add a skill or custom tool just for running background processes.  But that seems less than ideal since there'll be two tools that do almost the same to confuse the LLM.  So this patch allows also overriding built-in tools.

It comes with a security model that may be heavy.  If we don't care about which folder can override what then I believe this could be simplified.

Security model:
- Global tools (~/.pi/agent/tools/) CAN override built-ins (user-controlled)
- Project-local tools (.pi/tools/) CANNOT override built-ins (untrusted)
- Configured paths (settings.json, --tool) CAN override (user-configured)

This prevents malicious repositories from hijacking tool behavior while giving users full control over their own environment.

Changes:
- Add ToolPathInfo interface to track override permissions per tool path
- Check canOverrideBuiltIns flag when loading tools with built-in name conflicts
- Filter out shadowed built-ins when combining tool arrays in SDK
- Update docs with new "Can Override Built-ins" column