### PR TITLE
feat(coding-agent): add /init command to generate AGENTS.md

### DIFF
--- a/packages/coding-agent/src/core/prompts/index.ts
+++ b/packages/coding-agent/src/core/prompts/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Internal prompts used by pi commands.
+ */
+
+export { INIT_PROMPT } from "./init.js";

--- a/packages/coding-agent/src/core/prompts/init.ts
+++ b/packages/coding-agent/src/core/prompts/init.ts
@@ -1,0 +1,15 @@
+/**
+ * Prompt for the /init command that generates AGENTS.md files.
+ */
+
+export const INIT_PROMPT = `Analyze this codebase and create an AGENTS.md file in the project root.
+
+Explore the project structure, configuration files, and source code to understand:
+- What the project does and its purpose
+- Directory structure and architecture
+- Build system and common commands (check package.json, Makefile, Cargo.toml, etc.)
+- Code style conventions (look at existing code, linter configs, editorconfig, etc.)
+- Testing setup and how to run tests
+- Any other relevant patterns or guidelines
+
+Then write a comprehensive AGENTS.md file that will help AI coding agents work effectively on this project. Be specific and concrete based on what you find - don't use placeholder text.`;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -33,6 +33,7 @@ import type { CustomToolSessionEvent, LoadedCustomTool } from "../../core/custom
 import type { HookUIContext } from "../../core/hooks/index.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
 import { createCompactionSummaryMessage } from "../../core/messages.js";
+import { INIT_PROMPT } from "../../core/prompts/index.js";
 import { type SessionContext, SessionManager } from "../../core/session-manager.js";
 import { loadSkills } from "../../core/skills.js";
 import { loadProjectContextFiles } from "../../core/system-prompt.js";
@@ -198,6 +199,7 @@ export class InteractiveMode {
 			{ name: "new", description: "Start a new session" },
 			{ name: "compact", description: "Manually compact the session context" },
 			{ name: "resume", description: "Resume a different session" },
+			{ name: "init", description: "Create AGENTS.md for this project" },
 		];
 
 		// Load hide thinking block setting
@@ -976,6 +978,11 @@ export class InteractiveMode {
 			if (text === "/quit" || text === "/exit") {
 				this.editor.setText("");
 				await this.shutdown();
+				return;
+			}
+			if (text === "/init") {
+				this.editor.setText("");
+				await this.handleInitCommand();
 				return;
 			}
 
@@ -2509,6 +2516,19 @@ export class InteractiveMode {
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new ArminComponent(this.ui));
 		this.ui.requestRender();
+	}
+
+	private async handleInitCommand(): Promise<void> {
+		const agentsPath = path.join(process.cwd(), "AGENTS.md");
+
+		if (fs.existsSync(agentsPath)) {
+			this.showWarning(`AGENTS.md already exists at ${agentsPath}. Delete it first or edit it manually.`);
+			return;
+		}
+
+		if (this.onInputCallback) {
+			this.onInputCallback(INIT_PROMPT);
+		}
 	}
 
 	private async handleBashCommand(command: string, excludeFromContext = false): Promise<void> {


### PR DESCRIPTION
Added handy `/init` slash command that analyzes the codebase and creates an AGENTS.md file to help AI coding agents work effectively on the project. Like in openceode.ai

Changes:
- Add src/core/prompts/ directory for internal prompts
- Extract init prompt to src/core/prompts/init.ts
- Add /init command handler in interactive mode
- Add /init to slash commands autocomplete

The command checks if AGENTS.md already exists and warns the user if so, preventing accidental overwrites.