### PR TITLE
Fix edit tool failing on Windows due to CRLF line endings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4013,6 +4013,7 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.2.tgz",
 			"integrity": "sha512-o+avdUAD1v94oHkjGBhiMhBV4WBHxhbu0+CUVH78hhphKy/OKQLxtKjkmmNcrMlbYAhAbsM/9F+l3KnYxyD3Lg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -4582,6 +4583,7 @@
 			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
 			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@lit/reactive-element": "^2.1.0",
 				"lit-element": "^4.2.0",
@@ -5702,6 +5704,7 @@
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
 			"integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -5730,7 +5733,8 @@
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
 			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -5995,6 +5999,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
 			"integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`enabledModels` setting**: Configure whitelisted models in `settings.json` (same format as `--models` CLI flag). CLI `--models` takes precedence over the setting.
 
+### Fixed
+
+- **Edit tool fails on Windows due to CRLF line endings**: Files with CRLF line endings now match correctly when LLMs send LF-only text. Line endings are normalized before matching and restored to original style on write. ([#355](https://github.com/badlogic/pi-mono/issues/355))
+
 ## [0.30.2] - 2025-12-26
 
 ### Changed


### PR DESCRIPTION
## Problem

The `edit` tool fails on Windows because files use CRLF (`\r\n`) line endings, but LLMs generate `oldText` with LF (`\n`) only. The exact match requirement causes "text not found" errors.

## Solution

Normalize line endings before matching, restore original style on write.

### Helper functions added

```typescript
function detectLineEnding(content: string): "\r\n" | "\n" {
    const crlfIdx = content.indexOf("\r\n");
    const lfIdx = content.indexOf("\n");
    if (lfIdx === -1) return "\n";
    if (crlfIdx === -1) return "\n";
    return crlfIdx < lfIdx ? "\r\n" : "\n";
}

function normalizeToLF(text: string): string {
    return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
}

function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string {
    return ending === "\r\n" ? text.replace(/\n/g, "\r\n") : text;
}
```

### Flow

1. Detect original line ending style after reading file
2. Normalize file content, `oldText`, and `newText` to LF
3. Perform all matching and replacement on normalized content
4. Restore original line endings before writing

### Behavior changes

- Files with mixed line endings normalize to first-found style
- Same text appearing with different line endings now counts as duplicates (correct behavior)
- Lone CR (`\r`) is treated as line ending and normalized

## Tests added

- CRLF file + LF oldText from LLM matches successfully
- CRLF line endings preserved after edit
- LF line endings preserved for LF files  
- Duplicate text with different line endings errors correctly

Fixes #355