### PR TITLE
Fix version check URL typo

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -35,7 +35,7 @@ import { ensureTool } from "./utils/tools-manager.js";
 
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
 	try {
-		const response = await fetch("https://registry.npmjs.org/@mariozechner/pi -coding-agent/latest");
+		const response = await fetch("https://registry.npmjs.org/@mariozechner/pi-coding-agent/latest");
 		if (!response.ok) return undefined;
 
 		const data = (await response.json()) as { version?: string };


### PR DESCRIPTION
The npm registry URL for checking for new versions has a typo: a space between `pi` and `-coding-agent`. This causes the version check to always fail silently (404 from npm registry), so users never receive update notifications.

**Fix:** Remove the space from the URL: `pi -coding-agent` → `pi-coding-agent`

**Regression introduced in:** 54018b6cc0345492e988e7067cf573ab5aeffbc9 ("Refactor OAuth/API key handling: AuthStorage and ModelRegistry")


[Pi session](https://shittycodingagent.ai/session?cd7f2ffdd224c8d5f251b19b94667497)