### PR TITLE
fix: remove duplicate compaction warning message

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`enabledModels` setting**: Configure whitelisted models in `settings.json` (same format as `--models` CLI flag). CLI `--models` takes precedence over the setting.
 
+### Fixed
+
+- **Duplicate compaction warning**: Compaction message was displayed twice after manual `/compact` or auto-compaction. ([#341](https://github.com/badlogic/pi-mono/pull/341) by [@aliou](https://github.com/aliou))
+
 ## [0.30.2] - 2025-12-26
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -920,12 +920,9 @@ export class InteractiveMode {
 					this.showStatus("Auto-compaction cancelled");
 				} else if (event.result) {
 					// Rebuild chat to show compacted state
+					// Note: renderMessages() already creates the CompactionComponent from the summary message
 					this.chatContainer.clear();
 					this.rebuildChatFromMessages();
-					// Add compaction component (same as manual /compact)
-					const compactionComponent = new CompactionComponent(event.result.tokensBefore, event.result.summary);
-					compactionComponent.setExpanded(this.toolOutputExpanded);
-					this.chatContainer.addChild(compactionComponent);
 					this.footer.updateState(this.session.state);
 				}
 				this.ui.requestRender();
@@ -1941,16 +1938,12 @@ export class InteractiveMode {
 		this.ui.requestRender();
 
 		try {
-			const result = await this.session.compact(customInstructions);
+			await this.session.compact(customInstructions);
 
 			// Rebuild UI
+			// Note: renderMessages() already creates the CompactionComponent from the summary message
 			this.chatContainer.clear();
 			this.rebuildChatFromMessages();
-
-			// Add compaction component
-			const compactionComponent = new CompactionComponent(result.tokensBefore, result.summary);
-			compactionComponent.setExpanded(this.toolOutputExpanded);
-			this.chatContainer.addChild(compactionComponent);
 
 			this.footer.updateState(this.session.state);
 		} catch (error) {


### PR DESCRIPTION
Hello!



Noticed this while testing the custom compaction hook:

<img width="1126" height="1252" alt="Screenshot 2025-12-28 at 02 58 00 PM@2x" src="https://github.com/user-attachments/assets/3e20614c-66f8-4ea0-bc9c-226cee126352" />


It seems like this only occurs immediately after compaction; resuming a conversation doesn't display both message; looking at the session file only one entry is saved.

------

<details><summary>Summary by Opus</summary>
<p>

## Problem

When using `/compact` command (manual compaction) or auto-compaction, the compaction warning message was displayed **twice**:

```
Earlier messages compacted from 29,740 tokens (ctrl+o to expand)
Earlier messages compacted from 29,740 tokens (ctrl+o to expand)
```

Pressing `ctrl+o` to expand also showed the summary twice.

## Root Cause

After compaction completes, `rebuildChatFromMessages()` is called which internally calls `renderMessages()`. The `renderMessages()` function already detects summary messages (with `SUMMARY_PREFIX`) and creates a `CompactionComponent`. However, immediately after `rebuildChatFromMessages()` returned, the code was manually adding another `CompactionComponent`, causing duplication.

This happened in two places:
- Auto-compaction handler (`case "auto_compaction_end"`)
- Manual `/compact` command handler

## Fix

Removed the redundant manual `CompactionComponent` creation after `rebuildChatFromMessages()` in both handlers. The component is now only created once by `renderMessages()`.

</p>
</details>