### PR TITLE
feat(coding-agent): add /quit and /exit slash commands to exit

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -891,6 +891,11 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
+			if (text === "/quit" || text === "/exit") {
+				this.editor.setText("");
+				await this.shutdown();
+				return;
+			}
 
 			// Handle bash command (! for normal, !! for excluded from context)
 			if (text.startsWith("!")) {


### PR DESCRIPTION
## Summary

Adds `/quit` and `/exit` slash commands for gracefully exiting the interactive mode.

- `/quit` - exit the application
- `/exit` - alias for `/quit` (common CLI convention)

### Implementation

Both commands call `await this.shutdown()` which:
1. Emits `session_shutdown` event to hooks
2. Emits shutdown event to custom tools
3. Calls `process.exit(0)`

### Note on await behavior

Unlike `Ctrl+C` (twice) which uses `void this.shutdown()` (fire-and-forget), these commands properly `await` the shutdown, ensuring hooks and custom tools complete their cleanup handlers before the process exits.