### PR TITLE
feat(coding-agent): add pi.ui.setEditorComponent extension API

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Extensions can now provide custom editor components via `ctx.ui.setEditorComponent()`, enabling vim mode, emacs mode, or other custom editing experiences. See `examples/extensions/modal-editor.ts` for a working example.
+
 ## [0.37.8] - 2026-01-07
 
 ## [0.37.7] - 2026-01-07

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -45,6 +45,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `snake.ts` | Snake game with custom UI, keyboard handling, and session persistence |
 | `send-user-message.ts` | Demonstrates `pi.sendUserMessage()` for sending user messages from extensions |
 | `timed-confirm.ts` | Demonstrates AbortSignal for auto-dismissing `ctx.ui.confirm()` and `ctx.ui.select()` dialogs |
+| `modal-editor.ts` | Custom vim-like modal editor via `ctx.ui.setEditorComponent()` |
 
 ### Git Integration
 

--- a/packages/coding-agent/examples/extensions/modal-editor.ts
+++ b/packages/coding-agent/examples/extensions/modal-editor.ts
@@ -1,0 +1,119 @@
+/**
+ * Modal Editor - Example custom editor with vim-like modes
+ *
+ * This demonstrates how to use pi.ui.setEditorComponent() to create
+ * a custom editor with modal editing (normal/insert modes).
+ *
+ * Usage: pi --extension ./examples/extensions/modal-editor.ts
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Editor, type EditorTheme, matchesKey } from "@mariozechner/pi-tui";
+
+type Mode = "normal" | "insert";
+
+/**
+ * A simple modal editor that wraps the default Editor.
+ * - Press Escape to enter normal mode
+ * - Press 'i' in normal mode to enter insert mode
+ * - Basic hjkl navigation in normal mode
+ */
+class ModalEditor extends Editor {
+	private mode: Mode = "insert";
+
+	handleInput(data: string): void {
+		// Escape switches to normal mode
+		if (matchesKey(data, "escape")) {
+			if (this.mode === "insert") {
+				this.mode = "normal";
+				return;
+			}
+			// In normal mode, let escape pass through (for app handling)
+			super.handleInput(data);
+			return;
+		}
+
+		// In insert mode, pass everything to the base editor
+		if (this.mode === "insert") {
+			super.handleInput(data);
+			return;
+		}
+
+		// Normal mode key handling
+		switch (data) {
+			case "i":
+				this.mode = "insert";
+				break;
+			case "a":
+				this.mode = "insert";
+				// Move cursor right before inserting
+				super.handleInput("\x1b[C"); // Right arrow
+				break;
+			case "h":
+				super.handleInput("\x1b[D"); // Left arrow
+				break;
+			case "j":
+				super.handleInput("\x1b[B"); // Down arrow
+				break;
+			case "k":
+				super.handleInput("\x1b[A"); // Up arrow
+				break;
+			case "l":
+				super.handleInput("\x1b[C"); // Right arrow
+				break;
+			case "0":
+				super.handleInput("\x01"); // Ctrl+A (line start)
+				break;
+			case "$":
+				super.handleInput("\x05"); // Ctrl+E (line end)
+				break;
+			case "x":
+				// Delete char under cursor (forward delete)
+				super.handleInput("\x1b[3~"); // Delete key
+				break;
+			case "d":
+				// dd would need state tracking, simplified here
+				break;
+			default:
+				// Consume other keys in normal mode (don't insert them)
+				break;
+		}
+	}
+
+	render(width: number): string[] {
+		const lines = super.render(width);
+		// Add mode indicator to the bottom border line
+		if (lines.length > 0) {
+			const lastIndex = lines.length - 1;
+			const modeLabel = this.mode === "normal" ? " NORMAL " : " INSERT ";
+			const lastLine = lines[lastIndex]!;
+			// Replace end of last line with mode indicator
+			if (lastLine.length >= modeLabel.length) {
+				lines[lastIndex] = lastLine.slice(0, -modeLabel.length) + modeLabel;
+			}
+		}
+		return lines;
+	}
+}
+
+// Simple identity function for unstyled text
+const identity = (s: string) => s;
+
+export default function (pi: ExtensionAPI) {
+	// Create and set the custom editor on session start
+	pi.on("session_start", (_event, ctx) => {
+		// Create a simple editor theme
+		const editorTheme: EditorTheme = {
+			borderColor: (s: string) => ctx.ui.theme.fg("muted", s),
+			selectList: {
+				selectedPrefix: identity,
+				selectedText: identity,
+				description: identity,
+				scrollInfo: identity,
+				noMatch: identity,
+			},
+		};
+		const modalEditor = new ModalEditor(editorTheme);
+		ctx.ui.setEditorComponent(modalEditor);
+	});
+}

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -99,6 +99,7 @@ function createNoOpUIContext(): ExtensionUIContext {
 		setEditorText: () => {},
 		getEditorText: () => "",
 		editor: async () => undefined,
+		setEditorComponent: () => {},
 		get theme() {
 			return theme;
 		},

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -74,6 +74,7 @@ const noOpUIContext: ExtensionUIContext = {
 	setEditorText: () => {},
 	getEditorText: () => "",
 	editor: async () => undefined,
+	setEditorComponent: () => {},
 	get theme() {
 		return theme;
 	},

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -15,7 +15,7 @@ import type {
 	ThinkingLevel,
 } from "@mariozechner/pi-agent-core";
 import type { ImageContent, Model, TextContent, ToolResultMessage } from "@mariozechner/pi-ai";
-import type { Component, KeyId, TUI } from "@mariozechner/pi-tui";
+import type { Component, EditorComponent, KeyId, TUI } from "@mariozechner/pi-tui";
 import type { Static, TSchema } from "@sinclair/typebox";
 import type { Theme } from "../../modes/interactive/theme/theme.js";
 import type { CompactionPreparation, CompactionResult } from "../compaction/index.js";
@@ -96,6 +96,33 @@ export interface ExtensionUIContext {
 
 	/** Show a multi-line editor for text editing. */
 	editor(title: string, prefill?: string): Promise<string | undefined>;
+
+	/**
+	 * Set a custom editor component.
+	 * Pass undefined to restore the default editor.
+	 *
+	 * Custom editors must implement the EditorComponent interface from @mariozechner/pi-tui.
+	 * The editor receives all keyboard input when focused and is responsible for:
+	 * - Text editing and cursor management
+	 * - Calling onSubmit when the user wants to send a message
+	 * - Calling onChange when text changes
+	 *
+	 * @example
+	 * ```ts
+	 * import { Editor } from "@mariozechner/pi-tui";
+	 *
+	 * // Create a custom editor that wraps the default
+	 * class VimEditor extends Editor {
+	 *   handleInput(data: string): void {
+	 *     // Custom input handling...
+	 *     super.handleInput(data);
+	 *   }
+	 * }
+	 *
+	 * pi.ui.setEditorComponent(new VimEditor(theme));
+	 * ```
+	 */
+	setEditorComponent(editor: EditorComponent | undefined): void;
 
 	/** Get the current theme for styling. */
 	readonly theme: Theme;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -531,6 +531,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			setEditorText: () => {},
 			getEditorText: () => "",
 			editor: async () => undefined,
+			setEditorComponent: () => {},
 			get theme() {
 				return {} as any;
 			},

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -251,6 +251,10 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			});
 		},
 
+		setEditorComponent(): void {
+			// Custom editor components not supported in RPC mode
+		},
+
 		get theme() {
 			return theme;
 		},

--- a/packages/coding-agent/test/compaction-extensions.test.ts
+++ b/packages/coding-agent/test/compaction-extensions.test.ts
@@ -137,6 +137,7 @@ describe.skipIf(!API_KEY)("Compaction extensions", () => {
 				setEditorText: () => {},
 				getEditorText: () => "",
 				editor: async () => undefined,
+				setEditorComponent: () => {},
 				get theme() {
 					return theme;
 				},

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `EditorComponent` interface for custom editor implementations
+
 ## [0.37.8] - 2026-01-07
 
 ### Added

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -1,0 +1,65 @@
+import type { AutocompleteProvider } from "./autocomplete.js";
+import type { Component } from "./tui.js";
+
+/**
+ * Interface for custom editor components.
+ *
+ * This allows extensions to provide their own editor implementation
+ * (e.g., vim mode, emacs mode, custom keybindings) while maintaining
+ * compatibility with the core application.
+ */
+export interface EditorComponent extends Component {
+	// =========================================================================
+	// Core text access (required)
+	// =========================================================================
+
+	/** Get the current text content */
+	getText(): string;
+
+	/** Set the text content */
+	setText(text: string): void;
+
+	// =========================================================================
+	// Callbacks (required)
+	// =========================================================================
+
+	/** Called when user submits (e.g., Enter key) */
+	onSubmit?: (text: string) => void;
+
+	/** Called when text changes */
+	onChange?: (text: string) => void;
+
+	// =========================================================================
+	// History support (optional)
+	// =========================================================================
+
+	/** Add text to history for up/down navigation */
+	addToHistory?(text: string): void;
+
+	// =========================================================================
+	// Advanced text manipulation (optional)
+	// =========================================================================
+
+	/** Insert text at current cursor position */
+	insertTextAtCursor?(text: string): void;
+
+	/**
+	 * Get text with any markers expanded (e.g., paste markers).
+	 * Falls back to getText() if not implemented.
+	 */
+	getExpandedText?(): string;
+
+	// =========================================================================
+	// Autocomplete support (optional)
+	// =========================================================================
+
+	/** Set the autocomplete provider */
+	setAutocompleteProvider?(provider: AutocompleteProvider): void;
+
+	// =========================================================================
+	// Appearance (optional)
+	// =========================================================================
+
+	/** Border color function */
+	borderColor?: (str: string) => string;
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -20,6 +20,8 @@ export { type SettingItem, SettingsList, type SettingsListTheme } from "./compon
 export { Spacer } from "./components/spacer.js";
 export { Text } from "./components/text.js";
 export { TruncatedText } from "./components/truncated-text.js";
+// Editor component interface (for custom editors)
+export type { EditorComponent } from "./editor-component.js";
 // Keybindings
 export {
 	DEFAULT_EDITOR_KEYBINDINGS,


### PR DESCRIPTION
Adds a pluggable editor component API so extensions can provide custom editors (vim mode, emacs mode, etc).

## Changes

- Add `EditorComponent` interface to pi-tui for custom editors
- Add `setEditorComponent(editor)` to `ExtensionUIContext`
- Extensions can provide custom editor implementations that receive callbacks, autocomplete, and appearance settings
- Add `modal-editor.ts` example demonstrating vim-like modal editing (hjkl, insert/normal modes, dd, etc)

## Usage

```ts
import { Editor } from "@mariozechner/pi-tui";

class VimEditor extends Editor {
  handleInput(data: string): void {
    // Custom input handling...
    super.handleInput(data);
  }
}

pi.on("session_start", (_event, ctx) => {
  ctx.ui.setEditorComponent(new VimEditor(theme));
});
```

## Context

Discussed on Twitter: https://x.com/badlogicgames/status/2008592306434449534