### PR TITLE
feat: add granular footer statistics toggles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added footer display toggles: `showCost`, `showTokens`, `showContext` to hide/show individual stats in the footer for privacy or reduced clutter.
+
 ## [0.37.3] - 2026-01-06
 
 ### Added

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -39,6 +39,12 @@ export interface ImageSettings {
 	blockImages?: boolean; // default: false - when true, prevents all images from being sent to LLM providers
 }
 
+export interface FooterSettings {
+	showCost?: boolean; // default: true - display cost in footer
+	showTokens?: boolean; // default: true - display token counts in footer
+	showContext?: boolean; // default: true - display context window usage in footer
+}
+
 export interface Settings {
 	lastChangelogVersion?: string;
 	defaultProvider?: string;
@@ -57,6 +63,7 @@ export interface Settings {
 	skills?: SkillsSettings;
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
+	footer?: FooterSettings;
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
 	doubleEscapeAction?: "branch" | "tree"; // Action for double-escape with empty editor (default: "tree")
 }
@@ -421,6 +428,42 @@ export class SettingsManager {
 
 	setDoubleEscapeAction(action: "branch" | "tree"): void {
 		this.globalSettings.doubleEscapeAction = action;
+		this.save();
+	}
+
+	getFooterShowCost(): boolean {
+		return this.settings.footer?.showCost ?? true;
+	}
+
+	setFooterShowCost(show: boolean): void {
+		if (!this.globalSettings.footer) {
+			this.globalSettings.footer = {};
+		}
+		this.globalSettings.footer.showCost = show;
+		this.save();
+	}
+
+	getFooterShowTokens(): boolean {
+		return this.settings.footer?.showTokens ?? true;
+	}
+
+	setFooterShowTokens(show: boolean): void {
+		if (!this.globalSettings.footer) {
+			this.globalSettings.footer = {};
+		}
+		this.globalSettings.footer.showTokens = show;
+		this.save();
+	}
+
+	getFooterShowContext(): boolean {
+		return this.settings.footer?.showContext ?? true;
+	}
+
+	setFooterShowContext(show: boolean): void {
+		if (!this.globalSettings.footer) {
+			this.globalSettings.footer = {};
+		}
+		this.globalSettings.footer.showContext = show;
 		this.save();
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -26,6 +26,9 @@ export interface SettingsConfig {
 	showImages: boolean;
 	autoResizeImages: boolean;
 	blockImages: boolean;
+	showCost: boolean;
+	showTokens: boolean;
+	showContext: boolean;
 	steeringMode: "all" | "one-at-a-time";
 	followUpMode: "all" | "one-at-a-time";
 	thinkingLevel: ThinkingLevel;
@@ -42,6 +45,9 @@ export interface SettingsCallbacks {
 	onShowImagesChange: (enabled: boolean) => void;
 	onAutoResizeImagesChange: (enabled: boolean) => void;
 	onBlockImagesChange: (blocked: boolean) => void;
+	onShowCostChange: (show: boolean) => void;
+	onShowTokensChange: (show: boolean) => void;
+	onShowContextChange: (show: boolean) => void;
 	onSteeringModeChange: (mode: "all" | "one-at-a-time") => void;
 	onFollowUpModeChange: (mode: "all" | "one-at-a-time") => void;
 	onThinkingLevelChange: (level: ThinkingLevel) => void;
@@ -255,6 +261,34 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
+		// Footer statistics toggles (insert after block-images)
+		const blockImagesIndex = items.findIndex((item) => item.id === "block-images");
+		items.splice(blockImagesIndex + 1, 0, {
+			id: "show-cost",
+			label: "Show cost",
+			description: "Display cost in footer",
+			currentValue: config.showCost ? "true" : "false",
+			values: ["true", "false"],
+		});
+
+		const showCostIndex = items.findIndex((item) => item.id === "show-cost");
+		items.splice(showCostIndex + 1, 0, {
+			id: "show-tokens",
+			label: "Show tokens",
+			description: "Display token counts in footer",
+			currentValue: config.showTokens ? "true" : "false",
+			values: ["true", "false"],
+		});
+
+		const showTokensIndex = items.findIndex((item) => item.id === "show-tokens");
+		items.splice(showTokensIndex + 1, 0, {
+			id: "show-context",
+			label: "Show context",
+			description: "Display context window usage in footer",
+			currentValue: config.showContext ? "true" : "false",
+			values: ["true", "false"],
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -275,6 +309,15 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "block-images":
 						callbacks.onBlockImagesChange(newValue === "true");
+						break;
+					case "show-cost":
+						callbacks.onShowCostChange(newValue === "true");
+						break;
+					case "show-tokens":
+						callbacks.onShowTokensChange(newValue === "true");
+						break;
+					case "show-context":
+						callbacks.onShowContextChange(newValue === "true");
 						break;
 					case "steering-mode":
 						callbacks.onSteeringModeChange(newValue as "all" | "one-at-a-time");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -193,6 +193,9 @@ export class InteractiveMode {
 		this.editorContainer.addChild(this.editor);
 		this.footer = new FooterComponent(session);
 		this.footer.setAutoCompactEnabled(session.autoCompactionEnabled);
+		this.footer.setShowCost(this.settingsManager.getFooterShowCost());
+		this.footer.setShowTokens(this.settingsManager.getFooterShowTokens());
+		this.footer.setShowContext(this.settingsManager.getFooterShowContext());
 
 		// Define commands for autocomplete
 		const slashCommands: SlashCommand[] = [
@@ -1972,6 +1975,9 @@ export class InteractiveMode {
 					showImages: this.settingsManager.getShowImages(),
 					autoResizeImages: this.settingsManager.getImageAutoResize(),
 					blockImages: this.settingsManager.getBlockImages(),
+					showCost: this.settingsManager.getFooterShowCost(),
+					showTokens: this.settingsManager.getFooterShowTokens(),
+					showContext: this.settingsManager.getFooterShowContext(),
 					steeringMode: this.session.steeringMode,
 					followUpMode: this.session.followUpMode,
 					thinkingLevel: this.session.thinkingLevel,
@@ -2000,6 +2006,18 @@ export class InteractiveMode {
 					},
 					onBlockImagesChange: (blocked) => {
 						this.settingsManager.setBlockImages(blocked);
+					},
+					onShowCostChange: (show) => {
+						this.settingsManager.setFooterShowCost(show);
+						this.footer.setShowCost(show);
+					},
+					onShowTokensChange: (show) => {
+						this.settingsManager.setFooterShowTokens(show);
+						this.footer.setShowTokens(show);
+					},
+					onShowContextChange: (show) => {
+						this.settingsManager.setFooterShowContext(show);
+						this.footer.setShowContext(show);
 					},
 					onSteeringModeChange: (mode) => {
 						this.session.setSteeringMode(mode);


### PR DESCRIPTION
## Summary

- Add separate settings to toggle visibility of footer statistics: `showCost`, `showTokens`, `showContext`
- Allows users to hide cost (privacy during screen sharing), tokens, or context % independently
- All default to `true` (show), accessible via settings menu (Ctrl+,)