### PR TITLE
fix(sdk): extensions: [] now disables discovery as documented

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- SDK: passing `extensions: []` now disables extension discovery as documented ([#465](https://github.com/badlogic/pi-mono/pull/465) by [@aliou](https://github.com/aliou))
+
 ## [0.36.0] - 2026-01-05
 
 ### Added

--- a/packages/coding-agent/examples/sdk/12-full-control.ts
+++ b/packages/coding-agent/examples/sdk/12-full-control.ts
@@ -6,10 +6,6 @@
  * IMPORTANT: When providing `tools` with a custom `cwd`, use the tool factory
  * functions (createReadTool, createBashTool, etc.) to ensure tools resolve
  * paths relative to your cwd.
- *
- * NOTE: Extensions (extensions, custom tools) are always loaded via discovery.
- * To use custom extensions, place them in the extensions directory or
- * pass paths via additionalExtensionPaths.
  */
 
 import { getModel } from "@mariozechner/pi-ai";
@@ -57,8 +53,8 @@ const { session } = await createAgentSession({
 Available: read, bash. Be concise.`,
 	// Use factory functions with the same cwd to ensure path resolution works correctly
 	tools: [createReadTool(cwd), createBashTool(cwd)],
-	// Extensions are loaded from disk - use additionalExtensionPaths to add custom ones
-	// additionalExtensionPaths: ["./my-extension.ts"],
+	// Pass empty array to disable extension discovery, or provide inline factories
+	extensions: [],
 	skills: [],
 	contextFiles: [],
 	promptTemplates: [],

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -444,6 +444,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			errors: [],
 			setUIContext: () => {},
 		};
+	} else if (options.extensions !== undefined) {
+		// User explicitly provided extensions array (even if empty) - skip discovery
+		// Inline factories from options.extensions are loaded below
+		extensionsResult = {
+			extensions: [],
+			errors: [],
+			setUIContext: () => {},
+		};
 	} else {
 		// Discover extensions, merging with additional paths
 		const configuredPaths = [...settingsManager.getExtensionPaths(), ...(options.additionalExtensionPaths ?? [])];


### PR DESCRIPTION
Noticed the following issue after migrating some tools to extensions:
- before, passing `[]` to tools and hooks would prevent the auto discovery of those
- this was helpful for subagents created via the sdk to not call themselves recursively (e.g. a researcher subagent calling itself to research something 🙄) or trigger hooks that were not relevant (e.g. triggering a notification on turn end / tool error)

Since v0.35.0, we cannot opt-out of auto discovery which re-enabled the issues above (or how my mac's notification center crashed)

In the docs, it is also mentioned that this should still be the case but it wasn't the case in the code.


Investigation session: https://shittycodingagent.ai/session/?f783e2ca0e0ed62938a0f4e667ac3c66
Implementation session: https://shittycodingagent.ai/session/?054a1d3d3c660040eecfad4803f9319f

------
<details><summary>Summary by Opus:</summary>
<p>

## Problem

Passing `extensions: []` to `createAgentSession()` did not disable extension discovery, contradicting the documented behavior.

The SDK docs state that `extensions` "Replaces discovery", but the implementation always ran discovery unless `preloadedExtensions` was non-empty. This was a regression from v0.34.x where `hooks: []` correctly skipped discovery.

**v0.34.x behavior (correct):**
```typescript
if (preloadedHooks?.length > 0) { /* use preloaded */ }
else if (options.hooks !== undefined) { /* skip discovery */ }
else { /* discover */ }
```

**v0.35.0+ behavior (broken):**
```typescript
if (preloadedExtensions?.length > 0) { /* use preloaded */ }
else { /* always discover */ }
// then merge inline extensions
```

## Fix

Added the missing `else if (options.extensions !== undefined)` branch to skip discovery when extensions array is explicitly provided, even if empty.

## Changes

- `packages/coding-agent/src/core/sdk.ts`: Add branch to skip discovery when `extensions` option is set
- `packages/coding-agent/examples/sdk/12-full-control.ts`: Remove incorrect comment, add `extensions: []` to example
- `packages/coding-agent/CHANGELOG.md`: Add fix entry

</p>
</details>