### PR TITLE
Fix: Ignore Windows .exe binaries in migration warnings

### DIFF
--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -169,7 +169,7 @@ function checkDeprecatedExtensionDirs(baseDir: string, label: string): string[] 
 		// Check if tools/ contains anything other than fd/rg (which are auto-extracted binaries)
 		try {
 			const entries = readdirSync(toolsDir);
-			const customTools = entries.filter((e) => e !== "fd" && e !== "rg");
+			const customTools = entries.filter((e) => e !== "fd" && e !== "rg" && e !== "fd.exe" && e !== "rg.exe");
 			if (customTools.length > 0) {
 				warnings.push(
 					`${label} tools/ directory contains custom tools. Custom tools have been merged into extensions.`,


### PR DESCRIPTION
   ## Problem
   The migration system warns about "custom tools" when only auto-extracted binaries (`fd.exe`, `rg.exe`) are
 present in `~/.pi/agent/tools/` on Windows.

   ## Solution
   Updated the `checkDeprecatedExtensionDirs` function to also ignore `.exe` extensions when checking for
 auto-extracted binaries.

   ## Changes
   - Modified `packages/coding-agent/src/migrations.ts` line 180 to include `fd.exe` and `rg.exe` in the
 filter
