### PR TITLE
coding-agent: skills hot-swap watcher + reload visibility

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Skills hot-reload watcher (settings + CLI) with `/skills reload` and RPC `reload_skills`, emitting `skills:changed` events and `skills_reload` session entries
+
 ## [0.38.0] - 2026-01-08
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -612,6 +612,32 @@ Response:
 
 Returns `{"text": null}` if no assistant messages exist.
 
+#### reload_skills
+
+Reload skills from disk (equivalent to `/skills reload`).
+
+```json
+{"type": "reload_skills"}
+```
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "reload_skills",
+  "success": true,
+  "data": {
+    "reason": "manual",
+    "before": 2,
+    "after": 3,
+    "added": ["docker"],
+    "removed": [],
+    "updated": ["git"],
+    "warnings": []
+  }
+}
+```
+
 ## Events
 
 Events are streamed to stdout as JSON lines during agent operation. Events do NOT include an `id` field (only responses do).

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -155,6 +155,7 @@ Configure skill loading in `~/.pi/agent/settings.json`:
 {
   "skills": {
     "enabled": true,
+    "watch": false,
     "enableCodexUser": true,
     "enableClaudeUser": true,
     "enableClaudeProject": true,
@@ -170,6 +171,7 @@ Configure skill loading in `~/.pi/agent/settings.json`:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `enabled` | `true` | Master toggle for all skills |
+| `watch` | `false` | Watch skill directories and reload on changes |
 | `enableCodexUser` | `true` | Load from `~/.codex/skills/` |
 | `enableClaudeUser` | `true` | Load from `~/.claude/skills/` |
 | `enableClaudeProject` | `true` | Load from `<cwd>/.claude/skills/` |
@@ -197,6 +199,22 @@ pi --skills "aws-*"
 ```
 
 This overrides the `includeSkills` setting for the current session.
+
+### Hot Reloading
+
+Enable the watcher (opt-in) to reload skills when files change:
+
+```bash
+pi --watch-skills
+```
+
+Manual reload (interactive mode):
+
+```
+/skills reload
+```
+
+Print mode keeps watching off unless `--watch-skills` is explicitly set.
 
 ## How Skills Work
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -31,6 +31,7 @@ export interface Args {
 	print?: boolean;
 	export?: string;
 	noSkills?: boolean;
+	watchSkills?: boolean;
 	skills?: string[];
 	listModels?: string | true;
 	messages: string[];
@@ -121,6 +122,8 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			result.noExtensions = true;
 		} else if (arg === "--no-skills") {
 			result.noSkills = true;
+		} else if (arg === "--watch-skills") {
+			result.watchSkills = true;
 		} else if (arg === "--skills" && i + 1 < args.length) {
 			// Comma-separated glob patterns for skill filtering
 			result.skills = args[++i].split(",").map((s) => s.trim());
@@ -180,6 +183,7 @@ ${chalk.bold("Options:")}
   --extension, -e <path>         Load an extension file (can be used multiple times)
   --no-extensions                Disable extensions discovery and loading
   --no-skills                    Disable skills discovery and loading
+  --watch-skills                 Watch skills directories for changes
   --skills <patterns>            Comma-separated glob patterns to filter skills (e.g., git-*,docker)
   --export <file>                Export session file to HTML and exit
   --list-models [search]         List available models (with optional fuzzy search)

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -20,6 +20,7 @@ export interface RetrySettings {
 
 export interface SkillsSettings {
 	enabled?: boolean; // default: true
+	watch?: boolean; // default: false
 	enableCodexUser?: boolean; // default: true
 	enableClaudeUser?: boolean; // default: true
 	enableClaudeProject?: boolean; // default: true
@@ -378,6 +379,7 @@ export class SettingsManager {
 	getSkillsSettings(): Required<SkillsSettings> {
 		return {
 			enabled: this.settings.skills?.enabled ?? true,
+			watch: this.settings.skills?.watch ?? false,
 			enableCodexUser: this.settings.skills?.enableCodexUser ?? true,
 			enableClaudeUser: this.settings.skills?.enableClaudeUser ?? true,
 			enableClaudeProject: this.settings.skills?.enableClaudeProject ?? true,

--- a/packages/coding-agent/src/core/skills-watcher.ts
+++ b/packages/coding-agent/src/core/skills-watcher.ts
@@ -1,0 +1,124 @@
+import { type Dirent, existsSync, type FSWatcher, readdirSync, watch } from "fs";
+import { resolve } from "path";
+
+export interface SkillsWatcherOptions {
+	roots: string[];
+	debounceMs?: number;
+	onChange: () => void;
+}
+
+export class SkillsWatcher {
+	private watchers: FSWatcher[] = [];
+	private watchedDirs: Map<string, FSWatcher> = new Map();
+	private fallbackRoots: Set<string> = new Set();
+	private timer: ReturnType<typeof setTimeout> | undefined;
+	private disposed = false;
+	private debounceMs: number;
+	private onChange: () => void;
+	readonly roots: string[];
+	private _handleFsEvent = (): void => this.schedule();
+
+	constructor(options: SkillsWatcherOptions) {
+		this.debounceMs = options.debounceMs ?? 300;
+		this.onChange = options.onChange;
+		this.roots = Array.from(new Set(options.roots.map((root) => resolve(root))));
+		this.start();
+	}
+
+	private start(): void {
+		for (const root of this.roots) {
+			if (!existsSync(root)) {
+				continue;
+			}
+			this._startRootWatcher(root, this._handleFsEvent);
+		}
+	}
+
+	private _startRootWatcher(root: string, handler: () => void): void {
+		// Prefer native recursive watch where supported (macOS/Windows).
+		try {
+			const watcher = watch(root, { recursive: true }, handler);
+			this.watchers.push(watcher);
+			return;
+		} catch {
+			// Fall through to portable recursive emulation.
+		}
+
+		// On platforms without recursive support (notably Linux), emulate recursion by
+		// watching all subdirectories non-recursively. Refresh on change to pick up new dirs.
+		this.fallbackRoots.add(root);
+		this._refreshWatchedDirs(root, handler);
+	}
+
+	private _refreshWatchedDirs(root: string, handler: () => void): void {
+		const dirs = this._collectDirs(root);
+		for (const dir of dirs) {
+			if (this.watchedDirs.has(dir)) continue;
+			try {
+				const watcher = watch(dir, handler);
+				this.watchedDirs.set(dir, watcher);
+				this.watchers.push(watcher);
+			} catch {
+				// Ignore watcher creation failures (e.g. permission issues or transient dirs).
+			}
+		}
+	}
+
+	private _collectDirs(root: string): string[] {
+		const result: string[] = [];
+		const stack: string[] = [root];
+		while (stack.length > 0) {
+			const dir = stack.pop();
+			if (!dir) continue;
+			result.push(dir);
+			let entries: Dirent[];
+			try {
+				entries = readdirSync(dir, { withFileTypes: true });
+			} catch {
+				continue;
+			}
+			for (const entry of entries) {
+				if (!entry.isDirectory()) continue;
+				stack.push(resolve(dir, entry.name));
+			}
+		}
+		return result;
+	}
+
+	private schedule(): void {
+		if (this.disposed) return;
+		if (this.timer) {
+			clearTimeout(this.timer);
+		}
+		this.timer = setTimeout(() => {
+			this.timer = undefined;
+			if (!this.disposed) {
+				// Ensure fallback watchers stay in sync with new directories.
+				for (const root of this.fallbackRoots) {
+					if (!existsSync(root)) continue;
+					this._refreshWatchedDirs(root, this._handleFsEvent);
+				}
+				this.onChange();
+			}
+		}, this.debounceMs);
+	}
+
+	close(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = undefined;
+		}
+		for (const watcher of this.watchers) {
+			try {
+				watcher.close();
+			} catch {
+				// Ignore watcher close errors
+			}
+		}
+		this.watchers = [];
+		this.watchedDirs.clear();
+		this.fallbackRoots.clear();
+	}
+}

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -7,6 +7,8 @@ export {
 	type ModelCycleResult,
 	type PromptOptions,
 	type SessionStats,
+	type SkillsReloadReason,
+	type SkillsReloadSummary,
 } from "./core/agent-session.js";
 // Auth and model registry
 export { type ApiKeyCredential, type AuthCredential, AuthStorage, type OAuthCredential } from "./core/auth-storage.js";

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -139,6 +139,8 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 		}
 	}
 
+	session.stopSkillsWatcher();
+
 	// Ensure stdout is fully flushed before returning
 	// This prevents race conditions where the process exits before all output is written
 	await new Promise<void>((resolve, reject) => {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -8,7 +8,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import * as readline from "node:readline";
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
-import type { SessionStats } from "../../core/agent-session.js";
+import type { SessionStats, SkillsReloadSummary } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type { RpcCommand, RpcResponse, RpcSessionState } from "./rpc-types.js";
@@ -360,6 +360,14 @@ export class RpcClient {
 	async getLastAssistantText(): Promise<string | null> {
 		const response = await this.send({ type: "get_last_assistant_text" });
 		return this.getData<{ text: string | null }>(response).text;
+	}
+
+	/**
+	 * Reload skills from disk.
+	 */
+	async reloadSkills(): Promise<SkillsReloadSummary> {
+		const response = await this.send({ type: "reload_skills" });
+		return this.getData(response);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -506,6 +506,14 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				return success(id, "get_last_assistant_text", { text });
 			}
 
+			case "reload_skills": {
+				const summary = await session.reloadSkills("manual");
+				if (!summary) {
+					return error(id, "reload_skills", "Skills reload is disabled");
+				}
+				return success(id, "reload_skills", summary);
+			}
+
 			// =================================================================
 			// Messages
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -7,7 +7,7 @@
 
 import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent, Model } from "@mariozechner/pi-ai";
-import type { SessionStats } from "../../core/agent-session.js";
+import type { SessionStats, SkillsReloadSummary } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 
@@ -58,6 +58,7 @@ export type RpcCommand =
 	| { id?: string; type: "branch"; entryId: string }
 	| { id?: string; type: "get_branch_messages" }
 	| { id?: string; type: "get_last_assistant_text" }
+	| { id?: string; type: "reload_skills" }
 
 	// Messages
 	| { id?: string; type: "get_messages" };
@@ -163,6 +164,13 @@ export type RpcResponse =
 			command: "get_last_assistant_text";
 			success: true;
 			data: { text: string | null };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "reload_skills";
+			success: true;
+			data: SkillsReloadSummary;
 	  }
 
 	// Messages

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -170,6 +170,13 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("--watch-skills flag", () => {
+		test("parses --watch-skills flag", () => {
+			const result = parseArgs(["--watch-skills"]);
+			expect(result.watchSkills).toBe(true);
+		});
+	});
+
 	describe("messages and file args", () => {
 		test("parses plain text messages", () => {
 			const result = parseArgs(["hello", "world"]);

--- a/packages/coding-agent/test/skills-hot-swap.test.ts
+++ b/packages/coding-agent/test/skills-hot-swap.test.ts
@@ -1,0 +1,315 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@mariozechner/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@mariozechner/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { createEventBus } from "../src/core/event-bus.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { diffSkills, loadSkills, type Skill, type SkillWarning } from "../src/core/skills.js";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function createRng(seed: number): () => number {
+	let state = seed;
+	return () => {
+		state = (state * 48271) % 0x7fffffff;
+		return state / 0x7fffffff;
+	};
+}
+
+function randInt(rng: () => number, maxExclusive: number): number {
+	return Math.floor(rng() * maxExclusive);
+}
+
+function makeSkill(name: string, index: number): Skill {
+	return {
+		name,
+		description: `Skill ${name} ${index}`,
+		filePath: `/skills/${name}/SKILL.md`,
+		baseDir: `/skills/${name}`,
+		source: "test",
+	};
+}
+
+type SkillsChangedEvent = {
+	skills: { added: string[]; removed: string[]; updated: string[]; warnings: SkillWarning[] };
+};
+
+describe("skills hot-swap", () => {
+	it("diffSkills matches set relationships with randomized data", () => {
+		const rng = createRng(1337);
+		for (let i = 0; i < 100; i++) {
+			const baseCount = randInt(rng, 12);
+			const baseNames = Array.from({ length: baseCount }, (_unused, idx) => `skill-${i}-${idx}`);
+			const before = baseNames.map((name, idx) => makeSkill(name, idx));
+
+			const removed = new Set<string>();
+			const updated = new Set<string>();
+			const after: Skill[] = [];
+
+			for (const skill of before) {
+				if (rng() < 0.25) {
+					removed.add(skill.name);
+					continue;
+				}
+
+				let next = skill;
+				if (rng() < 0.35) {
+					next = { ...next, description: `${next.description} updated` };
+					updated.add(skill.name);
+				} else if (rng() < 0.1) {
+					next = { ...next, filePath: `${next.filePath}.moved` };
+					updated.add(skill.name);
+				}
+				after.push(next);
+			}
+
+			const added: Skill[] = [];
+			const addedCount = randInt(rng, 6);
+			for (let j = 0; j < addedCount; j++) {
+				const name = `added-${i}-${j}`;
+				added.push(makeSkill(name, j));
+			}
+			after.push(...added);
+
+			const expectedAdded = added.map((s) => s.name).sort();
+			const expectedRemoved = Array.from(removed).sort();
+			const expectedUpdated = Array.from(updated).sort();
+
+			const diff = diffSkills(before, after);
+			expect(diff.added).toEqual(expectedAdded);
+			expect(diff.removed).toEqual(expectedRemoved);
+			expect(diff.updated).toEqual(expectedUpdated);
+		}
+	});
+
+	describe("reloadSkills integration", () => {
+		let tempDir: string;
+		let session: AgentSession | undefined;
+
+		beforeEach(() => {
+			tempDir = mkdtempSync(join(tmpdir(), "pi-skills-hot-swap-"));
+			mkdirSync(join(tempDir, "agent", "skills"), { recursive: true });
+		});
+
+		afterEach(() => {
+			if (session) {
+				session.dispose();
+				session = undefined;
+			}
+			if (tempDir) {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		it("records reload summary, emits event, and updates prompt", async () => {
+			const skillsDir = join(tempDir, "agent", "skills");
+			const alphaDir = join(skillsDir, "alpha");
+			mkdirSync(alphaDir, { recursive: true });
+			writeFileSync(join(alphaDir, "SKILL.md"), "---\nname: alpha\ndescription: Alpha skill.\n---\n\n# Alpha\n");
+
+			const settingsManager = SettingsManager.inMemory({});
+			const skillsSettings = {
+				enabled: true,
+				watch: false,
+				enableCodexUser: false,
+				enableClaudeUser: false,
+				enableClaudeProject: false,
+				enablePiUser: true,
+				enablePiProject: false,
+				customDirectories: [],
+				ignoredSkills: [],
+				includeSkills: [],
+			};
+			const loaded = loadSkills({ ...skillsSettings, cwd: tempDir, agentDir: join(tempDir, "agent") });
+			const skillsState = { skills: loaded.skills };
+
+			const model = getModel("anthropic", "claude-sonnet-4-5")!;
+			const agent = new Agent({
+				getApiKey: () => "test-key",
+				initialState: {
+					model,
+					systemPrompt: `skills:${skillsState.skills.map((s) => s.name).join(",")}`,
+					tools: [],
+				},
+				streamFn: () => {
+					const stream = new MockAssistantStream();
+					queueMicrotask(() => {
+						stream.push({ type: "done", reason: "stop", message: createAssistantMessage("done") });
+					});
+					return stream;
+				},
+			});
+
+			const sessionManager = SessionManager.inMemory();
+			const authStorage = new AuthStorage(join(tempDir, "agent", "auth.json"));
+			authStorage.setRuntimeApiKey("anthropic", "test-key");
+			const modelRegistry = new ModelRegistry(authStorage, join(tempDir, "agent"));
+			const eventBus = createEventBus();
+
+			let lastEvent: SkillsChangedEvent | undefined;
+			eventBus.on("skills:changed", (data) => {
+				lastEvent = data as SkillsChangedEvent;
+			});
+
+			session = new AgentSession({
+				agent,
+				sessionManager,
+				settingsManager,
+				skillsSettings,
+				skills: loaded.skills,
+				skillWarnings: loaded.warnings,
+				skillsState,
+				skillsReloadEnabled: true,
+				modelRegistry,
+				rebuildSystemPrompt: () => `skills:${skillsState.skills.map((s) => s.name).join(",")}`,
+				eventBus,
+				cwd: tempDir,
+				agentDir: join(tempDir, "agent"),
+			});
+
+			const betaDir = join(skillsDir, "beta");
+			mkdirSync(betaDir, { recursive: true });
+			writeFileSync(join(betaDir, "SKILL.md"), "---\nname: beta\ndescription: Beta skill.\n---\n\n# Beta\n");
+			writeFileSync(
+				join(alphaDir, "SKILL.md"),
+				"---\nname: alpha\ndescription: Alpha skill updated.\n---\n\n# Alpha\n",
+			);
+
+			const summary = await session.reloadSkills("manual");
+			expect(summary).not.toBeNull();
+			expect(summary?.added).toEqual(["beta"]);
+			expect(summary?.updated).toEqual(["alpha"]);
+			expect(agent.state.systemPrompt).toContain("alpha");
+			expect(agent.state.systemPrompt).toContain("beta");
+
+			const entries = session.sessionManager.getEntries();
+			const reloadEntries = entries.filter(
+				(entry) => entry.type === "custom" && entry.customType === "skills_reload",
+			);
+			expect(reloadEntries).toHaveLength(1);
+
+			expect(lastEvent).toBeDefined();
+			if (!lastEvent) {
+				throw new Error("Expected skills:changed event");
+			}
+			expect(lastEvent.skills.added).toEqual(["beta"]);
+			expect(lastEvent.skills.updated).toEqual(["alpha"]);
+			expect(lastEvent.skills.warnings).toEqual([]);
+		});
+
+		it("does not emit or record a reload entry when reload is a no-op", async () => {
+			const skillsDir = join(tempDir, "agent", "skills");
+			const alphaDir = join(skillsDir, "alpha");
+			mkdirSync(alphaDir, { recursive: true });
+			writeFileSync(join(alphaDir, "SKILL.md"), "---\nname: alpha\ndescription: Alpha skill.\n---\n\n# Alpha\n");
+
+			const settingsManager = SettingsManager.inMemory({});
+			const skillsSettings = {
+				enabled: true,
+				watch: false,
+				enableCodexUser: false,
+				enableClaudeUser: false,
+				enableClaudeProject: false,
+				enablePiUser: true,
+				enablePiProject: false,
+				customDirectories: [],
+				ignoredSkills: [],
+				includeSkills: [],
+			};
+			const loaded = loadSkills({ ...skillsSettings, cwd: tempDir, agentDir: join(tempDir, "agent") });
+			const skillsState = { skills: loaded.skills };
+
+			const model = getModel("anthropic", "claude-sonnet-4-5")!;
+			const agent = new Agent({
+				getApiKey: () => "test-key",
+				initialState: {
+					model,
+					systemPrompt: `skills:${skillsState.skills.map((s) => s.name).join(",")}`,
+					tools: [],
+				},
+				streamFn: () => {
+					const stream = new MockAssistantStream();
+					queueMicrotask(() => {
+						stream.push({ type: "done", reason: "stop", message: createAssistantMessage("done") });
+					});
+					return stream;
+				},
+			});
+
+			const sessionManager = SessionManager.inMemory();
+			const authStorage = new AuthStorage(join(tempDir, "agent", "auth.json"));
+			authStorage.setRuntimeApiKey("anthropic", "test-key");
+			const modelRegistry = new ModelRegistry(authStorage, join(tempDir, "agent"));
+			const eventBus = createEventBus();
+
+			let eventCount = 0;
+			eventBus.on("skills:changed", () => {
+				eventCount++;
+			});
+
+			session = new AgentSession({
+				agent,
+				sessionManager,
+				settingsManager,
+				skillsSettings,
+				skills: loaded.skills,
+				skillWarnings: loaded.warnings,
+				skillsState,
+				skillsReloadEnabled: true,
+				modelRegistry,
+				rebuildSystemPrompt: () => `skills:${skillsState.skills.map((s) => s.name).join(",")}`,
+				eventBus,
+				cwd: tempDir,
+				agentDir: join(tempDir, "agent"),
+			});
+
+			const summary = await session.reloadSkills("manual");
+			expect(summary).not.toBeNull();
+			expect(summary?.changed).toBe(false);
+			expect(eventCount).toBe(0);
+
+			const entries = session.sessionManager.getEntries();
+			const reloadEntries = entries.filter(
+				(entry) => entry.type === "custom" && entry.customType === "skills_reload",
+			);
+			expect(reloadEntries).toHaveLength(0);
+		});
+	});
+});

--- a/packages/coding-agent/test/skills-watcher.test.ts
+++ b/packages/coding-agent/test/skills-watcher.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type MockWatcher = {
+	path: string;
+	handler: () => void;
+	closed: boolean;
+};
+
+const watchers: MockWatcher[] = [];
+
+vi.mock("fs", () => {
+	const existsSync = (path: string): boolean => path === "/root" || path === "/root/alpha";
+
+	const readdirSync = (path: string): Array<{ name: string; isDirectory: () => boolean }> => {
+		if (path === "/root") {
+			return [{ name: "alpha", isDirectory: () => true }];
+		}
+		return [];
+	};
+
+	const watch = (path: string, optionsOrListener: unknown, maybeListener?: unknown): { close: () => void } => {
+		const hasOptions = typeof optionsOrListener === "object" && optionsOrListener !== null;
+		const options = hasOptions ? (optionsOrListener as { recursive?: boolean }) : undefined;
+		const handler = (
+			typeof (hasOptions ? maybeListener : optionsOrListener) === "function"
+				? hasOptions
+					? maybeListener
+					: optionsOrListener
+				: undefined
+		) as (() => void) | undefined;
+
+		if (options?.recursive) {
+			throw new Error("ERR_FEATURE_UNAVAILABLE_ON_PLATFORM");
+		}
+		if (!handler) {
+			throw new Error("Missing handler");
+		}
+
+		const w: MockWatcher = { path, handler, closed: false };
+		watchers.push(w);
+		return {
+			close: () => {
+				w.closed = true;
+			},
+		};
+	};
+
+	return { existsSync, readdirSync, watch };
+});
+
+import { SkillsWatcher } from "../src/core/skills-watcher.js";
+
+describe("SkillsWatcher", () => {
+	afterEach(() => {
+		watchers.length = 0;
+		vi.useRealTimers();
+	});
+
+	it("falls back to watching subdirectories when recursive watch is unavailable", () => {
+		vi.useFakeTimers();
+		let changes = 0;
+		const watcher = new SkillsWatcher({
+			roots: ["/root"],
+			debounceMs: 10,
+			onChange: () => {
+				changes++;
+			},
+		});
+
+		const watchedPaths = watchers.map((w) => w.path).sort();
+		expect(watchedPaths).toEqual(["/root", "/root/alpha"]);
+
+		// Trigger a change in a nested directory watcher.
+		const alphaWatcher = watchers.find((w) => w.path === "/root/alpha");
+		expect(alphaWatcher).toBeDefined();
+		alphaWatcher!.handler();
+
+		vi.advanceTimersByTime(9);
+		expect(changes).toBe(0);
+		vi.advanceTimersByTime(1);
+		expect(changes).toBe(1);
+
+		watcher.close();
+	});
+});


### PR DESCRIPTION
Support skill hot swap by adding `--watch-skills` as opt-in behavior
Mostly done by gpt-5.2-high
My agentic coding skill is still not good, so it takes many sessions to polish.
Thanks for building `pi`.
It's fun to do things like this.

## PR Summary
(by gpt-5.2-high)

## What changes for users

- **Opt-in watcher**: when enabled, pi watches skill roots and reloads on filesystem changes.
- **Manual reload**: interactive command `/skills reload` and RPC command `reload_skills`.
- **Visibility**:
  - TUI transcript shows watcher-triggered reload summaries as a UI-only line (`[skills reload] ...`).
  - Session tree (TUI + exported HTML) shows persisted `skills_reload` entries in the **default** view.

## How it works (implementation + integration)

Reloads are centralized in `AgentSession.reloadSkills(reason)` and are only triggered from the watcher/commands.

- **Opt-in decision + session wiring** (`src/core/sdk.ts`)
  - Reads settings `skills.watch` (default `false`) and CLI opt-in `--watch-skills`.
  - Starts the watcher only when skills are enabled and reload is allowed:
    - `--no-skills` disables skills entirely.
    - `--skills <patterns>` (explicit skill list) disables reloads and watching (`skillsReloadEnabled: options.skills === undefined`).
  - Keeps the system prompt rebuildable via a mutable `skillsState` reference; reloads update `skillsState.skills` and rebuild the base prompt.

- **Watcher** (`src/core/skills-watcher.ts`)
  - Watches the skill source roots and calls `onChange()` after a debounce (default `300ms`).
  - Uses `fs.watch({ recursive: true })` where available; otherwise (notably Linux) emulates recursion by watching all subdirectories and refreshing the watched dir set on events.
  - Missing directories are ignored (no hard failure).

- **Reload + diff + no-op gating** (`src/core/agent-session.ts`)
  - `reloadSkills(reason: "watcher" | "manual" | "cli")` re-runs `loadSkills(...)`, diffs via `diffSkills`, and also diffs warnings.
  - Returns a `SkillsReloadSummary` including `changed: boolean`.
  - **No-op gating**: only when `summary.changed` is true does it:
    - append a persisted session entry (`customType: "skills_reload"`)
    - emit `skills:changed` on the shared event bus (extension-visible via `pi.events`)
    - rebuild the base system prompt
  - **Prompt safety**: if the agent is streaming, prompt rebuild is deferred until `agent_end` (next turn uses updated skills).

## What’s impacted (files + surfaces)

- **Settings**: `skills.watch` added to `SkillsSettings` (`src/core/settings-manager.ts`), default `false`.
- **CLI**: opt-in flag in `src/cli/args.ts`: `--watch-skills`.
- **Core session**: `AgentSession.startSkillsWatcher()`, `stopSkillsWatcher()`, `reloadSkills()` (`src/core/agent-session.ts`).
- **Interactive mode**:
  - Command: `/skills reload` (calls `session.reloadSkills("manual")`).
  - Transcript: subscribes to `skills:changed` and prints watcher-triggered reload summaries (`src/modes/interactive/interactive-mode.ts`).
- **RPC mode**:
  - Command: `reload_skills` mapped to `session.reloadSkills("manual")` (`src/modes/rpc/rpc-mode.ts`).
  - Typed client method: `RpcClient.reloadSkills()` (`src/modes/rpc/rpc-client.ts`).
  - Docs: `docs/rpc.md` includes the command; note the runtime response includes `changed` (see `SkillsReloadSummary` in `src/core/agent-session.ts`).
- **Session tree + HTML export visibility**:
  - TUI tree selector default filter treats `skills_reload` as non-settings (visible by default) (`src/modes/interactive/components/tree-selector.ts`).
  - HTML export template does the same and renders a human-readable summary/search text (`src/core/export-html/template.js`).
- **Print mode**: watcher is stopped before exit (`src/modes/print-mode.ts`) to avoid hanging the process.

## Testing
- Manual check 
- Typecheck/lint: `npm run check`

https://github.com/user-attachments/assets/be4f63a6-abd1-4d7a-8476-b572c7f6528f

