### PR TITLE
tui: distinguish agent working vs tool running

### DIFF
--- a/packages/coding-agent/test/bash-execution-component.test.ts
+++ b/packages/coding-agent/test/bash-execution-component.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test, vi } from "vitest";
+import { BashExecutionComponent } from "../src/modes/interactive/components/bash-execution.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+describe("BashExecutionComponent", () => {
+	test("can disable the inline loader to avoid duplicate running indicators", () => {
+		initTheme("dark");
+
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation(() => 123 as any);
+		vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+
+		const ui = { terminal: { columns: 80 }, requestRender: () => {} } as any;
+		const component = new BashExecutionComponent("sleep 5", ui, { showLoader: false });
+
+		expect(setIntervalSpy).not.toHaveBeenCalled();
+
+		const rendered = component.render(120).join("\n");
+		expect(rendered).not.toContain("Running...");
+
+		setIntervalSpy.mockRestore();
+	});
+});

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -2,10 +2,18 @@ import type { TUI } from "../tui.js";
 import { Text } from "./text.js";
 
 /**
- * Loader component that updates every 80ms with spinning animation
+ * Loader component that updates periodically with a spinning animation.
  */
+export interface LoaderOptions {
+	/** Animation frames to use (defaults to braille spinner) */
+	frames?: string[];
+	/** Interval between frames in ms (defaults to 80ms) */
+	intervalMs?: number;
+}
+
 export class Loader extends Text {
-	private frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+	private frames: string[] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+	private intervalMs = 80;
 	private currentFrame = 0;
 	private intervalId: NodeJS.Timeout | null = null;
 	private ui: TUI | null = null;
@@ -15,9 +23,16 @@ export class Loader extends Text {
 		private spinnerColorFn: (str: string) => string,
 		private messageColorFn: (str: string) => string,
 		private message: string = "Loading...",
+		options: LoaderOptions = {},
 	) {
 		super("", 1, 0);
 		this.ui = ui;
+		if (options.frames && options.frames.length > 0) {
+			this.frames = options.frames;
+		}
+		if (typeof options.intervalMs === "number" && Number.isFinite(options.intervalMs) && options.intervalMs > 0) {
+			this.intervalMs = options.intervalMs;
+		}
 		this.start();
 	}
 
@@ -30,7 +45,7 @@ export class Loader extends Text {
 		this.intervalId = setInterval(() => {
 			this.currentFrame = (this.currentFrame + 1) % this.frames.length;
 			this.updateDisplay();
-		}, 80);
+		}, this.intervalMs);
 	}
 
 	stop() {

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Loader } from "../src/components/loader.js";
+
+describe("Loader", () => {
+	it("uses default braille frames and 80ms interval by default", () => {
+		const originalSetInterval = globalThis.setInterval;
+		const originalClearInterval = globalThis.clearInterval;
+
+		let intervalMs: number | undefined;
+		let tick: (() => void) | undefined;
+		let cleared: any;
+
+		(globalThis as any).setInterval = (fn: () => void, ms: number) => {
+			intervalMs = ms;
+			tick = fn;
+			return 123 as any;
+		};
+		(globalThis as any).clearInterval = (id: any) => {
+			cleared = id;
+		};
+
+		try {
+			const ui = { requestRender: () => {} } as any;
+			const loader = new Loader(
+				ui,
+				(s) => s,
+				(s) => s,
+				"MSG",
+			);
+
+			// First frame should be braille spinner start (⠋)
+			const first = loader.render(40)[1].trim();
+			assert.ok(first.startsWith("⠋ "), `expected first frame to start with '⠋', got: ${first}`);
+			assert.ok(first.includes("MSG"));
+			assert.strictEqual(intervalMs, 80);
+
+			// Simulate one tick -> should advance to next braille frame (⠙)
+			assert.ok(tick);
+			tick?.();
+			const second = loader.render(40)[1].trim();
+			assert.ok(second.startsWith("⠙ "), `expected second frame to start with '⠙', got: ${second}`);
+
+			loader.stop();
+			assert.strictEqual(cleared, 123);
+		} finally {
+			globalThis.setInterval = originalSetInterval;
+			globalThis.clearInterval = originalClearInterval;
+		}
+	});
+
+	it("supports custom frames and interval", () => {
+		const originalSetInterval = globalThis.setInterval;
+		(globalThis as any).setInterval = (fn: () => void, ms: number) => {
+			// Capture interval and tick, but don't actually schedule.
+			(globalThis as any).__ms = ms;
+			(globalThis as any).__tick = fn;
+			return 456 as any;
+		};
+
+		try {
+			const ui = { requestRender: () => {} } as any;
+			const loader = new Loader(
+				ui,
+				(s) => s,
+				(s) => s,
+				"MSG",
+				{
+					frames: ["A", "B"],
+					intervalMs: 100,
+				},
+			);
+
+			assert.strictEqual((globalThis as any).__ms, 100);
+			assert.ok(loader.render(40)[1].trim().startsWith("A "));
+
+			(globalThis as any).__tick();
+			assert.ok(loader.render(40)[1].trim().startsWith("B "));
+		} finally {
+			globalThis.setInterval = originalSetInterval;
+			delete (globalThis as any).__ms;
+			delete (globalThis as any).__tick;
+		}
+	});
+});


### PR DESCRIPTION
# PR: tui: distinguish agent working vs tool running (+ loader options)

## Title
`tui: distinguish agent working vs tool running (+ tests)`

## Context
The status line currently uses a single “working” indicator, which makes it hard to tell whether the agent is thinking vs a tool/command is currently executing.

## What this changes
### Status line (coding-agent interactive mode)
- Tracks whether an agent turn is active (`agent_start`..`agent_end`).
- Tracks currently-running tool calls (agent tool execution events) and manual `!` bash commands.
- Status line behavior:
  - When the agent is active (and no tool is running): show **"Working..."** with the normal spinner.
  - When one or more tools/commands are running: show **"Running …"** with a **distinct spinner** and a slightly different message.
    - For `bash`, includes a truncated preview of the command.
    - For common file tools (`read`/`write`/`edit`), includes a shortened path.
    - Shows `(+N more)` when multiple tools are in-flight.
- Does not overwrite the existing auto-compaction / retry loaders.
- For manual `!` bash commands, the inline spinner inside the bash execution component is suppressed to avoid duplicate running indicators (the status line remains the primary indicator).
  - This is implemented via an optional `showLoader?: boolean` option on `BashExecutionComponent`.

### Loader (pi-tui)
- `Loader` now supports optional `LoaderOptions`:
  - `frames?: string[]`
  - `intervalMs?: number`
- Defaults remain unchanged (braille frames + 80ms).

## ESC semantics
- ESC interrupts the agent only while an agent turn is active.
- ESC cancels a running manual bash command (and does not abort an idle agent).

## Tests
- Adds unit tests for `Loader` defaults and custom frame/interval support.
- Adds a unit test ensuring the bash execution component can suppress its inline loader (to avoid duplicate running indicators when the status line is active).

## How to test manually
- While idle: run a manual command (e.g. `!sleep 5`) and confirm:
  - the status line shows the distinct “Running bash: …” spinner/message
  - there is no second/duplicate inline "Running..." spinner inside the bash execution component
  - press ESC to cancel
- Trigger an agent tool call (e.g. ask the agent to read a file) and confirm the status line switches to “Running <tool> …”.

## Links
- Part of: #364
