### PR TITLE
fix: move managed binaries to bin/ and ignore hidden files in migration check

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -142,9 +142,14 @@ export function getSettingsPath(): string {
 	return join(getAgentDir(), "settings.json");
 }
 
-/** Get path to tools directory */
+/** Get path to tools directory (deprecated, use extensions/ for JS/TS tools) */
 export function getToolsDir(): string {
 	return join(getAgentDir(), "tools");
+}
+
+/** Get path to managed binaries directory (fd, rg) */
+export function getBinDir(): string {
+	return join(getAgentDir(), "bin");
 }
 
 /** Get path to prompt templates directory */

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -5,9 +5,9 @@ import { arch, platform } from "os";
 import { join } from "path";
 import { Readable } from "stream";
 import { finished } from "stream/promises";
-import { APP_NAME, getToolsDir } from "../config.js";
+import { APP_NAME, getBinDir } from "../config.js";
 
-const TOOLS_DIR = getToolsDir();
+const TOOLS_DIR = getBinDir();
 
 interface ToolConfig {
 	name: string;


### PR DESCRIPTION
This PR resolves an issue where the agent auto-downloads managed binaries (fd, rg) into the `tools/` directory, which then triggers a deprecation/migration warning introduced in v0.35.0.

Changes:
1. Introduced `getBinDir()` in `config.ts` pointing to `~/.pi/agent/bin/`.
2. Updated `tools-manager.ts` to use the new `bin/` directory for managed binaries.
3. Added a migration in `migrations.ts` to move existing `fd`/`rg` binaries from `tools/` to `bin/`.
4. Improved the `checkDeprecatedExtensionDirs` migration check to ignore hidden files (like `.DS_Store`) which often cause false-positive warnings on macOS.

This ensures that the `tools/` directory is either empty (and thus ignorable) or only contains actual custom tools that the user needs to migrate to `extensions/`.