### PR TITLE
fix(ai): Add supportsSystemRole compat flag for GLM models

### DIFF
--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -441,7 +441,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -460,7 +460,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -479,7 +479,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -498,7 +498,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -517,7 +517,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: false,
 			input: ["text", "image"],
 			cost: {
@@ -536,7 +536,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -555,7 +555,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -574,7 +574,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: false,
 			input: ["text", "image"],
 			cost: {
@@ -593,7 +593,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: false,
 			input: ["text", "image"],
 			cost: {
@@ -756,7 +756,7 @@ export const MODELS = {
 			provider: "github-copilot",
 			baseUrl: "https://api.individual.githubcopilot.com",
 			headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
+			compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsSystemRole":false,"supportsReasoningEffort":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -7189,7 +7189,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false},
+			compat: {"supportsDeveloperRole":false,"supportsSystemRole":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -7207,7 +7207,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false},
+			compat: {"supportsDeveloperRole":false,"supportsSystemRole":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -7225,7 +7225,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false},
+			compat: {"supportsDeveloperRole":false,"supportsSystemRole":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -7243,7 +7243,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false},
+			compat: {"supportsDeveloperRole":false,"supportsSystemRole":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -7261,7 +7261,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false},
+			compat: {"supportsDeveloperRole":false,"supportsSystemRole":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -7279,7 +7279,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false},
+			compat: {"supportsDeveloperRole":false,"supportsSystemRole":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -7297,7 +7297,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false},
+			compat: {"supportsDeveloperRole":false,"supportsSystemRole":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -192,6 +192,8 @@ export type AssistantMessageEvent =
 export interface OpenAICompat {
 	/** Whether the provider supports the `store` field. Default: auto-detected from URL. */
 	supportsStore?: boolean;
+	/** Whether the provider supports the `system` role. Default: true. When false, system prompt is prepended to first user message. */
+	supportsSystemRole?: boolean;
 	/** Whether the provider supports the `developer` role (vs `system`). Default: auto-detected from URL. */
 	supportsDeveloperRole?: boolean;
 	/** Whether the provider supports `reasoning_effort`. Default: auto-detected from URL. */


### PR DESCRIPTION
## Summary
Fixes #547 — GLM (z.ai) models return 400 'Incorrect role information' when receiving conversation history from other models.

## Problem
GLM models don't support the `system` role. When used as a fallback (after Claude, for example), they receive a conversation with a system message and reject it with a 400 error.

## Solution
Add a new `supportsSystemRole` compatibility flag to the `OpenAICompat` interface. When set to `false`, the system prompt is prepended to the first user message instead of being sent as a separate system message.

## Changes
- `packages/ai/src/types.ts`: Add `supportsSystemRole?: boolean` to `OpenAICompat`
- `packages/ai/src/providers/openai-completions.ts`: 
  - Add default `supportsSystemRole: true` to detected compat
  - Handle system prompt prepending when `supportsSystemRole` is false
- `packages/ai/src/models.generated.ts`: Set `supportsSystemRole: false` for GLM models

## Testing
- [ ] Builds successfully
- [ ] TypeScript compiles without errors
- [ ] (Needs runtime test with actual GLM model)

## AI-assisted
- [x] Built with AI assistance (Claude)
- [ ] Needs testing with real GLM model