### PR TITLE
feat(coding-agent): add customDirectories for prompt templates

### DIFF
--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -42,7 +42,12 @@ import { convertToLlm } from "./messages.js";
 import { ModelRegistry } from "./model-registry.js";
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "./prompt-templates.js";
 import { SessionManager } from "./session-manager.js";
-import { type Settings, SettingsManager, type SkillsSettings } from "./settings-manager.js";
+import {
+	type PromptTemplatesSettings,
+	type Settings,
+	SettingsManager,
+	type SkillsSettings,
+} from "./settings-manager.js";
 import { loadSkills as loadSkillsInternal, type Skill } from "./skills.js";
 import {
 	buildSystemPrompt as buildSystemPromptInternal,
@@ -247,8 +252,13 @@ export function discoverContextFiles(cwd?: string, agentDir?: string): Array<{ p
 /**
  * Discover prompt templates from cwd and agentDir.
  */
-export function discoverPromptTemplates(cwd?: string, agentDir?: string): PromptTemplate[] {
+export function discoverPromptTemplates(
+	cwd?: string,
+	agentDir?: string,
+	settings?: PromptTemplatesSettings,
+): PromptTemplate[] {
 	return loadPromptTemplatesInternal({
+		...settings,
 		cwd: cwd ?? process.cwd(),
 		agentDir: agentDir ?? getDefaultAgentDir(),
 	});
@@ -605,7 +615,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const systemPrompt = rebuildSystemPrompt(initialActiveToolNames);
 	time("buildSystemPrompt");
 
-	const promptTemplates = options.promptTemplates ?? discoverPromptTemplates(cwd, agentDir);
+	const promptTemplates =
+		options.promptTemplates ?? discoverPromptTemplates(cwd, agentDir, settingsManager.getPromptTemplatesSettings());
 	time("discoverPromptTemplates");
 
 	// Create convertToLlm wrapper that filters images if blockImages is enabled (defense-in-depth)

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -30,6 +30,10 @@ export interface SkillsSettings {
 	includeSkills?: string[]; // default: [] (empty = include all; glob patterns to filter)
 }
 
+export interface PromptTemplatesSettings {
+	customDirectories?: string[]; // default: []
+}
+
 export interface TerminalSettings {
 	showImages?: boolean; // default: true (only relevant if terminal supports images)
 }
@@ -55,6 +59,7 @@ export interface Settings {
 	collapseChangelog?: boolean; // Show condensed changelog after update (use /changelog for full)
 	extensions?: string[]; // Array of extension file paths
 	skills?: SkillsSettings;
+	promptTemplates?: PromptTemplatesSettings;
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
@@ -422,5 +427,11 @@ export class SettingsManager {
 	setDoubleEscapeAction(action: "branch" | "tree"): void {
 		this.globalSettings.doubleEscapeAction = action;
 		this.save();
+	}
+
+	getPromptTemplatesSettings(): Required<PromptTemplatesSettings> {
+		return {
+			customDirectories: [...(this.settings.promptTemplates?.customDirectories ?? [])],
+		};
 	}
 }

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -150,6 +150,7 @@ export {
 export {
 	type CompactionSettings,
 	type ImageSettings,
+	type PromptTemplatesSettings,
 	type RetrySettings,
 	type Settings,
 	SettingsManager,


### PR DESCRIPTION
## Summary

Add `customDirectories` support for prompt templates, mirroring the existing skills pattern. This 

## Problem

Skills have `customDirectories` support, allowing users to load skills from arbitrary directories. Prompt templates (slash commands from `.md` files) lack this feature and could only be loaded from two fixed locations:
- `~/.pi/agent/prompts/` (user)
- `<cwd>/.pi/prompts/` (project)

This is limiting for users who want to:

- Share prompt templates across machines via a git repo
- Use team-shared prompts from a central location
- Organize prompts outside the standard directories

## Solution

Add `customDirectories` option for prompt templates in settings:

```json
{
  "promptTemplates": {
    "customDirectories": ["~/my-prompts-repo", "/shared/team-prompts"]
  }
}
```

Templates from custom directories get a `(custom)` or `(custom:subdir)` source tag.

## Changes

- **`settings-manager.ts`**: Add `PromptTemplatesSettings` interface and `getPromptTemplatesSettings()` method
- **`prompt-templates.ts`**: Extend `LoadPromptTemplatesOptions` to accept `customDirectories`, iterate over custom dirs with tilde expansion
- **`sdk.ts`**: Update `discoverPromptTemplates()` to pass settings
- **`index.ts`**: Export `PromptTemplatesSettings` type
