### PR TITLE
feat(coding-agent): add /exit and /quit to slash command autocomplete

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -198,6 +198,8 @@ export class InteractiveMode {
 			{ name: "new", description: "Start a new session" },
 			{ name: "compact", description: "Manually compact the session context" },
 			{ name: "resume", description: "Resume a different session" },
+			{ name: "exit", description: "Exit the application" },
+			{ name: "quit", description: "Exit the application" },
 		];
 
 		// Load hide thinking block setting


### PR DESCRIPTION
The /exit and /quit commands were added in #426 but were missing from the autocomplete suggestions shown when typing `/`.

This adds them to the `slashCommands` array so they appear in autocomplete.