### PR TITLE
Fix UTF-8 decoding of chunked stdout/stderr in bash-executor

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed potential text decoding issues in bash executor by using streaming TextDecoder instead of Buffer.toString()
 
 ## [0.33.0] - 2026-01-04
 

--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -97,11 +97,13 @@ export function executeBash(command: string, options?: BashExecutorOptions): Pro
 			options.signal.addEventListener("abort", abortHandler, { once: true });
 		}
 
+		const decoder = new TextDecoder();
+
 		const handleData = (data: Buffer) => {
 			totalBytes += data.length;
 
 			// Sanitize once at the source: strip ANSI, replace binary garbage, normalize newlines
-			const text = sanitizeBinaryOutput(stripAnsi(data.toString())).replace(/\r/g, "");
+			const text = sanitizeBinaryOutput(stripAnsi(decoder.decode(data, { stream: true }))).replace(/\r/g, "");
 
 			// Start writing to temp file if exceeds threshold
 			if (totalBytes > DEFAULT_MAX_BYTES && !tempFilePath) {


### PR DESCRIPTION
Fixes corruption of multi-byte UTF-8 output from bash commands.

----

`handleData` in [bash-executor.ts#L99-L135](https://github.com/badlogic/pi-mono/blob/7e2a99b485b247248ebbab034ce1a5fdde5971aa/packages/coding-agent/src/core/bash-executor.ts#L99C1-L135C40) assumes that the incoming chunks are always made up of complete UTF-8 sequences and calls `Buffer.toString()` concating the resulting string. This assumption doesn't really hold, so this ends up corrupting any multi-byte UTF-8 sequence split across chunk boundaries.

The proper way to handle this is to use a streaming TextDecoder which buffers incomplete sequences until they terminate, which I've done like so:

```diff
+const decoder = new TextDecoder();
+
 const handleData = (data: Buffer) => {
-    const text = sanitizeBinaryOutput(stripAnsi(data.toString())).replace(/\r/g, "");
+    const text = sanitizeBinaryOutput(stripAnsi(decoder.decode(data, { stream: true }))).replace(/\r/g, "");