### PR TITLE
fix(coding-agent): show release URL for bun binary updates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `--no-tools` flag to disable all built-in tools, allowing extension-only tool setups ([#555](https://github.com/badlogic/pi-mono/issues/555))
 
+### Fixed
+
+- Update notification for bun binary installs now shows release download URL instead of npm command ([#567](https://github.com/badlogic/pi-mono/pull/567) by [@ferologics](https://github.com/ferologics))
+
 ## [0.38.0] - 2026-01-08
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -32,7 +32,7 @@ import {
 	visibleWidth,
 } from "@mariozechner/pi-tui";
 import { spawn, spawnSync } from "child_process";
-import { APP_NAME, getAuthPath, getDebugLogPath, VERSION } from "../../config.js";
+import { APP_NAME, getAuthPath, getDebugLogPath, isBunBinary, VERSION } from "../../config.js";
 import type { AgentSession, AgentSessionEvent } from "../../core/agent-session.js";
 import type {
 	ExtensionContext,
@@ -2148,17 +2148,16 @@ export class InteractiveMode {
 	}
 
 	showNewVersionNotification(newVersion: string): void {
+		const updateInstruction = isBunBinary
+			? theme.fg("muted", `New version ${newVersion} is available. Download from: `) +
+				theme.fg("accent", "https://github.com/badlogic/pi-mono/releases/latest")
+			: theme.fg("muted", `New version ${newVersion} is available. Run: `) +
+				theme.fg("accent", "npm install -g @mariozechner/pi-coding-agent");
+
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
 		this.chatContainer.addChild(
-			new Text(
-				theme.bold(theme.fg("warning", "Update Available")) +
-					"\n" +
-					theme.fg("muted", `New version ${newVersion} is available. Run: `) +
-					theme.fg("accent", "npm install -g @mariozechner/pi-coding-agent"),
-				1,
-				0,
-			),
+			new Text(`${theme.bold(theme.fg("warning", "Update Available"))}\n${updateInstruction}`, 1, 0),
 		);
 		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
 		this.ui.requestRender();


### PR DESCRIPTION
For bun binary installs, show 'Download from: <releases URL>' instead of 'npm install -g' since npm doesn't apply to standalone binaries.

**Before (bun binary):**
> New version X is available. Run: npm install -g @mariozechner/pi-coding-agent

**After (bun binary):**
> New version X is available. Download from: https://github.com/badlogic/pi-mono/releases/latest

npm installs still show the npm command as before.