### PR TITLE
Make dependency on @crosscopy/clipboard optional

### DIFF
--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -1,5 +1,18 @@
-import Clipboard from "@crosscopy/clipboard";
 import { spawnSync } from "child_process";
+
+type ClipboardModule = typeof import("@crosscopy/clipboard");
+let _clipboard: ClipboardModule | null | undefined;
+
+function getClipboard(): ClipboardModule | null {
+	if (_clipboard === undefined) {
+		try {
+			_clipboard = require("@crosscopy/clipboard");
+		} catch {
+			_clipboard = null;
+		}
+	}
+	return _clipboard as ClipboardModule | null;
+}
 
 export type ClipboardImage = {
 	bytes: Uint8Array;
@@ -143,11 +156,12 @@ export async function readClipboardImage(options?: {
 		return readClipboardImageViaWlPaste() ?? readClipboardImageViaXclip();
 	}
 
-	if (!Clipboard.hasImage()) {
+	const clipboard = getClipboard();
+	if (!clipboard || !clipboard.hasImage()) {
 		return null;
 	}
 
-	const imageData = await Clipboard.getImageBinary();
+	const imageData = await clipboard.getImageBinary();
 	if (!imageData || imageData.length === 0) {
 		return null;
 	}


### PR DESCRIPTION
This dependency is a binary package, but not available for Linux on x86_64, so start-up fails. Make the dependency optional, falling back to existing logic with `wl-copy` or `xclip` if it is absent.

https://github.com/badlogic/pi-mono/issues/533