### PR TITLE
fix(coding-agent): keep draft editor text when previously queued messages send

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1167,7 +1167,6 @@ export class InteractiveMode {
 					this.ui.requestRender();
 				} else if (event.message.role === "user") {
 					this.addMessageToChat(event.message);
-					this.editor.setText("");
 					this.updatePendingMessagesDisplay();
 					this.ui.requestRender();
 				} else if (event.message.role === "assistant") {


### PR DESCRIPTION
Tiny edit included for convenience alongside https://github.com/badlogic/pi-mono/issues/502

## Summary                                                                                                                                                                  
One-line change to:
- Stop clearing the editor on user message start so queued steering/follow-up doesn’t wipe draft input.                                                                                 
- Keep pending queue display updates intact.

## Testing
- npm run check
- manual tests locally - works with both steering and follow-up messages, doesn't seem to affect other behaviour

## Notes
Also had Pi triple check the history of that line:
> - **When it was introduced:** 0020de8518f91bc7deb9c19b46c9a6028ec18203 (2025‑12‑09, “WP15: Create InteractiveMode using AgentSession”). It added the message_start handler in packages/coding-agent/src/modes/interactive/interactive-mode.ts and included this.editor.setText("") for user messages.
> - **Why it likely existed:** At the time, it looks like a safety net to clear the input whenever a user message enters the conversation. But the editor already clears itself on submit in packages/tui/src/components/editor.ts, and interactive-mode clears the editor explicitly for slash commands and for streaming queueing. So that line was redundant even then.
> - **What relies on it today:** I couldn’t find any functional dependency. Normal input flow already clears before message_start fires. Queued steering/follow‑up uses session.prompt(...,streamingBehavior) which clears the editor explicitly. Pending queue display is driven by AgentSession removing queued messages before emitting message_start, and updatePendingMessagesDisplay() is still called.                                                                                                                            
> - **Behavioral change if we remove it:** The only case that changes is when a user message is injected without a direct editor submission (queued steering/follow‑up or pi.sendUserMessage() from an extension). In those cases, the draft now stays instead of being wiped — which is the bug you reported. This doesn’t impact any other flows I can see.