### PR TITLE
feat: set terminal tab title to show current dir name

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -303,6 +303,10 @@ export class InteractiveMode {
 		this.ui.start();
 		this.isInitialized = true;
 
+		// Set terminal title
+		const cwdBasename = path.basename(process.cwd());
+		this.ui.terminal.setTitle(`pi - ${cwdBasename}`);
+
 		// Initialize hooks with TUI-based UI context
 		await this.initHooksAndCustomTools();
 

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -26,6 +26,9 @@ export interface Terminal {
 	clearLine(): void; // Clear current line
 	clearFromCursor(): void; // Clear from cursor to end of screen
 	clearScreen(): void; // Clear entire screen and move cursor to (0,0)
+
+	// Title operations
+	setTitle(title: string): void; // Set terminal window title
 }
 
 /**
@@ -126,5 +129,10 @@ export class ProcessTerminal implements Terminal {
 
 	clearScreen(): void {
 		process.stdout.write("\x1b[2J\x1b[H"); // Clear screen and move to home (1,1)
+	}
+
+	setTitle(title: string): void {
+		// OSC 0;title BEL - set terminal window title
+		process.stdout.write(`\x1b]0;${title}\x07`);
 	}
 }

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -86,6 +86,11 @@ export class VirtualTerminal implements Terminal {
 		this.xterm.write("\x1b[2J\x1b[H"); // Clear screen and move to home (1,1)
 	}
 
+	setTitle(title: string): void {
+		// OSC 0;title BEL - set terminal window title
+		this.xterm.write(`\x1b]0;${title}\x07`);
+	}
+
 	// Test-specific methods not in Terminal interface
 
 	/**


### PR DESCRIPTION
Coding agent now displays current directory in title bar as "pi - dirname", making it easier to identify which project session you're in when switching between terminal windows.

Changes:
- Add setTitle(title: string) to Terminal interface
- Implement in ProcessTerminal using OSC sequence
- Implement no-op in VirtualTerminal for testing
- Set title as "pi - dirname" in coding agent