### PR TITLE
feat(coding-agent): add PI_SKIP_VERSION_CHECK env variable

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -34,6 +34,8 @@ import { getChangelogPath, getNewEntries, parseChangelog } from "./utils/changel
 import { ensureTool } from "./utils/tools-manager.js";
 
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
+	if (process.env.PI_SKIP_VERSION_CHECK) return undefined;
+
 	try {
 		const response = await fetch("https://registry.npmjs.org/@mariozechner/pi-coding-agent/latest");
 		if (!response.ok) return undefined;


### PR DESCRIPTION
Since this is now a nix package, and the primary way to get packages from nix is through nix itself, it doesn't make sense to have the new version check run when I won't be able to install it via `npm install`. It's probably the same for your GH releases :-)

This PR adds an environment variable `PI_SKIP_VERSION_CHECK` that just short-circuits the call if it's defined.

I didn't know where to document it and my agent didn't have a clue either, so I'll leave it up to you if you want this feature documented.

Thank you for pi btw! It's been great - especially the new extensions API!