### PR TITLE
feat(coding-agent): add live progress display for print mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Extension UI dialogs (`ctx.ui.select()`, `ctx.ui.confirm()`, `ctx.ui.input()`) now support a `timeout` option that auto-dismisses the dialog with a live countdown display. Simpler alternative to `AbortSignal` for timed dialogs.
 - Extensions can now provide custom editor components via `ctx.ui.setEditorComponent((tui, theme, keybindings) => ...)`. Extend `CustomEditor` for full app keybinding support (escape, ctrl+d, model switching, etc.). See `examples/extensions/modal-editor.ts`, `examples/extensions/rainbow-editor.ts`, and `docs/tui.md` Pattern 7.
+- Print mode (`-p`) now shows a live progress line on TTY stderr with spinner, current activity, cumulative token stats, cost, model/thinking level, and elapsed time. Automatically disabled for non-TTY (piped output) or with `--quiet`/`-q` flag.
 
 ### Fixed
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -1115,7 +1115,8 @@ pi [options] [@files...] [messages...]
 | `--system-prompt <text\|file>` | Custom system prompt (text or file path) |
 | `--append-system-prompt <text\|file>` | Append to system prompt |
 | `--mode <mode>` | Output mode: `text`, `json`, `rpc` (implies `--print`) |
-| `--print`, `-p` | Non-interactive: process prompt and exit |
+| `--print`, `-p` | Non-interactive mode: process prompt and exit |
+| `--quiet`, `-q` | Suppress progress output in non-interactive mode |
 | `--no-session` | Don't save session |
 | `--session <path>` | Use specific session file |
 | `--session-dir <dir>` | Directory for session storage and lookup |

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -28,6 +28,7 @@ export interface Args {
 	tools?: ToolName[];
 	extensions?: string[];
 	print?: boolean;
+	quiet?: boolean;
 	export?: string;
 	noSkills?: boolean;
 	skills?: string[];
@@ -111,6 +112,8 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			}
 		} else if (arg === "--print" || arg === "-p") {
 			result.print = true;
+		} else if (arg === "--quiet" || arg === "-q") {
+			result.quiet = true;
 		} else if (arg === "--export" && i + 1 < args.length) {
 			result.export = args[++i];
 		} else if ((arg === "--extension" || arg === "-e") && i + 1 < args.length) {
@@ -164,6 +167,7 @@ ${chalk.bold("Options:")}
   --append-system-prompt <text>  Append text or file contents to the system prompt
   --mode <mode>                  Output mode: text (default), json, or rpc
   --print, -p                    Non-interactive mode: process prompt and exit
+  --quiet, -q                    Suppress progress output in non-interactive mode
   --continue, -c                 Continue previous session
   --resume, -r                   Select a session to resume
   --session <path>               Use specific session file

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -512,7 +512,9 @@ export async function main(args: string[]) {
 			fdPath,
 		);
 	} else {
-		await runPrintMode(session, mode, parsed.messages, initialMessage, initialImages);
+		await runPrintMode(session, mode, parsed.messages, initialMessage, initialImages, {
+			quiet: parsed.quiet,
+		});
 		stopThemeWatcher();
 		if (process.stdout.writableLength > 0) {
 			await new Promise<void>((resolve) => process.stdout.once("drain", resolve));

--- a/packages/coding-agent/src/modes/print-mode-progress.ts
+++ b/packages/coding-agent/src/modes/print-mode-progress.ts
@@ -1,0 +1,450 @@
+/**
+ * Progress renderer for print mode (non-interactive).
+ *
+ * Shows two updating lines:
+ * Line 1: Spinner + current activity (tool call, thinking, text generation)
+ * Line 2: Token stats, cost, model, elapsed time (styled like interactive footer)
+ */
+
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, Model, ThinkingContent, ToolCall } from "@mariozechner/pi-ai";
+import type { AgentSessionEvent } from "../core/agent-session.js";
+import { theme } from "./interactive/theme/theme.js";
+
+/** Strip ANSI escape codes from a string */
+function stripAnsi(str: string): string {
+	return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/** Calculate visible width of a string (excluding ANSI codes) */
+function visibleWidth(str: string): number {
+	return stripAnsi(str).length;
+}
+
+/** Truncate a string with ANSI codes to a maximum visible width */
+function truncateToWidth(text: string, maxWidth: number, ellipsis = "..."): string {
+	const textWidth = visibleWidth(text);
+	if (textWidth <= maxWidth) {
+		return text;
+	}
+
+	const ellipsisWidth = ellipsis.length;
+	const targetWidth = maxWidth - ellipsisWidth;
+	if (targetWidth <= 0) {
+		return ellipsis.slice(0, maxWidth);
+	}
+
+	// Walk through the string, tracking visible characters
+	let visibleCount = 0;
+	const ansiRegex = /\x1b\[[0-9;]*m/g;
+	let result = "";
+	let lastIndex = 0;
+
+	// Find all ANSI sequences and their positions
+	for (const match of text.matchAll(ansiRegex)) {
+		// Add visible characters before this ANSI sequence
+		const beforeAnsi = text.slice(lastIndex, match.index);
+		for (const char of beforeAnsi) {
+			if (visibleCount >= targetWidth) break;
+			result += char;
+			visibleCount++;
+		}
+		if (visibleCount >= targetWidth) break;
+		// Add the ANSI sequence (doesn't count toward visible width)
+		result += match[0];
+		lastIndex = (match.index ?? 0) + match[0].length;
+	}
+
+	// Add remaining visible characters after last ANSI sequence
+	if (visibleCount < targetWidth) {
+		const remaining = text.slice(lastIndex);
+		for (const char of remaining) {
+			if (visibleCount >= targetWidth) break;
+			result += char;
+			visibleCount++;
+		}
+	}
+
+	// Reset any open ANSI sequences and add ellipsis
+	return `${result}\x1b[0m${ellipsis}`;
+}
+
+/** Spinner frames (braille pattern, same as TUI Loader) */
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const SPINNER_INTERVAL_MS = 80;
+
+/** Cumulative usage stats */
+interface CumulativeUsage {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	cost: number;
+}
+
+/** Context usage from last message (for percentage calculation) */
+interface ContextUsage {
+	tokens: number;
+	window: number;
+}
+
+/** Progress renderer state */
+export class PrintModeProgress {
+	private spinnerFrame = 0;
+	private spinnerInterval: NodeJS.Timeout | null = null;
+	private startTime: number;
+	private currentActivity = "";
+	private currentActivityType: "tool" | "thinking" | "text" | "system" = "system";
+	private currentToolName = "";
+	private usage: CumulativeUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 };
+	private context: ContextUsage = { tokens: 0, window: 0 };
+	private hasReceivedStats = false;
+	private model: Model<any> | undefined;
+	private thinkingLevel: ThinkingLevel = "off";
+	private isActive = false;
+	private hasRenderedOnce = false;
+
+	constructor() {
+		this.startTime = Date.now();
+	}
+
+	/**
+	 * Start the progress display.
+	 * Should be called before processing begins.
+	 */
+	start(model: Model<any> | undefined, thinkingLevel: ThinkingLevel): void {
+		this.model = model;
+		this.thinkingLevel = thinkingLevel;
+		this.startTime = Date.now();
+		this.isActive = true;
+		this.hasReceivedStats = false;
+		this.currentActivity = "Starting...";
+		this.currentActivityType = "system";
+		this.context = { tokens: 0, window: model?.contextWindow || 0 };
+		this.hasRenderedOnce = false;
+
+		// Start spinner animation
+		this.spinnerInterval = setInterval(() => {
+			this.spinnerFrame = (this.spinnerFrame + 1) % SPINNER_FRAMES.length;
+			this.render();
+		}, SPINNER_INTERVAL_MS);
+
+		this.render();
+	}
+
+	/**
+	 * Stop the progress display and clear the lines.
+	 */
+	stop(): void {
+		this.isActive = false;
+
+		if (this.spinnerInterval) {
+			clearInterval(this.spinnerInterval);
+			this.spinnerInterval = null;
+		}
+
+		// Clear all lines
+		this.clearLines();
+	}
+
+	/**
+	 * Handle an agent session event to update progress display.
+	 */
+	handleEvent(event: AgentSessionEvent): void {
+		if (!this.isActive) return;
+
+		switch (event.type) {
+			case "message_start":
+				if (event.message.role === "assistant") {
+					this.currentActivity = "Working...";
+					this.currentActivityType = "system";
+				}
+				break;
+
+			case "message_update":
+				if (event.message.role === "assistant") {
+					this.updateFromAssistantMessage(event.message as AssistantMessage);
+				}
+				break;
+
+			case "message_end":
+				if (event.message.role === "assistant") {
+					const msg = event.message as AssistantMessage;
+					// Update cumulative usage
+					this.usage.input += msg.usage.input;
+					this.usage.output += msg.usage.output;
+					this.usage.cacheRead += msg.usage.cacheRead;
+					this.usage.cacheWrite += msg.usage.cacheWrite;
+					this.usage.cost += msg.usage.cost.total;
+					// Update context usage from last message (for percentage calculation)
+					this.context.tokens = msg.usage.input + msg.usage.output + msg.usage.cacheRead + msg.usage.cacheWrite;
+					this.hasReceivedStats = true;
+				}
+				break;
+
+			case "auto_compaction_start":
+				this.currentActivity = "Compacting context...";
+				this.currentActivityType = "system";
+				break;
+
+			case "auto_retry_start":
+				this.currentActivity = `Retrying (${event.attempt}/${event.maxAttempts})...`;
+				this.currentActivityType = "system";
+				break;
+		}
+
+		this.render();
+	}
+
+	/**
+	 * Update activity from streaming assistant message content.
+	 */
+	private updateFromAssistantMessage(msg: AssistantMessage): void {
+		// Check for tool calls first
+		const toolCalls = msg.content.filter((c): c is ToolCall => c.type === "toolCall");
+		if (toolCalls.length > 0) {
+			const lastToolCall = toolCalls[toolCalls.length - 1];
+			this.currentToolName = lastToolCall.name;
+			this.currentActivity = this.formatToolCall(lastToolCall);
+			this.currentActivityType = "tool";
+			return;
+		}
+
+		// Check for thinking content
+		const thinkingBlocks = msg.content.filter((c): c is ThinkingContent => c.type === "thinking");
+		if (thinkingBlocks.length > 0) {
+			const lastThinking = thinkingBlocks[thinkingBlocks.length - 1];
+			if (lastThinking.thinking?.trim()) {
+				this.currentActivity = this.normalizeText(lastThinking.thinking);
+			} else {
+				this.currentActivity = "";
+			}
+			this.currentActivityType = "thinking";
+			return;
+		}
+
+		// Check for text content
+		const textBlocks = msg.content.filter((c) => c.type === "text");
+		if (textBlocks.length > 0) {
+			const lastText = textBlocks[textBlocks.length - 1];
+			if ("text" in lastText && lastText.text) {
+				this.currentActivity = this.normalizeText(lastText.text);
+				this.currentActivityType = "text";
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Format a tool call for display (returns just the details, not the label).
+	 */
+	private formatToolCall(toolCall: ToolCall): string {
+		const name = toolCall.name;
+		const args = toolCall.arguments as Record<string, unknown>;
+
+		switch (name) {
+			case "read": {
+				const path = this.shortenPath(String(args.path || args.file_path || ""));
+				return path;
+			}
+			case "write": {
+				const path = this.shortenPath(String(args.path || args.file_path || ""));
+				return path;
+			}
+			case "edit": {
+				const path = this.shortenPath(String(args.path || args.file_path || ""));
+				return path;
+			}
+			case "bash": {
+				return this.normalizeText(String(args.command || ""));
+			}
+			case "grep": {
+				const pattern = String(args.pattern || "");
+				const path = this.shortenPath(String(args.path || "."));
+				return `/${pattern}/ in ${path}`;
+			}
+			case "find": {
+				const pattern = String(args.pattern || "");
+				const path = this.shortenPath(String(args.path || "."));
+				return `${pattern} in ${path}`;
+			}
+			case "ls": {
+				return this.shortenPath(String(args.path || "."));
+			}
+			default: {
+				// For custom tools, show truncated JSON args
+				const argsStr = JSON.stringify(args);
+				return argsStr.length > 40 ? `${argsStr.slice(0, 37)}...` : argsStr;
+			}
+		}
+	}
+
+	/**
+	 * Shorten a path by replacing home directory with ~.
+	 */
+	private shortenPath(path: string): string {
+		const home = process.env.HOME || process.env.USERPROFILE || "";
+		if (home && path.startsWith(home)) {
+			return `~${path.slice(home.length)}`;
+		}
+		return path;
+	}
+
+	/**
+	 * Normalize text for single-line display (collapse whitespace).
+	 * Truncation is handled at render time based on terminal width.
+	 */
+	private normalizeText(text: string): string {
+		// Normalize whitespace (replace newlines, tabs with space, collapse multiple spaces)
+		return text
+			.replace(/[\r\n\t]/g, " ")
+			.replace(/ +/g, " ")
+			.trim();
+	}
+
+	/**
+	 * Format token count for display.
+	 */
+	private formatTokens(count: number): string {
+		if (count < 1000) return count.toString();
+		if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
+		if (count < 1000000) return `${Math.round(count / 1000)}k`;
+		if (count < 10000000) return `${(count / 1000000).toFixed(1)}M`;
+		return `${Math.round(count / 1000000)}M`;
+	}
+
+	/**
+	 * Format elapsed time for display.
+	 */
+	private formatElapsedTime(): string {
+		const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
+		if (elapsed < 60) {
+			return `${elapsed}s`;
+		}
+		const minutes = Math.floor(elapsed / 60);
+		const seconds = elapsed % 60;
+		return `${minutes}m ${seconds}s`;
+	}
+
+	/**
+	 * Build the activity line (line 1).
+	 */
+	private buildActivityLine(): string {
+		const spinner = theme.fg("accent", SPINNER_FRAMES[this.spinnerFrame]);
+
+		switch (this.currentActivityType) {
+			case "tool":
+				// Tool label in accent color, details plain
+				return `${spinner} ${theme.fg("accent", `[${this.currentToolName}]`)} ${this.currentActivity}`;
+			case "thinking":
+				// Thinking label in accent color, content plain (like tools)
+				if (this.currentActivity) {
+					return `${spinner} ${theme.fg("accent", "[thinking]")} ${this.currentActivity}`;
+				}
+				return `${spinner} ${theme.fg("accent", "[thinking]")}`;
+			case "text":
+				return `${spinner} ${this.currentActivity}`;
+			default:
+				// System messages like "Starting...", "Compacting...", "Retrying..."
+				if (this.currentActivity.startsWith("Retrying")) {
+					return `${theme.fg("warning", SPINNER_FRAMES[this.spinnerFrame])} ${theme.fg("warning", this.currentActivity)}`;
+				}
+				return `${spinner} ${this.currentActivity}`;
+		}
+	}
+
+	/**
+	 * Build the stats line (line 2).
+	 */
+	private buildStatsLine(): string {
+		const parts: string[] = [];
+		const placeholder = "---";
+
+		// Token stats (show placeholders before first stats received)
+		if (this.hasReceivedStats) {
+			parts.push(`↑${this.formatTokens(this.usage.input)}`);
+			parts.push(`↓${this.formatTokens(this.usage.output)}`);
+			parts.push(`R${this.formatTokens(this.usage.cacheRead)}`);
+			parts.push(`W${this.formatTokens(this.usage.cacheWrite)}`);
+			parts.push(`$${this.usage.cost.toFixed(3)}`);
+		} else {
+			parts.push(`↑${placeholder}`);
+			parts.push(`↓${placeholder}`);
+			parts.push(`R${placeholder}`);
+			parts.push(`W${placeholder}`);
+			parts.push(`$${placeholder}`);
+		}
+
+		// Context percentage (like interactive mode footer)
+		if (this.context.window > 0) {
+			if (this.hasReceivedStats) {
+				const contextPercent = (this.context.tokens / this.context.window) * 100;
+				const contextDisplay = `${contextPercent.toFixed(1)}%/${this.formatTokens(this.context.window)}`;
+				// Colorize based on usage
+				if (contextPercent > 90) {
+					parts.push(theme.fg("error", contextDisplay));
+				} else if (contextPercent > 70) {
+					parts.push(theme.fg("warning", contextDisplay));
+				} else {
+					parts.push(contextDisplay);
+				}
+			} else {
+				parts.push(`${placeholder}/${this.formatTokens(this.context.window)}`);
+			}
+		}
+
+		// Model and thinking level
+		if (this.model) {
+			let modelPart = this.model.id;
+			if (this.model.reasoning && this.thinkingLevel !== "off") {
+				modelPart += `:${this.thinkingLevel}`;
+			}
+			parts.push(modelPart);
+		}
+
+		// Elapsed time
+		parts.push(this.formatElapsedTime());
+
+		return theme.fg("dim", parts.join(" | "));
+	}
+
+	/**
+	 * Render the progress lines to stderr.
+	 * Layout: empty line, activity line, stats line, empty line (4 lines total)
+	 */
+	private render(): void {
+		if (!this.isActive) return;
+
+		const activityLine = this.buildActivityLine();
+		const statsLine = this.buildStatsLine();
+
+		// Get terminal width, default to 80 if not available
+		const termWidth = process.stderr.columns || 80;
+
+		// Truncate lines to terminal width using proper ANSI-aware truncation
+		const displayActivity =
+			visibleWidth(activityLine) > termWidth ? truncateToWidth(activityLine, termWidth) : activityLine;
+		const displayStats = visibleWidth(statsLine) > termWidth ? truncateToWidth(statsLine, termWidth) : statsLine;
+
+		// On first render, just write the lines
+		// On subsequent renders, move up first to overwrite previous content
+		// Cursor always ends at the bottom (end of line 4)
+		const moveUp = this.hasRenderedOnce ? `\x1b[3A\r` : ""; // Move up 3 lines (from line 4 to line 1)
+		this.hasRenderedOnce = true;
+
+		process.stderr.write(
+			`${moveUp}\x1b[K\n` + // Line 1: empty
+				`\x1b[K${displayActivity}\n` + // Line 2: activity
+				`\x1b[K${displayStats}\n` + // Line 3: stats
+				`\x1b[K`, // Line 4: empty, cursor stays here
+		);
+	}
+
+	/**
+	 * Clear all progress lines (4 lines total).
+	 */
+	private clearLines(): void {
+		// Move up 3 lines (to line 1) and clear all 4 lines, cursor ends at line 1
+		process.stderr.write(`\x1b[3A\r\x1b[K\n\x1b[K\n\x1b[K\n\x1b[K\x1b[3A\r`);
+	}
+}

--- a/packages/coding-agent/test/print-mode-progress.test.ts
+++ b/packages/coding-agent/test/print-mode-progress.test.ts
@@ -1,0 +1,480 @@
+import type { MockInstance } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import type { AgentSessionEvent } from "../src/core/agent-session.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import { shouldShowProgress } from "../src/modes/print-mode.js";
+import { PrintModeProgress } from "../src/modes/print-mode-progress.js";
+
+/** Strip ANSI escape codes for easier assertions */
+function stripAnsi(str: string): string {
+	return str.replace(/\x1b\[[0-9;]*m/g, "").replace(/\x1b\[\?25[hl]/g, "");
+}
+
+/** Create a mock model */
+function createMockModel(contextWindow = 200000) {
+	return {
+		id: "test-model",
+		contextWindow,
+		reasoning: false,
+	} as any;
+}
+
+/** Create a mock assistant message */
+function createMockAssistantMessage(overrides: Record<string, any> = {}): any {
+	return {
+		role: "assistant" as const,
+		content: [],
+		usage: {
+			input: 1000,
+			output: 500,
+			cacheRead: 2000,
+			cacheWrite: 100,
+			cost: { total: 0.05 },
+		},
+		...overrides,
+	};
+}
+
+describe("PrintModeProgress", () => {
+	let stderrOutput: string;
+	let stderrSpy: MockInstance;
+	let progress: PrintModeProgress;
+
+	beforeAll(() => {
+		// Initialize theme (required by PrintModeProgress)
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		stderrOutput = "";
+		stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+			stderrOutput += chunk;
+			return true;
+		});
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+		progress = new PrintModeProgress();
+	});
+
+	afterEach(() => {
+		progress.stop();
+		stderrSpy.mockRestore();
+		vi.useRealTimers();
+	});
+
+	describe("placeholder stats", () => {
+		test("shows placeholder stats (---) before first message_end", () => {
+			progress.start(createMockModel(), "off");
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("↑---");
+			expect(output).toContain("↓---");
+			expect(output).toContain("R---");
+			expect(output).toContain("W---");
+			expect(output).toContain("$---");
+		});
+
+		test("shows placeholder for context percentage before first message_end", () => {
+			progress.start(createMockModel(200000), "off");
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("---/200k");
+		});
+
+		test("shows actual stats after message_end event", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = ""; // Clear initial render
+
+			const event = {
+				type: "message_end",
+				message: createMockAssistantMessage(),
+			};
+			progress.handleEvent(event as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			// Token counts are formatted (e.g., 1000 -> "1.0k", 2000 -> "2.0k")
+			expect(output).toContain("↑1.0k");
+			expect(output).toContain("↓500");
+			expect(output).toContain("R2.0k");
+			expect(output).toContain("W100");
+			expect(output).toContain("$0.050");
+		});
+	});
+
+	describe("context percentage", () => {
+		test("calculates context percentage from last message", () => {
+			const model = createMockModel(100000); // 100k context
+			progress.start(model, "off");
+			stderrOutput = "";
+
+			// Message uses 10k tokens total (10% of context)
+			const event = {
+				type: "message_end",
+				message: createMockAssistantMessage({
+					usage: {
+						input: 5000,
+						output: 2000,
+						cacheRead: 2500,
+						cacheWrite: 500,
+						cost: { total: 0.01 },
+					},
+				}),
+			};
+			progress.handleEvent(event as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("10.0%/100k");
+		});
+
+		test("does not show context percentage when context window is 0", () => {
+			progress.start(createMockModel(0), "off");
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).not.toContain("%/");
+		});
+	});
+
+	describe("activity display", () => {
+		test("shows 'Starting...' initially", () => {
+			progress.start(createMockModel(), "off");
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("Starting...");
+		});
+
+		test("shows 'Working...' on message_start", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			const event = {
+				type: "message_start",
+				message: { role: "assistant", content: [] } as any,
+			};
+			progress.handleEvent(event as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("Working...");
+		});
+
+		test("shows tool name for tool calls", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			const event = {
+				type: "message_update",
+				message: createMockAssistantMessage({
+					content: [
+						{
+							type: "toolCall",
+							name: "bash",
+							arguments: { command: "npm run check" },
+						},
+					],
+				}),
+			};
+			progress.handleEvent(event as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("[bash]");
+			expect(output).toContain("npm run check");
+		});
+
+		test("shows [thinking] for thinking content", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			const event = {
+				type: "message_update",
+				message: createMockAssistantMessage({
+					content: [
+						{
+							type: "thinking",
+							thinking: "Let me analyze this problem...",
+						},
+					],
+				}),
+			};
+			progress.handleEvent(event as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("[thinking]");
+			expect(output).toContain("Let me analyze this problem...");
+		});
+
+		test("shows text content preview", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			const event = {
+				type: "message_update",
+				message: createMockAssistantMessage({
+					content: [
+						{
+							type: "text",
+							text: "Here is my response to your question",
+						},
+					],
+				}),
+			};
+			progress.handleEvent(event as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("Here is my response to your question");
+		});
+
+		test("shows 'Compacting context...' on auto_compaction_start", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			const event = {
+				type: "auto_compaction_start",
+			} as any;
+			progress.handleEvent(event as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("Compacting context...");
+		});
+
+		test("shows retry message on auto_retry_start", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			const event = {
+				type: "auto_retry_start",
+				attempt: 2,
+				maxAttempts: 3,
+			} as any;
+			progress.handleEvent(event as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("Retrying (2/3)...");
+		});
+	});
+
+	describe("model display", () => {
+		test("shows model ID", () => {
+			progress.start(createMockModel(), "off");
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("test-model");
+		});
+
+		test("shows thinking level when model supports reasoning", () => {
+			const model = {
+				id: "reasoning-model",
+				contextWindow: 200000,
+				reasoning: true,
+			} as any;
+			progress.start(model, "high");
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("reasoning-model:high");
+		});
+
+		test("does not show thinking level when off", () => {
+			const model = {
+				id: "reasoning-model",
+				contextWindow: 200000,
+				reasoning: true,
+			} as any;
+			progress.start(model, "off");
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("reasoning-model");
+			expect(output).not.toContain("reasoning-model:");
+		});
+	});
+
+	describe("elapsed time", () => {
+		test("shows elapsed seconds", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			vi.advanceTimersByTime(5080); // 5 seconds + one spinner frame
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toMatch(/[45]s/); // May show 4s or 5s depending on timing
+		});
+
+		test("shows minutes and seconds for longer durations", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			vi.advanceTimersByTime(125080); // 2 minutes 5 seconds + one spinner frame
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toMatch(/2m [45]s/); // May show 2m 4s or 2m 5s
+		});
+	});
+
+	describe("cumulative stats", () => {
+		test("accumulates stats across multiple messages", () => {
+			progress.start(createMockModel(), "off");
+
+			// First message
+			progress.handleEvent({
+				type: "message_end",
+				message: createMockAssistantMessage({
+					usage: {
+						input: 100,
+						output: 50,
+						cacheRead: 0,
+						cacheWrite: 0,
+						cost: { total: 0.01 },
+					},
+				}),
+			});
+
+			// Second message
+			progress.handleEvent({
+				type: "message_end",
+				message: createMockAssistantMessage({
+					usage: {
+						input: 200,
+						output: 100,
+						cacheRead: 0,
+						cacheWrite: 0,
+						cost: { total: 0.02 },
+					},
+				}),
+			});
+
+			stderrOutput = "";
+			vi.advanceTimersByTime(80); // Trigger re-render
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("↑300"); // 100 + 200
+			expect(output).toContain("↓150"); // 50 + 100
+			expect(output).toContain("$0.030"); // 0.01 + 0.02
+		});
+	});
+
+	describe("tool formatting", () => {
+		test("formats read tool with path", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			progress.handleEvent({
+				type: "message_update",
+				message: createMockAssistantMessage({
+					content: [
+						{
+							type: "toolCall",
+							name: "read",
+							arguments: { path: "/home/user/file.ts" },
+						},
+					],
+				}),
+			} as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("[read]");
+		});
+
+		test("formats grep tool with pattern and path", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			progress.handleEvent({
+				type: "message_update",
+				message: createMockAssistantMessage({
+					content: [
+						{
+							type: "toolCall",
+							name: "grep",
+							arguments: { pattern: "TODO", path: "./src" },
+						},
+					],
+				}),
+			} as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("[grep]");
+			expect(output).toContain("/TODO/");
+			expect(output).toContain("./src");
+		});
+
+		test("shows full bash command (truncation happens at render based on terminal width)", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			const longCommand = "npm run build && npm run test && npm run lint && npm run format";
+			progress.handleEvent({
+				type: "message_update",
+				message: createMockAssistantMessage({
+					content: [
+						{
+							type: "toolCall",
+							name: "bash",
+							arguments: { command: longCommand },
+						},
+					],
+				}),
+			} as AgentSessionEvent);
+
+			const output = stripAnsi(stderrOutput);
+			expect(output).toContain("[bash]");
+			// Full command is included (truncation at render time based on terminal width)
+			expect(output).toContain(longCommand);
+		});
+	});
+
+	describe("lifecycle", () => {
+		test("does not render after stop()", () => {
+			progress.start(createMockModel(), "off");
+			progress.stop();
+			stderrOutput = "";
+
+			progress.handleEvent({
+				type: "message_start",
+				message: { role: "assistant", content: [] } as any,
+			});
+
+			// Should not have rendered anything after stop
+			// (only the clear sequence from stop itself)
+			expect(stripAnsi(stderrOutput)).toBe("");
+		});
+
+		test("clears lines on stop()", () => {
+			progress.start(createMockModel(), "off");
+			stderrOutput = "";
+
+			progress.stop();
+
+			// Should contain cursor movement/clear sequences
+			expect(stderrOutput).toContain("\x1b[");
+		});
+	});
+});
+
+describe("shouldShowProgress", () => {
+	test("returns true for text mode on TTY without quiet", () => {
+		expect(shouldShowProgress("text", true, false)).toBe(true);
+		expect(shouldShowProgress("text", true, undefined)).toBe(true);
+	});
+
+	test("returns false for json mode", () => {
+		expect(shouldShowProgress("json", true, false)).toBe(false);
+		expect(shouldShowProgress("json", true, undefined)).toBe(false);
+	});
+
+	test("returns false when not a TTY", () => {
+		expect(shouldShowProgress("text", false, false)).toBe(false);
+		expect(shouldShowProgress("text", false, undefined)).toBe(false);
+	});
+
+	test("returns false when quiet flag is set", () => {
+		expect(shouldShowProgress("text", true, true)).toBe(false);
+	});
+
+	test("returns false when multiple conditions fail", () => {
+		// json mode + non-TTY
+		expect(shouldShowProgress("json", false, false)).toBe(false);
+		// json mode + quiet
+		expect(shouldShowProgress("json", true, true)).toBe(false);
+		// non-TTY + quiet
+		expect(shouldShowProgress("text", false, true)).toBe(false);
+		// all conditions fail
+		expect(shouldShowProgress("json", false, true)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a live progress indicator for non-interactive print mode (`-p`/`--print`) that shows real-time feedback while the agent is working.

## Why This Feature?

When running `pi -p "prompt"`, the terminal would sit silently for seconds or minutes with no indication of what was happening. Users had no way to know if the agent was working, stuck, or how far along it was. This made print mode feel unresponsive compared to interactive mode.

This PR adds the same progress feedback available in interactive mode to print mode, showing current activity, token usage, cost, and elapsed time. For scripting use cases, progress is automatically suppressed when output is piped, and can be explicitly disabled with `--quiet`.

**Note: for Mario / code reviewer agent: we could maybe make this opt-in with a flag instead, and preserve the original behavior of no progress output**

## Progress Display

When running in print mode on a TTY, a continuously updating two-line status is shown on stderr:

```
⠸ [bash] npm run check
↑12.3k | ↓4.1k | R8.2k | W1.2k | $0.038 | 4.5%/200k | gemini-2.5-flash | 32s
```

Before first stats are received, placeholders are shown to prevent layout shift:

```
⠸ Working...
↑--- | ↓--- | R--- | W--- | $--- | ---/200k | gemini-2.5-flash | 0s
```

Example of it in action:

https://github.com/user-attachments/assets/4a1511f9-b17a-40bf-a9ce-ae243456c726


### Components

**Line 1 - Activity:**
- **Spinner**: Braille animation (same as interactive mode)
- **Current activity**: Shows what the agent is doing
  - Tool calls: `[bash] command...`, `[read] ~/path`, `[edit] ~/path`, etc.
  - Thinking: `[thinking] content preview...` (styled like tools)
  - Text generation: First ~50 chars of response
  - System states: `Working...`, `Compacting context...`, `Retrying (2/3)...`

**Line 2 - Stats:**
- **Token stats**: Cumulative input (↑), output (↓), cache read (R), cache write (W)
- **Cost**: Running total
- **Context usage**: Percentage of context window used (with color coding at 70%/90% thresholds)
- **Model**: Current model ID, with thinking level if enabled (e.g., `claude-sonnet:high`)
- **Elapsed time**: How long since the prompt was sent

## TTY Detection

Progress is automatically disabled when output is piped or redirected:

```bash
# Shows progress (TTY)
pi -p "List files"

# No progress (piped)
pi -p "List files" > output.txt
pi -p "List files" | jq
```

## --quiet Flag

New `--quiet`/`-q` flag to explicitly disable progress even on TTY:

```bash
pi -p -q "List files"   # No progress, just final output
```

## Technical Details

- Progress renders to **stderr**, final output goes to **stdout** (unchanged)
- Uses ANSI escape sequences for cursor movement and line clearing
- 4-line layout: empty padding, activity, stats, empty padding
- Cursor positioned at bottom during rendering for natural appearance
- Progress lines cleared before final output is written
- No impact on JSON mode (`--mode json`)
- Tracks events from `AgentSessionEvent` to update display
