### PR TITLE
ai: always include reasoning.encrypted_content for Codex

### DIFF
--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -323,7 +323,9 @@ export async function transformRequestBody(
 		verbosity: options.textVerbosity || "medium",
 	};
 
-	body.include = options.include || ["reasoning.encrypted_content"];
+	const include = Array.isArray(options.include) ? [...options.include] : [];
+	include.push("reasoning.encrypted_content");
+	body.include = Array.from(new Set(include));
 
 	delete body.max_output_tokens;
 	delete body.max_completion_tokens;

--- a/packages/ai/test/openai-codex-include.test.ts
+++ b/packages/ai/test/openai-codex-include.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { type RequestBody, transformRequestBody } from "../src/providers/openai-codex/request-transformer.js";
+
+describe("openai-codex include handling", () => {
+	it("always includes reasoning.encrypted_content when caller include is custom", async () => {
+		const body: RequestBody = {
+			model: "gpt-5.1-codex",
+		};
+
+		const transformed = await transformRequestBody(body, "CODEX_INSTRUCTIONS", { include: ["foo"] }, true);
+		expect(transformed.include).toEqual(["foo", "reasoning.encrypted_content"]);
+	});
+
+	it("does not duplicate reasoning.encrypted_content", async () => {
+		const body: RequestBody = {
+			model: "gpt-5.1-codex",
+		};
+
+		const transformed = await transformRequestBody(
+			body,
+			"CODEX_INSTRUCTIONS",
+			{ include: ["foo", "reasoning.encrypted_content"] },
+			true,
+		);
+		expect(transformed.include).toEqual(["foo", "reasoning.encrypted_content"]);
+	});
+});


### PR DESCRIPTION
## Problem
Codex Responses requests require `reasoning.encrypted_content` to be included so downstream can decode/handle encrypted reasoning content. Today, if the caller passes a custom `include`, we overwrite the default and accidentally omit `reasoning.encrypted_content`.

## Fix
- Always append `reasoning.encrypted_content` to the `include` array.
- Deduplicate to avoid repeated entries.

## Tests
- Added `packages/ai/test/openai-codex-include.test.ts` covering:
  - custom include still contains `reasoning.encrypted_content`
  - no duplicates when caller already includes it

## Checks
- Ran `npm run check`.