### PR TITLE
fix: --tools flag now properly filters extension tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `--tools` flag now properly filters extension tools. Previously, extension tools were always included regardless of the `--tools` flag setting. Now `--tools read,subagent` correctly enables only those specific tools.
+- `--tools` flag now accepts extension tool names without warning. Previously, specifying extension tools like `--tools subagent` would warn "Unknown tool" and ignore them.
+
 ## [0.42.0] - 2026-01-09
 
 ### Added

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -5,7 +5,6 @@
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import chalk from "chalk";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR } from "../config.js";
-import { allTools, type ToolName } from "../core/tools/index.js";
 
 export type Mode = "text" | "json" | "rpc";
 
@@ -25,7 +24,8 @@ export interface Args {
 	session?: string;
 	sessionDir?: string;
 	models?: string[];
-	tools?: ToolName[];
+	/** Tool names to enable - validated after extensions are loaded */
+	tools?: string[];
 	noTools?: boolean;
 	extensions?: string[];
 	noExtensions?: boolean;
@@ -90,18 +90,8 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 		} else if (arg === "--no-tools") {
 			result.noTools = true;
 		} else if (arg === "--tools" && i + 1 < args.length) {
-			const toolNames = args[++i].split(",").map((s) => s.trim());
-			const validTools: ToolName[] = [];
-			for (const name of toolNames) {
-				if (name in allTools) {
-					validTools.push(name as ToolName);
-				} else {
-					console.error(
-						chalk.yellow(`Warning: Unknown tool "${name}". Valid tools: ${Object.keys(allTools).join(", ")}`),
-					);
-				}
-			}
-			result.tools = validTools;
+			// Store raw tool names - validation happens after extensions are loaded
+			result.tools = args[++i].split(",").map((s) => s.trim());
 		} else if (arg === "--thinking" && i + 1 < args.length) {
 			const level = args[++i];
 			if (isValidThinkingLevel(level)) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -24,7 +24,7 @@ import { SessionManager } from "./core/session-manager.js";
 import { SettingsManager } from "./core/settings-manager.js";
 import { resolvePromptInput } from "./core/system-prompt.js";
 import { printTimings, time } from "./core/timings.js";
-import { allTools } from "./core/tools/index.js";
+
 import { runMigrations, showDeprecationWarnings } from "./migrations.js";
 import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.js";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.js";
@@ -177,16 +177,12 @@ function buildSessionOptions(
 	}
 
 	// Tools
-	if (parsed.noTools) {
-		// --no-tools: start with no built-in tools
-		// --tools can still add specific ones back
-		if (parsed.tools && parsed.tools.length > 0) {
-			options.tools = parsed.tools.map((name) => allTools[name]);
-		} else {
-			options.tools = [];
-		}
-	} else if (parsed.tools) {
-		options.tools = parsed.tools.map((name) => allTools[name]);
+	if (parsed.tools) {
+		// Pass tool names to SDK for validation and filtering
+		options.toolNames = parsed.tools;
+	} else if (parsed.noTools) {
+		// --no-tools: disable all tools
+		options.toolNames = [];
 	}
 
 	// Skills

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -170,6 +170,25 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("--tools flag", () => {
+		test("parses built-in tool names", () => {
+			const result = parseArgs(["--tools", "read,bash,edit"]);
+			expect(result.tools).toEqual(["read", "bash", "edit"]);
+		});
+
+		test("accepts unknown tool names (validation deferred to extension loading)", () => {
+			// Unknown tool names like extension tools are accepted at parse time
+			// Validation happens later when extensions are loaded
+			const result = parseArgs(["--tools", "read,subagent,custom-tool"]);
+			expect(result.tools).toEqual(["read", "subagent", "custom-tool"]);
+		});
+
+		test("trims whitespace from tool names", () => {
+			const result = parseArgs(["--tools", " read , bash , edit "]);
+			expect(result.tools).toEqual(["read", "bash", "edit"]);
+		});
+	});
+
 	describe("--no-tools flag", () => {
 		test("parses --no-tools flag", () => {
 			const result = parseArgs(["--no-tools"]);

--- a/packages/coding-agent/test/sdk-tools.test.ts
+++ b/packages/coding-agent/test/sdk-tools.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { bashTool, createAgentSession, editTool, readTool, writeTool } from "../src/core/sdk.js";
+import { SessionManager } from "../src/core/session-manager.js";
+
+// Mock console.error to capture warnings
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+describe("SDK tool filtering", () => {
+	beforeEach(() => {
+		consoleErrorSpy.mockClear();
+	});
+
+	it("uses default tools when toolNames not specified", async () => {
+		const { session } = await createAgentSession({
+			sessionManager: SessionManager.inMemory(),
+			extensions: [], // Skip extension discovery
+			skills: [],
+		});
+
+		const toolNames = session.getActiveToolNames();
+		expect(toolNames).toContain("read");
+		expect(toolNames).toContain("bash");
+		expect(toolNames).toContain("edit");
+		expect(toolNames).toContain("write");
+	});
+
+	it("filters to only specified built-in tools via toolNames", async () => {
+		const { session } = await createAgentSession({
+			sessionManager: SessionManager.inMemory(),
+			extensions: [],
+			skills: [],
+			toolNames: ["read", "bash"],
+		});
+
+		const toolNames = session.getActiveToolNames();
+		expect(toolNames).toEqual(["read", "bash"]);
+		expect(toolNames).not.toContain("edit");
+		expect(toolNames).not.toContain("write");
+	});
+
+	it("enables no tools when toolNames is empty array", async () => {
+		const { session } = await createAgentSession({
+			sessionManager: SessionManager.inMemory(),
+			extensions: [],
+			skills: [],
+			toolNames: [],
+		});
+
+		const toolNames = session.getActiveToolNames();
+		expect(toolNames).toEqual([]);
+	});
+
+	it("warns about unknown tool names", async () => {
+		await createAgentSession({
+			sessionManager: SessionManager.inMemory(),
+			extensions: [],
+			skills: [],
+			toolNames: ["read", "nonexistent-tool"],
+		});
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown tool "nonexistent-tool"'));
+	});
+
+	it("ignores unknown tools but keeps valid ones", async () => {
+		const { session } = await createAgentSession({
+			sessionManager: SessionManager.inMemory(),
+			extensions: [],
+			skills: [],
+			toolNames: ["read", "nonexistent", "bash"],
+		});
+
+		const toolNames = session.getActiveToolNames();
+		expect(toolNames).toEqual(["read", "bash"]);
+	});
+
+	it("toolNames overrides tools option", async () => {
+		const { session } = await createAgentSession({
+			sessionManager: SessionManager.inMemory(),
+			extensions: [],
+			skills: [],
+			tools: [readTool, bashTool, editTool, writeTool], // All 4 tools
+			toolNames: ["read"], // But only enable read
+		});
+
+		const toolNames = session.getActiveToolNames();
+		expect(toolNames).toEqual(["read"]);
+	});
+});


### PR DESCRIPTION
This is an alternate implementation of https://github.com/badlogic/pi-mono/pull/589, which is great:

 - Small, surgical diff
 - Backward compatible - existing tools API unchanged
 - Low refactoring risk

 But:
 - Two parallel fields (`tools` + `toolFilter`) for similar purpose - confusing API
 - `tools` still validated against built-in only in `args.ts` (partial fix)
 - Validation logic inline in `createAgentSession` (adds complexity to already large function)

In this PR, we replaces the `tools` type with `string[]`, adding a unified `toolNames` option to the SDK.

*   args.ts:  `tools?: string[]`
*   sdk.ts:   `tools?: Tool[]` + `toolNames?: string[]`
*   main.ts:  just passes `toolNames`

Pros:
 - Cleaner API - `toolNames` is explicit about what it does
 - Extracted `resolveActiveTools()` helper - a bit easier to test
 - Removes dead code (unused import in `args.ts`)
 - Includes tests and changelog
 - `main.ts` is simpler (-8 lines)

 Cons:
 - Larger diff, more files touched
 - Changes `Args.tools` type from `ToolName[]` to `string[]` (minor breaking change to internal type)
 - More refactoring, more risk
