### PR TITLE
feat(coding-agent): add favorite models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5276,7 +5276,6 @@
 			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
 			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@lit/reactive-element": "^2.1.0",
 				"lit-element": "^4.2.0",
@@ -6624,7 +6623,6 @@
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
 			"integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -6653,8 +6651,7 @@
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
 			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -6840,7 +6837,6 @@
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -6920,7 +6916,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
 			"integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Exported truncation utilities for custom tools: `truncateHead`, `truncateTail`, `truncateLine`, `formatSize`, `DEFAULT_MAX_BYTES`, `DEFAULT_MAX_LINES`, `TruncationOptions`, `TruncationResult`
 - New example `truncated-tool.ts` demonstrating proper output truncation with custom rendering for extensions
 - Documentation for output truncation best practices in `docs/extensions.md`
+- Model selector favorites are now navigable - use arrow keys to select a favorite, then press * to unfavorite it
 
 ## [0.37.4] - 2026-01-06
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -297,7 +297,8 @@ Both modes are configurable via `/settings`: "one-at-a-time" delivers messages o
 | Ctrl+Z | Suspend to background (use `fg` in shell to resume) |
 | Shift+Tab | Cycle thinking level |
 | Ctrl+P / Shift+Ctrl+P | Cycle models forward/backward (scoped by `--models`) |
-| Ctrl+L | Open model selector |
+| Alt+P / Shift+Alt+P | Cycle favorite models forward/backward |
+| Ctrl+L | Open model selector (press `*` to toggle favorite) |
 | Ctrl+O | Toggle tool output expansion |
 | Ctrl+T | Toggle thinking block visibility |
 | Ctrl+G | Edit message in external editor (`$VISUAL` or `$EDITOR`) |

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -207,6 +207,8 @@ export class ExtensionRunner {
 		"ctrl+g",
 		"shift+tab",
 		"shift+ctrl+p",
+		"alt+p",
+		"shift+alt+p",
 		"alt+enter",
 		"escape",
 		"enter",

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -22,6 +22,8 @@ export type AppAction =
 	| "cycleThinkingLevel"
 	| "cycleModelForward"
 	| "cycleModelBackward"
+	| "cycleFavoriteForward"
+	| "cycleFavoriteBackward"
 	| "selectModel"
 	| "expandTools"
 	| "toggleThinking"
@@ -51,6 +53,8 @@ export const DEFAULT_APP_KEYBINDINGS: Record<AppAction, KeyId | KeyId[]> = {
 	cycleThinkingLevel: "shift+tab",
 	cycleModelForward: "ctrl+p",
 	cycleModelBackward: "shift+ctrl+p",
+	cycleFavoriteForward: "alt+p",
+	cycleFavoriteBackward: "shift+alt+p",
 	selectModel: "ctrl+l",
 	expandTools: "ctrl+o",
 	toggleThinking: "ctrl+t",
@@ -75,6 +79,8 @@ const APP_ACTIONS: AppAction[] = [
 	"cycleThinkingLevel",
 	"cycleModelForward",
 	"cycleModelBackward",
+	"cycleFavoriteForward",
+	"cycleFavoriteBackward",
 	"selectModel",
 	"expandTools",
 	"toggleThinking",

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -1,5 +1,7 @@
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import { type Model, modelsAreEqual } from "@mariozechner/pi-ai";
-import { Container, getEditorKeybindings, Input, Spacer, Text, type TUI } from "@mariozechner/pi-tui";
+import { Container, getEditorKeybindings, Input, matchesKey, Spacer, Text, type TUI } from "@mariozechner/pi-tui";
+import type { KeybindingsManager } from "../../../core/keybindings.js";
 import type { ModelRegistry } from "../../../core/model-registry.js";
 import type { SettingsManager } from "../../../core/settings-manager.js";
 import { fuzzyFilter } from "../../../utils/fuzzy.js";
@@ -10,6 +12,14 @@ interface ModelItem {
 	provider: string;
 	id: string;
 	model: Model<any>;
+	isFavorite: boolean;
+	isProjectFavorite: boolean; // True if favorite is from project settings (read-only)
+}
+
+/** Represents either a favorite or non-favorite item for unified navigation */
+interface NavigableItem {
+	item: ModelItem;
+	isFavoriteSection: boolean;
 }
 
 interface ScopedModelItem {
@@ -17,16 +27,32 @@ interface ScopedModelItem {
 	thinkingLevel: string;
 }
 
+/** Sort comparator for model items: current model first, then favorites, then by provider */
+function createModelSortComparator(currentModel: Model<any> | undefined) {
+	return (a: ModelItem, b: ModelItem): number => {
+		const aIsCurrent = modelsAreEqual(currentModel, a.model);
+		const bIsCurrent = modelsAreEqual(currentModel, b.model);
+		if (aIsCurrent && !bIsCurrent) return -1;
+		if (!aIsCurrent && bIsCurrent) return 1;
+		if (a.isFavorite && !b.isFavorite) return -1;
+		if (!a.isFavorite && b.isFavorite) return 1;
+		return a.provider.localeCompare(b.provider);
+	};
+}
+
 /**
  * Component that renders a model selector with search
  */
 export class ModelSelectorComponent extends Container {
 	private searchInput: Input;
+	private pinnedContainer: Container;
 	private listContainer: Container;
 	private allModels: ModelItem[] = [];
 	private filteredModels: ModelItem[] = [];
+	private navigableItems: NavigableItem[] = [];
 	private selectedIndex: number = 0;
 	private currentModel?: Model<any>;
+	private currentThinkingLevel: ThinkingLevel;
 	private settingsManager: SettingsManager;
 	private modelRegistry: ModelRegistry;
 	private onSelectCallback: (model: Model<any>) => void;
@@ -34,12 +60,15 @@ export class ModelSelectorComponent extends Container {
 	private errorMessage?: string;
 	private tui: TUI;
 	private scopedModels: ReadonlyArray<ScopedModelItem>;
+	private keybindings: KeybindingsManager;
 
 	constructor(
 		tui: TUI,
 		currentModel: Model<any> | undefined,
+		currentThinkingLevel: ThinkingLevel,
 		settingsManager: SettingsManager,
 		modelRegistry: ModelRegistry,
+		keybindings: KeybindingsManager,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
 		onSelect: (model: Model<any>) => void,
 		onCancel: () => void,
@@ -48,8 +77,10 @@ export class ModelSelectorComponent extends Container {
 
 		this.tui = tui;
 		this.currentModel = currentModel;
+		this.currentThinkingLevel = currentThinkingLevel;
 		this.settingsManager = settingsManager;
 		this.modelRegistry = modelRegistry;
+		this.keybindings = keybindings;
 		this.scopedModels = scopedModels;
 		this.onSelectCallback = onSelect;
 		this.onCancelCallback = onCancel;
@@ -64,19 +95,28 @@ export class ModelSelectorComponent extends Container {
 				? "Showing models from --models scope"
 				: "Only showing models with configured API keys (see README for details)";
 		this.addChild(new Text(theme.fg("warning", hintText), 0, 0));
+		const cycleFavoriteKey = this.keybindings.getDisplayString("cycleFavoriteForward");
+		this.addChild(
+			new Text(theme.fg("muted", `Press * to toggle favorite (${cycleFavoriteKey} cycles favorites)`), 0, 0),
+		);
 		this.addChild(new Spacer(1));
 
 		// Create search input
 		this.searchInput = new Input();
 		this.searchInput.onSubmit = () => {
-			// Enter on search input selects the first filtered item
-			if (this.filteredModels[this.selectedIndex]) {
-				this.handleSelect(this.filteredModels[this.selectedIndex].model);
+			// Enter on search input selects the currently selected item
+			const selectedNavItem = this.navigableItems[this.selectedIndex];
+			if (selectedNavItem) {
+				this.handleSelect(selectedNavItem.item.model);
 			}
 		};
 		this.addChild(this.searchInput);
 
 		this.addChild(new Spacer(1));
+
+		// Pinned favorites container
+		this.pinnedContainer = new Container();
+		this.addChild(this.pinnedContainer);
 
 		// Create list container
 		this.listContainer = new Container();
@@ -104,6 +144,8 @@ export class ModelSelectorComponent extends Container {
 				provider: scoped.model.provider,
 				id: scoped.model.id,
 				model: scoped.model,
+				isFavorite: this.settingsManager.isFavoriteModel(scoped.model.provider, scoped.model.id),
+				isProjectFavorite: this.settingsManager.isFavoriteFromProject(scoped.model.provider, scoped.model.id),
 			}));
 		} else {
 			// Refresh to pick up any changes to models.json
@@ -122,6 +164,8 @@ export class ModelSelectorComponent extends Container {
 					provider: model.provider,
 					id: model.id,
 					model,
+					isFavorite: this.settingsManager.isFavoriteModel(model.provider, model.id),
+					isProjectFavorite: this.settingsManager.isFavoriteFromProject(model.provider, model.id),
 				}));
 			} catch (error) {
 				this.allModels = [];
@@ -132,63 +176,158 @@ export class ModelSelectorComponent extends Container {
 		}
 
 		// Sort: current model first, then by provider
-		models.sort((a, b) => {
-			const aIsCurrent = modelsAreEqual(this.currentModel, a.model);
-			const bIsCurrent = modelsAreEqual(this.currentModel, b.model);
-			if (aIsCurrent && !bIsCurrent) return -1;
-			if (!aIsCurrent && bIsCurrent) return 1;
-			return a.provider.localeCompare(b.provider);
-		});
+		models.sort(createModelSortComparator(this.currentModel));
 
 		this.allModels = models;
-		this.filteredModels = models;
-		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, models.length - 1));
+		const favorites = models.filter((m) => m.isFavorite);
+		this.filteredModels = models.filter((m) => !m.isFavorite);
+		this.navigableItems = [
+			...favorites.map((item) => ({ item, isFavoriteSection: true })),
+			...this.filteredModels.map((item) => ({ item, isFavoriteSection: false })),
+		];
+		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.navigableItems.length - 1));
+	}
+
+	private getFavoriteKey(provider: string, modelId: string): string {
+		// Use current thinking level (what user sees in UI), not default
+		return `${provider}/${modelId}:${this.currentThinkingLevel}`;
+	}
+
+	private toggleFavorite(item: ModelItem): void {
+		// Can't toggle project-level favorites from UI
+		if (item.isProjectFavorite) {
+			return; // Silently ignore - the star already shows it's locked
+		}
+
+		// Remember the current item to maintain selection
+		const currentItemKey = `${item.provider}/${item.id}`;
+
+		// Find existing global favorite key for this model
+		const existingKey = this.settingsManager.findGlobalFavoriteKey(item.provider, item.id);
+
+		if (existingKey) {
+			this.settingsManager.removeFavoriteModel(existingKey);
+			item.isFavorite = false;
+		} else {
+			const favoriteKey = this.getFavoriteKey(item.provider, item.id);
+			this.settingsManager.addFavoriteModel(favoriteKey);
+			item.isFavorite = true;
+		}
+
+		this.resortModels();
+
+		// Restore selection to the same item after re-sort
+		const newIndex = this.navigableItems.findIndex((n) => `${n.item.provider}/${n.item.id}` === currentItemKey);
+		if (newIndex !== -1) {
+			this.selectedIndex = newIndex;
+		}
+
+		this.updateList();
+	}
+
+	private resortModels(): void {
+		this.allModels.sort(createModelSortComparator(this.currentModel));
+		this.filterModels(this.searchInput.getValue());
 	}
 
 	private filterModels(query: string): void {
-		this.filteredModels = fuzzyFilter(this.allModels, query, ({ id, provider }) => `${id} ${provider}`);
-		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredModels.length - 1));
+		// Filter all models
+		const allFiltered = fuzzyFilter(this.allModels, query, ({ id, provider }) => `${id} ${provider}`);
+		// Separate favorites and non-favorites
+		const favorites = allFiltered.filter((m) => m.isFavorite);
+		this.filteredModels = allFiltered.filter((m) => !m.isFavorite);
+		// Build unified navigable list: favorites first, then non-favorites
+		this.navigableItems = [
+			...favorites.map((item) => ({ item, isFavoriteSection: true })),
+			...this.filteredModels.map((item) => ({ item, isFavoriteSection: false })),
+		];
+		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.navigableItems.length - 1));
 		this.updateList();
 	}
 
 	private updateList(): void {
+		this.pinnedContainer.clear();
 		this.listContainer.clear();
 
+		// Get favorites from navigableItems for display
+		const favoriteItems = this.navigableItems.filter((n) => n.isFavoriteSection);
+		const nonFavoriteItems = this.navigableItems.filter((n) => !n.isFavoriteSection);
+
+		// Show pinned favorites section (always visible at top, now navigable)
+		if (favoriteItems.length > 0) {
+			// Calculate max ID length for alignment
+			const maxIdLength = Math.max(...favoriteItems.map((f) => f.item.id.length));
+
+			this.pinnedContainer.addChild(new Text(theme.fg("muted", "  Favorites:"), 0, 0));
+			for (let i = 0; i < favoriteItems.length; i++) {
+				const navItem = favoriteItems[i];
+				if (!navItem) continue;
+				const fav = navItem.item;
+				const isSelected = this.selectedIndex === i;
+				const isCurrent = modelsAreEqual(this.currentModel, fav.model);
+				const paddedId = fav.id.padEnd(maxIdLength);
+				const providerBadge = theme.fg("muted", fav.provider);
+				// Use locked star (☆) for project favorites, filled star (★) for user favorites
+				const star = fav.isProjectFavorite ? theme.fg("muted", "☆ ") : theme.fg("warning", "★ ");
+
+				let line = "";
+				if (isSelected) {
+					const prefix = theme.fg("accent", "→ ");
+					const checkmark = isCurrent ? theme.fg("success", "✓ ") : "  ";
+					line = `${prefix}${checkmark}${star}${theme.fg("accent", paddedId)}  ${providerBadge}`;
+				} else {
+					const checkmark = isCurrent ? theme.fg("success", "✓ ") : "  ";
+					line = `  ${checkmark}${star}${paddedId}  ${providerBadge}`;
+				}
+				this.pinnedContainer.addChild(new Text(line, 0, 0));
+			}
+			this.pinnedContainer.addChild(new Spacer(1));
+		}
+
+		// For non-favorites, calculate the adjusted selected index
+		const favoritesCount = favoriteItems.length;
+		const adjustedSelectedIndex = this.selectedIndex - favoritesCount;
+
+		// Scrolling for non-favorites list
 		const maxVisible = 10;
 		const startIndex = Math.max(
 			0,
-			Math.min(this.selectedIndex - Math.floor(maxVisible / 2), this.filteredModels.length - maxVisible),
+			Math.min(adjustedSelectedIndex - Math.floor(maxVisible / 2), nonFavoriteItems.length - maxVisible),
 		);
-		const endIndex = Math.min(startIndex + maxVisible, this.filteredModels.length);
+		const endIndex = Math.min(startIndex + maxVisible, nonFavoriteItems.length);
 
-		// Show visible slice of filtered models
+		// Calculate max ID length from ALL non-favorites for stable alignment while scrolling
+		const maxIdLength = nonFavoriteItems.length > 0 ? Math.max(...nonFavoriteItems.map((m) => m.item.id.length)) : 0;
+
+		// Show visible slice of filtered models (non-favorites only)
 		for (let i = startIndex; i < endIndex; i++) {
-			const item = this.filteredModels[i];
-			if (!item) continue;
+			const navItem = nonFavoriteItems[i];
+			if (!navItem) continue;
+			const item = navItem.item;
 
-			const isSelected = i === this.selectedIndex;
+			const isSelected = i + favoritesCount === this.selectedIndex;
 			const isCurrent = modelsAreEqual(this.currentModel, item.model);
+			const paddedId = item.id.padEnd(maxIdLength);
 
 			let line = "";
 			if (isSelected) {
 				const prefix = theme.fg("accent", "→ ");
-				const modelText = `${item.id}`;
-				const providerBadge = theme.fg("muted", `[${item.provider}]`);
-				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
-				line = `${prefix + theme.fg("accent", modelText)} ${providerBadge}${checkmark}`;
+				const checkmark = isCurrent ? theme.fg("success", "✓ ") : "  ";
+				const providerBadge = theme.fg("muted", item.provider);
+				line = `${prefix}${checkmark}${theme.fg("accent", paddedId)}  ${providerBadge}`;
 			} else {
-				const modelText = `  ${item.id}`;
-				const providerBadge = theme.fg("muted", `[${item.provider}]`);
-				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
-				line = `${modelText} ${providerBadge}${checkmark}`;
+				const checkmark = isCurrent ? theme.fg("success", "✓ ") : "  ";
+				const providerBadge = theme.fg("muted", item.provider);
+				line = `  ${checkmark}${paddedId}  ${providerBadge}`;
 			}
 
 			this.listContainer.addChild(new Text(line, 0, 0));
 		}
 
 		// Add scroll indicator if needed
-		if (startIndex > 0 || endIndex < this.filteredModels.length) {
-			const scrollInfo = theme.fg("muted", `  (${this.selectedIndex + 1}/${this.filteredModels.length})`);
+		if (startIndex > 0 || endIndex < nonFavoriteItems.length) {
+			const displayIndex = adjustedSelectedIndex >= 0 ? adjustedSelectedIndex + 1 : 0;
+			const scrollInfo = theme.fg("muted", `  (${displayIndex}/${nonFavoriteItems.length})`);
 			this.listContainer.addChild(new Text(scrollInfo, 0, 0));
 		}
 
@@ -199,7 +338,7 @@ export class ModelSelectorComponent extends Container {
 			for (const line of errorLines) {
 				this.listContainer.addChild(new Text(theme.fg("error", line), 0, 0));
 			}
-		} else if (this.filteredModels.length === 0) {
+		} else if (this.navigableItems.length === 0) {
 			this.listContainer.addChild(new Text(theme.fg("muted", "  No matching models"), 0, 0));
 		}
 	}
@@ -208,26 +347,31 @@ export class ModelSelectorComponent extends Container {
 		const kb = getEditorKeybindings();
 		// Up arrow - wrap to bottom when at top
 		if (kb.matches(keyData, "selectUp")) {
-			if (this.filteredModels.length === 0) return;
-			this.selectedIndex = this.selectedIndex === 0 ? this.filteredModels.length - 1 : this.selectedIndex - 1;
+			if (this.navigableItems.length === 0) return;
+			this.selectedIndex = this.selectedIndex === 0 ? this.navigableItems.length - 1 : this.selectedIndex - 1;
 			this.updateList();
 		}
 		// Down arrow - wrap to top when at bottom
 		else if (kb.matches(keyData, "selectDown")) {
-			if (this.filteredModels.length === 0) return;
-			this.selectedIndex = this.selectedIndex === this.filteredModels.length - 1 ? 0 : this.selectedIndex + 1;
+			if (this.navigableItems.length === 0) return;
+			this.selectedIndex = this.selectedIndex === this.navigableItems.length - 1 ? 0 : this.selectedIndex + 1;
 			this.updateList();
 		}
 		// Enter
 		else if (kb.matches(keyData, "selectConfirm")) {
-			const selectedModel = this.filteredModels[this.selectedIndex];
-			if (selectedModel) {
-				this.handleSelect(selectedModel.model);
+			const selectedNavItem = this.navigableItems[this.selectedIndex];
+			if (selectedNavItem) {
+				this.handleSelect(selectedNavItem.item.model);
 			}
 		}
 		// Escape or Ctrl+C
 		else if (kb.matches(keyData, "selectCancel")) {
 			this.onCancelCallback();
+		} else if (matchesKey(keyData, "*")) {
+			const selectedNavItem = this.navigableItems[this.selectedIndex];
+			if (selectedNavItem) {
+				this.toggleFavorite(selectedNavItem.item);
+			}
 		}
 		// Pass everything else to search input
 		else {


### PR DESCRIPTION
## Summary
Add favorite models for quick access via dedicated keybindings and a pinned section in the model selector.

### Changes

**Model Selector (`Ctrl+L`)**
- Press `*` to toggle favorite on the selected model
- Favorites appear in a pinned section at top, fully navigable with arrow keys
- Visual indicators: ★ for user favorites, ☆ for project-level favorites (read-only)

**Keybindings**
- `Alt+P` / `Shift+Alt+P` to cycle through favorite models
- Respects `--models` scope (only cycles favorites within scope)

**Settings**
- Favorites stored in global `~/.pi/settings.json` as `favoriteModels`
- Format: `provider/modelId:thinkingLevel` (e.g., `anthropic/claude-sonnet-4:medium`)
- Project-level favorites supported via `.pi/settings.json` (read-only in UI)
- Duplicate prevention: same model with different thinking levels is normalized

**Other**
- Startup banner and `/help` updated with new keybindings
- Reserved `Alt+P` / `Shift+Alt+P` in extension runner