### PR TITLE
docs(coding-agent): correct filename in subagent example README

### DIFF
--- a/packages/coding-agent/examples/custom-tools/subagent/README.md
+++ b/packages/coding-agent/examples/custom-tools/subagent/README.md
@@ -16,7 +16,7 @@ Delegate tasks to specialized subagents with isolated context windows.
 ```
 subagent/
 ├── README.md            # This file
-├── subagent.ts          # The custom tool (entry point)
+├── index.ts             # The custom tool (entry point)
 ├── agents.ts            # Agent discovery logic
 ├── agents/              # Sample agent definitions
 │   ├── scout.md         # Fast recon, returns compressed context
@@ -36,7 +36,7 @@ From the repository root, symlink the files:
 ```bash
 # Symlink the tool (must be in a subdirectory with index.ts)
 mkdir -p ~/.pi/agent/tools/subagent
-ln -sf "$(pwd)/packages/coding-agent/examples/custom-tools/subagent/subagent.ts" ~/.pi/agent/tools/subagent/index.ts
+ln -sf "$(pwd)/packages/coding-agent/examples/custom-tools/subagent/index.ts" ~/.pi/agent/tools/subagent/index.ts
 ln -sf "$(pwd)/packages/coding-agent/examples/custom-tools/subagent/agents.ts" ~/.pi/agent/tools/subagent/agents.ts
 
 # Symlink agents


### PR DESCRIPTION
The README in `packages/coding-agent/examples/custom-tools/subagent/` referenced `subagent.ts` in two places, but the actual file is `index.ts`.

**Changes:**
- Updated structure tree to show `index.ts` instead of `subagent.ts`
- Updated installation symlink command to reference the correct source file