### PR TITLE
feat(ai): OpenAI prompt caching key + retention

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `promptCacheKey` option on `Agent` to forward provider-specific prompt caching identifiers to `@mariozechner/pi-ai` streaming calls.
+
 ## [0.37.2] - 2026-01-05
 
 ## [0.37.1] - 2026-01-05

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- OpenAI Codex (ChatGPT backend): added `promptCacheKey` stream option to enable server-side prompt/session caching via internal headers.
+- OpenAI (Responses APIs): added `promptCacheRetention` stream option to control prompt cache retention (`in_memory` vs `24h`) where supported.
+
 ## [0.37.2] - 2026-01-05
 
 ### Fixed

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -94,7 +94,13 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				model: model.id,
 				input: messages,
 				stream: true,
+				prompt_cache_key: options?.promptCacheKey,
 			};
+
+			if (options?.promptCacheRetention) {
+				params.prompt_cache_retention =
+					options.promptCacheRetention === "in_memory" ? "in-memory" : options.promptCacheRetention;
+			}
 
 			if (options?.maxTokens) {
 				params.max_output_tokens = options.maxTokens;

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -38,6 +38,7 @@ export interface RequestBody {
 	};
 	include?: string[];
 	prompt_cache_key?: string;
+	prompt_cache_retention?: "in_memory" | "in-memory" | "24h";
 	max_output_tokens?: number;
 	max_completion_tokens?: number;
 	[key: string]: unknown;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -365,6 +365,11 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		stream: true,
 	};
 
+	if (options?.promptCacheRetention) {
+		params.prompt_cache_retention =
+			options.promptCacheRetention === "in_memory" ? "in-memory" : options.promptCacheRetention;
+	}
+
 	if (options?.maxTokens) {
 		params.max_output_tokens = options?.maxTokens;
 	}

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -177,6 +177,8 @@ function mapOptionsForApi<TApi extends Api>(
 		maxTokens: options?.maxTokens || Math.min(model.maxTokens, 32000),
 		signal: options?.signal,
 		apiKey: apiKey || options?.apiKey,
+		promptCacheKey: options?.promptCacheKey,
+		promptCacheRetention: options?.promptCacheRetention,
 	};
 
 	// Helper to clamp xhigh to high for providers that don't support it

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -58,12 +58,33 @@ export type Provider = KnownProvider | string;
 
 export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh";
 
+/**
+ * OpenAI prompt cache retention policy for supported APIs/models.
+ *
+ * See: https://platform.openai.com/docs/guides/prompt-caching
+ */
+export type PromptCacheRetention = "in_memory" | "in-memory" | "24h";
+
 // Base options all providers share
 export interface StreamOptions {
 	temperature?: number;
 	maxTokens?: number;
 	signal?: AbortSignal;
 	apiKey?: string;
+	/**
+	 * Provider-specific prompt caching key.
+	 *
+	 * Currently used by the OpenAI Codex (ChatGPT backend) provider to set internal
+	 * request headers that control server-side context/caching.
+	 */
+	promptCacheKey?: string;
+	/**
+	 * OpenAI prompt caching retention policy (Responses API).
+	 *
+	 * - Default is `in_memory`/`in-memory` if omitted.
+	 * - `24h` may not be supported by all models; OpenAI will reject unsupported combinations.
+	 */
+	promptCacheRetention?: PromptCacheRetention;
 }
 
 // Unified options with reasoning passed to streamSimple() and completeSimple()

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -82,6 +82,8 @@ describe("openai-codex streaming", () => {
 				expect(headers?.get("chatgpt-account-id")).toBe("acc_test");
 				expect(headers?.get("OpenAI-Beta")).toBe("responses=experimental");
 				expect(headers?.get("originator")).toBe("codex_cli_rs");
+				expect(headers?.has("conversation_id")).toBe(false);
+				expect(headers?.has("session_id")).toBe(false);
 				expect(headers?.get("accept")).toBe("text/event-stream");
 				expect(headers?.has("x-api-key")).toBe(false);
 				return new Response(stream, {
@@ -128,5 +130,107 @@ describe("openai-codex streaming", () => {
 
 		expect(sawTextDelta).toBe(true);
 		expect(sawDone).toBe(true);
+	});
+
+	it("sets conversation_id/session_id headers when promptCacheKey is provided", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+
+		const payload = Buffer.from(
+			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
+			"utf8",
+		).toString("base64");
+		const token = `aaa.${payload}.bbb`;
+
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 5,
+						output_tokens: 3,
+						total_tokens: 8,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		const promptCacheKey = "test-session-123";
+		const promptCacheRetention = "24h" as const;
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				const headers = init?.headers instanceof Headers ? init.headers : undefined;
+				expect(headers?.get("conversation_id")).toBe(promptCacheKey);
+				expect(headers?.get("session_id")).toBe(promptCacheKey);
+
+				const body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+				expect(body?.prompt_cache_retention).toBe(promptCacheRetention);
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		});
+
+		global.fetch = fetchMock as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			promptCacheKey,
+			promptCacheRetention,
+		});
+		await streamResult.result();
 	});
 });

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -856,6 +856,7 @@ export class AgentSession {
 		await this.abort();
 		this.agent.reset();
 		this.sessionManager.newSession(options);
+		this.agent.setPromptCacheKey(this.sessionManager.getSessionId());
 		this._steeringMessages = [];
 		this._followUpMessages = [];
 		this._pendingNextTurnMessages = [];
@@ -1666,6 +1667,7 @@ export class AgentSession {
 
 		// Set new session
 		this.sessionManager.setSessionFile(sessionPath);
+		this.agent.setPromptCacheKey(this.sessionManager.getSessionId());
 
 		// Reload messages
 		const sessionContext = this.sessionManager.buildSessionContext();
@@ -1745,6 +1747,7 @@ export class AgentSession {
 		} else {
 			this.sessionManager.createBranchedSession(selectedEntry.parentId);
 		}
+		this.agent.setPromptCacheKey(this.sessionManager.getSessionId());
 
 		// Reload messages from entries (works for both file and in-memory mode)
 		const sessionContext = this.sessionManager.buildSessionContext();

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -613,6 +613,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			tools: activeToolsArray,
 		},
 		convertToLlm,
+		promptCacheKey: sessionManager.getSessionId(),
 		transformContext: extensionRunner
 			? async (messages) => {
 					return extensionRunner.emitContext(messages);


### PR DESCRIPTION
## Summary

Enable OpenAI prompt caching best practices across pi-mono.

- Adds `promptCacheKey` to `StreamOptions` and wires it into the OpenAI Codex (ChatGPT backend) provider (request `prompt_cache_key` + `conversation_id`/`session_id` headers) to stabilize routing and improve cache hit rates for long shared prefixes.
- Adds `promptCacheRetention` to control OpenAI Responses prompt cache retention (`in-memory`/`24h`) and normalizes the OpenAI SDK spelling (`in_memory` -> `in-memory`).
- Ensures `pi-coding-agent` updates the cache key when sessions change (`/new`, `/switchSession`, `/branch`).

## Tests

- `packages/ai/test/openai-codex-stream.test.ts`: asserts Codex cache headers and `prompt_cache_retention` are sent.
- `packages/agent/test/agent.test.ts`: asserts `Agent` forwards `promptCacheKey` into `streamFn` options and updates on `setPromptCacheKey()`.

## Notes

Prompt caching still requires >=1024 prompt tokens and stable prompt prefixes (system/tools/examples first, per OpenAI docs).
