### PR TITLE
make mom fetch apiKey from `authStorage`

### DIFF
--- a/packages/mom/README.md
+++ b/packages/mom/README.md
@@ -64,8 +64,7 @@ export MOM_SLACK_APP_TOKEN=xapp-...
 export MOM_SLACK_BOT_TOKEN=xoxb-...
 # Option 1: Anthropic API key
 export ANTHROPIC_API_KEY=sk-ant-...
-# Option 2: Anthropic Pro/Max (use `claude setup-token`)
-export ANTHROPIC_OAUTH_TOKEN=sk-ant-...
+# Option 2: use /login command in pi agent, then copy/link auth.json to ~/.pi/mom/
 
 # Create Docker sandbox (recommended)
 docker run -d \
@@ -96,8 +95,24 @@ Options:
 |----------|-------------|
 | `MOM_SLACK_APP_TOKEN` | Slack app-level token (xapp-...) |
 | `MOM_SLACK_BOT_TOKEN` | Slack bot token (xoxb-...) |
-| `ANTHROPIC_API_KEY` | Anthropic API key |
-| `ANTHROPIC_OAUTH_TOKEN` | Alternative: Anthropic OAuth token |
+| `ANTHROPIC_API_KEY` | (Optional) Anthropic API key |
+
+## Authentication
+
+Mom needs credentials for Anthropic API. The options to set it are:
+
+1. **Environment Variable**
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+2. **OAuth Login via coding agent command** (Recommended for Claude Pro/Max)
+
+- run interactive coding agent session: `npx @mariozechner/pi-coding-agent`
+- enter `/login` command
+  - choose "Anthropic" provider
+  - follow instructions in the browser
+- link `auth.json` to mom: `ln -s ~/.pi/agent/auth.json ~/.pi/mom/auth.json`
 
 ## How Mom Works
 

--- a/packages/mom/src/main.ts
+++ b/packages/mom/src/main.ts
@@ -16,8 +16,6 @@ import { ChannelStore } from "./store.js";
 
 const MOM_SLACK_APP_TOKEN = process.env.MOM_SLACK_APP_TOKEN;
 const MOM_SLACK_BOT_TOKEN = process.env.MOM_SLACK_BOT_TOKEN;
-const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
-const ANTHROPIC_OAUTH_TOKEN = process.env.ANTHROPIC_OAUTH_TOKEN;
 
 interface ParsedArgs {
 	workingDir?: string;
@@ -74,8 +72,8 @@ if (!parsedArgs.workingDir) {
 
 const { workingDir, sandbox } = { workingDir: parsedArgs.workingDir, sandbox: parsedArgs.sandbox };
 
-if (!MOM_SLACK_APP_TOKEN || !MOM_SLACK_BOT_TOKEN || (!ANTHROPIC_API_KEY && !ANTHROPIC_OAUTH_TOKEN)) {
-	console.error("Missing env: MOM_SLACK_APP_TOKEN, MOM_SLACK_BOT_TOKEN, ANTHROPIC_API_KEY or ANTHROPIC_OAUTH_TOKEN");
+if (!MOM_SLACK_APP_TOKEN || !MOM_SLACK_BOT_TOKEN) {
+	console.error("Missing env: MOM_SLACK_APP_TOKEN, MOM_SLACK_BOT_TOKEN");
 	process.exit(1);
 }
 


### PR DESCRIPTION
Addresses https://github.com/badlogic/pi-mono/issues/340.

Use AuthStorage to get the API key.
If auth.json is found in ~/.pi/mom/ it will be used for auth.
ANTHROPIC_API_KEY still works as fallback (not the OAUTH tho).