### PR TITLE
tui: coalesce sequential status messages

### DIFF
--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1,0 +1,57 @@
+import { Container } from "@mariozechner/pi-tui";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+function renderLastLine(container: Container, width = 120): string {
+	const last = container.children[container.children.length - 1];
+	if (!last) return "";
+	return last.render(width).join("\n");
+}
+
+describe("InteractiveMode.showStatus", () => {
+	beforeAll(() => {
+		// showStatus uses the global theme instance
+		initTheme("dark");
+	});
+
+	test("coalesces immediately-sequential status messages", () => {
+		const fakeThis: any = {
+			chatContainer: new Container(),
+			ui: { requestRender: vi.fn() },
+			lastStatusSpacer: null,
+			lastStatusText: null,
+		};
+
+		(InteractiveMode as any).prototype.showStatus.call(fakeThis, "STATUS_ONE");
+		expect(fakeThis.chatContainer.children).toHaveLength(2);
+		expect(renderLastLine(fakeThis.chatContainer)).toContain("STATUS_ONE");
+
+		(InteractiveMode as any).prototype.showStatus.call(fakeThis, "STATUS_TWO");
+		// second status updates the previous line instead of appending
+		expect(fakeThis.chatContainer.children).toHaveLength(2);
+		expect(renderLastLine(fakeThis.chatContainer)).toContain("STATUS_TWO");
+		expect(renderLastLine(fakeThis.chatContainer)).not.toContain("STATUS_ONE");
+	});
+
+	test("appends a new status line if something else was added in between", () => {
+		const fakeThis: any = {
+			chatContainer: new Container(),
+			ui: { requestRender: vi.fn() },
+			lastStatusSpacer: null,
+			lastStatusText: null,
+		};
+
+		(InteractiveMode as any).prototype.showStatus.call(fakeThis, "STATUS_ONE");
+		expect(fakeThis.chatContainer.children).toHaveLength(2);
+
+		// Something else gets added to the chat in between status updates
+		fakeThis.chatContainer.addChild({ render: () => ["OTHER"], invalidate: () => {} });
+		expect(fakeThis.chatContainer.children).toHaveLength(3);
+
+		(InteractiveMode as any).prototype.showStatus.call(fakeThis, "STATUS_TWO");
+		// adds spacer + text
+		expect(fakeThis.chatContainer.children).toHaveLength(5);
+		expect(renderLastLine(fakeThis.chatContainer)).toContain("STATUS_TWO");
+	});
+});


### PR DESCRIPTION
# PR: tui: coalesce sequential status messages

## Title
`tui: coalesce sequential status messages`

## Context
The interactive TUI currently appends a new chat-line for every status update. When status updates come in rapid succession (e.g. cycling thinking levels), this can spam the chat log.

## What this changes
In `InteractiveMode.showStatus()` we now **mutate the most recent status line** when the next status update is emitted *immediately sequentially* (i.e. nothing else was appended to the chat in between).

Behavior:
- If two status messages happen back-to-back: update the previous status `Text` instead of appending a new spacer + line.
- If anything else was added to the chat between status calls: append a fresh status line (unchanged behavior).

## Implementation notes
- Tracks the last status `Spacer` and `Text` instance; only coalesces when the chat tail still matches those exact instances.

## Tests
- Added unit test coverage for coalescing and the “something else added in between” case.

## How to test manually
- In interactive mode, rapidly change thinking level (Shift+Tab) and confirm the chat log does not grow with repeated “Thinking level: …” lines.

## Links
- Part of: #364
