### PR TITLE
feat(coding-agent): export mode utilities for programmatic SDK usage

### DIFF
--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -229,11 +229,17 @@ export {
 	UserMessageSelectorComponent,
 	type VisualTruncateResult,
 } from "./modes/interactive/components/index.js";
+// Modes for programmatic usage
+export { InteractiveMode } from "./modes/interactive/interactive-mode.js";
 // Theme utilities for custom tools and extensions
 export {
 	getMarkdownTheme,
 	getSelectListTheme,
 	getSettingsListTheme,
+	initTheme,
+	stopThemeWatcher,
 	Theme,
 	type ThemeColor,
 } from "./modes/interactive/theme/theme.js";
+export { runPrintMode } from "./modes/print-mode.js";
+export { runRpcMode } from "./modes/rpc/rpc-mode.js";


### PR DESCRIPTION
Exports `InteractiveMode`, `runRpcMode`, `runPrintMode`, `initTheme`, and `stopThemeWatcher` from the main package entry point.

**Use case:** Building tooling that customizes session creation via `createAgentSession()` (e.g., controlling `contextFiles`, custom skills discovery) while using the standard mode implementations.

```typescript
import {
  createAgentSession,
  runRpcMode,
  InteractiveMode,
  initTheme
} from "@mariozechner/pi-coding-agent";

// Custom session setup
const { session, extensionsResult } = await createAgentSession({
  contextFiles: [{ path: "./AGENT.md", content: agentMd }],
  // ... other custom options
});

// Then use standard modes
await runRpcMode(session);

// Or interactive:
initTheme(undefined, true);
const mode = new InteractiveMode(session, "1.0", undefined, extensionsResult.extensions, extensionsResult.setUIContext);
await mode.init();
```

These are already implemented and exported internally from `./modes/index.js` - this just re-exports them from the main entry point for discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)