### PR TITLE
fix(coding-agent): preserve original escape handler across retry attempts

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1751,8 +1751,10 @@ export class InteractiveMode {
 			}
 
 			case "auto_retry_start": {
-				// Set up escape to abort retry
-				this.retryEscapeHandler = this.defaultEditor.onEscape;
+				// Set up escape to abort retry - only save on first attempt
+				if (!this.retryEscapeHandler) {
+					this.retryEscapeHandler = this.defaultEditor.onEscape;
+				}
 				this.defaultEditor.onEscape = () => {
 					this.session.abortRetry();
 				};


### PR DESCRIPTION
Noticed this issue today because I had a pretty flaky connection: after pi retries its request, the escape key stopped working and it wasn't possible to go up in the tree. 

------

<details><summary>Summary by Opus 4.5:</summary>
<p>

## Problem

When a connection error triggers auto-retry and multiple retry attempts occur, the escape key stops working after the retries complete (either by exhausting max retries or succeeding).

## Root Cause

In `interactive-mode.ts`, the `auto_retry_start` event handler unconditionally saves the current escape handler before replacing it:

```typescript
case "auto_retry_start": {
    this.retryEscapeHandler = this.defaultEditor.onEscape;  // Always overwrites
    this.defaultEditor.onEscape = () => {
        this.session.abortRetry();
    };
```

On the **first** retry, this correctly saves the original handler. But on subsequent retries, `onEscape` is already the abort handler from the previous retry, so `retryEscapeHandler` gets overwritten with the abort handler instead of the original.

When `auto_retry_end` fires and restores `retryEscapeHandler`, it restores the abort handler instead of the original, leaving escape non-functional.

## Fix

Only save the escape handler on the first retry attempt (when `retryEscapeHandler` is undefined):

```typescript
case "auto_retry_start": {
    if (!this.retryEscapeHandler) {
        this.retryEscapeHandler = this.defaultEditor.onEscape;
    }
    this.defaultEditor.onEscape = () => {
        this.session.abortRetry();
    };
```

</p>
</details>