### PR TITLE
Fix LM Studio compatibility

### DIFF
--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -543,7 +543,7 @@ function convertTools(tools: Tool[]): OpenAITool[] {
 		name: tool.name,
 		description: tool.description,
 		parameters: tool.parameters as any, // TypeBox already generates JSON Schema
-		strict: null,
+		strict: false,
 	}));
 }
 


### PR DESCRIPTION
lm-studio hosted openai-like api endpoint requires this parameter to either be a defined boolean, or not specifying this option entirely. null will fail the API validation.

Current null will make LM Studio to throw:

```
{
  "error": {
    "message": "Expected boolean, received null",
    "type": "invalid_request_error",
    "param": "tools.0.strict",
    "code": "invalid_type"
  }
}
```