### PR TITLE
fix(ai): classify Google thoughtSignature as thinking

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -20,7 +20,14 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import type { GoogleThinkingLevel } from "./google-gemini-cli.js";
-import { convertMessages, convertTools, mapStopReason, mapToolChoice } from "./google-shared.js";
+import {
+	convertMessages,
+	convertTools,
+	isThinkingPart,
+	mapStopReason,
+	mapToolChoice,
+	retainThoughtSignature,
+} from "./google-shared.js";
 
 export interface GoogleVertexOptions extends StreamOptions {
 	toolChoice?: "auto" | "none" | "any";
@@ -88,7 +95,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex"> = (
 				if (candidate?.content?.parts) {
 					for (const part of candidate.content.parts) {
 						if (part.text !== undefined) {
-							const isThinking = part.thought === true;
+							const isThinking = isThinkingPart(part);
 							if (
 								!currentBlock ||
 								(isThinking && currentBlock.type !== "thinking") ||
@@ -123,7 +130,10 @@ export const streamGoogleVertex: StreamFunction<"google-vertex"> = (
 							}
 							if (currentBlock.type === "thinking") {
 								currentBlock.thinking += part.text;
-								currentBlock.thinkingSignature = part.thoughtSignature;
+								currentBlock.thinkingSignature = retainThoughtSignature(
+									currentBlock.thinkingSignature,
+									part.thoughtSignature,
+								);
 								stream.push({
 									type: "thinking_delta",
 									contentIndex: blockIndex(),

--- a/packages/ai/test/google-thinking-signature.test.ts
+++ b/packages/ai/test/google-thinking-signature.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { isThinkingPart, retainThoughtSignature } from "../src/providers/google-shared.js";
+
+describe("Google thinking detection (thoughtSignature)", () => {
+	it("treats part.thought === true as thinking", () => {
+		expect(isThinkingPart({ thought: true, thoughtSignature: undefined })).toBe(true);
+	});
+
+	it("treats a non-empty thoughtSignature as thinking even if thought is missing", () => {
+		// This is the bug: some backends omit `thought: true` but still include `thoughtSignature`
+		expect(isThinkingPart({ thought: undefined, thoughtSignature: "opaque-signature" })).toBe(true);
+		expect(isThinkingPart({ thought: false, thoughtSignature: "opaque-signature" })).toBe(true);
+	});
+
+	it("does not treat empty/missing signatures as thinking if thought is not set", () => {
+		expect(isThinkingPart({ thought: undefined, thoughtSignature: undefined })).toBe(false);
+		expect(isThinkingPart({ thought: false, thoughtSignature: "" })).toBe(false);
+	});
+
+	it("preserves the existing signature when subsequent deltas omit thoughtSignature", () => {
+		const first = retainThoughtSignature(undefined, "sig-1");
+		expect(first).toBe("sig-1");
+
+		const second = retainThoughtSignature(first, undefined);
+		expect(second).toBe("sig-1");
+
+		const third = retainThoughtSignature(second, "");
+		expect(third).toBe("sig-1");
+	});
+
+	it("updates the signature when a new non-empty signature arrives", () => {
+		const updated = retainThoughtSignature("sig-1", "sig-2");
+		expect(updated).toBe("sig-2");
+	});
+
+	// Note: signature-only parts (empty text + thoughtSignature) are handled by isThinkingPart via thoughtSignature presence.
+});


### PR DESCRIPTION
Google streaming may emit thought signatures without `thought: true` (including empty-text signature-only parts). This could cause thought content to be mislabeled as normal assistant text.

### Changes
- Treat any non-empty `thoughtSignature` as thinking in Google streamers (Gemini CLI/Antigravity, Generative AI, Vertex).
- Retain the last non-empty `thoughtSignature` across streaming deltas so it isn't overwritten when later chunks omit the field.
- Add unit test coverage for thinking classification + signature retention.

### Notes
- Signature-bearing parts are preserved as emitted (no merging/moving across parts), matching the thought-signatures docs.
