### PR TITLE
Add AbortSignal support to extension UI dialogs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Extension UI dialogs (`ctx.ui.select()`, `ctx.ui.confirm()`, `ctx.ui.input()`) now accept an optional `AbortSignal` to programmatically dismiss dialogs. Useful for implementing timeouts. See `examples/extensions/timed-confirm.ts`. ([#474](https://github.com/badlogic/pi-mono/issues/474))
+
 ## [0.37.5] - 2026-01-06
 
 ### Added

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1094,6 +1094,38 @@ ctx.ui.notify("Done!", "info");  // "info" | "warning" | "error"
 - `ctx.ui.editor()`: [handoff.ts](../examples/extensions/handoff.ts)
 - `ctx.ui.setEditorText()`: [handoff.ts](../examples/extensions/handoff.ts), [qna.ts](../examples/extensions/qna.ts)
 
+#### Auto-Dismissing Dialogs
+
+Dialogs can be programmatically dismissed using `AbortSignal`. This is useful for implementing timeouts:
+
+```typescript
+const controller = new AbortController();
+const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+const confirmed = await ctx.ui.confirm(
+  "Timed Confirmation",
+  "This dialog will auto-cancel in 5 seconds. Confirm?",
+  { signal: controller.signal }
+);
+
+clearTimeout(timeoutId);
+
+if (confirmed) {
+  // User confirmed
+} else if (controller.signal.aborted) {
+  // Dialog timed out
+} else {
+  // User cancelled (pressed Escape or selected "No")
+}
+```
+
+**Return values on abort:**
+- `select()` returns `undefined`
+- `confirm()` returns `false`
+- `input()` returns `undefined`
+
+See [examples/extensions/timed-confirm.ts](../examples/extensions/timed-confirm.ts) for a complete example.
+
 ### Widgets, Status, and Footer
 
 ```typescript

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -44,6 +44,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `status-line.ts` | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors |
 | `snake.ts` | Snake game with custom UI, keyboard handling, and session persistence |
 | `send-user-message.ts` | Demonstrates `pi.sendUserMessage()` for sending user messages from extensions |
+| `timed-confirm.ts` | Demonstrates AbortSignal for auto-dismissing `ctx.ui.confirm()` and `ctx.ui.select()` dialogs |
 
 ### Git Integration
 

--- a/packages/coding-agent/examples/extensions/timed-confirm.ts
+++ b/packages/coding-agent/examples/extensions/timed-confirm.ts
@@ -1,0 +1,63 @@
+/**
+ * Example extension demonstrating AbortSignal for auto-dismissing dialogs.
+ *
+ * Commands:
+ * - /timed - Shows confirm dialog that auto-cancels after 5 seconds
+ * - /timed-select - Shows select dialog that auto-cancels after 10 seconds
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+	pi.registerCommand("timed", {
+		description: "Show a timed confirmation dialog (auto-cancels in 5s)",
+		handler: async (_args, ctx) => {
+			const controller = new AbortController();
+			const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+			ctx.ui.notify("Dialog will auto-cancel in 5 seconds...", "info");
+
+			const confirmed = await ctx.ui.confirm(
+				"Timed Confirmation",
+				"This dialog will auto-cancel in 5 seconds. Confirm?",
+				{ signal: controller.signal },
+			);
+
+			clearTimeout(timeoutId);
+
+			if (confirmed) {
+				ctx.ui.notify("Confirmed by user!", "info");
+			} else if (controller.signal.aborted) {
+				ctx.ui.notify("Dialog timed out (auto-cancelled)", "warning");
+			} else {
+				ctx.ui.notify("Cancelled by user", "info");
+			}
+		},
+	});
+
+	pi.registerCommand("timed-select", {
+		description: "Show a timed select dialog (auto-cancels in 10s)",
+		handler: async (_args, ctx) => {
+			const controller = new AbortController();
+			const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+			ctx.ui.notify("Select dialog will auto-cancel in 10 seconds...", "info");
+
+			const choice = await ctx.ui.select(
+				"Pick an option (auto-cancels in 10s)",
+				["Option A", "Option B", "Option C"],
+				{ signal: controller.signal },
+			);
+
+			clearTimeout(timeoutId);
+
+			if (choice) {
+				ctx.ui.notify(`Selected: ${choice}`, "info");
+			} else if (controller.signal.aborted) {
+				ctx.ui.notify("Selection timed out", "warning");
+			} else {
+				ctx.ui.notify("Selection cancelled", "info");
+			}
+		},
+	});
+}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -52,13 +52,13 @@ export type { AgentToolResult, AgentToolUpdateCallback };
  */
 export interface ExtensionUIContext {
 	/** Show a selector and return the user's choice. */
-	select(title: string, options: string[]): Promise<string | undefined>;
+	select(title: string, options: string[], opts?: { signal?: AbortSignal }): Promise<string | undefined>;
 
 	/** Show a confirmation dialog. */
-	confirm(title: string, message: string): Promise<boolean>;
+	confirm(title: string, message: string, opts?: { signal?: AbortSignal }): Promise<boolean>;
 
 	/** Show a text input dialog. */
-	input(title: string, placeholder?: string): Promise<string | undefined>;
+	input(title: string, placeholder?: string, opts?: { signal?: AbortSignal }): Promise<string | undefined>;
 
 	/** Show a notification to the user. */
 	notify(message: string, type?: "info" | "warning" | "error"): void;


### PR DESCRIPTION
Adds optional `AbortSignal` parameter to `ctx.ui.select()`, `ctx.ui.confirm()`, and `ctx.ui.input()` so extensions can programmatically dismiss dialogs - useful for implementing timeouts.

When using `Promise.race` with a timeout, the dialog stays visible after the timeout fires. Users see stale options that won't do anything, which is confusing.

## Solution

```typescript
const controller = new AbortController();
const timeoutId = setTimeout(() => controller.abort(), 5000);

const confirmed = await ctx.ui.confirm("Title", "Message", { signal: controller.signal });

clearTimeout(timeoutId);

if (controller.signal.aborted) {
  // timed out
}
```

When the signal aborts, the dialog dismisses and resolves with:
- `select()` → `undefined`
- `confirm()` → `false`
- `input()` → `undefined`

## Changes

- **types.ts**: Added `opts?: { signal?: AbortSignal }` to select/confirm/input signatures
- **interactive-mode.ts**: Abort handling in showExtensionSelector, showExtensionConfirm, showExtensionInput
- **rpc-mode.ts**: Same abort handling for RPC clients
- **timed-confirm.ts**: Example extension with `/timed` and `/timed-select` commands
- **extensions.md**: New "Auto-Dismissing Dialogs" section
- **examples README**: Added timed-confirm.ts entry

The `opts` parameter is optional, so existing extensions work unchanged. No-op stubs in loader.ts/runner.ts continue to work via TypeScript structural typing.

Originally discussed in https://github.com/badlogic/pi-mono/issues/474