### PR TITLE
feat(coding-agent): add blockImages setting to prevent image uploads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `blockImages` setting to prevent images from being sent to LLM providers. Provides defense-in-depth blocking at Read tool, CLI file processor, AgentSession, and convertToLlm layer. ([#492](https://github.com/badlogic/pi-mono/pull/492))
+
 ## [0.37.2] - 2026-01-05
 
 ### Fixed

--- a/packages/coding-agent/src/cli/file-processor.ts
+++ b/packages/coding-agent/src/cli/file-processor.ts
@@ -18,6 +18,8 @@ export interface ProcessedFiles {
 export interface ProcessFileOptions {
 	/** Whether to auto-resize images to 2000x2000 max. Default: true */
 	autoResizeImages?: boolean;
+	/** When true, skip image files with warning. Default: false */
+	blockImages?: boolean;
 }
 
 /** Process @file arguments into text content and image attachments */
@@ -48,6 +50,11 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 		const mimeType = await detectSupportedImageMimeTypeFromFile(absolutePath);
 
 		if (mimeType) {
+			// Check if images are blocked
+			if (options?.blockImages) {
+				console.warn(chalk.yellow(`[blockImages] Skipping image file: ${absolutePath}`));
+				continue;
+			}
 			// Handle image file
 			const content = await readFile(absolutePath);
 			const base64Content = content.toString("base64");

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -592,7 +592,13 @@ export class AgentSession {
 		// Add user message
 		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
 		if (options?.images) {
-			userContent.push(...options.images);
+			const blockImages = this.settingsManager.getBlockImages();
+			if (blockImages) {
+				// Log warning for blocked images
+				console.warn(`[blockImages] Blocked ${options.images.length} image(s) from being sent to provider`);
+			} else {
+				userContent.push(...options.images);
+			}
 		}
 		messages.push({
 			role: "user",

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -36,6 +36,7 @@ export interface TerminalSettings {
 
 export interface ImageSettings {
 	autoResize?: boolean; // default: true (resize images to 2000x2000 max for better model compatibility)
+	blockImages?: boolean; // default: false - when true, prevents all images from being sent to LLM providers
 }
 
 export interface Settings {
@@ -395,6 +396,23 @@ export class SettingsManager {
 			this.globalSettings.images = {};
 		}
 		this.globalSettings.images.autoResize = enabled;
+		this.save();
+	}
+
+	getBlockImages(): boolean {
+		return this.settings.images?.blockImages ?? false;
+	}
+
+	setBlockImages(blocked: boolean): void {
+		if (!this.globalSettings.images) {
+			this.globalSettings.images = {};
+		}
+		this.globalSettings.images.blockImages = blocked;
+		// Also update active settings for inMemory mode
+		if (!this.settings.images) {
+			this.settings.images = {};
+		}
+		this.settings.images.blockImages = blocked;
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -25,6 +25,7 @@ export interface SettingsConfig {
 	autoCompact: boolean;
 	showImages: boolean;
 	autoResizeImages: boolean;
+	blockImages: boolean;
 	steeringMode: "all" | "one-at-a-time";
 	followUpMode: "all" | "one-at-a-time";
 	thinkingLevel: ThinkingLevel;
@@ -40,6 +41,7 @@ export interface SettingsCallbacks {
 	onAutoCompactChange: (enabled: boolean) => void;
 	onShowImagesChange: (enabled: boolean) => void;
 	onAutoResizeImagesChange: (enabled: boolean) => void;
+	onBlockImagesChange: (blocked: boolean) => void;
 	onSteeringModeChange: (mode: "all" | "one-at-a-time") => void;
 	onFollowUpModeChange: (mode: "all" | "one-at-a-time") => void;
 	onThinkingLevelChange: (level: ThinkingLevel) => void;
@@ -243,6 +245,16 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
+		// Block images toggle (always available, insert after auto-resize-images)
+		const autoResizeIndex = items.findIndex((item) => item.id === "auto-resize-images");
+		items.splice(autoResizeIndex + 1, 0, {
+			id: "block-images",
+			label: "Block images",
+			description: "Prevent images from being sent to LLM providers (restart session for full effect)",
+			currentValue: config.blockImages ? "true" : "false",
+			values: ["true", "false"],
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -260,6 +272,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "auto-resize-images":
 						callbacks.onAutoResizeImagesChange(newValue === "true");
+						break;
+					case "block-images":
+						callbacks.onBlockImagesChange(newValue === "true");
 						break;
 					case "steering-mode":
 						callbacks.onSteeringModeChange(newValue as "all" | "one-at-a-time");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1936,6 +1936,7 @@ export class InteractiveMode {
 					autoCompact: this.session.autoCompactionEnabled,
 					showImages: this.settingsManager.getShowImages(),
 					autoResizeImages: this.settingsManager.getImageAutoResize(),
+					blockImages: this.settingsManager.getBlockImages(),
 					steeringMode: this.session.steeringMode,
 					followUpMode: this.session.followUpMode,
 					thinkingLevel: this.session.thinkingLevel,
@@ -1961,6 +1962,9 @@ export class InteractiveMode {
 					},
 					onAutoResizeImagesChange: (enabled) => {
 						this.settingsManager.setImageAutoResize(enabled);
+					},
+					onBlockImagesChange: (blocked) => {
+						this.settingsManager.setBlockImages(blocked);
 					},
 					onSteeringModeChange: (mode) => {
 						this.session.setSteeringMode(mode);

--- a/packages/coding-agent/test/block-images.test.ts
+++ b/packages/coding-agent/test/block-images.test.ts
@@ -1,0 +1,147 @@
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { processFileArguments } from "../src/cli/file-processor.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { createReadTool } from "../src/core/tools/read.js";
+
+// 1x1 red PNG image as base64 (smallest valid PNG)
+const TINY_PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+
+describe("blockImages setting", () => {
+	describe("SettingsManager", () => {
+		it("should default blockImages to false", () => {
+			const manager = SettingsManager.inMemory({});
+			expect(manager.getBlockImages()).toBe(false);
+		});
+
+		it("should return true when blockImages is set to true", () => {
+			const manager = SettingsManager.inMemory({ images: { blockImages: true } });
+			expect(manager.getBlockImages()).toBe(true);
+		});
+
+		it("should persist blockImages setting via setBlockImages", () => {
+			const manager = SettingsManager.inMemory({});
+			expect(manager.getBlockImages()).toBe(false);
+
+			manager.setBlockImages(true);
+			expect(manager.getBlockImages()).toBe(true);
+
+			manager.setBlockImages(false);
+			expect(manager.getBlockImages()).toBe(false);
+		});
+
+		it("should handle blockImages alongside autoResize", () => {
+			const manager = SettingsManager.inMemory({
+				images: { autoResize: true, blockImages: true },
+			});
+			expect(manager.getImageAutoResize()).toBe(true);
+			expect(manager.getBlockImages()).toBe(true);
+		});
+	});
+
+	describe("Read tool", () => {
+		let testDir: string;
+
+		beforeEach(() => {
+			testDir = join(tmpdir(), `block-images-test-${Date.now()}`);
+			mkdirSync(testDir, { recursive: true });
+		});
+
+		afterEach(() => {
+			rmSync(testDir, { recursive: true, force: true });
+		});
+
+		it("should return text message when blockImages is true", async () => {
+			// Create test image
+			const imagePath = join(testDir, "test.png");
+			writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+			const tool = createReadTool(testDir, { blockImages: true });
+			const result = await tool.execute("test-1", { path: imagePath });
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0].type).toBe("text");
+			const textContent = result.content[0] as { type: "text"; text: string };
+			expect(textContent.text).toContain("Image reading is disabled");
+			expect(textContent.text).toContain("blockImages");
+		});
+
+		it("should return image content when blockImages is false", async () => {
+			// Create test image
+			const imagePath = join(testDir, "test.png");
+			writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+			const tool = createReadTool(testDir, { blockImages: false });
+			const result = await tool.execute("test-2", { path: imagePath });
+
+			// Should have text note + image content
+			expect(result.content.length).toBeGreaterThanOrEqual(1);
+			const hasImage = result.content.some((c) => c.type === "image");
+			expect(hasImage).toBe(true);
+		});
+
+		it("should read text files normally even when blockImages is true", async () => {
+			// Create test text file
+			const textPath = join(testDir, "test.txt");
+			writeFileSync(textPath, "Hello, world!");
+
+			const tool = createReadTool(testDir, { blockImages: true });
+			const result = await tool.execute("test-3", { path: textPath });
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0].type).toBe("text");
+			const textContent = result.content[0] as { type: "text"; text: string };
+			expect(textContent.text).toContain("Hello, world!");
+		});
+	});
+
+	describe("processFileArguments", () => {
+		let testDir: string;
+
+		beforeEach(() => {
+			testDir = join(tmpdir(), `block-images-process-test-${Date.now()}`);
+			mkdirSync(testDir, { recursive: true });
+		});
+
+		afterEach(() => {
+			rmSync(testDir, { recursive: true, force: true });
+		});
+
+		it("should skip image files when blockImages is true", async () => {
+			// Create test image
+			const imagePath = join(testDir, "test.png");
+			writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+			const result = await processFileArguments([imagePath], { blockImages: true });
+
+			expect(result.images).toHaveLength(0);
+			// Text should be empty since image was skipped
+			expect(result.text).toBe("");
+		});
+
+		it("should include image files when blockImages is false", async () => {
+			// Create test image
+			const imagePath = join(testDir, "test.png");
+			writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+			const result = await processFileArguments([imagePath], { blockImages: false });
+
+			expect(result.images).toHaveLength(1);
+			expect(result.images[0].type).toBe("image");
+		});
+
+		it("should process text files normally when blockImages is true", async () => {
+			// Create test text file
+			const textPath = join(testDir, "test.txt");
+			writeFileSync(textPath, "Hello, world!");
+
+			const result = await processFileArguments([textPath], { blockImages: true });
+
+			expect(result.images).toHaveLength(0);
+			expect(result.text).toContain("Hello, world!");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds a `blockImages` setting that prevents images from being sent to LLM providers.

**Why this matters:** Pi coding agents may operate in environments where screenshots, diagrams, or other images contain PII (personally identifiable information), proprietary data, or sensitive content. For privacy-conscious users and enterprise deployments, having a text-only mode ensures no image data leaves the local environment - even accidentally.

### Changes

- Added `blockImages` setting to `ImageSettings` (default: `false`)
- Defense-in-depth blocking at multiple layers:
  - **Read tool**: Returns text message instead of image content
  - **CLI file processor**: Skips image files with `[blockImages]` warning
  - **AgentSession**: Filters images from user messages
  - **convertToLlm layer**: Final safety net filtering before API calls
- UI toggle in settings menu
- 10 unit tests covering all blocking layers

## Test plan

- [x] Enable `blockImages` in settings menu
- [x] Read tool returns "Image reading is disabled" for image files
- [x] CLI shows `[blockImages] Skipping image file` warning for `@image.png` args
- [x] Text files work normally when `blockImages` is enabled
- [x] All 10 unit tests pass (`npm test`)
- [x] `npm run check` passes