### PR TITLE
feat: add search parameter and auto-select to /model command

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1368,8 +1368,9 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/model") {
-				this.showModelSelector();
+			if (text === "/model" || text.startsWith("/model ")) {
+				const searchTerm = text.startsWith("/model ") ? text.slice(7).trim() : undefined;
+				this.showModelSelector(searchTerm);
 				this.editor.setText("");
 				return;
 			}
@@ -2469,7 +2470,7 @@ export class InteractiveMode {
 		});
 	}
 
-	private showModelSelector(): void {
+	private showModelSelector(initialSearchInput?: string): void {
 		this.showSelector((done) => {
 			const selector = new ModelSelectorComponent(
 				this.ui,
@@ -2479,10 +2480,10 @@ export class InteractiveMode {
 				this.session.scopedModels,
 				async (model) => {
 					try {
+						done();
 						await this.session.setModel(model);
 						this.footer.invalidate();
 						this.updateEditorBorderColor();
-						done();
 						this.showStatus(`Model: ${model.id}`);
 					} catch (error) {
 						done();
@@ -2493,6 +2494,7 @@ export class InteractiveMode {
 					done();
 					this.ui.requestRender();
 				},
+				initialSearchInput,
 			);
 			return { component: selector, focus: selector };
 		});


### PR DESCRIPTION
# Add Search Parameter and Auto-Select to `/model` Command

## Summary

This PR adds:
- Pre-filtered search: `/model claude` (opens selector with "claude" pre-filled)
- Direct model switching: `/model claude-3-5-sonnet-20241022` (auto-selects if unique)
- Provider disambiguation: `/model openai/gpt-4` (when multiple providers have same model)

## Technical Details

### Auto-Select Rules
- **Auto-selects when**: Exactly ONE exact ID match (case-insensitive) across all providers
- **Shows selector when**: Multiple providers have same model ID, partial matches, or no matches
- **Provider syntax**: `provider/model` forces specific provider match

### Why `done()` Was Moved

**Before** (race condition):
```typescript
async (model) => {
    try {
        await this.session.setModel(model);  // Async - takes time
        done();  // UI cleanup happens AFTER model change
        this.showStatus(`Model: ${model.id}`);
```

**Problem**: During auto-select, the selector component is added to UI, then `loadModels()` async callback runs. By the time `setModel()` completes and `done()` is called, the hint text has already been rendered.

**After** (fixed):
```typescript
async (model) => {
    done();  // UI cleanup happens IMMEDIATELY (synchronous)
    try {
        await this.session.setModel(model);  // Model change after cleanup
        this.showStatus(`Model: ${model.id}`);
```

**Solution**: `done()` clears the selector UI synchronously. Model change and status message happen afterward. No visual flicker of hint text.


## Checklist

- [x] Code follows project style guidelines (biome)
- [x] All checks pass (`npm run check`)
- [x] Build succeeds (`npm run build`)
- [x] Manually tested all scenarios
- [x] No breaking changes
- [x] Backward compatible
- [x] Commit message follows convention (`feat:`)
- [x] Changes documented in PR description
