### PR TITLE
feat(oauth): show paste input immediately during OpenAI Codex login

### DIFF
--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -157,6 +157,8 @@ export class AuthStorage {
 			onAuth: (info: { url: string; instructions?: string }) => void;
 			onPrompt: (prompt: { message: string; placeholder?: string }) => Promise<string>;
 			onProgress?: (message: string) => void;
+			/** For providers with local callback servers (e.g., openai-codex), races with browser callback */
+			onManualCodeInput?: () => Promise<string>;
 		},
 	): Promise<void> {
 		let credentials: OAuthCredentials;
@@ -182,7 +184,12 @@ export class AuthStorage {
 				credentials = await loginAntigravity(callbacks.onAuth, callbacks.onProgress);
 				break;
 			case "openai-codex":
-				credentials = await loginOpenAICodex(callbacks);
+				credentials = await loginOpenAICodex({
+					onAuth: callbacks.onAuth,
+					onPrompt: callbacks.onPrompt,
+					onProgress: callbacks.onProgress,
+					onManualCodeInput: callbacks.onManualCodeInput,
+				});
 				break;
 			default:
 				throw new Error(`Unknown OAuth provider: ${provider}`);


### PR DESCRIPTION
## Problem

When using `/login` for the OpenAI Codex OAuth provider, the CLI starts a local HTTP server on `localhost:1455` to capture the OAuth callback. After displaying the auth URL, it waits up to **60 seconds** for the browser to redirect back to this local server.

This works well on local machines, but in **SSH/VPS sessions**, the browser callback cannot reach the remote machine's localhost. Users must wait the full 60 seconds before the CLI falls back to the manual paste prompt.

## Solution

Show the paste input **immediately** alongside the browser instructions. The browser callback and manual paste input race - whichever completes first wins.

### User Experience

**Before:**
```
A browser window should open. Complete login to finish.
[waits up to 60 seconds...]
Paste the authorization code (or full redirect URL):
[input appears after timeout]
```

**After:**
```
A browser window should open. Complete login to finish.
Alternatively, paste the authorization code or redirect URL below:
[input appears immediately]
```

- **Desktop users**: Complete login in browser, callback succeeds, input is cleaned up automatically
- **SSH/VPS users**: Paste the code immediately without waiting

## Technical Details

### Changes to `@mariozechner/pi-ai`

**`packages/ai/src/utils/oauth/openai-codex.ts`**

1. Added `cancelWait()` method to abort the callback polling loop early
2. Replaced `onWaitForCallback` with `onManualCodeInput`
3. Race between browser callback and manual input:

### Changes to `@mariozechner/pi-coding-agent`

**`packages/coding-agent/src/core/auth-storage.ts`**

- Updated callback interface: `onWaitForCallback` → `onManualCodeInput`

**`packages/coding-agent/src/modes/interactive/interactive-mode.ts`**

- Show paste input immediately in `onAuth` for OpenAI Codex
- Input resolves `manualCodePromise` when user submits
- Clean up input when browser callback succeeds (login completes)

### Why OpenAI Codex Only?

Other OAuth providers use different flows:
- **Anthropic**: Always uses manual paste (no local server)
- **GitHub Copilot**: Uses device code flow (user enters code on GitHub)
- **Google (Gemini CLI, Antigravity)**: Uses local server but waits indefinitely

OpenAI Codex is unique in having both a local callback server AND a timeout with fallback.

## Testing

1. Run `/login` and select "ChatGPT Plus/Pro (Codex Subscription)"
2. Verify paste input appears immediately below the instructions
3. **Test browser path**: Complete login in browser → callback succeeds → input cleaned up
4. **Test manual path**: Paste code in input → login succeeds immediately