### PR TITLE
fix: --tools flag now filters extension tools, not just built-in tools

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -26,6 +26,8 @@ export interface Args {
 	sessionDir?: string;
 	models?: string[];
 	tools?: ToolName[];
+	/** Raw tool names from --tools flag (includes extension tool names) */
+	toolFilter?: string[];
 	noTools?: boolean;
 	extensions?: string[];
 	noExtensions?: boolean;
@@ -91,15 +93,15 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			result.noTools = true;
 		} else if (arg === "--tools" && i + 1 < args.length) {
 			const toolNames = args[++i].split(",").map((s) => s.trim());
+			// Store raw tool names for filtering (includes extension tools)
+			result.toolFilter = toolNames;
+			// Also extract valid built-in tools
 			const validTools: ToolName[] = [];
 			for (const name of toolNames) {
 				if (name in allTools) {
 					validTools.push(name as ToolName);
-				} else {
-					console.error(
-						chalk.yellow(`Warning: Unknown tool "${name}". Valid tools: ${Object.keys(allTools).join(", ")}`),
-					);
 				}
+				// Don't warn about unknown tools - they might be extension tools
 			}
 			result.tools = validTools;
 		} else if (arg === "--thinking" && i + 1 < args.length) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -189,6 +189,11 @@ function buildSessionOptions(
 		options.tools = parsed.tools.map((name) => allTools[name]);
 	}
 
+	// Pass raw tool filter for extension tool filtering
+	if (parsed.toolFilter) {
+		options.toolFilter = parsed.toolFilter;
+	}
+
 	// Skills
 	if (parsed.noSkills) {
 		options.skills = [];


### PR DESCRIPTION
## Problem

The `--tools` CLI flag only filtered built-in tools (read, bash, edit, write, etc.) but unconditionally included all extension-registered tools.

This meant running:
```
pi --tools read,ls "do something"
```

Would give the agent access to `read`, `ls`, AND all extension tools (subagent, ssh, web-fetch, etc.).

Additionally, specifying extension tool names like `--tools subagent` would warn "Unknown tool" and ignore them entirely.

## Impact

This breaks tool sandboxing for subagents. When a subagent is defined with `tools: read, find, grep, ls`, it should only have those tools but it was getting all extension tools too.

## Fix

- Added `toolFilter` option to pass raw tool names through the CLI -> sdk pipeline
- Extension tool names in `--tools` no longer trigger false warnings
- Unknown tool warning moved to after extension loading (when we know all available tools)
- Both built-in and extension tools are now filtered against the `--tools` allowlist
- If `--tools` is not specified, behavior is unchanged (all tools available)

## Tested:

- [x] `--tools subagent` - Only has subagent tool (extension), no built-in tools
- [x] `--tools read,subagent` - Mix of built-in and extension works
- [x] `--tools read,ls` - Only built-in tools, no extension tools leak
- [x] `--tools foobar` - Shows "Unknown tool" warning with full list of valid tools
- [x] No `--tools` flag - All tools available (unchanged behavior)
