### PR TITLE
dynamic tool list in Codex bridge prompt

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Codex bridge prompt now dynamically lists active tools from the request, including custom extension tools. Previously only built-in tools were hardcoded in the prompt.
+
 ## [0.37.2] - 2026-01-05
 
 ### Fixed

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getCodexInstructions } from "../src/providers/openai-codex/prompts/codex.js";
-import { CODEX_PI_BRIDGE } from "../src/providers/openai-codex/prompts/pi-codex-bridge.js";
+import { buildCodexPiBridge } from "../src/providers/openai-codex/prompts/pi-codex-bridge.js";
 import {
 	normalizeModel,
 	type RequestBody,
@@ -52,7 +52,9 @@ describe("openai-codex request transformer", () => {
 		expect(input.some((item) => item.type === "item_reference")).toBe(false);
 		expect(input.some((item) => "id" in item)).toBe(false);
 		expect(input[0]?.type).toBe("message");
-		expect(input[0]?.content).toEqual([{ type: "input_text", text: CODEX_PI_BRIDGE }]);
+		expect(input[0]?.content).toEqual([
+			{ type: "input_text", text: buildCodexPiBridge([{ name: "tool", description: "" }]) },
+		]);
 
 		const orphaned = input.find((item) => item.type === "message" && item.role === "assistant");
 		expect(orphaned?.content).toMatch(/Previous tool result/);


### PR DESCRIPTION
Codex sometimes doesn't acknowledge custom tools, cause we're hardcoding the list. Solution is to keep it dynamic.