### PR TITLE
feat(coding-agent): auto theme switching based on system appearance (macOS)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Auto theme switching: `"theme": "auto"` follows system appearance (macOS only). Watches for changes in real-time. Optional `autoThemeLight`/`autoThemeDark` settings to map to custom themes.
 - `--no-tools` flag to disable all built-in tools, allowing extension-only tool setups ([#557](https://github.com/badlogic/pi-mono/pull/557) by [@cv](https://github.com/cv))
 - Pluggable operations for built-in tools enabling remote execution via SSH or other transports ([#564](https://github.com/badlogic/pi-mono/issues/564)). Interfaces: `ReadOperations`, `WriteOperations`, `EditOperations`, `BashOperations`, `LsOperations`, `GrepOperations`, `FindOperations`
 - `setActiveTools()` in ExtensionAPI for dynamic tool management

--- a/packages/coding-agent/docs/AUTO_THEME_PLAN.md
+++ b/packages/coding-agent/docs/AUTO_THEME_PLAN.md
@@ -1,0 +1,113 @@
+# Auto Theme Switching Implementation Plan
+
+## Problem
+
+Manually switching between light/dark themes via `/settings` is tedious when done twice daily (morning→light, evening→dark). Users want themes to follow system appearance automatically.
+
+## Scope
+
+- **macOS only** for initial implementation
+- Linux/Windows: TODO (detection returns undefined, falls back to current behavior)
+- No 3rd party dependencies
+- Lightweight - use native Node.js `fs.watch` (FSEvents on macOS)
+
+## Design Decisions
+
+1. **Don't change existing users' settings** - Only new installs default to `"auto"`
+2. **Simple defaults** - If `autoThemeLight`/`autoThemeDark` not set, use built-in `"light"`/`"dark"`
+3. **Live updates** - Watch macOS preferences plist for changes
+4. **No polling** - Use file system events via `fs.watch`
+
+## Implementation
+
+### Settings
+
+```json
+{
+  "theme": "auto",                    // "auto" | "dark" | "light" | "<custom>"
+  "autoThemeLight": "light",          // optional, defaults to "light"
+  "autoThemeDark": "dark"             // optional, defaults to "dark"
+}
+```
+
+- **Existing users:** Keep their `theme` setting untouched
+- **New installs:** Default to `"auto"` (detected via missing settings file)
+
+### macOS Detection
+
+**Read current appearance:**
+```typescript
+import { execSync } from "child_process";
+
+function detectMacOSAppearance(): "dark" | "light" {
+  try {
+    const result = execSync("defaults read -g AppleInterfaceStyle", {
+      encoding: "utf-8",
+      timeout: 1000,
+    }).trim();
+    return result === "Dark" ? "dark" : "light";
+  } catch {
+    return "light"; // No AppleInterfaceStyle = light mode
+  }
+}
+```
+
+**Watch for changes:**
+```typescript
+import { watch } from "fs";
+const PREFS_PLIST = "~/Library/Preferences/.GlobalPreferences.plist";
+
+// Watch plist for changes, re-detect appearance when it changes
+fs.watch(PREFS_PLIST, { persistent: false }, (event) => {
+  if (event === "change") {
+    const appearance = detectMacOSAppearance();
+    // Update theme if changed
+  }
+});
+```
+
+### Files Changed
+
+**`theme.ts`:**
+- `detectSystemAppearance()` - macOS only, returns `"dark" | "light" | undefined`
+- `startSystemAppearanceWatcher(callback)` - watches plist, returns cleanup function
+- `initTheme(options)` - now takes options object with auto theme settings
+- `setTheme(name, options)` - now takes options object
+- `getCurrentThemeSetting()` - returns raw setting (may be "auto")
+- `getCurrentThemeName()` - returns resolved theme name
+
+**`settings-manager.ts`:**
+- Added `autoThemeLight?: string` and `autoThemeDark?: string` to Settings
+- Added `getAutoThemeLight()`, `setAutoThemeLight()`
+- Added `getAutoThemeDark()`, `setAutoThemeDark()`
+
+**`theme-selector.ts`:**
+- Shows "auto" option at top of theme list in /settings
+- Shows "(follows system)" or "(follows system, currently: dark)" as description
+
+**`interactive-mode.ts`:**
+- Updated to pass auto theme settings to initTheme/setTheme
+- Added "auto" to available themes list
+
+### Platform Support
+
+| Platform | Detection | Live Updates |
+|----------|-----------|--------------|
+| macOS    | ✅ `defaults read` | ✅ Watch plist |
+| Linux    | TODO | TODO |
+| Windows  | TODO | TODO |
+
+When detection returns `undefined` (unsupported platform), falls back to `COLORFGBG` env var or default dark theme.
+
+---
+
+## TODO (Future)
+
+### Linux Support
+- GNOME: `gsettings get org.gnome.desktop.interface color-scheme`
+- KDE: `kreadconfig5 --group General --key ColorScheme`  
+- Watch: dconf or gsettings monitor
+
+### Windows Support
+- Registry: `HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize\AppsUseLightTheme`
+- Watch: Registry change notifications (may need native addon)

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -53,7 +53,9 @@ export interface Settings {
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 	steeringMode?: "all" | "one-at-a-time";
 	followUpMode?: "all" | "one-at-a-time";
-	theme?: string;
+	theme?: string; // "auto" | "dark" | "light" | "<custom-theme>"
+	autoThemeLight?: string; // Theme to use in light mode when theme="auto" (default: "light")
+	autoThemeDark?: string; // Theme to use in dark mode when theme="auto" (default: "dark")
 	compaction?: CompactionSettings;
 	branchSummary?: BranchSummarySettings;
 	retry?: RetrySettings;
@@ -261,6 +263,24 @@ export class SettingsManager {
 
 	setTheme(theme: string): void {
 		this.globalSettings.theme = theme;
+		this.save();
+	}
+
+	getAutoThemeLight(): string {
+		return this.settings.autoThemeLight ?? "light";
+	}
+
+	setAutoThemeLight(theme: string): void {
+		this.globalSettings.autoThemeLight = theme;
+		this.save();
+	}
+
+	getAutoThemeDark(): string {
+		return this.settings.autoThemeDark ?? "dark";
+	}
+
+	setAutoThemeDark(theme: string): void {
+		this.globalSettings.autoThemeDark = theme;
 		this.save();
 	}
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -261,10 +261,16 @@ export {
 } from "./modes/interactive/components/index.js";
 // Theme utilities for custom tools and extensions
 export {
+	detectSystemAppearance,
+	getCurrentThemeName,
+	getCurrentThemeSetting,
 	getMarkdownTheme,
 	getSelectListTheme,
 	getSettingsListTheme,
+	type InitThemeOptions,
 	initTheme,
+	type SetThemeOptions,
+	setTheme,
 	Theme,
 	type ThemeColor,
 } from "./modes/interactive/theme/theme.js";

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -292,7 +292,12 @@ export async function main(args: string[]) {
 	time("prepareInitialMessage");
 	const isInteractive = !parsed.print && parsed.mode === undefined;
 	const mode = parsed.mode || "text";
-	initTheme(settingsManager.getTheme(), isInteractive);
+	initTheme({
+		themeName: settingsManager.getTheme(),
+		enableWatcher: isInteractive,
+		autoThemeLight: settingsManager.getAutoThemeLight(),
+		autoThemeDark: settingsManager.getAutoThemeDark(),
+	});
 	time("initTheme");
 
 	// Show deprecation warnings in interactive mode

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -230,7 +230,12 @@ export class InteractiveMode {
 		this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
 
 		// Initialize theme with watcher for interactive mode
-		initTheme(this.settingsManager.getTheme(), true);
+		initTheme({
+			themeName: this.settingsManager.getTheme(),
+			enableWatcher: true,
+			autoThemeLight: this.settingsManager.getAutoThemeLight(),
+			autoThemeDark: this.settingsManager.getAutoThemeDark(),
+		});
 	}
 
 	private setupAutocomplete(fdPath: string | undefined): void {
@@ -2354,8 +2359,8 @@ export class InteractiveMode {
 					followUpMode: this.session.followUpMode,
 					thinkingLevel: this.session.thinkingLevel,
 					availableThinkingLevels: this.session.getAvailableThinkingLevels(),
-					currentTheme: this.settingsManager.getTheme() || "dark",
-					availableThemes: getAvailableThemes(),
+					currentTheme: this.settingsManager.getTheme() || "auto",
+					availableThemes: ["auto", ...getAvailableThemes()],
 					hideThinkingBlock: this.hideThinkingBlock,
 					collapseChangelog: this.settingsManager.getCollapseChangelog(),
 					doubleEscapeAction: this.settingsManager.getDoubleEscapeAction(),
@@ -2391,7 +2396,11 @@ export class InteractiveMode {
 						this.updateEditorBorderColor();
 					},
 					onThemeChange: (themeName) => {
-						const result = setTheme(themeName, true);
+						const result = setTheme(themeName, {
+							enableWatcher: true,
+							autoThemeLight: this.settingsManager.getAutoThemeLight(),
+							autoThemeDark: this.settingsManager.getAutoThemeDark(),
+						});
 						this.settingsManager.setTheme(themeName);
 						this.ui.invalidate();
 						if (!result.success) {
@@ -2399,7 +2408,11 @@ export class InteractiveMode {
 						}
 					},
 					onThemePreview: (themeName) => {
-						const result = setTheme(themeName, true);
+						const result = setTheme(themeName, {
+							enableWatcher: true,
+							autoThemeLight: this.settingsManager.getAutoThemeLight(),
+							autoThemeDark: this.settingsManager.getAutoThemeDark(),
+						});
 						if (result.success) {
 							this.ui.invalidate();
 							this.ui.requestRender();

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -12,7 +12,7 @@ function renderLastLine(container: Container, width = 120): string {
 describe("InteractiveMode.showStatus", () => {
 	beforeAll(() => {
 		// showStatus uses the global theme instance
-		initTheme("dark");
+		initTheme({ themeName: "dark" });
 	});
 
 	test("coalesces immediately-sequential status messages", () => {

--- a/packages/coding-agent/test/streaming-render-debug.ts
+++ b/packages/coding-agent/test/streaming-render-debug.ts
@@ -17,7 +17,7 @@ const __dirname = dirname(__filename);
 
 // Initialize dark theme with full color support
 process.env.COLORTERM = "truecolor";
-initTheme("dark");
+initTheme({ themeName: "dark" });
 
 // Load the real fixture that caused the bug
 const fixtureMessage: AssistantMessage = JSON.parse(

--- a/packages/coding-agent/test/test-theme-colors.ts
+++ b/packages/coding-agent/test/test-theme-colors.ts
@@ -2,7 +2,7 @@ import { initTheme, theme } from "../src/modes/interactive/theme/theme.js";
 
 // Initialize with dark theme explicitly
 process.env.COLORTERM = "truecolor";
-initTheme("dark");
+initTheme({ themeName: "dark" });
 
 console.log("\n=== Foreground Colors ===\n");
 


### PR DESCRIPTION
## Summary

Adds automatic theme switching that follows system appearance on macOS.

## Changes

- New theme option: `"theme": "auto"` follows system dark/light mode
- Watches `~/Library/Preferences/.GlobalPreferences.plist` for live updates when appearance changes
- Optional `autoThemeLight`/`autoThemeDark` settings to customize which themes are used (defaults to built-in light/dark)
- Only affects new installs - existing users keep their current theme setting

## How it works

1. On startup, if theme is `"auto"`, detect system appearance via `defaults read -g AppleInterfaceStyle`
2. Watch the macOS preferences plist for changes (uses native `fs.watch` with FSEvents)
3. When appearance changes, reload the appropriate theme and refresh UI

## Settings

```json
{
  "theme": "auto",
  "autoThemeLight": "light",  // optional, default
  "autoThemeDark": "dark"     // optional, default
}
```

## Platform support

| Platform | Detection | Live Updates |
|----------|-----------|--------------|
| macOS    | ✅ | ✅ |
| Linux    | TODO | TODO |
| Windows  | TODO | TODO |

Non-macOS platforms fall back to existing behavior (`COLORFGBG` env var detection or dark theme default).

## Testing

- [x] Type checks pass
- [ ] Manual testing on macOS with dark/light mode switching