### PR TITLE
Fix crash when input contains certain Unicode Format characters

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -1,11 +1,15 @@
 import stringWidth from "string-width";
 
+// Format characters that crash string-width (Format but not Default_Ignorable_Code_Point)
+const CRASHING_FORMAT_CHARS =
+	/[\u0600-\u0605\u06DD\u070F\u0890\u0891\u08E2\uFFF9-\uFFFB\u{110BD}\u{110CD}\u{13430}-\u{1343F}\u{1BCA0}-\u{1BCA3}]/gu;
+
 /**
  * Calculate the visible width of a string in terminal columns.
  */
 export function visibleWidth(str: string): number {
 	if (!str) return 0;
-	const normalized = str.replace(/\t/g, "   ");
+	const normalized = str.replace(/\t/g, "   ").replace(CRASHING_FORMAT_CHARS, "");
 	return stringWidth(normalized);
 }
 


### PR DESCRIPTION
Fixes a crash that happens when the users paste or type text containing certain Unicode Format characters.

----

`string-width@8.1.0` throws when the input contains format characters that are not `Default_Ignorable_Code_Point`. 

This crashes pi-tui when users paste or type:
- `U+0600-U+0605` Arabic number signs
- `U+06DD` Arabic end of Ayah
- `U+FFF9-U+FFFB` Interlinear annotations
- `U+13430-U+1343F` Egyptian hieroglyph joiners

## Stack trace

```
get-east-asian-width/index.js:5
                throw new TypeError(`Expected a code point, got \`${typeof codePoint}\`.`);
                ^

TypeError: Expected a code point, got `undefined`.
    at validate (get-east-asian-width/index.js:5:9)
    at eastAsianWidth (get-east-asian-width/index.js:16:2)
    at stringWidth (string-width/index.js:82:12)
    at visibleWidth (@mariozechner/pi-tui/dist/utils.js:7:12)
    at CustomEditor.layoutText (@mariozechner/pi-tui/dist/components/editor.js:416:38)
    at CustomEditor.render (@mariozechner/pi-tui/dist/components/editor.js:103:34)
    at Container.render (@mariozechner/pi-tui/dist/tui.js:35:33)
    at TUI.render (@mariozechner/pi-tui/dist/tui.js:35:33)
    at TUI.doRender (@mariozechner/pi-tui/dist/tui.js:152:31)
    at @mariozechner/pi-tui/dist/tui.js:90:18
```

## Repro

1. `printf '\uFFF9' | wl-copy`
2. Paste into the editor
