### PR TITLE
feat(coding-agent): Improve /model sorting and search relevance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Update notification for bun binary installs now shows release download URL instead of npm command ([#567](https://github.com/badlogic/pi-mono/pull/567) by [@ferologics](https://github.com/ferologics))
 
+### Changed
+
+- `/model` selector now orders by version-aware model id (major/minor, undated before dated with newest-first), then provider; search prioritizes id matches over provider matches.
+
 ## [0.38.0] - 2026-01-08
 
 ### Breaking Changes

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -249,6 +249,8 @@ The agent reads, writes, and edits files, and executes commands via bash.
 | `/copy` | Copy last agent message to clipboard |
 | `/compact [instructions]` | Manually compact conversation context |
 
+Results are sorted by version-aware model ids (major/minor, undated before dated with newest-first), then provider; search prioritizes id matches over provider matches.
+
 ### Editor Features
 
 **File reference (`@`):** Type `@` to fuzzy-search project files. Respects `.gitignore`.

--- a/packages/coding-agent/src/utils/model-sorting.ts
+++ b/packages/coding-agent/src/utils/model-sorting.ts
@@ -1,0 +1,87 @@
+function tokenizeModelId(id: string): string[] {
+	return id.split(/[.-]/).filter((token) => token.length > 0);
+}
+
+function isNumericToken(token: string): boolean {
+	return /^\d+$/.test(token);
+}
+
+function extractVersion(tokens: string[]): { major: number | null; minor: number | null } {
+	// Treat the first 1-2 digit numeric token as major and the next 1-2 digit token as minor.
+	for (let i = 0; i < tokens.length; i++) {
+		const token = tokens[i]!;
+		if (!isNumericToken(token) || token.length > 2) {
+			continue;
+		}
+
+		const major = Number(token);
+		let minor: number | null = null;
+		const nextToken = tokens[i + 1];
+		if (nextToken && isNumericToken(nextToken) && nextToken.length <= 2) {
+			minor = Number(nextToken);
+		}
+		return { major, minor };
+	}
+
+	return { major: null, minor: null };
+}
+
+function extractDate(tokens: string[]): number | null {
+	// Look for date-like numeric tokens (e.g. 20251101) at the end of the id.
+	for (let i = tokens.length - 1; i >= 0; i--) {
+		const token = tokens[i]!;
+		if (isNumericToken(token) && token.length >= 6 && token.length <= 8) {
+			return Number(token);
+		}
+	}
+
+	return null;
+}
+
+export function normalizeModelSearchText(text: string): string {
+	return text.replace(/[.-]/g, " ");
+}
+
+// Version-first ordering: higher major/minor first, then newer dates, then shorter ids, then lexicographic.
+export function compareModelIds(left: string, right: string): number {
+	const leftTokens = tokenizeModelId(left);
+	const rightTokens = tokenizeModelId(right);
+	const leftVersion = extractVersion(leftTokens);
+	const rightVersion = extractVersion(rightTokens);
+
+	if (leftVersion.major !== null || rightVersion.major !== null) {
+		if (leftVersion.major === null) return 1;
+		if (rightVersion.major === null) return -1;
+		if (leftVersion.major !== rightVersion.major) {
+			return rightVersion.major - leftVersion.major;
+		}
+
+		const leftMinor = leftVersion.minor ?? -1;
+		const rightMinor = rightVersion.minor ?? -1;
+		if (leftMinor !== rightMinor) {
+			return rightMinor - leftMinor;
+		}
+
+		const leftDate = extractDate(leftTokens);
+		const rightDate = extractDate(rightTokens);
+		if (leftDate !== null || rightDate !== null) {
+			if (leftDate === null) return -1;
+			if (rightDate === null) return 1;
+			if (leftDate !== rightDate) {
+				return rightDate - leftDate;
+			}
+		}
+
+		if (leftTokens.length !== rightTokens.length) {
+			return leftTokens.length - rightTokens.length;
+		}
+	}
+
+	const leftLower = left.toLowerCase();
+	const rightLower = right.toLowerCase();
+	if (leftLower !== rightLower) {
+		return leftLower.localeCompare(rightLower);
+	}
+
+	return left.localeCompare(right);
+}

--- a/packages/coding-agent/test/model-sorting.test.ts
+++ b/packages/coding-agent/test/model-sorting.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import { compareModelIds, normalizeModelSearchText } from "../src/utils/model-sorting.js";
+
+describe("normalizeModelSearchText", () => {
+	test("treats dots and dashes as separators", () => {
+		expect(normalizeModelSearchText("gpt-5.2-codex")).toBe("gpt 5 2 codex");
+		expect(normalizeModelSearchText("claude-opus-4-5")).toBe("claude opus 4 5");
+	});
+});
+
+describe("compareModelIds", () => {
+	test("orders higher minor versions before lower ones", () => {
+		expect(compareModelIds("gpt-5.2-codex", "gpt-5-codex")).toBeLessThan(0);
+	});
+
+	test("orders 4.5 before 4", () => {
+		expect(compareModelIds("claude-sonnet-4.5", "claude-sonnet-4")).toBeLessThan(0);
+	});
+
+	test("orders higher patch numbers before lower ones", () => {
+		expect(compareModelIds("claude-opus-4-5", "claude-opus-4-1")).toBeLessThan(0);
+	});
+
+	test("orders shorter ids before dated suffixes", () => {
+		expect(compareModelIds("claude-opus-4-5", "claude-opus-4-5-20251101")).toBeLessThan(0);
+	});
+
+	test("orders newer dates before older ones", () => {
+		expect(compareModelIds("claude-opus-4-5-20251101", "claude-opus-4-5-20250805")).toBeLessThan(0);
+	});
+
+	test("puts non-versioned ids after versioned ids", () => {
+		expect(compareModelIds("codex-mini-latest", "gpt-5-codex")).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
# Improve /model sorting and search relevance

## Motivation
- Current `/model` ordering does not meet expectations for versioned models and dated variants. I'd expect the latest one the be on top.
- Searching for `codex` surfaces provider-only matches above id matches, which feels wrong.

## Features
- Version-aware ordering by model id (major/minor, undated before dated, dated newest-first)
- Provider as final tie-breaker after id
- Search prioritizes id matches over provider-only matches
- `.` and `-` treated as equivalent separators in search

## Implementation
- New `compareModelIds` + normalization helpers in `packages/coding-agent/src/utils/model-sorting.ts`
- `/model` selector uses the helpers for base ordering and search filtering
- Search now ranks matches by specificity (id-only > mixed > provider-only)
- Added unit tests in `packages/coding-agent/test/model-sorting.test.ts`

## Examples

| query | current | this PR | notes |
| --- | --- | --- | --- |
| `(none)` | <img width="326" height="198" alt="Screenshot 2026-01-08 at 18 39 06" src="https://github.com/user-attachments/assets/1c87e0c1-81c2-464c-9c4e-dac4fb4d19d7" /> | <img width="296" height="199" alt="Screenshot 2026-01-08 at 18 40 13" src="https://github.com/user-attachments/assets/2c94a54d-c730-4437-a7ed-7b29904e7376" /> | [^1] |
| `opus`  | <img width="315" height="151" alt="Screenshot 2026-01-08 at 18 41 01" src="https://github.com/user-attachments/assets/6728a9e6-f133-44fb-ac34-edcb8258ef39" /> | <img width="316" height="150" alt="Screenshot 2026-01-08 at 18 41 23" src="https://github.com/user-attachments/assets/6135b6d7-2053-4a1f-a39c-050fe5de2cd3" /> |  [^2] |
| `opus 4.5`  | <img width="281" height="29" alt="Screenshot 2026-01-08 at 18 42 45" src="https://github.com/user-attachments/assets/f0099a20-276c-4a6d-b8dd-884f0968f5a3" /> | <img width="311" height="96" alt="Screenshot 2026-01-08 at 18 43 18" src="https://github.com/user-attachments/assets/a7f64684-c5ef-44a9-a12e-d67f92c83666" /> | [^2] |
| `opus 4-5`  | <img width="312" height="81" alt="Screenshot 2026-01-08 at 18 44 10" src="https://github.com/user-attachments/assets/37d1c981-37df-4afc-bfb3-a081dcfc7aea" /> | <img width="311" height="92" alt="Screenshot 2026-01-08 at 18 44 38" src="https://github.com/user-attachments/assets/bf359a1e-fd53-4e54-9752-c7babd9cdf95" /> |  |
| `codex`  | <img width="303" height="202" alt="Screenshot 2026-01-08 at 18 45 14" src="https://github.com/user-attachments/assets/13104e4f-298c-4d75-bfb5-c2b07938afec" /> | <img width="300" height="198" alt="Screenshot 2026-01-08 at 18 45 41" src="https://github.com/user-attachments/assets/32cea57d-b9e5-4390-9fd7-a40caf99c80d" /> |  |

[^1]: Default sorting is tokenlength > lexicographic 
[^2]: `.` and `-` treated as equivalent separators in search, hence why it matches to both, the Anthropic (`4-5` and Github-Copilot entry (`4.5`) 

## Tests
- `npx vitest packages/coding-agent/test/model-sorting.test.ts`

## Labels
- `pkg:coding-agent`

## AI Disclaimer
- This PR was created with the careful use of `gpt-5.2-codex` via `pi`
- Double-checked every LOC to the best of my knowledge