### PR TITLE
Add the codex bridge prompt in the html export

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -3,6 +3,7 @@ export * from "./providers/anthropic.js";
 export * from "./providers/google.js";
 export * from "./providers/google-gemini-cli.js";
 export * from "./providers/google-vertex.js";
+export * from "./providers/openai-codex/index.js";
 export * from "./providers/openai-completions.js";
 export * from "./providers/openai-responses.js";
 export * from "./stream.js";

--- a/packages/ai/src/providers/openai-codex/index.ts
+++ b/packages/ai/src/providers/openai-codex/index.ts
@@ -1,0 +1,7 @@
+/**
+ * OpenAI Codex utilities - exported for use by coding-agent export
+ */
+
+export { type CacheMetadata, getCodexInstructions, getModelFamily, type ModelFamily } from "./prompts/codex.js";
+export { buildCodexPiBridge } from "./prompts/pi-codex-bridge.js";
+export { buildCodexSystemPrompt, type CodexSystemPrompt } from "./prompts/system-prompt.js";

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2057,9 +2057,9 @@ export class AgentSession {
 	 * @param outputPath Optional output path (defaults to session directory)
 	 * @returns Path to exported file
 	 */
-	exportToHtml(outputPath?: string): string {
+	async exportToHtml(outputPath?: string): Promise<string> {
 		const themeName = this.settingsManager.getTheme();
-		return exportSessionToHtml(this.sessionManager, this.state, { outputPath, themeName });
+		return await exportSessionToHtml(this.sessionManager, this.state, { outputPath, themeName });
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/export-html/template.css
+++ b/packages/coding-agent/src/core/export-html/template.css
@@ -593,6 +593,17 @@
       display: block;
     }
 
+    .system-prompt.provider-prompt {
+      border-left: 3px solid var(--warning);
+    }
+
+    .system-prompt-note {
+      font-size: 10px;
+      font-style: italic;
+      color: var(--muted);
+      margin-top: 4px;
+    }
+
     /* Tools list */
     .tools-list {
       background: var(--customMessageBg);

--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -12,7 +12,7 @@
         bytes[i] = binary.charCodeAt(i);
       }
       const data = JSON.parse(new TextDecoder('utf-8').decode(bytes));
-      const { header, entries, leafId: defaultLeafId, systemPrompt, tools } = data;
+      const { header, entries, leafId: defaultLeafId, systemPrompt, providerSystemPrompt, tools } = data;
 
       // ============================================================
       // URL PARAMETER HANDLING
@@ -1060,7 +1060,32 @@
             </div>
           </div>`;
 
-        if (systemPrompt) {
+        // Render provider-injected system prompt (e.g., Codex) if present
+        if (providerSystemPrompt) {
+          const lines = providerSystemPrompt.content.split('\n');
+          const previewLines = 10;
+          const noteHtml = providerSystemPrompt.note 
+            ? `<div class="system-prompt-note">${escapeHtml(providerSystemPrompt.note)}</div>` 
+            : '';
+          if (lines.length > previewLines) {
+            const preview = lines.slice(0, previewLines).join('\n');
+            const remaining = lines.length - previewLines;
+            html += `<div class="system-prompt provider-prompt expandable" onclick="this.classList.toggle('expanded')">
+              <div class="system-prompt-header">${escapeHtml(providerSystemPrompt.title)}</div>
+              ${noteHtml}
+              <div class="system-prompt-preview">${escapeHtml(preview)}</div>
+              <div class="system-prompt-expand-hint">... (${remaining} more lines, click to expand)</div>
+              <div class="system-prompt-full">${escapeHtml(providerSystemPrompt.content)}</div>
+            </div>`;
+          } else {
+            html += `<div class="system-prompt provider-prompt">
+              <div class="system-prompt-header">${escapeHtml(providerSystemPrompt.title)}</div>
+              ${noteHtml}
+              <div class="system-prompt-full" style="display: block">${escapeHtml(providerSystemPrompt.content)}</div>
+            </div>`;
+          }
+        } else if (systemPrompt) {
+          // Standard system prompt (non-Codex providers)
           const lines = systemPrompt.split('\n');
           const previewLines = 10;
           if (lines.length > previewLines) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -999,7 +999,7 @@ export class InteractiveMode {
 				return;
 			}
 			if (text.startsWith("/export")) {
-				this.handleExportCommand(text);
+				await this.handleExportCommand(text);
 				this.editor.setText("");
 				return;
 			}
@@ -2402,12 +2402,12 @@ export class InteractiveMode {
 	// Command handlers
 	// =========================================================================
 
-	private handleExportCommand(text: string): void {
+	private async handleExportCommand(text: string): Promise<void> {
 		const parts = text.split(/\s+/);
 		const outputPath = parts.length > 1 ? parts[1] : undefined;
 
 		try {
-			const filePath = this.session.exportToHtml(outputPath);
+			const filePath = await this.session.exportToHtml(outputPath);
 			this.showStatus(`Session exported to: ${filePath}`);
 		} catch (error: unknown) {
 			this.showError(`Failed to export session: ${error instanceof Error ? error.message : "Unknown error"}`);
@@ -2430,7 +2430,7 @@ export class InteractiveMode {
 		// Export to a temp file
 		const tmpFile = path.join(os.tmpdir(), "session.html");
 		try {
-			this.session.exportToHtml(tmpFile);
+			await this.session.exportToHtml(tmpFile);
 		} catch (error: unknown) {
 			this.showError(`Failed to export session: ${error instanceof Error ? error.message : "Unknown error"}`);
 			return;

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -431,7 +431,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			}
 
 			case "export_html": {
-				const path = session.exportToHtml(command.outputPath);
+				const path = await session.exportToHtml(command.outputPath);
 				return success(id, "export_html", { path });
 			}
 


### PR DESCRIPTION
This extends the hackery done for codex to the export system.  I think without this it's a bit confusing what actually happens.  The way this works now is that it shows the used bridge prompt in the model change message.

* A session before: https://shittycodingagent.ai/session/?5b26bd7a97bc111f95acca75e5cb50b8
* A session after: https://shittycodingagent.ai/session/?42233a47e902f234d08e8f6ce6ee0f2b

Not at all sure if this is the right way of going about it, maybe that whole thing would eventually have to be refactored.