### PR TITLE
tui: refine thinking trace color (theme token)

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -53,16 +53,15 @@ export class AssistantMessageComponent extends Container {
 
 				if (this.hideThinkingBlock) {
 					// Show static "Thinking..." label when hidden
-					this.contentContainer.addChild(new Text(theme.fg("muted", "Thinking..."), 1, 0));
+					this.contentContainer.addChild(new Text(theme.italic(theme.fg("thinkingText", "Thinking...")), 1, 0));
 					if (hasTextAfter) {
 						this.contentContainer.addChild(new Spacer(1));
 					}
 				} else {
-					// Thinking traces in muted color, italic
-					// Use Markdown component with default text style for consistent styling
+					// Thinking traces: subtle/harmonized color, italic
 					this.contentContainer.addChild(
 						new Markdown(content.thinking.trim(), 1, 0, getMarkdownTheme(), {
-							color: (text: string) => theme.fg("muted", text),
+							color: (text: string) => theme.fg("thinkingText", text),
 							italic: true,
 						}),
 					);

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -29,6 +29,7 @@
 		"muted": "gray",
 		"dim": "dimGray",
 		"text": "",
+		"thinkingText": "#c0c0c0",
 
 		"selectedBg": "selectedBg",
 		"userMessageBg": "userMsgBg",

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -28,6 +28,7 @@
 		"muted": "mediumGray",
 		"dim": "dimGray",
 		"text": "",
+		"thinkingText": "mediumGray",
 
 		"selectedBg": "selectedBg",
 		"userMessageBg": "userMsgBg",

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -34,6 +34,8 @@ const ThemeJsonSchema = Type.Object({
 		muted: ColorValueSchema,
 		dim: ColorValueSchema,
 		text: ColorValueSchema,
+		// Thinking traces (assistant reasoning)
+		thinkingText: ColorValueSchema,
 		// Backgrounds & Content Text (11 colors)
 		selectedBg: ColorValueSchema,
 		userMessageBg: ColorValueSchema,
@@ -98,6 +100,7 @@ export type ThemeColor =
 	| "muted"
 	| "dim"
 	| "text"
+	| "thinkingText"
 	| "userMessageText"
 	| "customMessageText"
 	| "customMessageLabel"
@@ -466,7 +469,11 @@ function loadThemeJson(name: string): ThemeJson {
 		for (const e of errors) {
 			// Check for missing required color properties
 			const match = e.path.match(/^\/colors\/(\w+)$/);
-			if (match && e.message.includes("Required")) {
+			const isMissingRequired =
+				e.message.includes("Required") ||
+				e.message.includes("required property") ||
+				e.message.includes("Expected required property");
+			if (match && isMissingRequired) {
 				missingColors.push(match[1]);
 			} else {
 				otherErrors.push(`  - ${e.path}: ${e.message}`);
@@ -509,7 +516,12 @@ function createTheme(themeJson: ThemeJson, mode?: ColorMode): Theme {
 			fgColors[key as ThemeColor] = value;
 		}
 	}
-	return new Theme(fgColors, bgColors, colorMode);
+
+	return new Theme(
+		fgColors as Record<ThemeColor, string | number>,
+		bgColors as Record<ThemeBg, string | number>,
+		colorMode,
+	);
 }
 
 function loadTheme(name: string, mode?: ColorMode): Theme {

--- a/packages/coding-agent/test/theme-thinking-text.test.ts
+++ b/packages/coding-agent/test/theme-thinking-text.test.ts
@@ -1,0 +1,52 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { initTheme, setTheme, theme } from "../src/modes/interactive/theme/theme.js";
+
+describe("theme: thinkingText", () => {
+	const prevAgentDir = process.env.PI_CODING_AGENT_DIR;
+	let tmpAgentDir: string;
+
+	beforeAll(() => {
+		initTheme("dark");
+
+		tmpAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-agent-dir-"));
+		process.env.PI_CODING_AGENT_DIR = tmpAgentDir;
+		fs.mkdirSync(path.join(tmpAgentDir, "themes"), { recursive: true });
+
+		// Base it on the built-in dark theme, but remove thinkingText.
+		// This simulates an outdated custom theme file.
+		const darkThemePath = path.join(process.cwd(), "src", "modes", "interactive", "theme", "dark.json");
+		const json = JSON.parse(fs.readFileSync(darkThemePath, "utf-8"));
+		json.name = "no-thinking-text";
+		delete json.colors.thinkingText;
+
+		fs.writeFileSync(path.join(tmpAgentDir, "themes", "no-thinking-text.json"), JSON.stringify(json, null, 2));
+	});
+
+	afterAll(() => {
+		// Restore environment
+		if (prevAgentDir === undefined) {
+			delete process.env.PI_CODING_AGENT_DIR;
+		} else {
+			process.env.PI_CODING_AGENT_DIR = prevAgentDir;
+		}
+
+		try {
+			fs.rmSync(tmpAgentDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test("rejects a custom theme without thinkingText", () => {
+		const result = setTheme("no-thinking-text");
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("Missing required color tokens");
+		expect(result.error).toContain("thinkingText");
+
+		// Should still have a valid theme loaded (fallback to dark)
+		expect(() => theme.fg("thinkingText", "hello")).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary
This PR makes the thinking trace color theme-configurable via a new **required** theme token: `thinkingText`.

Thinking traces (and the hidden "Thinking…" placeholder) are rendered using:
- `thinkingText` color
- italic styling

No extra indentation/padding is applied (to keep copy/paste clean).

## Theme changes
- `thinkingText` is now a **required** color token in the theme JSON schema.
- Built-in themes (`dark.json`, `light.json`) define `thinkingText`.
- Custom themes missing `thinkingText` are rejected with a validation error that lists missing required tokens.

## Tests
- Adds a test that loads a custom theme missing `thinkingText` and verifies it is rejected.

## Manual test
- Use a model that emits thinking blocks.
- Confirm thinking traces are subtler/different from normal assistant text (theme-dependent), and copy/paste does not gain leading spaces.

Part of #364
