### PR TITLE
feat(coding-agent): add --no-tools flag to disable built-in tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `--no-tools` flag to disable all built-in tools, allowing extension-only tool setups ([#555](https://github.com/badlogic/pi-mono/issues/555))
+
 ## [0.38.0] - 2026-01-08
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -209,7 +209,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 
 	// Build tools list based on selected tools
 	const tools = selectedTools || (["read", "bash", "edit", "write"] as ToolName[]);
-	const toolsList = tools.map((t) => `- ${t}: ${toolDescriptions[t]}`).join("\n");
+	const toolsList = tools.length > 0 ? tools.map((t) => `- ${t}: ${toolDescriptions[t]}`).join("\n") : "(none)";
 
 	// Build guidelines based on which tools are actually available
 	const guidelinesList: string[] = [];
@@ -222,8 +222,9 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const hasLs = tools.includes("ls");
 	const hasRead = tools.includes("read");
 
-	// Read-only mode notice (no bash, edit, or write)
-	if (!hasBash && !hasEdit && !hasWrite) {
+	// Read-only mode notice (only if we have some read-only tools but no write tools)
+	// Skip this if there are no built-in tools at all (extensions may provide write capabilities)
+	if (tools.length > 0 && !hasBash && !hasEdit && !hasWrite) {
 		guidelinesList.push("You are in READ-ONLY mode - you cannot modify files or execute arbitrary commands");
 	}
 
@@ -265,7 +266,9 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 
 	// Always include these
 	guidelinesList.push("Be concise in your responses");
-	guidelinesList.push("Show file paths clearly when working with files");
+	if (tools.length > 0) {
+		guidelinesList.push("Show file paths clearly when working with files");
+	}
 
 	const guidelines = guidelinesList.map((g) => `- ${g}`).join("\n");
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -177,7 +177,15 @@ function buildSessionOptions(
 	}
 
 	// Tools
-	if (parsed.tools) {
+	if (parsed.noTools) {
+		// --no-tools: start with no built-in tools
+		// --tools can still add specific ones back
+		if (parsed.tools && parsed.tools.length > 0) {
+			options.tools = parsed.tools.map((name) => allTools[name]);
+		} else {
+			options.tools = [];
+		}
+	} else if (parsed.tools) {
 		options.tools = parsed.tools.map((name) => allTools[name]);
 	}
 

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -170,6 +170,24 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("--no-tools flag", () => {
+		test("parses --no-tools flag", () => {
+			const result = parseArgs(["--no-tools"]);
+			expect(result.noTools).toBe(true);
+		});
+
+		test("parses --no-tools with explicit --tools flags", () => {
+			const result = parseArgs(["--no-tools", "--tools", "read,bash"]);
+			expect(result.noTools).toBe(true);
+			expect(result.tools).toEqual(["read", "bash"]);
+		});
+
+		test("parses --tools with empty string", () => {
+			const result = parseArgs(["--tools", ""]);
+			expect(result.tools).toEqual([]);
+		});
+	});
+
 	describe("messages and file args", () => {
 		test("parses plain text messages", () => {
 			const result = parseArgs(["hello", "world"]);

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { buildSystemPrompt } from "../src/core/system-prompt.js";
+
+describe("buildSystemPrompt", () => {
+	describe("empty tools", () => {
+		test("does not show READ-ONLY mode when no built-in tools", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			// Should not mention READ-ONLY mode when there are no tools
+			// (extensions may provide write capabilities)
+			expect(prompt).not.toContain("READ-ONLY mode");
+		});
+
+		test("shows (none) for empty tools list", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).toContain("Available tools:\n(none)");
+		});
+
+		test("does not show file paths guideline when no tools", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).not.toContain("Show file paths clearly");
+		});
+	});
+
+	describe("read-only tools", () => {
+		test("shows READ-ONLY mode when only read tools available", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: ["read", "grep", "find", "ls"],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).toContain("READ-ONLY mode");
+		});
+	});
+
+	describe("default tools", () => {
+		test("does not show READ-ONLY mode with default tools", () => {
+			const prompt = buildSystemPrompt({
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).not.toContain("READ-ONLY mode");
+			expect(prompt).toContain("- read:");
+			expect(prompt).toContain("- bash:");
+			expect(prompt).toContain("- edit:");
+			expect(prompt).toContain("- write:");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add `--no-tools` flag that allows starting pi without any built-in tools, enabling extension-only tool setups (e.g., pi-ssh-remote).

## Changes

- Add `--no-tools` flag to CLI args parsing
- Handle `--tools ''` (empty string) as equivalent to no tools
- Fix system prompt to not show READ-ONLY mode when no tools (extensions may provide write capabilities)
- Add tests for new flag and system prompt behavior

## Usage Examples

```bash
# No built-in tools at all
pi --no-tools -e ./my-extension

# No built-in tools, but add specific ones back
pi --no-tools --tools read,bash

# Alternative: empty string also works
pi --tools '' -e ./my-extension
```

fixes #555