### PR TITLE
Add tool_before_apply hook event for edit tool

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `tool_before_apply` hook event for edit tool - fires after diff is computed but before file is written, allowing hooks to accept/reject or modify changes
+
 ### Fixed
 
 - Crash when displaying bash output containing Unicode format characters like U+0600-U+0604 ([#372](https://github.com/badlogic/pi-mono/pull/372) by [@HACKE-RC](https://github.com/HACKE-RC))

--- a/packages/coding-agent/docs/hooks.md
+++ b/packages/coding-agent/docs/hooks.md
@@ -114,7 +114,9 @@ user sends prompt ────────────────────�
   │   │                                            │       │
   │   │   LLM responds, may call tools:            │       │
   │   │     ├─► tool_call (can block)              │       │
-  │   │     │   tool executes                      │       │
+  │   │     │   tool reads/computes                │       │
+  │   │     ├─► tool_before_apply (edit only)      │       │
+  │   │     │   tool applies changes               │       │
   │   │     └─► tool_result (can modify)           │       │
   │   │                                            │       │
   │   └─► turn_end                                 │       │
@@ -357,6 +359,28 @@ Tool inputs:
 - `ls`: `{ path?, limit? }`
 - `find`: `{ pattern, path?, limit? }`
 - `grep`: `{ pattern, path?, glob?, ignoreCase?, literal?, context?, limit? }`
+
+#### tool_before_apply
+
+Fired after edit tool computes diff but before writing. **Can block or modify.**
+
+```typescript
+pi.on("tool_before_apply", async (event, ctx) => {
+  if (event.toolName !== "edit") return;
+
+  // event.preview.path - file being edited
+  // event.preview.diff - unified diff of changes
+  // event.preview.firstChangedLine - line number of first change
+  // event.preview.newContent - the content that will be written
+
+  const ok = await ctx.ui.confirm("Apply edit?", "");
+  if (!ok) {
+    return { block: true, reason: "User rejected the edit" };
+  }
+
+  // Optionally modify content: return { newContent: "..." };
+});
+```
 
 #### tool_result
 

--- a/packages/coding-agent/src/core/hooks/tool-wrapper.ts
+++ b/packages/coding-agent/src/core/hooks/tool-wrapper.ts
@@ -4,11 +4,23 @@
 
 import type { AgentTool, AgentToolUpdateCallback } from "@mariozechner/pi-agent-core";
 import type { HookRunner } from "./runner.js";
-import type { ToolCallEventResult, ToolResultEventResult } from "./types.js";
+import type {
+	ToolBeforeApplyEvent,
+	ToolBeforeApplyEventResult,
+	ToolCallEventResult,
+	ToolResultEventResult,
+} from "./types.js";
+
+/**
+ * Callback for tool_before_apply event.
+ * Tools that support preview can call this before applying changes.
+ */
+export type BeforeApplyCallback = (event: ToolBeforeApplyEvent) => Promise<ToolBeforeApplyEventResult | undefined>;
 
 /**
  * Wrap a tool with hook callbacks.
  * - Emits tool_call event before execution (can block)
+ * - Emits tool_before_apply event for tools that support it (can block)
  * - Emits tool_result event after execution (can modify result)
  * - Forwards onUpdate callback to wrapped tool for progress streaming
  */
@@ -45,9 +57,33 @@ export function wrapToolWithHooks<T>(tool: AgentTool<any, T>, hookRunner: HookRu
 				}
 			}
 
+			// Create beforeApply callback for tools that support it
+			let beforeApplyCallback: BeforeApplyCallback | undefined;
+			if (hookRunner.hasHandlers("tool_before_apply")) {
+				beforeApplyCallback = async (event: ToolBeforeApplyEvent) => {
+					try {
+						const result = await hookRunner.emitToolBeforeApply(event);
+						if (result?.block) {
+							throw new Error(result.reason || "Blocked by hook");
+						}
+						return result;
+					} catch (err) {
+						if (err instanceof Error) {
+							throw err;
+						}
+						throw new Error(`Hook failed: ${String(err)}`);
+					}
+				};
+			}
+
 			// Execute the actual tool, forwarding onUpdate for progress streaming
+			// Tools that support beforeApply will use the callback, others will ignore it
 			try {
-				const result = await tool.execute(toolCallId, params, signal, onUpdate);
+				const executeParams = beforeApplyCallback
+					? { ...params, __beforeApplyCallback: beforeApplyCallback }
+					: params;
+
+				const result = await tool.execute(toolCallId, executeParams, signal, onUpdate);
 
 				// Emit tool_result event - hooks can modify the result
 				if (hookRunner.hasHandlers("tool_result")) {


### PR DESCRIPTION
**Problem:**
For edit, we don't show diff at tool_call stage, so any hook there would be meaningless like permission to allow edit, we don't have content so no point.

Also we can't update the content of edit tool with just tool_call.

**Changes:**
- New hook event `tool_before_apply` (for edit tool), it is triggered just after we have the diff and are about to apply.
- Now edit diff get's rendered before applying (useful for permission hooks)
- We can also intercept the new content and modify it

**Alternative approaches:**
1. **Move tool_call to fire after diff computation** (instead of adding tool_before_apply)
     - Cons: Changes the conceptual meaning of tool_call. Currently it means "LLM requested this tool - allow it?"
 (permission gate before any I/O). Moving it later would mean some work has already happened, making it inconsistent with other tools where tool_call fires before any execution.
 2. **Show diff preview in TUI before tool_call fires**
     - Cons: At tool_call time, the file hasn't been read yet, so we can't compute the actual diff with line numbers. We'd
 only have oldText/newText from params, not the computed diff showing exactly which lines number change.
 
 
**Flow:**

    LLM responds, may call tools:
        ├─► tool_call (can block)
        │   tool reads/computes
       ├─► tool_before_apply (edit only)
        │   tool applies changes
       └─► tool_result (can modify)   
       
Note: Regarding the naming, have kept it general. But tool_before_apply is only used for edit, so can rename to edit_before_apply if needed

Happy to iterate or scrap this completely, this solves my problem but there might be better approach to solve this.

https://github.com/user-attachments/assets/3722016c-3523-48e7-ab4b-865c9521ad52

