### PR TITLE
feat: add headless OAuth flow for Google providers

### DIFF
--- a/packages/ai/src/utils/oauth/google-gemini-cli.ts
+++ b/packages/ai/src/utils/oauth/google-gemini-cli.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Server } from "http";
+import { HEADLESS_INSTRUCTIONS, parseOAuthRedirectUrl } from "./headless.js";
 import { generatePKCE } from "./pkce.js";
 import type { OAuthCredentials } from "./types.js";
 
@@ -252,105 +253,136 @@ export async function refreshGoogleCloudToken(refreshToken: string, projectId: s
 	};
 }
 
+/** Options for headless OAuth flow */
+export interface GeminiCliLoginOptions {
+	/** If true, use manual URL paste instead of localhost callback server */
+	headless?: boolean;
+	/** Callback to prompt user to paste redirect URL (required if headless) */
+	onPromptUrl?: () => Promise<string>;
+}
+
 /**
  * Login with Gemini CLI (Google Cloud Code Assist) OAuth
  *
  * @param onAuth - Callback with URL and optional instructions
  * @param onProgress - Optional progress callback
+ * @param options - Optional settings for headless environments
  */
 export async function loginGeminiCli(
 	onAuth: (info: { url: string; instructions?: string }) => void,
 	onProgress?: (message: string) => void,
+	options?: GeminiCliLoginOptions,
 ): Promise<OAuthCredentials> {
 	const { verifier, challenge } = await generatePKCE();
+	const headless = options?.headless ?? false;
 
-	// Start local server for callback
-	onProgress?.("Starting local server for OAuth callback...");
-	const { server, getCode } = await startCallbackServer();
+	// Build authorization URL
+	const authParams = new URLSearchParams({
+		client_id: CLIENT_ID,
+		response_type: "code",
+		redirect_uri: REDIRECT_URI,
+		scope: SCOPES.join(" "),
+		code_challenge: challenge,
+		code_challenge_method: "S256",
+		state: verifier,
+		access_type: "offline",
+		prompt: "consent",
+	});
 
-	try {
-		// Build authorization URL
-		const authParams = new URLSearchParams({
-			client_id: CLIENT_ID,
-			response_type: "code",
-			redirect_uri: REDIRECT_URI,
-			scope: SCOPES.join(" "),
-			code_challenge: challenge,
-			code_challenge_method: "S256",
-			state: verifier,
-			access_type: "offline",
-			prompt: "consent",
-		});
+	const authUrl = `${AUTH_URL}?${authParams.toString()}`;
 
-		const authUrl = `${AUTH_URL}?${authParams.toString()}`;
+	let code: string;
+	let state: string;
 
-		// Notify caller with URL to open
+	if (headless) {
+		// Headless mode: user manually pastes the redirect URL
+		if (!options?.onPromptUrl) {
+			throw new Error("onPromptUrl callback is required for headless OAuth flow");
+		}
+
 		onAuth({
 			url: authUrl,
-			instructions: "Complete the sign-in in your browser. The callback will be captured automatically.",
+			instructions: HEADLESS_INSTRUCTIONS,
 		});
 
-		// Wait for the callback
-		onProgress?.("Waiting for OAuth callback...");
-		const { code, state } = await getCode();
+		const redirectUrl = await options.onPromptUrl();
+		const parsed = parseOAuthRedirectUrl(redirectUrl, "/oauth2callback");
+		code = parsed.code;
+		state = parsed.state;
+	} else {
+		// Standard mode: localhost callback server
+		onProgress?.("Starting local server for OAuth callback...");
+		const { server, getCode } = await startCallbackServer();
 
-		// Verify state matches
-		if (state !== verifier) {
-			throw new Error("OAuth state mismatch - possible CSRF attack");
+		try {
+			onAuth({
+				url: authUrl,
+				instructions: "Complete the sign-in in your browser. The callback will be captured automatically.",
+			});
+
+			onProgress?.("Waiting for OAuth callback...");
+			const result = await getCode();
+			code = result.code;
+			state = result.state;
+		} finally {
+			server.close();
 		}
-
-		// Exchange code for tokens
-		onProgress?.("Exchanging authorization code for tokens...");
-		const tokenResponse = await fetch(TOKEN_URL, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/x-www-form-urlencoded",
-			},
-			body: new URLSearchParams({
-				client_id: CLIENT_ID,
-				client_secret: CLIENT_SECRET,
-				code,
-				grant_type: "authorization_code",
-				redirect_uri: REDIRECT_URI,
-				code_verifier: verifier,
-			}),
-		});
-
-		if (!tokenResponse.ok) {
-			const error = await tokenResponse.text();
-			throw new Error(`Token exchange failed: ${error}`);
-		}
-
-		const tokenData = (await tokenResponse.json()) as {
-			access_token: string;
-			refresh_token: string;
-			expires_in: number;
-		};
-
-		if (!tokenData.refresh_token) {
-			throw new Error("No refresh token received. Please try again.");
-		}
-
-		// Get user email
-		onProgress?.("Getting user info...");
-		const email = await getUserEmail(tokenData.access_token);
-
-		// Discover project
-		const projectId = await discoverProject(tokenData.access_token, onProgress);
-
-		// Calculate expiry time (current time + expires_in seconds - 5 min buffer)
-		const expiresAt = Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000;
-
-		const credentials: OAuthCredentials = {
-			refresh: tokenData.refresh_token,
-			access: tokenData.access_token,
-			expires: expiresAt,
-			projectId,
-			email,
-		};
-
-		return credentials;
-	} finally {
-		server.close();
 	}
+
+	// Verify state matches
+	if (state !== verifier) {
+		throw new Error("OAuth state mismatch - possible CSRF attack");
+	}
+
+	// Exchange code for tokens
+	onProgress?.("Exchanging authorization code for tokens...");
+	const tokenResponse = await fetch(TOKEN_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		body: new URLSearchParams({
+			client_id: CLIENT_ID,
+			client_secret: CLIENT_SECRET,
+			code,
+			grant_type: "authorization_code",
+			redirect_uri: REDIRECT_URI,
+			code_verifier: verifier,
+		}),
+	});
+
+	if (!tokenResponse.ok) {
+		const error = await tokenResponse.text();
+		throw new Error(`Token exchange failed: ${error}`);
+	}
+
+	const tokenData = (await tokenResponse.json()) as {
+		access_token: string;
+		refresh_token: string;
+		expires_in: number;
+	};
+
+	if (!tokenData.refresh_token) {
+		throw new Error("No refresh token received. Please try again.");
+	}
+
+	// Get user email
+	onProgress?.("Getting user info...");
+	const email = await getUserEmail(tokenData.access_token);
+
+	// Discover project
+	const projectId = await discoverProject(tokenData.access_token, onProgress);
+
+	// Calculate expiry time (current time + expires_in seconds - 5 min buffer)
+	const expiresAt = Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000;
+
+	const credentials: OAuthCredentials = {
+		refresh: tokenData.refresh_token,
+		access: tokenData.access_token,
+		expires: expiresAt,
+		projectId,
+		email,
+	};
+
+	return credentials;
 }

--- a/packages/ai/src/utils/oauth/headless.ts
+++ b/packages/ai/src/utils/oauth/headless.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared utilities for headless OAuth flows.
+ * Used when localhost callback server isn't reachable (SSH, remote environments).
+ */
+
+/**
+ * Parse OAuth code and state from a redirect URL.
+ * Used in headless mode where user pastes the failed localhost redirect URL.
+ *
+ * @param url - The full redirect URL from the browser's address bar
+ * @param expectedPath - Expected path (e.g., "/oauth2callback" or "/oauth-callback")
+ * @returns Parsed code and state
+ * @throws Error if URL is invalid or missing required parameters
+ */
+export function parseOAuthRedirectUrl(url: string, expectedPath: string): { code: string; state: string } {
+	let parsed: URL;
+	try {
+		parsed = new URL(url.trim());
+	} catch {
+		throw new Error("Invalid URL. Please paste the complete URL from your browser's address bar.");
+	}
+
+	// Verify it looks like the expected callback URL
+	if (!parsed.pathname.endsWith(expectedPath)) {
+		throw new Error(
+			`Unexpected URL path. Expected a URL containing "${expectedPath}". ` +
+				"Please paste the URL from your browser after the failed redirect.",
+		);
+	}
+
+	const code = parsed.searchParams.get("code");
+	const state = parsed.searchParams.get("state");
+	const error = parsed.searchParams.get("error");
+
+	if (error) {
+		throw new Error(`OAuth error: ${error}`);
+	}
+
+	if (!code) {
+		throw new Error("Missing 'code' parameter in URL. Please paste the complete redirect URL.");
+	}
+
+	if (!state) {
+		throw new Error("Missing 'state' parameter in URL. Please paste the complete redirect URL.");
+	}
+
+	return { code, state };
+}
+
+/**
+ * Instructions shown to user in headless mode.
+ */
+export const HEADLESS_INSTRUCTIONS =
+	"After authorizing, your browser will show a connection error. " +
+	"Copy the full URL from your browser's address bar and paste it below.";

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -20,14 +20,18 @@ export {
 } from "./github-copilot.js";
 // Google Antigravity
 export {
+	type AntigravityLoginOptions,
 	loginAntigravity,
 	refreshAntigravityToken,
 } from "./google-antigravity.js";
 // Google Gemini CLI
 export {
+	type GeminiCliLoginOptions,
 	loginGeminiCli,
 	refreshGoogleCloudToken,
 } from "./google-gemini-cli.js";
+// Headless utilities
+export { HEADLESS_INSTRUCTIONS, parseOAuthRedirectUrl } from "./headless.js";
 
 export * from "./types.js";
 

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -15,6 +15,7 @@ import {
 } from "@mariozechner/pi-ai";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname } from "path";
+import { isHeadlessEnvironment } from "../utils/environment.js";
 
 export type ApiKeyCredential = {
 	type: "api_key";
@@ -175,10 +176,16 @@ export class AuthStorage {
 				});
 				break;
 			case "google-gemini-cli":
-				credentials = await loginGeminiCli(callbacks.onAuth, callbacks.onProgress);
+				credentials = await loginGeminiCli(callbacks.onAuth, callbacks.onProgress, {
+					headless: isHeadlessEnvironment(),
+					onPromptUrl: () => callbacks.onPrompt({ message: "Paste the redirect URL from your browser:" }),
+				});
 				break;
 			case "google-antigravity":
-				credentials = await loginAntigravity(callbacks.onAuth, callbacks.onProgress);
+				credentials = await loginAntigravity(callbacks.onAuth, callbacks.onProgress, {
+					headless: isHeadlessEnvironment(),
+					onPromptUrl: () => callbacks.onPrompt({ message: "Paste the redirect URL from your browser:" }),
+				});
 				break;
 			default:
 				throw new Error(`Unknown OAuth provider: ${provider}`);

--- a/packages/coding-agent/src/utils/environment.ts
+++ b/packages/coding-agent/src/utils/environment.ts
@@ -1,0 +1,96 @@
+/**
+ * Environment detection utilities for terminal capabilities.
+ */
+
+/**
+ * Detects if running in a headless environment (SSH, no display, etc.)
+ * where browser auto-open and hyperlinks won't work properly.
+ */
+export function isHeadlessEnvironment(): boolean {
+	// SSH session detection
+	const isSSH = !!(process.env.SSH_CLIENT || process.env.SSH_TTY || process.env.SSH_CONNECTION);
+
+	// No graphical display (Linux/Unix)
+	const noDisplay = process.platform !== "win32" && process.platform !== "darwin" && !process.env.DISPLAY;
+
+	// Dumb terminal
+	const isDumbTerminal = process.env.TERM === "dumb";
+
+	// Running inside tmux (may not pass through OSC 8 hyperlinks)
+	const inTmux = !!process.env.TMUX;
+
+	// Running inside screen
+	const inScreen = !!process.env.STY;
+
+	return isSSH || noDisplay || isDumbTerminal || inTmux || inScreen;
+}
+
+/**
+ * Detects if the terminal likely supports OSC 8 hyperlinks.
+ * This is a best-effort detection since there's no reliable way to query support.
+ */
+export function supportsHyperlinks(): boolean {
+	// If in a headless environment, hyperlinks likely won't work
+	if (isHeadlessEnvironment()) {
+		return false;
+	}
+
+	// Known terminals with good hyperlink support
+	const termProgram = process.env.TERM_PROGRAM?.toLowerCase() || "";
+	const term = process.env.TERM?.toLowerCase() || "";
+
+	// Terminals known to support OSC 8 hyperlinks
+	const supportedTerminals = [
+		"iterm.app",
+		"hyper",
+		"wezterm",
+		"kitty",
+		"alacritty",
+		"vscode",
+		"ghostty",
+		"contour",
+		"foot",
+	];
+
+	if (supportedTerminals.some((t) => termProgram.includes(t) || term.includes(t))) {
+		return true;
+	}
+
+	// Check for specific environment variables
+	if (process.env.KITTY_WINDOW_ID || process.env.WEZTERM_PANE || process.env.ITERM_SESSION_ID) {
+		return true;
+	}
+
+	// Default to false for unknown terminals - safer to show plain URL
+	return false;
+}
+
+/**
+ * Detects if we can attempt to auto-open a browser.
+ * Returns false for SSH sessions and environments without a display.
+ */
+export function canOpenBrowser(): boolean {
+	// macOS and Windows generally always have a way to open URLs
+	if (process.platform === "darwin" || process.platform === "win32") {
+		// But not if we're in an SSH session
+		if (process.env.SSH_CLIENT || process.env.SSH_TTY || process.env.SSH_CONNECTION) {
+			return false;
+		}
+		return true;
+	}
+
+	// Linux/Unix needs DISPLAY or Wayland
+	if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+		return false;
+	}
+
+	// SSH session without X forwarding won't work
+	if (process.env.SSH_CLIENT || process.env.SSH_TTY || process.env.SSH_CONNECTION) {
+		// Check if X11 forwarding is enabled (DISPLAY would be set to something like localhost:10.0)
+		if (!process.env.DISPLAY) {
+			return false;
+		}
+	}
+
+	return true;
+}


### PR DESCRIPTION
## Problem

OAuth login fails or is unusable in headless environments (SSH, tmux, screen):

1. **No visible URL** - Only an OSC 8 hyperlink ("Click here to login") was shown, which doesn't render in many terminals, leaving users with no way to access the auth URL
2. **Browser auto-open fails** - `xdg-open` silently fails without a display
3. **Localhost callbacks unreachable** - Google OAuth redirects to `localhost:PORT` which the local browser can't reach on a remote server

## Solution

### 1. Always show the plain auth URL
Previously only an OSC 8 hyperlink was displayed. Now the raw URL is always shown first, with the clickable hyperlink shown below it only when the terminal supports OSC 8. This ensures users can always copy/paste the URL regardless of terminal capabilities.

### 2. Conditional terminal features
- Only show OSC 8 clickable hyperlinks when terminal supports them (iTerm, Kitty, WezTerm, etc.)
- Only attempt browser auto-open in graphical environments
- Add environment detection for SSH, tmux, screen, missing DISPLAY, etc.

### 3. Redirect URL paste flow for Google OAuth
For providers that use localhost callback servers (gemini-cli, antigravity), add headless mode where users paste the failed redirect URL from their browser. The auth code is extracted from the URL parameters.

### User flow in headless mode
1. Run `/login google-gemini-cli`
2. Copy the displayed URL to local browser
3. Authorize in browser
4. Browser redirects to `localhost:PORT/...` (connection refused)
5. Copy the failed URL from address bar, paste back into pi
6. Login completes

### Files changed
- `packages/ai/src/utils/oauth/headless.ts` - new helper to parse auth code from redirect URLs
- `packages/ai/src/utils/oauth/google-gemini-cli.ts` - add `headless` and `onPromptUrl` options
- `packages/ai/src/utils/oauth/google-antigravity.ts` - add `headless` and `onPromptUrl` options
- `packages/coding-agent/src/utils/environment.ts` - new environment detection utilities
- `packages/coding-agent/src/core/auth-storage.ts` - wire up headless mode for Google providers
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` - always show plain URL, conditional hyperlink/browser