### PR TITLE
feat(coding-agent): queue compaction submissions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Migration warnings now ignore `fd.exe` and `rg.exe` in `tools/` on Windows ([#458](https://github.com/badlogic/pi-mono/pull/458) by [@carlosgtrz](https://github.com/carlosgtrz))
 - CI: add `examples/extensions/with-deps` to workspaces to fix typecheck ([#467](https://github.com/badlogic/pi-mono/pull/467) by [@aliou](https://github.com/aliou))
 - SDK: passing `extensions: []` now disables extension discovery as documented ([#465](https://github.com/badlogic/pi-mono/pull/465) by [@aliou](https://github.com/aliou))
+- Messages submitted during compaction are queued and delivered after compaction completes, preserving steering and follow-up behavior.
 
 ## [0.36.0] - 2026-01-05
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -84,6 +84,11 @@ function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
 
+type CompactionQueuedMessage = {
+	text: string;
+	mode: "steer" | "followUp";
+};
+
 export class InteractiveMode {
 	private session: AgentSession;
 	private ui: TUI;
@@ -135,6 +140,9 @@ export class InteractiveMode {
 	// Auto-compaction state
 	private autoCompactionLoader: Loader | undefined = undefined;
 	private autoCompactionEscapeHandler?: () => void;
+
+	// Messages queued while compaction is running
+	private compactionQueuedMessages: CompactionQueuedMessage[] = [];
 
 	// Auto-retry state
 	private retryLoader: Loader | undefined = undefined;
@@ -459,6 +467,7 @@ export class InteractiveMode {
 				// Clear UI state
 				this.chatContainer.clear();
 				this.pendingMessagesContainer.clear();
+				this.compactionQueuedMessages = [];
 				this.streamingComponent = undefined;
 				this.streamingMessage = undefined;
 				this.pendingTools.clear();
@@ -1012,12 +1021,7 @@ export class InteractiveMode {
 			if (text === "/compact" || text.startsWith("/compact ")) {
 				const customInstructions = text.startsWith("/compact ") ? text.slice(9).trim() : undefined;
 				this.editor.setText("");
-				this.editor.disableSubmit = true;
-				try {
-					await this.handleCompactCommand(customInstructions);
-				} finally {
-					this.editor.disableSubmit = false;
-				}
+				await this.handleCompactCommand(customInstructions);
 				return;
 			}
 			if (text === "/debug") {
@@ -1059,8 +1063,9 @@ export class InteractiveMode {
 				}
 			}
 
-			// Block input during compaction
+			// Queue input during compaction
 			if (this.session.isCompacting) {
+				this.queueCompactionMessage(text, "steer");
 				return;
 			}
 
@@ -1251,8 +1256,7 @@ export class InteractiveMode {
 				break;
 
 			case "auto_compaction_start": {
-				// Disable submit to preserve editor text during compaction
-				this.editor.disableSubmit = true;
+				// Keep editor active; submissions are queued during compaction.
 				// Set up escape to abort auto-compaction
 				this.autoCompactionEscapeHandler = this.editor.onEscape;
 				this.editor.onEscape = () => {
@@ -1273,8 +1277,6 @@ export class InteractiveMode {
 			}
 
 			case "auto_compaction_end": {
-				// Re-enable submit
-				this.editor.disableSubmit = false;
 				// Restore escape handler
 				if (this.autoCompactionEscapeHandler) {
 					this.editor.onEscape = this.autoCompactionEscapeHandler;
@@ -1302,6 +1304,7 @@ export class InteractiveMode {
 					});
 					this.footer.invalidate();
 				}
+				void this.flushCompactionQueue({ willRetry: event.willRetry });
 				this.ui.requestRender();
 				break;
 			}
@@ -1593,6 +1596,11 @@ export class InteractiveMode {
 		const text = this.editor.getText().trim();
 		if (!text) return;
 
+		if (this.session.isCompacting) {
+			this.queueCompactionMessage(text, "followUp");
+			return;
+		}
+
 		// Alt+Enter queues a follow-up message (waits until agent finishes)
 		// This handles extension commands (execute immediately), prompt template expansion, and queueing
 		if (this.session.isStreaming) {
@@ -1761,8 +1769,14 @@ export class InteractiveMode {
 
 	private updatePendingMessagesDisplay(): void {
 		this.pendingMessagesContainer.clear();
-		const steeringMessages = this.session.getSteeringMessages();
-		const followUpMessages = this.session.getFollowUpMessages();
+		const steeringMessages = [
+			...this.session.getSteeringMessages(),
+			...this.compactionQueuedMessages.filter((msg) => msg.mode === "steer").map((msg) => msg.text),
+		];
+		const followUpMessages = [
+			...this.session.getFollowUpMessages(),
+			...this.compactionQueuedMessages.filter((msg) => msg.mode === "followUp").map((msg) => msg.text),
+		];
 		if (steeringMessages.length > 0 || followUpMessages.length > 0) {
 			this.pendingMessagesContainer.addChild(new Spacer(1));
 			for (const message of steeringMessages) {
@@ -1773,6 +1787,96 @@ export class InteractiveMode {
 				const text = theme.fg("dim", `Follow-up: ${message}`);
 				this.pendingMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
+		}
+	}
+
+	private queueCompactionMessage(text: string, mode: "steer" | "followUp"): void {
+		this.compactionQueuedMessages.push({ text, mode });
+		this.editor.addToHistory(text);
+		this.editor.setText("");
+		this.updatePendingMessagesDisplay();
+		this.showStatus("Queued message for after compaction");
+	}
+
+	private isExtensionCommand(text: string): boolean {
+		if (!text.startsWith("/")) return false;
+
+		const extensionRunner = this.session.extensionRunner;
+		if (!extensionRunner) return false;
+
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		return !!extensionRunner.getCommand(commandName);
+	}
+
+	private async flushCompactionQueue(options?: { willRetry?: boolean }): Promise<void> {
+		if (this.compactionQueuedMessages.length === 0) {
+			return;
+		}
+
+		const queuedMessages = [...this.compactionQueuedMessages];
+		this.compactionQueuedMessages = [];
+		this.updatePendingMessagesDisplay();
+
+		const restoreQueue = (error: unknown) => {
+			this.session.clearQueue();
+			this.compactionQueuedMessages = queuedMessages;
+			this.updatePendingMessagesDisplay();
+			this.showError(
+				`Failed to send queued message${queuedMessages.length > 1 ? "s" : ""}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		};
+
+		try {
+			if (options?.willRetry) {
+				for (const message of queuedMessages) {
+					if (this.isExtensionCommand(message.text)) {
+						await this.session.prompt(message.text);
+					} else if (message.mode === "followUp") {
+						await this.session.followUp(message.text);
+					} else {
+						await this.session.steer(message.text);
+					}
+				}
+				this.updatePendingMessagesDisplay();
+				return;
+			}
+
+			const firstPromptIndex = queuedMessages.findIndex((message) => !this.isExtensionCommand(message.text));
+			if (firstPromptIndex === -1) {
+				for (const message of queuedMessages) {
+					await this.session.prompt(message.text);
+				}
+				return;
+			}
+
+			const preCommands = queuedMessages.slice(0, firstPromptIndex);
+			const firstPrompt = queuedMessages[firstPromptIndex];
+			const rest = queuedMessages.slice(firstPromptIndex + 1);
+
+			for (const message of preCommands) {
+				await this.session.prompt(message.text);
+			}
+
+			const promptPromise = this.session.prompt(firstPrompt.text).catch((error) => {
+				restoreQueue(error);
+			});
+
+			for (const message of rest) {
+				if (this.isExtensionCommand(message.text)) {
+					await this.session.prompt(message.text);
+				} else if (message.mode === "followUp") {
+					await this.session.followUp(message.text);
+				} else {
+					await this.session.steer(message.text);
+				}
+			}
+			this.updatePendingMessagesDisplay();
+			void promptPromise;
+		} catch (error) {
+			restoreQueue(error);
 		}
 	}
 
@@ -2089,6 +2193,7 @@ export class InteractiveMode {
 
 		// Clear UI state
 		this.pendingMessagesContainer.clear();
+		this.compactionQueuedMessages = [];
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		this.pendingTools.clear();
@@ -2132,7 +2237,6 @@ export class InteractiveMode {
 						let manualCodeInput: Input | undefined;
 
 						try {
-
 							await this.session.modelRegistry.authStorage.login(providerId as OAuthProvider, {
 								onAuth: (info: { url: string; instructions?: string }) => {
 									this.chatContainer.addChild(new Spacer(1));
@@ -2169,7 +2273,10 @@ export class InteractiveMode {
 										this.chatContainer.addChild(new Spacer(1));
 										this.chatContainer.addChild(
 											new Text(
-												theme.fg("dim", "Alternatively, paste the authorization code or redirect URL below:"),
+												theme.fg(
+													"dim",
+													"Alternatively, paste the authorization code or redirect URL below:",
+												),
 												1,
 												0,
 											),
@@ -2594,6 +2701,7 @@ export class InteractiveMode {
 		// Clear UI state
 		this.chatContainer.clear();
 		this.pendingMessagesContainer.clear();
+		this.compactionQueuedMessages = [];
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		this.pendingTools.clear();
@@ -2747,6 +2855,7 @@ export class InteractiveMode {
 			this.statusContainer.clear();
 			this.editor.onEscape = originalOnEscape;
 		}
+		void this.flushCompactionQueue({ willRetry: false });
 	}
 
 	stop(): void {


### PR DESCRIPTION
Related to the issue [#475 Feature proposal: allow send+queueing enter/alt+enter during compaction](https://github.com/badlogic/pi-mono/issues/475).

Writeup below but please let me know your thoughts / any feedback!

## Summary
- keep submit enabled during compaction and queue input instead of dropping it
- preserve steer vs follow‑up intent for compaction‑queued messages
- flush queued messages after manual and auto‑compaction (including auto‑retry)
- keep pending queue UI consistent and clear compaction queue on new/resume

## Testing
- npm run check
- manual testing locally

## Notes
Prepared/tested with Codex xhigh; session transcript attached: [session-transcript-2026-01-05.md](https://github.com/user-attachments/files/24440030/session-transcript-2026-01-05.md)

  
 Codex-generated timeline of stuff done:
- Inspected AGENTS.md, packages/coding-agent/src/modes/interactive/interactive-mode.ts, and related session/agent code.
- Identified compaction submission behavior and compared it with #179’s prior fix (disable submit during compaction).
- Implemented a minimal follow‑up: queue compaction submissions and preserve steer vs follow‑up semantics; flush after manual/auto compaction; keep pending UI consistent; clear compaction queue on new/resume; updated packages/coding-agent/CHANGELOG.md.
- Ran npm install (required for proper-lockfile), then npm run check (biome + tsgo + web‑ui checks).
- Reverted package-lock.json to keep diff minimal.
- Created branch fix/compaction-queue, committed fix(coding-agent): queue compaction submissions.
- Tried pushing to upstream badlogic/pi-mono (403), forked to tmustier/pi-mono, pushed branch there.
- Compare link prepared: https://github.com/badlogic/pi-mono/compare/main...tmustier:fix/compaction-queue.