### PR TITLE
feat(coding-agent): make ctx.shutdown() available for extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Extension UI dialogs (`ctx.ui.select()`, `ctx.ui.confirm()`, `ctx.ui.input()`) now support a `timeout` option with live countdown display ([#522](https://github.com/badlogic/pi-mono/pull/522) by [@nicobailon](https://github.com/nicobailon))
 - Extensions can now provide custom editor components via `ctx.ui.setEditorComponent()`. See `examples/extensions/modal-editor.ts` and `docs/tui.md` Pattern 7.
 - Extension factories can now be async, enabling dynamic imports and lazy-loaded dependencies ([#513](https://github.com/badlogic/pi-mono/pull/513) by [@austinm911](https://github.com/austinm911))
+- `ctx.shutdown()` is now available in extension contexts for requesting a graceful shutdown. In interactive mode, shutdown is deferred until the agent becomes idle (after processing all queued steering and follow-up messages). In RPC mode, shutdown is deferred until after completing the current command response. In print mode, shutdown is a no-op as the process exits automatically when prompts complete.
 
 ### Fixed
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -556,6 +556,24 @@ Access to models and API keys.
 
 Control flow helpers.
 
+### ctx.shutdown()
+
+Request a graceful shutdown of pi.
+
+- **Interactive mode:** Deferred until the agent becomes idle (after processing all queued steering and follow-up messages).
+- **RPC mode:** Deferred until the next idle state (after completing the current command response, when waiting for the next command).
+- **Print mode:** No-op. The process exits automatically when all prompts are processed.
+
+Emits `session_shutdown` event to all extensions before exiting. Available in all contexts (event handlers, tools, commands, shortcuts).
+
+```typescript
+pi.on("tool_call", (event, ctx) => {
+  if (isFatal(event.input)) {
+    ctx.shutdown();
+  }
+});
+```
+
 ## ExtensionCommandContext
 
 Command handlers receive `ExtensionCommandContext`, which extends `ExtensionContext` with session control methods. These are only available in commands because they can deadlock if called from event handlers.

--- a/packages/coding-agent/examples/extensions/shutdown-command.ts
+++ b/packages/coding-agent/examples/extensions/shutdown-command.ts
@@ -1,0 +1,63 @@
+/**
+ * Shutdown Command Extension
+ *
+ * Adds a /quit command that allows extensions to trigger clean shutdown.
+ * Demonstrates how extensions can use ctx.shutdown() to exit pi cleanly.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+export default function (pi: ExtensionAPI) {
+	// Register a /quit command that cleanly exits pi
+	pi.registerCommand("quit", {
+		description: "Exit pi cleanly",
+		handler: async (_args, ctx) => {
+			await ctx.shutdown();
+		},
+	});
+
+	// You can also create a tool that shuts down after completing work
+	pi.registerTool({
+		name: "finish_and_exit",
+		label: "Finish and Exit",
+		description: "Complete a task and exit pi",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params, _onUpdate, ctx, _signal) {
+			// Do any final work here...
+			// Then shutdown
+			await ctx.shutdown();
+
+			// This return won't be reached, but required by type
+			return {
+				content: [{ type: "text", text: "Shutting down..." }],
+				details: {},
+			};
+		},
+	});
+
+	// You could also create a more complex tool with parameters
+	pi.registerTool({
+		name: "deploy_and_exit",
+		label: "Deploy and Exit",
+		description: "Deploy the application and exit pi",
+		parameters: Type.Object({
+			environment: Type.String({ description: "Target environment (e.g., production, staging)" }),
+		}),
+		async execute(_toolCallId, params, onUpdate, ctx, _signal) {
+			onUpdate?.({ content: [{ type: "text", text: `Deploying to ${params.environment}...` }], details: {} });
+
+			// Example deployment logic
+			// const result = await pi.exec("npm", ["run", "deploy", params.environment], { signal });
+
+			// On success, shutdown
+			onUpdate?.({ content: [{ type: "text", text: "Deployment complete, exiting..." }], details: {} });
+			await ctx.shutdown();
+
+			return {
+				content: [{ type: "text", text: "Done!" }],
+				details: { environment: params.environment },
+			};
+		},
+	});
+}

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -8,7 +8,13 @@ export {
 	loadExtensionFromFactory,
 	loadExtensions,
 } from "./loader.js";
-export type { BranchHandler, ExtensionErrorListener, NavigateTreeHandler, NewSessionHandler } from "./runner.js";
+export type {
+	BranchHandler,
+	ExtensionErrorListener,
+	NavigateTreeHandler,
+	NewSessionHandler,
+	ShutdownHandler,
+} from "./runner.js";
 export { ExtensionRunner } from "./runner.js";
 export type {
 	AgentEndEvent,

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -175,6 +175,8 @@ export interface ExtensionContext {
 	abort(): void;
 	/** Whether there are queued messages waiting */
 	hasPendingMessages(): boolean;
+	/** Gracefully shutdown pi and exit. Available in all contexts. */
+	shutdown(): void;
 }
 
 /**
@@ -775,6 +777,7 @@ export interface ExtensionContextActions {
 	isIdle: () => boolean;
 	abort: () => void;
 	hasPendingMessages: () => boolean;
+	shutdown: () => void;
 }
 
 /**

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -527,6 +527,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		abort: () => {
 			session.abort();
 		},
+		shutdown: () => {},
 	}));
 
 	// Create tool registry mapping name -> tool (for extension getTools/setTools)

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -66,6 +66,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 				isIdle: () => !session.isStreaming,
 				abort: () => session.abort(),
 				hasPendingMessages: () => session.pendingMessageCount > 0,
+				shutdown: () => {},
 			},
 			// ExtensionCommandContextActions - commands invokable via prompt("/command")
 			{

--- a/packages/coding-agent/test/compaction-extensions.test.ts
+++ b/packages/coding-agent/test/compaction-extensions.test.ts
@@ -121,6 +121,7 @@ describe.skipIf(!API_KEY)("Compaction extensions", () => {
 				isIdle: () => !session.isStreaming,
 				abort: () => session.abort(),
 				hasPendingMessages: () => session.pendingMessageCount > 0,
+				shutdown: () => {},
 			},
 		);
 


### PR DESCRIPTION
The LLM claims that "The session_shutdown event is emitted to all extensions before exiting, giving them a chance to clean up resources.", but I haven't tested that, tbh. Opening this to probe first if it's useful to merge

- Add ctx.shutdown() to ExtensionContext (available in event handlers, tools, commands, shortcuts)
- Add re-entrancy guard to InteractiveMode.shutdown() to prevent recursive calls
- Add shutdown handler support to print-mode and rpc-mode
- Add no-op shutdown() to SDK context to fix type error
- Add shutdown-command.ts example demonstrating /quit command and tool usage
- Update docs: extensions.md with ctx.shutdown() documentation
- Export ShutdownHandler type from extensions/index.ts