### PR TITLE
feat(ai): auto-detect Vertex AI credentials from gcloud ADC

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Vertex AI dummy value for `getEnvApiKey()`: Returns `"<authenticated>"` when Application Default Credentials are configured (`~/.config/gcloud/application_default_credentials.json` exists) and both `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) and `GOOGLE_CLOUD_LOCATION` are set. This allows `streamSimple()` to work with Vertex AI without explicit `apiKey` option.
+- Vertex AI dummy value for `getEnvApiKey()`: Returns `"<authenticated>"` when Application Default Credentials are configured (`~/.config/gcloud/application_default_credentials.json` exists) and both `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) and `GOOGLE_CLOUD_LOCATION` are set. This allows `streamSimple()` to work with Vertex AI without explicit `apiKey` option. The ADC credentials file existence check is cached per-process to avoid repeated filesystem access.
 
 ## [0.34.2] - 2026-01-04
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -24,6 +24,17 @@ import type {
 	SimpleStreamOptions,
 } from "./types.js";
 
+const VERTEX_ADC_CREDENTIALS_PATH = join(homedir(), ".config", "gcloud", "application_default_credentials.json");
+
+let cachedVertexAdcCredentialsExists: boolean | null = null;
+
+function hasVertexAdcCredentials(): boolean {
+	if (cachedVertexAdcCredentialsExists === null) {
+		cachedVertexAdcCredentialsExists = existsSync(VERTEX_ADC_CREDENTIALS_PATH);
+	}
+	return cachedVertexAdcCredentialsExists;
+}
+
 /**
  * Get API key for provider from known environment variables, e.g. OPENAI_API_KEY.
  *
@@ -45,8 +56,7 @@ export function getEnvApiKey(provider: any): string | undefined {
 	// Vertex AI uses Application Default Credentials, not API keys.
 	// Auth is configured via `gcloud auth application-default login`.
 	if (provider === "google-vertex") {
-		const credentialsPath = join(homedir(), ".config", "gcloud", "application_default_credentials.json");
-		const hasCredentials = existsSync(credentialsPath);
+		const hasCredentials = hasVertexAdcCredentials();
 		const hasProject = !!(process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT);
 		const hasLocation = !!process.env.GOOGLE_CLOUD_LOCATION;
 


### PR DESCRIPTION
## Problem

Users with Vertex AI set up correctly via `gcloud auth application-default login` currently have to manually add `google-vertex` to `auth.json` to use Vertex AI models, even though their credentials are already configured.

## Solution

Auto-detect Vertex AI Application Default Credentials (ADC) and return a dummy `"<authenticated>"` value when:

1. ADC credentials file exists at `~/.config/gcloud/application_default_credentials.json`
2. `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) environment variable is set
3. `GOOGLE_CLOUD_LOCATION` environment variable is set

This allows `streamSimple()` to work with Vertex AI without requiring explicit `apiKey` configuration in `auth.json`.

## Changes

- Modified `getEnvApiKey()` in `packages/ai/src/stream.ts` to check for Vertex AI ADC configuration
- Added CHANGELOG entry documenting the fix

## Testing

- Verified Vertex AI appears in `/model` menu when ADC is configured
- Tested `streamSimple()` works without manual auth.json entry