### PR TITLE
Fix crash when drag-dropping files into editor

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -131,7 +131,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const filtered = this.commands
 					.filter((cmd) => {
 						const name = "name" in cmd ? cmd.name : cmd.value; // Check if SlashCommand or AutocompleteItem
-						return name?.toLowerCase().startsWith(prefix.toLowerCase());
+						return typeof name === "string" && name.toLowerCase().startsWith(prefix.toLowerCase());
 					})
 					.map((cmd) => ({
 						value: "name" in cmd ? cmd.name : cmd.value,


### PR DESCRIPTION
Drag-dropping a file (like a macOS screenshot) into the editor would crash pi instantly:

```
TypeError: name?.toLowerCase is not a function
    at CombinedAutocompleteProvider.getSuggestions
```

The file path starts with `/` which triggers slash command autocomplete. Turns out some command in the array has a non-string `name` at runtime (despite TypeScript types). Added a `typeof` guard to filter those out.
