### PR TITLE
Add memory mode for saving instructions to AGENTS.md files

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Added
 
+- Memory mode: Type `#` followed by an instruction to save it to memory files. The editor border turns blue to indicate memory mode. On submit, a selector lets you choose to save to Project Local (`AGENTS.local.md`, gitignored), Project (`AGENTS.md`, shared), or Global (`~/.pi/agent/AGENTS.md`). The current model intelligently integrates the instruction into the existing file structure, avoiding duplicates and maintaining consistent formatting. A preview is shown before saving.
 - Clipboard image paste support via `Ctrl+V`. Images are saved to a temp file and attached to the message. Works on macOS, Windows, and Linux (X11). ([#419](https://github.com/badlogic/pi-mono/issues/419))
 - Configurable keybindings via `~/.pi/agent/keybindings.json`. All keyboard shortcuts (editor navigation, deletion, app actions like model cycling, etc.) can now be customized. Supports multiple bindings per action. ([#405](https://github.com/badlogic/pi-mono/pull/405) by [@hjanuschka](https://github.com/hjanuschka))
 - `/quit` and `/exit` slash commands to gracefully exit the application. Unlike double Ctrl+C, these properly await hook and custom tool cleanup handlers before exiting. ([#426](https://github.com/badlogic/pi-mono/pull/426) by [@ben-vargas](https://github.com/ben-vargas))

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -26,6 +26,7 @@ Works on Linux, macOS, and Windows (requires bash; see [Windows Setup](#windows-
   - [Keyboard Shortcuts](#keyboard-shortcuts)
   - [Custom Keybindings](#custom-keybindings)
   - [Bash Mode](#bash-mode)
+  - [Memory Mode](#memory-mode)
   - [Image Support](#image-support)
 - [Sessions](#sessions)
   - [Session Management](#session-management)
@@ -360,6 +361,35 @@ Ran `ls -la`
 ```
 
 Run multiple commands before prompting; all outputs are included together.
+
+### Memory Mode
+
+Prefix instructions with `#` to save them to memory files (the editor border turns blue):
+
+```
+# Always use TypeScript strict mode
+# Prefer async/await over callbacks
+# Never use git commands
+```
+
+When you submit:
+
+1. **Select location** - Choose where to save:
+
+| Location | File | Use Case |
+|----------|------|----------|
+| Project Local | `./AGENTS.local.md` | Personal preferences, auto-added to `.gitignore` |
+| Project | `./AGENTS.md` | Team-shared project instructions |
+| Global | `~/.pi/agent/AGENTS.md` | Your preferences across all projects |
+
+2. **AI integration** - The current model intelligently integrates your instruction into the existing file:
+   - Groups related instructions under appropriate headings
+   - Avoids duplicating existing rules (updates them instead)
+   - Maintains consistent formatting
+
+3. **Preview & confirm** - Review the proposed changes before saving
+
+Pi loads these files at startup as part of the system prompt.
 
 ### Image Support
 

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -75,7 +75,8 @@
 		"thinkingHigh": "#b294bb",
 		"thinkingXhigh": "#d183e8",
 
-		"bashMode": "green"
+		"bashMode": "green",
+		"memoryMode": "blue"
 	},
 	"export": {
 		"pageBg": "#18181e",

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -74,7 +74,8 @@
 		"thinkingHigh": "#875f87",
 		"thinkingXhigh": "#8b008b",
 
-		"bashMode": "green"
+		"bashMode": "green",
+		"memoryMode": "blue"
 	},
 	"export": {
 		"pageBg": "#f8f8f8",

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
@@ -264,6 +264,10 @@
 				"bashMode": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Editor border color in bash mode"
+				},
+				"memoryMode": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Editor border color in memory mode (# instructions)"
 				}
 			},
 			"additionalProperties": false

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -140,7 +140,8 @@ export type ThemeColor =
 	| "thinkingMedium"
 	| "thinkingHigh"
 	| "thinkingXhigh"
-	| "bashMode";
+	| "bashMode"
+	| "memoryMode";
 
 export type ThemeBg =
 	| "selectedBg"
@@ -414,6 +415,14 @@ export class Theme {
 
 	getBashModeBorderColor(): (str: string) => string {
 		return (str: string) => this.fg("bashMode", str);
+	}
+
+	getMemoryModeBorderColor(): (str: string) => string {
+		// Fall back to "border" color for custom themes without memoryMode
+		if (this.fgColors.has("memoryMode")) {
+			return (str: string) => this.fg("memoryMode", str);
+		}
+		return (str: string) => this.fg("border", str);
 	}
 }
 


### PR DESCRIPTION
## Summary

Add a new memory mode that allows users to quickly save instructions to AGENTS.md files, similar to Claude Code's memory feature.

## Features

- **Memory mode trigger**: Type `#` followed by an instruction (editor border turns blue)
- **Save location selector**: Choose between:
  - Project Local (`./AGENTS.local.md`) - gitignored, personal preferences
  - Project (`./AGENTS.md`) - shared with team
  - Global (`~/.pi/agent/AGENTS.md`) - all your projects
- **AI-assisted integration**: The current model intelligently integrates the instruction into existing file structure:
  - Groups related instructions under appropriate headings
  - Avoids duplicating rules (updates existing ones instead)
  - Maintains consistent formatting
- **Preview before save**: Review the proposed changes before committing

## Example

```
# never use git commands
```

→ Select "Project Local"
→ AI integrates into existing AGENTS.local.md structure
→ Preview shown
→ Confirm to save

## Changes

- `interactive-mode.ts`: New `handleMemoryInstruction` and `showMemoryPreview` methods
- `theme/*.json`: Added `memoryMode` color (blue)
- `theme.ts`: Added `getMemoryModeBorderColor()` with fallback for custom themes
- `README.md`: Documentation
- `CHANGELOG.md`: Feature entry


<img width="1075" height="143" alt="Bildschirmfoto 2026-01-04 um 09 36 50" src="https://github.com/user-attachments/assets/71aed054-e808-4d3c-9059-ee2d4a121639" />

<img width="1410" height="372" alt="Bildschirmfoto 2026-01-04 um 09 37 31" src="https://github.com/user-attachments/assets/ef84fc7c-b4c7-48b4-954d-adc8269eb064" />
