### PR TITLE
Fix status bar git branch detection in worktrees and submodules

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Status bar now shows correct git branch when running in a git worktree
+
 ## [0.37.2] - 2026-01-05
 
 ### Fixed


### PR DESCRIPTION
In git worktrees and submodules, `.git` is a file containing `gitdir: <path>` rather than a directory. The old code assumed `.git` was always a directory and looked for `.git/HEAD` directly, so the branch was never detected.

The fix checks whether `.git` is a file or directory. If it's a file, it parses the gitdir path and resolves HEAD from there.

If reading `.git` fails for any reason, we return `null` rather than continuing to walk up the tree. This is intentional - a `.git` entry (even a broken one) marks the git root for that directory. Walking up could incorrectly report a parent repo's branch.