### PR TITLE
Fix /copy after aborts

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1525,7 +1525,13 @@ export class AgentSession {
 		const lastAssistant = this.messages
 			.slice()
 			.reverse()
-			.find((m) => m.role === "assistant");
+			.find((m) => {
+				if (m.role !== "assistant") return false;
+				const msg = m as AssistantMessage;
+				// Skip aborted messages with no content
+				if (msg.stopReason === "aborted" && msg.content.length === 0) return false;
+				return true;
+			});
 
 		if (!lastAssistant) return null;
 


### PR DESCRIPTION
When a user aborts a request (ctrl+c), an assistant message with empty content and stopReason: "aborted" is saved to the session. After resuming with `--resume`, the `/copy` command failed with "Error: No agent messages to copy yet." because `getLastAssistantText()` finds this empty aborted message and returns null.

This changes it to just ignore abort messages.