### PR TITLE
fix(markdown): avoid ordered list numbering resets in assistant messages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Assistant message markdown rendering no longer resets ordered list numbering across blank-line separated blocks.
+
 ## [0.37.8] - 2026-01-07
 
 ## [0.37.7] - 2026-01-07

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -46,7 +46,11 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, getMarkdownTheme()));
+				this.contentContainer.addChild(
+					new Markdown(content.text.trim(), 1, 0, getMarkdownTheme(), undefined, {
+						continueOrderedListNumberingAcrossBlocks: true,
+					}),
+				);
 			} else if (content.type === "thinking" && content.thinking.trim()) {
 				// Check if there's text content after this thinking block
 				const hasTextAfter = message.content.slice(i + 1).some((c) => c.type === "text" && c.text.trim());
@@ -60,10 +64,19 @@ export class AssistantMessageComponent extends Container {
 				} else {
 					// Thinking traces in thinkingText color, italic
 					this.contentContainer.addChild(
-						new Markdown(content.thinking.trim(), 1, 0, getMarkdownTheme(), {
-							color: (text: string) => theme.fg("thinkingText", text),
-							italic: true,
-						}),
+						new Markdown(
+							content.thinking.trim(),
+							1,
+							0,
+							getMarkdownTheme(),
+							{
+								color: (text: string) => theme.fg("thinkingText", text),
+								italic: true,
+							},
+							{
+								continueOrderedListNumberingAcrossBlocks: true,
+							},
+						),
 					);
 					this.contentContainer.addChild(new Spacer(1));
 				}

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Markdown renderer option to continue ordered list numbering across separated list blocks.
+
+### Fixed
+
+- Markdown renderer now respects ordered list start numbers.
+
 ## [0.37.8] - 2026-01-07
 
 ### Added

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -97,6 +97,50 @@ describe("Markdown component", () => {
 		});
 	});
 
+	describe("Ordered list numbering", () => {
+		it("should respect the list start number", () => {
+			const markdown = new Markdown(
+				`3. Third
+4. Fourth`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80);
+			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+
+			assert.ok(plainLines.some((line) => line.includes("3. Third")));
+			assert.ok(plainLines.some((line) => line.includes("4. Fourth")));
+		});
+
+		it("should continue numbering across separated ordered list blocks when enabled", () => {
+			const markdown = new Markdown(
+				`1. First
+
+Some details in between.
+
+1. Second
+
+More details.
+
+1. Third`,
+				0,
+				0,
+				defaultMarkdownTheme,
+				undefined,
+				{ continueOrderedListNumberingAcrossBlocks: true },
+			);
+
+			const lines = markdown.render(80);
+			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+
+			assert.ok(plainLines.some((line) => line.includes("1. First")));
+			assert.ok(plainLines.some((line) => line.includes("2. Second")));
+			assert.ok(plainLines.some((line) => line.includes("3. Third")));
+		});
+	});
+
 	describe("Tables", () => {
 		it("should render simple table", () => {
 			const markdown = new Markdown(


### PR DESCRIPTION
Fix ordered list numbering in assistant-rendered markdown so blank-line separated list blocks keep counting instead of restarting at 1.