### PR TITLE
feat(coding-agent): add interactive shell command support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5276,7 +5276,6 @@
 			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
 			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@lit/reactive-element": "^2.1.0",
 				"lit-element": "^4.2.0",
@@ -6624,7 +6623,6 @@
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
 			"integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -6653,8 +6651,7 @@
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
 			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -6840,7 +6837,6 @@
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -6920,7 +6916,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
 			"integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Interactive shell commands: Commands like `vim`, `git rebase`, `htop`, `less`, etc. now get full terminal access. These are auto-detected, or use `!i` prefix to force interactive mode for any command. Configure via `interactiveCommands` in settings.json.
 - Extension UI dialogs (`ctx.ui.select()`, `ctx.ui.confirm()`, `ctx.ui.input()`) now support a `timeout` option that auto-dismisses the dialog with a live countdown display. Simpler alternative to `AbortSignal` for timed dialogs.
 
 ## [0.37.8] - 2026-01-07

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -415,6 +415,24 @@ Ran `ls -la`
 
 Run multiple commands before prompting; all outputs are included together.
 
+**Prefix variants:**
+
+| Prefix | Description |
+|--------|-------------|
+| `!` | Run command, include output in LLM context |
+| `!!` | Run command, exclude output from context |
+| `!i` | Run interactively with full terminal access |
+
+**Interactive mode (`!i`)**: Some commands need direct terminal access - editors (vim, nano), pagers (less), git interactive operations (rebase -i, commit), TUI tools (htop, lazygit), etc. These are automatically detected and run interactively. Use `!i` to force interactive mode for any command:
+
+```
+!i vim file.txt
+!i git rebase -i HEAD~3
+!i htop
+```
+
+Interactive commands get full terminal control. The TUI suspends while they run and resumes after they exit.
+
 ### Image Support
 
 **Pasting images:** Press `Ctrl+V` to paste an image from your clipboard.
@@ -705,6 +723,10 @@ Global `~/.pi/agent/settings.json` stores persistent preferences:
     "autoResize": true,
     "blockImages": false
   },
+  "interactiveCommands": {
+    "additionalCommands": ["mycli", "custom-editor"],
+    "excludeCommands": ["vim"]
+  },
   "extensions": ["/path/to/extension.ts"]
 }
 ```
@@ -732,6 +754,8 @@ Global `~/.pi/agent/settings.json` stores persistent preferences:
 | `images.autoResize` | Auto-resize images to 2000x2000 max for better model compatibility | `true` |
 | `images.blockImages` | Prevent images from being sent to LLM providers | `false` |
 | `doubleEscapeAction` | Action for double-escape with empty editor: `tree` or `branch` | `tree` |
+| `interactiveCommands.additionalCommands` | Extra commands to run interactively (full terminal access) | `[]` |
+| `interactiveCommands.excludeCommands` | Commands to exclude from interactive detection | `[]` |
 | `extensions` | Additional extension file paths | `[]` |
 
 ---

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -39,6 +39,15 @@ export interface ImageSettings {
 	blockImages?: boolean; // default: false - when true, prevents all images from being sent to LLM providers
 }
 
+export interface InteractiveCommandsSettings {
+	/** Additional commands to run interactively (exact command names, e.g., "mycli", "kubectl edit") */
+	additionalCommands?: string[];
+	/** Additional regex patterns to match interactive commands */
+	additionalPatterns?: string[];
+	/** Commands to exclude from interactive detection (overrides built-in patterns) */
+	excludeCommands?: string[];
+}
+
 export interface Settings {
 	lastChangelogVersion?: string;
 	defaultProvider?: string;
@@ -59,6 +68,7 @@ export interface Settings {
 	images?: ImageSettings;
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
 	doubleEscapeAction?: "branch" | "tree"; // Action for double-escape with empty editor (default: "tree")
+	interactiveCommands?: InteractiveCommandsSettings; // Configure interactive command detection
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -428,5 +438,12 @@ export class SettingsManager {
 	setDoubleEscapeAction(action: "branch" | "tree"): void {
 		this.globalSettings.doubleEscapeAction = action;
 		this.save();
+	}
+
+	getInteractiveCommandsSettings(): InteractiveCommandsSettings {
+		return {
+			additionalCommands: [...(this.settings.interactiveCommands?.additionalCommands ?? [])],
+			excludeCommands: [...(this.settings.interactiveCommands?.excludeCommands ?? [])],
+		};
 	}
 }

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -1,4 +1,12 @@
-export { type BashToolDetails, bashTool, createBashTool } from "./bash.js";
+export {
+	type BashToolDetails,
+	type BashToolOptions,
+	bashTool,
+	createBashTool,
+	createInteractiveExecutorHolder,
+	type InteractiveExecutor,
+	type InteractiveExecutorHolder,
+} from "./bash.js";
 export { createEditTool, editTool } from "./edit.js";
 export { createFindTool, type FindToolDetails, findTool } from "./find.js";
 export { createGrepTool, type GrepToolDetails, grepTool } from "./grep.js";
@@ -17,7 +25,7 @@ export {
 export { createWriteTool, writeTool } from "./write.js";
 
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { bashTool, createBashTool } from "./bash.js";
+import { type BashToolOptions, bashTool, createBashTool } from "./bash.js";
 import { createEditTool, editTool } from "./edit.js";
 import { createFindTool, findTool } from "./find.js";
 import { createGrepTool, grepTool } from "./grep.js";
@@ -50,13 +58,20 @@ export type ToolName = keyof typeof allTools;
 export interface ToolsOptions {
 	/** Options for the read tool */
 	read?: ReadToolOptions;
+	/** Options for the bash tool */
+	bash?: BashToolOptions;
 }
 
 /**
  * Create coding tools configured for a specific working directory.
  */
 export function createCodingTools(cwd: string, options?: ToolsOptions): Tool[] {
-	return [createReadTool(cwd, options?.read), createBashTool(cwd), createEditTool(cwd), createWriteTool(cwd)];
+	return [
+		createReadTool(cwd, options?.read),
+		createBashTool(cwd, options?.bash),
+		createEditTool(cwd),
+		createWriteTool(cwd),
+	];
 }
 
 /**
@@ -72,7 +87,7 @@ export function createReadOnlyTools(cwd: string, options?: ToolsOptions): Tool[]
 export function createAllTools(cwd: string, options?: ToolsOptions): Record<ToolName, Tool> {
 	return {
 		read: createReadTool(cwd, options?.read),
-		bash: createBashTool(cwd),
+		bash: createBashTool(cwd, options?.bash),
 		edit: createEditTool(cwd),
 		write: createWriteTool(cwd),
 		grep: createGrepTool(cwd),

--- a/packages/coding-agent/src/utils/interactive-commands.ts
+++ b/packages/coding-agent/src/utils/interactive-commands.ts
@@ -1,0 +1,169 @@
+/**
+ * Detection and handling of interactive shell commands.
+ *
+ * Interactive commands are those that need full terminal access to work correctly,
+ * such as editors (vim, nano), pagers (less, more), and interactive git operations
+ * (git rebase -i, git commit without -m, etc.).
+ */
+
+/**
+ * Default list of interactive commands.
+ * These commands will be run with full terminal access (stdio: "inherit").
+ *
+ * Format:
+ * - Simple command name: "vim" matches "vim", "vim file.txt", etc.
+ * - Command with subcommand: "git commit" matches "git commit", "git commit --amend", etc.
+ * - Prefix match: command is matched at the start or after a pipe
+ */
+export const DEFAULT_INTERACTIVE_COMMANDS: string[] = [
+	// Editors
+	"vim",
+	"nvim",
+	"vi",
+	"nano",
+	"emacs",
+	"pico",
+	"joe",
+	"micro",
+	"helix",
+	"hx",
+	"kak", // kakoune
+
+	// Pagers
+	"less",
+	"more",
+	"most",
+
+	// Git interactive commands
+	"git commit",
+	"git rebase",
+	"git merge",
+	"git cherry-pick",
+	"git revert",
+	"git am",
+	"git add -p",
+	"git add --patch",
+	"git add -i",
+	"git add --interactive",
+	"git stash -p",
+	"git stash --patch",
+	"git stash push -p",
+	"git stash push --patch",
+	"git reset -p",
+	"git reset --patch",
+	"git checkout -p",
+	"git checkout --patch",
+	"git difftool",
+	"git mergetool",
+	"git send-email",
+
+	// System monitors
+	"htop",
+	"top",
+	"btop",
+	"glances",
+	"nmon",
+
+	// Disk usage
+	"ncdu",
+
+	// File managers
+	"ranger",
+	"nnn",
+	"lf",
+	"mc",
+	"vifm",
+
+	// Git TUIs
+	"tig",
+	"lazygit",
+	"gitui",
+
+	// Fuzzy finders
+	"fzf",
+	"sk",
+
+	// Remote sessions
+	"ssh",
+	"telnet",
+	"mosh",
+
+	// Database clients (interactive mode)
+	"psql",
+	"mysql",
+	"sqlite3",
+	"mongosh",
+	"redis-cli",
+
+	// Kubernetes
+	"kubectl edit",
+	"kubectl exec -it",
+	"kubectl exec --stdin --tty",
+
+	// Docker
+	"docker exec -it",
+	"docker run -it",
+	"docker attach",
+
+	// Other TUIs
+	"tmux",
+	"screen",
+	"weechat",
+	"irssi",
+	"mutt",
+	"neomutt",
+	"aerc",
+];
+
+// Configuration state
+let additionalCommands: string[] = [];
+let excludedCommands: string[] = [];
+
+/**
+ * Configure interactive command detection.
+ * Call this at startup with settings from SettingsManager.
+ */
+export function configureInteractiveCommands(config: { additional?: string[]; excluded?: string[] }): void {
+	additionalCommands = config.additional ?? [];
+	excludedCommands = config.excluded ?? [];
+}
+
+/**
+ * Get all active interactive commands (default + additional - excluded).
+ */
+export function getInteractiveCommands(): string[] {
+	const excludeSet = new Set(excludedCommands.map((c) => c.toLowerCase()));
+	const commands = [...DEFAULT_INTERACTIVE_COMMANDS, ...additionalCommands];
+	return commands.filter((cmd) => !excludeSet.has(cmd.toLowerCase()));
+}
+
+/**
+ * Check if a command needs interactive terminal access.
+ *
+ * @param command - The shell command to check
+ * @returns true if the command should be run interactively
+ */
+export function isInteractiveCommand(command: string): boolean {
+	const trimmed = command.trim().toLowerCase();
+	const commands = getInteractiveCommands();
+
+	for (const interactiveCmd of commands) {
+		const cmdLower = interactiveCmd.toLowerCase();
+
+		// Check if command starts with the interactive command
+		if (trimmed === cmdLower || trimmed.startsWith(`${cmdLower} `) || trimmed.startsWith(`${cmdLower}\t`)) {
+			return true;
+		}
+
+		// Check after pipe: "cat file | less"
+		const pipeIndex = trimmed.lastIndexOf("|");
+		if (pipeIndex !== -1) {
+			const afterPipe = trimmed.slice(pipeIndex + 1).trim();
+			if (afterPipe === cmdLower || afterPipe.startsWith(`${cmdLower} `) || afterPipe.startsWith(`${cmdLower}\t`)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}

--- a/packages/coding-agent/test/interactive-commands.test.ts
+++ b/packages/coding-agent/test/interactive-commands.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	configureInteractiveCommands,
+	DEFAULT_INTERACTIVE_COMMANDS,
+	getInteractiveCommands,
+	isInteractiveCommand,
+} from "../src/utils/interactive-commands.js";
+
+describe("isInteractiveCommand", () => {
+	beforeEach(() => {
+		// Reset to defaults before each test
+		configureInteractiveCommands({ additional: [], excluded: [] });
+	});
+
+	describe("editors", () => {
+		it("detects vim", () => {
+			expect(isInteractiveCommand("vim file.txt")).toBe(true);
+			expect(isInteractiveCommand("vim")).toBe(true);
+			expect(isInteractiveCommand("nvim file.txt")).toBe(true);
+			expect(isInteractiveCommand("vi file.txt")).toBe(true);
+		});
+
+		it("detects nano", () => {
+			expect(isInteractiveCommand("nano file.txt")).toBe(true);
+		});
+
+		it("detects emacs", () => {
+			expect(isInteractiveCommand("emacs file.txt")).toBe(true);
+		});
+
+		it("detects helix", () => {
+			expect(isInteractiveCommand("helix file.txt")).toBe(true);
+			expect(isInteractiveCommand("hx file.txt")).toBe(true);
+		});
+
+		it("detects editors in pipes", () => {
+			expect(isInteractiveCommand("cat file.txt | vim -")).toBe(true);
+		});
+	});
+
+	describe("pagers", () => {
+		it("detects less", () => {
+			expect(isInteractiveCommand("less file.txt")).toBe(true);
+		});
+
+		it("detects more", () => {
+			expect(isInteractiveCommand("more file.txt")).toBe(true);
+		});
+
+		it("detects piped pagers", () => {
+			expect(isInteractiveCommand("cat file.txt | less")).toBe(true);
+			expect(isInteractiveCommand("git log | less")).toBe(true);
+		});
+	});
+
+	describe("git interactive", () => {
+		it("detects git rebase (can have conflicts)", () => {
+			expect(isInteractiveCommand("git rebase main")).toBe(true);
+			expect(isInteractiveCommand("git rebase -i HEAD~3")).toBe(true);
+			expect(isInteractiveCommand("git rebase --interactive HEAD~3")).toBe(true);
+		});
+
+		it("detects git merge (can have conflicts)", () => {
+			expect(isInteractiveCommand("git merge feature")).toBe(true);
+		});
+
+		it("detects git cherry-pick (can have conflicts)", () => {
+			expect(isInteractiveCommand("git cherry-pick abc123")).toBe(true);
+		});
+
+		it("detects git commit", () => {
+			expect(isInteractiveCommand("git commit")).toBe(true);
+			expect(isInteractiveCommand("git commit --amend")).toBe(true);
+			expect(isInteractiveCommand("git commit -m 'message'")).toBe(true); // still interactive (editor may open)
+		});
+
+		it("detects git add -p", () => {
+			expect(isInteractiveCommand("git add -p")).toBe(true);
+			expect(isInteractiveCommand("git add --patch")).toBe(true);
+			expect(isInteractiveCommand("git add -p file.txt")).toBe(true);
+		});
+
+		it("detects git difftool and mergetool", () => {
+			expect(isInteractiveCommand("git difftool")).toBe(true);
+			expect(isInteractiveCommand("git mergetool")).toBe(true);
+		});
+	});
+
+	describe("TUI tools", () => {
+		it("detects htop/top/btop", () => {
+			expect(isInteractiveCommand("htop")).toBe(true);
+			expect(isInteractiveCommand("top")).toBe(true);
+			expect(isInteractiveCommand("btop")).toBe(true);
+		});
+
+		it("detects ncdu", () => {
+			expect(isInteractiveCommand("ncdu")).toBe(true);
+		});
+
+		it("detects file managers", () => {
+			expect(isInteractiveCommand("ranger")).toBe(true);
+			expect(isInteractiveCommand("nnn")).toBe(true);
+			expect(isInteractiveCommand("mc")).toBe(true);
+		});
+
+		it("detects git TUIs", () => {
+			expect(isInteractiveCommand("tig")).toBe(true);
+			expect(isInteractiveCommand("lazygit")).toBe(true);
+			expect(isInteractiveCommand("gitui")).toBe(true);
+		});
+
+		it("detects fzf", () => {
+			expect(isInteractiveCommand("fzf")).toBe(true);
+		});
+	});
+
+	describe("remote sessions", () => {
+		it("detects ssh", () => {
+			expect(isInteractiveCommand("ssh user@host")).toBe(true);
+		});
+
+		it("detects telnet", () => {
+			expect(isInteractiveCommand("telnet host")).toBe(true);
+		});
+
+		it("detects mosh", () => {
+			expect(isInteractiveCommand("mosh user@host")).toBe(true);
+		});
+	});
+
+	describe("database clients", () => {
+		it("detects psql", () => {
+			expect(isInteractiveCommand("psql")).toBe(true);
+			expect(isInteractiveCommand("psql -U user db")).toBe(true);
+		});
+
+		it("detects mysql", () => {
+			expect(isInteractiveCommand("mysql")).toBe(true);
+			expect(isInteractiveCommand("mysql -u root db")).toBe(true);
+		});
+
+		it("detects sqlite3", () => {
+			expect(isInteractiveCommand("sqlite3 db.sqlite")).toBe(true);
+		});
+	});
+
+	describe("docker/kubernetes", () => {
+		it("detects kubectl edit", () => {
+			expect(isInteractiveCommand("kubectl edit deployment/app")).toBe(true);
+		});
+
+		it("detects kubectl exec -it", () => {
+			expect(isInteractiveCommand("kubectl exec -it pod -- /bin/bash")).toBe(true);
+		});
+
+		it("detects docker exec -it", () => {
+			expect(isInteractiveCommand("docker exec -it container bash")).toBe(true);
+		});
+
+		it("detects docker run -it", () => {
+			expect(isInteractiveCommand("docker run -it ubuntu bash")).toBe(true);
+		});
+	});
+
+	describe("non-interactive commands", () => {
+		it("returns false for regular commands", () => {
+			expect(isInteractiveCommand("ls -la")).toBe(false);
+			expect(isInteractiveCommand("cat file.txt")).toBe(false);
+			expect(isInteractiveCommand("grep pattern file")).toBe(false);
+			expect(isInteractiveCommand("echo hello")).toBe(false);
+			expect(isInteractiveCommand("curl https://example.com")).toBe(false);
+			expect(isInteractiveCommand("npm install")).toBe(false);
+		});
+
+		it("returns false for git non-interactive commands", () => {
+			expect(isInteractiveCommand("git status")).toBe(false);
+			expect(isInteractiveCommand("git log --oneline")).toBe(false);
+			expect(isInteractiveCommand("git diff")).toBe(false);
+			expect(isInteractiveCommand("git push")).toBe(false);
+			expect(isInteractiveCommand("git pull")).toBe(false);
+		});
+	});
+
+	describe("edge cases", () => {
+		it("handles whitespace", () => {
+			expect(isInteractiveCommand("  vim file.txt  ")).toBe(true);
+			expect(isInteractiveCommand("\tvim file.txt")).toBe(true);
+		});
+
+		it("handles git stash variations", () => {
+			expect(isInteractiveCommand("git stash -p")).toBe(true);
+			expect(isInteractiveCommand("git stash push -p")).toBe(true);
+			expect(isInteractiveCommand("git stash --patch")).toBe(true);
+		});
+
+		it("is case insensitive", () => {
+			expect(isInteractiveCommand("VIM file.txt")).toBe(true);
+			expect(isInteractiveCommand("Git Commit")).toBe(true);
+		});
+	});
+
+	describe("configuration", () => {
+		it("can add custom commands", () => {
+			expect(isInteractiveCommand("mycustomtool")).toBe(false);
+
+			configureInteractiveCommands({ additional: ["mycustomtool"] });
+
+			expect(isInteractiveCommand("mycustomtool")).toBe(true);
+			expect(isInteractiveCommand("mycustomtool --flag")).toBe(true);
+		});
+
+		it("can exclude default commands", () => {
+			expect(isInteractiveCommand("vim")).toBe(true);
+
+			configureInteractiveCommands({ excluded: ["vim"] });
+
+			expect(isInteractiveCommand("vim")).toBe(false);
+			expect(isInteractiveCommand("nvim")).toBe(true); // other editors still work
+		});
+
+		it("getInteractiveCommands returns merged list", () => {
+			configureInteractiveCommands({
+				additional: ["myeditor"],
+				excluded: ["vim"],
+			});
+
+			const commands = getInteractiveCommands();
+			expect(commands).toContain("myeditor");
+			expect(commands).not.toContain("vim");
+			expect(commands).toContain("nvim");
+		});
+
+		it("DEFAULT_INTERACTIVE_COMMANDS is exported", () => {
+			expect(DEFAULT_INTERACTIVE_COMMANDS).toContain("vim");
+			expect(DEFAULT_INTERACTIVE_COMMANDS).toContain("git commit");
+			expect(DEFAULT_INTERACTIVE_COMMANDS).toContain("htop");
+		});
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `TUI.execInteractive(command)` method to run commands with full terminal access (editors, pagers, etc.)
+
 ## [0.37.8] - 2026-01-07
 
 ### Added


### PR DESCRIPTION
Commands like vim, git rebase, htop, less, etc. now get full terminal access. The TUI suspends while they run and resumes after exit.

**Because I died on a hill waiting for 'git rebase' to finish.**

## Features
- Auto-detection of interactive commands (editors, pagers, git ops, TUIs)
- User prefix `!i` to force interactive mode for any command
- Agent bash tool also supports interactive commands
- Configurable via settings.json `interactiveCommands.additionalCommands` and `interactiveCommands.excludeCommands`

## Implementation
- `TUI.execInteractive(command)` suspends TUI and runs with `stdio: inherit`
- Bash tool checks `isInteractiveCommand()` and delegates to executor
- `InteractiveExecutorHolder` pattern bridges SDK creation and TUI init
- `DEFAULT_INTERACTIVE_COMMANDS` list covers common tools

## Usage

```bash
# Auto-detected interactive commands
!git rebase -i HEAD~3
!vim file.txt
!htop

# Force interactive mode
!i any-command-here

# Exclude from context (unchanged)
!!ls -la
```

## Configuration

```json
{
  "interactiveCommands": {
    "additionalCommands": ["mycli", "custom-editor"],
    "excludeCommands": ["vim"]
  }
}
```

## Labels
pkg:coding-agent, pkg:tui