### PR TITLE
feat(coding-agent): allow tool_call event to provide result

### DIFF
--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -492,6 +492,8 @@ export interface ContextEventResult {
 export interface ToolCallEventResult {
 	block?: boolean;
 	reason?: string;
+	/** Short-circuit tool execution with this result instead of running the tool */
+	result?: AgentToolResult<unknown>;
 }
 
 export interface ToolResultEventResult {

--- a/packages/coding-agent/src/core/extensions/wrapper.ts
+++ b/packages/coding-agent/src/core/extensions/wrapper.ts
@@ -2,7 +2,7 @@
  * Tool wrappers for extensions.
  */
 
-import type { AgentTool, AgentToolUpdateCallback } from "@mariozechner/pi-agent-core";
+import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@mariozechner/pi-agent-core";
 import type { ExtensionRunner } from "./runner.js";
 import type { ExtensionContext, RegisteredTool, ToolCallEventResult, ToolResultEventResult } from "./types.js";
 
@@ -55,6 +55,9 @@ export function wrapToolWithExtensions<T>(tool: AgentTool<any, T>, runner: Exten
 						input: params,
 					})) as ToolCallEventResult | undefined;
 
+					if (callResult?.result) {
+						return callResult.result as AgentToolResult<T>;
+					}
 					if (callResult?.block) {
 						const reason = callResult.reason || "Tool execution was blocked by an extension";
 						throw new Error(reason);


### PR DESCRIPTION
 Extensions can now short-circuit tool execution by returning a result
 directly from the tool_call event handler, instead of only being able to
 block execution.

 Changes

 - Added optional result field to ToolCallEventResult interface
 - Updated wrapToolWithExtensions to return the provided result when present

 Use Cases

 ### Sandboxed Execution

 Run commands in isolated environments (bubblewrap, firejail, Docker):

 ```typescript
   pi.on('tool_call', async (event, ctx) => {
     if (event.toolName === 'bash') {
       const cmd = event.input.command as string;

       // Run git commands in read-only sandbox
       if (cmd.startsWith('git ')) {
         const result = await exec('bwrap', [
           '--ro-bind', '.', '.',
           '--unshare-net',
           'bash', '-c', cmd
         ]);
         return { result: { content: [{ type: 'text', text: result.stdout }],
 details: undefined } };
       }

       // Run npm/node without network access
       if (cmd.startsWith('npm ') || cmd.startsWith('node ')) {
         const result = await exec('firejail', ['--net=none', 'bash', '-c',
 cmd]);
         return { result: { content: [{ type: 'text', text: result.stdout }],
 details: undefined } };
       }
     }
   });
 ```

 ### Tool Result Caching

 Cache expensive operations:

 ```typescript
   const cache = new Map<string, AgentToolResult>();

   pi.on('tool_call', async (event) => {
     const key = `${event.toolName}:${JSON.stringify(event.input)}`;
     if (cache.has(key)) {
       return { result: cache.get(key)! };
     }
   });

   pi.on('tool_result', async (event) => {
     const key = `${event.toolName}:${JSON.stringify(event.input)}`;
     cache.set(key, { content: event.content, details: event.details });
   });
 ```

 ### Mocking Tools in Tests

 ```typescript
   pi.on('tool_call', async (event) => {
     if (event.toolName === 'bash' && event.input.command === 'curl
 api.example.com') {
       return {
         result: {
           content: [{ type: 'text', text: '{"status": "ok"}' }],
           details: undefined,
         },
       };
     }
   });
 ```

 ### Remote Execution

 Delegate to remote machines or containers:

 ```typescript
   pi.on('tool_call', async (event) => {
     if (event.toolName === 'bash') {
       const result = await fetch('https://sandbox.example.com/exec', {
         method: 'POST',
         body: JSON.stringify({ command: event.input.command }),
       }).then(r => r.json());

       return { result: { content: [{ type: 'text', text: result.output }],
 details: undefined } };
     }
   });
 ```