### PR TITLE
feat(hooks): expose setTitle to HookUIContext

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Hook API: `ctx.ui.setTitle(title)` allows hooks to set the terminal window/tab title ([#446](https://github.com/badlogic/pi-mono/pull/446) by [@aliou](https://github.com/aliou))
+
 ### Changed
 
 - Expanded keybinding documentation to list all 32 supported symbol keys with notes on ctrl+symbol behavior ([#450](https://github.com/badlogic/pi-mono/pull/450) by [@kaofelix](https://github.com/kaofelix))

--- a/packages/coding-agent/docs/hooks.md
+++ b/packages/coding-agent/docs/hooks.md
@@ -437,6 +437,9 @@ ctx.ui.setWidget("my-todos", [
 ]);
 ctx.ui.setWidget("my-todos", undefined);  // Clear widget
 
+// Set the terminal window/tab title
+ctx.ui.setTitle("pi - my-project");
+
 // Set the core input editor text (pre-fill prompts, generated content)
 ctx.ui.setEditorText("Generated prompt text here...");
 
@@ -456,6 +459,10 @@ const currentText = ctx.ui.getEditorText();
 - `setWidget()` accepts either a string array or a component factory function
 - Supports ANSI styling via `ctx.ui.theme` (including `strikethrough`)
 - **Caution:** Keep widgets small (a few lines). Large widgets from multiple hooks can cause viewport overflow and TUI flicker. Max 10 lines total across all string widgets.
+
+**Terminal title notes:**
+- Uses OSC escape sequence (works in most modern terminals like iTerm2, Terminal.app, Windows Terminal)
+- Useful for showing project name, current task, or session status in the terminal tab/window title
 
 **Custom widget components:**
 

--- a/packages/coding-agent/src/core/custom-tools/loader.ts
+++ b/packages/coding-agent/src/core/custom-tools/loader.ts
@@ -93,6 +93,7 @@ function createNoOpUIContext(): HookUIContext {
 		notify: () => {},
 		setStatus: () => {},
 		setWidget: () => {},
+		setTitle: () => {},
 		custom: async () => undefined as never,
 		setEditorText: () => {},
 		getEditorText: () => "",

--- a/packages/coding-agent/src/core/hooks/runner.ts
+++ b/packages/coding-agent/src/core/hooks/runner.ts
@@ -59,6 +59,7 @@ const noOpUIContext: HookUIContext = {
 	notify: () => {},
 	setStatus: () => {},
 	setWidget: () => {},
+	setTitle: () => {},
 	custom: async () => undefined as never,
 	setEditorText: () => {},
 	getEditorText: () => "",

--- a/packages/coding-agent/src/core/hooks/types.ts
+++ b/packages/coding-agent/src/core/hooks/types.ts
@@ -121,6 +121,13 @@ export interface HookUIContext {
 	setWidget(key: string, content: ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined): void;
 
 	/**
+	 * Set the terminal window/tab title.
+	 * Uses OSC escape sequence (works in most modern terminals).
+	 * @param title - Title text to display
+	 */
+	setTitle(title: string): void;
+
+	/**
 	 * Show a custom component with keyboard focus.
 	 * The factory receives TUI, theme, and a done() callback to close the component.
 	 * Can be async for fire-and-forget work (don't await the work, just start it).

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -685,6 +685,7 @@ export class InteractiveMode {
 			notify: (message, type) => this.showHookNotify(message, type),
 			setStatus: (key, text) => this.setHookStatus(key, text),
 			setWidget: (key, content) => this.setHookWidget(key, content),
+			setTitle: (title) => this.ui.terminal.setTitle(title),
 			custom: (factory) => this.showHookCustom(factory),
 			setEditorText: (text) => this.editor.setText(text),
 			getEditorText: () => this.editor.getText(),

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -145,6 +145,16 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			// Component factories are not supported in RPC mode - would need TUI access
 		},
 
+		setTitle(title: string): void {
+			// Fire and forget - host can implement terminal title control
+			output({
+				type: "hook_ui_request",
+				id: crypto.randomUUID(),
+				method: "setTitle",
+				title,
+			} as RpcHookUIRequest);
+		},
+
 		async custom() {
 			// Custom UI not supported in RPC mode
 			return undefined as never;

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -196,6 +196,7 @@ export type RpcHookUIRequest =
 			widgetKey: string;
 			widgetLines: string[] | undefined;
 	  }
+	| { type: "hook_ui_request"; id: string; method: "setTitle"; title: string }
 	| { type: "hook_ui_request"; id: string; method: "set_editor_text"; text: string };
 
 // ============================================================================

--- a/packages/coding-agent/test/compaction-hooks.test.ts
+++ b/packages/coding-agent/test/compaction-hooks.test.ts
@@ -121,6 +121,7 @@ describe.skipIf(!API_KEY)("Compaction hooks", () => {
 				notify: () => {},
 				setStatus: () => {},
 				setWidget: () => {},
+				setTitle: () => {},
 				custom: async () => undefined as never,
 				setEditorText: () => {},
 				getEditorText: () => "",


### PR DESCRIPTION
Follow #407 and allows setting the title from hooks. Currently, I have a hook that sets the title to whatever steps the agent is in. With this change, it could look like this:

```ts
export default (pi: HookAPI) => {
  pi.on("session_start", async (_event, ctx) => {
    ctx.ui.setTitle(`pi: ${path.basename(ctx.cwd)}`);
  });

  pi.on("agent_start", async (_event, ctx) => {
    ctx.ui.setTitle(`pi: ${path.basename(ctx.cwd)} (thinking...)`);
  });

  pi.on("tool_call", async (event, ctx) => {
    ctx.ui.setTitle(`pi: ${path.basename(ctx.cwd)} (${event.toolName})`);
  });

  pi.on("agent_end", async (_event, ctx) => {
    ctx.ui.setTitle(`pi: ${path.basename(ctx.cwd)}`);
  });
};
```


<details><summary>Summary by opus:</summary>
<p>

Adds `setTitle()` method to `HookUIContext`, allowing hooks and custom tools to set the terminal window/tab title programmatically.

### Changes

- **`HookUIContext` interface** (`types.ts`): Added `setTitle(title: string): void` method with JSDoc describing OSC escape sequence usage
- **Interactive mode**: Wires `setTitle` to `this.ui.terminal.setTitle(title)`
- **RPC mode**: Emits `hook_ui_request` with `method: "setTitle"` so RPC hosts can implement terminal title control
- **No-op contexts** (`loader.ts`, `runner.ts`, test file): Added empty `setTitle` stub for headless/test environments

### Usage

```typescript
export default (pi: HookAPI) => {
  pi.on("session_start", async (_event, ctx) => {
    ctx.ui.setTitle(`pi: ${path.basename(ctx.cwd)}`);
  });

  pi.on("agent_start", async (_event, ctx) => {
    ctx.ui.setTitle(`pi: ${path.basename(ctx.cwd)} (thinking...)`);
  });

  pi.on("tool_call", async (event, ctx) => {
    ctx.ui.setTitle(`pi: ${path.basename(ctx.cwd)} (${event.toolName})`);
  });

  pi.on("agent_end", async (_event, ctx) => {
    ctx.ui.setTitle(`pi: ${path.basename(ctx.cwd)}`);
  });

  pi.on("session_shutdown", async () => {
    ctx.ui.setTitle("Terminal");
  });
};
```

</p>
</details>
