### PR TITLE
feat(coding-agent): add preset configurations (#347)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `$ARGUMENTS` syntax for custom slash commands as alternative to `$@` for all arguments joined. Aligns with patterns used by Claude, Codex, and OpenCode. Both syntaxes remain fully supported. ([#418](https://github.com/badlogic/pi-mono/pull/418) by [@skuridin](https://github.com/skuridin))
+- Preset configurations: define named presets in `settings.json` with tools, models, thinking level, instructions, hooks, and more. Use `--preset <name>` to load a preset, `--list-presets` to see available presets. CLI flags override preset values. ([#347](https://github.com/badlogic/pi-mono/issues/347))
 
 ### Fixed
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -33,6 +33,8 @@ export interface Args {
 	noSkills?: boolean;
 	skills?: string[];
 	listModels?: string | true;
+	listPresets?: boolean;
+	preset?: string;
 	messages: string[];
 	fileArgs: string[];
 }
@@ -129,6 +131,10 @@ export function parseArgs(args: string[]): Args {
 			} else {
 				result.listModels = true;
 			}
+		} else if (arg === "--list-presets") {
+			result.listPresets = true;
+		} else if (arg === "--preset" && i + 1 < args.length) {
+			result.preset = args[++i];
 		} else if (arg.startsWith("@")) {
 			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
 		} else if (!arg.startsWith("-")) {
@@ -169,6 +175,8 @@ ${chalk.bold("Options:")}
   --skills <patterns>            Comma-separated glob patterns to filter skills (e.g., git-*,docker)
   --export <file>                Export session file to HTML and exit
   --list-models [search]         List available models (with optional fuzzy search)
+  --list-presets                 List available presets from settings.json
+  --preset <name>                Load a preset configuration from settings.json
   --help, -h                     Show this help
   --version, -v                  Show version number
 
@@ -208,6 +216,9 @@ ${chalk.bold("Examples:")}
 
   # Read-only mode (no file modifications possible)
   ${APP_NAME} --tools read,grep,find,ls -p "Review the code in src/"
+
+  # Use a preset for research mode (read-only, brief answers)
+  ${APP_NAME} --preset research "How does authentication work?"
 
   # Export a session file to HTML
   ${APP_NAME} --export ~/${CONFIG_DIR_NAME}/agent/sessions/--path--/session.jsonl

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -38,6 +38,16 @@ export interface ImageSettings {
 	autoResize?: boolean; // default: true (resize images to 2000x2000 max for better model compatibility)
 }
 
+export interface Preset {
+	tools?: string[]; // Tool names: read, bash, edit, write, grep, find, ls
+	models?: string[]; // Model patterns (same as --models)
+	thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	instructions?: string; // Appended to system prompt
+	hooks?: string[]; // Additional hook paths
+	customTools?: string[]; // Additional custom tool paths
+	noSkills?: boolean; // Disable skills
+}
+
 export interface Settings {
 	lastChangelogVersion?: string;
 	defaultProvider?: string;
@@ -59,6 +69,7 @@ export interface Settings {
 	images?: ImageSettings;
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
 	doubleEscapeAction?: "branch" | "tree"; // Action for double-escape with empty editor (default: "tree")
+	presets?: Record<string, Preset>; // Named preset configurations
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -419,5 +430,13 @@ export class SettingsManager {
 	setDoubleEscapeAction(action: "branch" | "tree"): void {
 		this.globalSettings.doubleEscapeAction = action;
 		this.save();
+	}
+
+	getPreset(name: string): Preset | undefined {
+		return this.settings.presets?.[name];
+	}
+
+	getPresetNames(): string[] {
+		return Object.keys(this.settings.presets ?? {});
 	}
 }

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -190,3 +190,25 @@ describe("parseArgs", () => {
 		});
 	});
 });
+
+describe("--preset flag", () => {
+	test("parses --preset flag", () => {
+		const result = parseArgs(["--preset", "research"]);
+		expect(result.preset).toBe("research");
+	});
+
+	test("--preset with other flags", () => {
+		const result = parseArgs(["--preset", "fast", "--tools", "bash", "-p", "test"]);
+		expect(result.preset).toBe("fast");
+		expect(result.tools).toEqual(["bash"]);
+		expect(result.print).toBe(true);
+		expect(result.messages).toContain("test");
+	});
+});
+
+describe("--list-presets flag", () => {
+	test("parses --list-presets flag", () => {
+		const result = parseArgs(["--list-presets"]);
+		expect(result.listPresets).toBe(true);
+	});
+});


### PR DESCRIPTION
Add `--preset` flag to load named configurations from `settings.json`. 
Presets can specify `tools`, `models`, `thinking level`, `instructions`, `hooks`, `custom tools`, and `noSkills`.

- Add Preset interface to `settings-manager.ts`
- Add `--preset <name>` and `--list-presets` CLI flags
- Preset values act as defaults (CLI flags override)
- Hooks and customTools are merged (preset + CLI)


 ## Layering

 ```
   global settings → project settings → PRESET → CLI args
 ```

 - Preset fills in undefined CLI args as defaults
 - CLI flags always override preset values
 - Hooks and customTools are merged (preset + CLI)
 
  ## Example

 ```json
   // ~/.pi/agent/settings.json
   {
     "presets": {
       "research": {
         "tools": ["read", "grep", "find", "ls"],
         "instructions": "Briefly answer by researching the codebase."
       }
     }
   }
 ```

 ```bash
   pi --preset research "How does auth work?"
   pi --list-presets
 ```