### PR TITLE
fix for gatewayz provider, optional parameter 

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fixed 422 error with non-standard providers (gatewayz.ai, chutes.ai, etc.) by adding `supportsStreamOptions` compatibility flag and conditionally sending `stream_options` parameter.
+
 ## [0.42.0] - 2026-01-09
 
 ### Added

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -367,8 +367,11 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 		model: model.id,
 		messages,
 		stream: true,
-		stream_options: { include_usage: true },
 	};
+
+	if (compat.supportsStreamOptions) {
+		(params as any).stream_options = { include_usage: true };
+	}
 
 	if (compat.supportsStore) {
 		params.store = false;
@@ -641,7 +644,8 @@ function detectCompatFromUrl(baseUrl: string): Required<OpenAICompat> {
 		baseUrl.includes("cerebras.ai") ||
 		baseUrl.includes("api.x.ai") ||
 		baseUrl.includes("mistral.ai") ||
-		baseUrl.includes("chutes.ai");
+		baseUrl.includes("chutes.ai") ||
+		baseUrl.includes("gatewayz.ai");
 
 	const useMaxTokens = baseUrl.includes("mistral.ai") || baseUrl.includes("chutes.ai");
 
@@ -653,6 +657,7 @@ function detectCompatFromUrl(baseUrl: string): Required<OpenAICompat> {
 		supportsStore: !isNonStandard,
 		supportsDeveloperRole: !isNonStandard,
 		supportsReasoningEffort: !isGrok,
+		supportsStreamOptions: !isNonStandard,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,
 		requiresAssistantAfterToolResult: false, // Mistral no longer requires this as of Dec 2024
@@ -673,6 +678,7 @@ function getCompat(model: Model<"openai-completions">): Required<OpenAICompat> {
 		supportsStore: model.compat.supportsStore ?? detected.supportsStore,
 		supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
 		supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
+		supportsStreamOptions: model.compat.supportsStreamOptions ?? detected.supportsStreamOptions,
 		maxTokensField: model.compat.maxTokensField ?? detected.maxTokensField,
 		requiresToolResultName: model.compat.requiresToolResultName ?? detected.requiresToolResultName,
 		requiresAssistantAfterToolResult:

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -207,6 +207,8 @@ export interface OpenAICompat {
 	supportsDeveloperRole?: boolean;
 	/** Whether the provider supports `reasoning_effort`. Default: auto-detected from URL. */
 	supportsReasoningEffort?: boolean;
+	/** Whether the provider supports `stream_options`. Default: auto-detected from URL. */
+	supportsStreamOptions?: boolean;
 	/** Which field to use for max tokens. Default: auto-detected from URL. */
 	maxTokensField?: "max_completion_tokens" | "max_tokens";
 	/** Whether tool results require the `name` field. Default: auto-detected from URL. */


### PR DESCRIPTION

<img width="819" height="276" alt="imaxe" src="https://github.com/user-attachments/assets/6a1a36f3-7e89-4ffa-aca6-937e5a036452" />


```
    "gatewayz": {
      "baseUrl": "https://api.gatewayz.ai/v1",
      "apiKey": "some-api-key",
      "api": "openai-completions",
      "models": [
        {
          "id": "deepseek/deepseek-v3.2",
          "name": "Deepseek v3.2 (Gatewayz)",
          "reasoning": true,
          "input": ["text"],
          "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
          "contextWindow": 128000,
          "maxTokens": 32000
        }
      ]
    }
```


The issue was that stream_options: { include_usage: true } was being sent to all
 OpenAI-compatible providers, but gatewayz.ai doesn't support this parameter and returns 422
 (validation error) for unknown fields.

 Changes made:

 1. packages/ai/src/types.ts: Added supportsStreamOptions?: boolean to OpenAICompat interface
 2. packages/ai/src/providers/openai-completions.ts:
     - Added gatewayz.ai to non-standard providers in detectCompatFromUrl() so
 supportsStreamOptions defaults to false
     - Updated getCompat() to merge the new field
     - Modified buildParams() to conditionally include stream_options only when
 compat.supportsStreamOptions is true
