### PR TITLE
fix(tui): Strip OSC 8 hyperlink sequences in visibleWidth

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -108,7 +108,10 @@ export function visibleWidth(str: string): number {
 		clean = clean.replace(/\t/g, "   ");
 	}
 	if (clean.includes("\x1b")) {
+		// Strip SGR codes (\x1b[...m) and cursor codes (\x1b[...G/K/H/J)
 		clean = clean.replace(/\x1b\[[0-9;]*[mGKHJ]/g, "");
+		// Strip OSC 8 hyperlinks: \x1b]8;;URL\x07 and \x1b]8;;\x07
+		clean = clean.replace(/\x1b\]8;;[^\x07]*\x07/g, "");
 	}
 
 	// Calculate width


### PR DESCRIPTION
## Problem

PR #349 added clickable OAuth login links using OSC 8 hyperlinks:
```
\x1b]8;;https://...\x07Click here to login\x1b]8;;\x07
```

PR #369 rewrote `visibleWidth` for performance, but the new ANSI stripping regex only handles SGR codes (`\x1b[...`), not OSC sequences (`\x1b]...`). This causes the URL inside the hyperlink to be counted as visible width, breaking text wrapping:

```
ype=code&redirect_uri=https%3A%2F%2Fconsole.anthropic.com...Click here to login
```

## Fix

Add regex to strip OSC 8 hyperlink sequences:
```typescript
clean = clean.replace(/\x1b\]8;;[^\x07]*\x07/g, "");
```