### PR TITLE
fix(tui): trim trailing whitespace in wrapped lines to prevent width overflow

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -498,7 +498,7 @@ function wrapSingleLine(line: string, width: number): string[] {
 		const totalNeeded = currentVisibleLength + tokenVisibleLength;
 
 		if (totalNeeded > width && currentVisibleLength > 0) {
-			// Add specific reset for underline only (preserves background)
+			// Trim trailing whitespace, then add underline reset (not full reset, to preserve background)
 			let lineToWrap = currentLine.trimEnd();
 			const lineEndReset = tracker.getLineEndReset();
 			if (lineEndReset) {
@@ -527,7 +527,8 @@ function wrapSingleLine(line: string, width: number): string[] {
 		wrapped.push(currentLine);
 	}
 
-	return wrapped.length > 0 ? wrapped : [""];
+	// Trailing whitespace can cause lines to exceed the requested width
+	return wrapped.length > 0 ? wrapped.map((line) => line.trimEnd()) : [""];
 }
 
 const PUNCTUATION_REGEX = /[(){}[\]<>.,;:'"!?+\-=*/\\|&%^$#@~`]/;

--- a/packages/tui/test/wrap-ansi.test.ts
+++ b/packages/tui/test/wrap-ansi.test.ts
@@ -12,12 +12,22 @@ describe("wrapTextWithAnsi", () => {
 
 			const wrapped = wrapTextWithAnsi(text, 40);
 
-			// First line should NOT contain underline code - it's just "read this thread "
-			assert.strictEqual(wrapped[0], "read this thread ");
+			// First line should NOT contain underline code - it's just "read this thread"
+			assert.strictEqual(wrapped[0], "read this thread");
 
 			// Second line should start with underline, have URL content
 			assert.strictEqual(wrapped[1].startsWith(underlineOn), true);
 			assert.ok(wrapped[1].includes("https://"));
+		});
+
+		it("should not have whitespace before underline reset code", () => {
+			const underlineOn = "\x1b[4m";
+			const underlineOff = "\x1b[24m";
+			const textWithUnderlinedTrailingSpace = `${underlineOn}underlined text here ${underlineOff}more`;
+
+			const wrapped = wrapTextWithAnsi(textWithUnderlinedTrailingSpace, 18);
+
+			assert.ok(!wrapped[0].includes(` ${underlineOff}`));
 		});
 
 		it("should not bleed underline to padding - each line should end with reset for underline only", () => {
@@ -99,6 +109,11 @@ describe("wrapTextWithAnsi", () => {
 			for (const line of wrapped) {
 				assert.ok(visibleWidth(line) <= 10);
 			}
+		});
+
+		it("should truncate trailing whitespace that exceeds width", () => {
+			const twoSpacesWrappedToWidth1 = wrapTextWithAnsi("  ", 1);
+			assert.ok(visibleWidth(twoSpacesWrappedToWidth1[0]) <= 1);
 		});
 
 		it("should preserve color codes across wraps", () => {


### PR DESCRIPTION
## Bug
When you paste text with content that triggers `Markdown.render` (``` ````, >, ``) (bold and italics seem fine though)  which also has trailing whitespace that exceeds the width of the terminal, it causes pi to crash with the following error:
```
Error: Rendered line 1855 exceeds terminal width.
```

This happened to me a lot when copy-pasting from another terminal (so it had a lot of trailing white space on every line as well as markdown content).

## Root cause / fix
It took me awhile to figure out why I could only repro sometimes even though in this code it seemed liked the bug was clear. But we are actually protected in most scenarios due to `Editor.wordWrapLine` trimming.  

And for non whitespace characters we are protected by `breakLongWord` . 

So this bug only happens for specific cases when you paste with content that goes through `Markdown.render` and has white space beyond the width of terminal you are pasting into.


The wrapping logic in `wrapTextWithAnsi` intentionally skips breaking whitespace-only tokens to avoid generating lines of individual spaces. But this means if you paste something like 120 spaces into a 100-character-wide terminal, the line passes through unchanged and exceeds the width limit.

It seems like a safe enough fix is to `trimEnd()` all wrapped lines before returning, but I could be missing something here. But it looks like trailing whitespace doesn't need to be preserved since padding is [added later by the rendering layer](https://github.com/badlogic/pi-mono/blob/main/packages/tui/src/components/markdown.ts#L135). There was already a `trimEnd()` call at one wrap point in the code, so this just consolidates the behavior to catch all cases.

## Testing
Added two tests: one for a minimal repro of the original crash case, and one to guard the existing behavior where trailing whitespace must be trimmed before adding ANSI underline reset codes (otherwise the reset code ends up after the whitespace instead of immediately after the content).

I also manually repro'ed with ``` ```, >, and '' and confirmed they were fixed with this change by running pi built from this branch's source. 
