### PR TITLE
feat(coding-agent): add FooterDataProvider for git branch and extension statuses

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -33,13 +33,13 @@ const claudeCodeVersion = "2.1.2";
 
 // Map pi! tool names to Claude Code's exact tool names
 const claudeCodeToolNames: Record<string, string> = {
-	"read": "Read",
-	"write": "Write",
-	"edit": "Edit",
-	"bash": "Bash",
-	"grep": "Grep",
-	"find": "Glob",
-	"ls": "Glob",
+	read: "Read",
+	write: "Write",
+	edit: "Edit",
+	bash: "Bash",
+	grep: "Grep",
+	find: "Glob",
+	ls: "Glob",
 };
 
 const toClaudeCodeName = (name: string) => claudeCodeToolNames[name] || name;

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -624,22 +624,23 @@ ctx.ui.setWidget("my-widget", undefined);
 
 ### Pattern 6: Custom Footer
 
-Replace the entire footer with custom content.
+Replace the footer. `footerData` exposes data not otherwise accessible to extensions.
 
 ```typescript
-ctx.ui.setFooter((_tui, theme) => ({
-  render(width: number): string[] {
-    const left = theme.fg("dim", "custom footer");
-    const right = theme.fg("accent", "status");
-    const padding = " ".repeat(Math.max(1, width - visibleWidth(left) - visibleWidth(right)));
-    return [truncateToWidth(left + padding + right, width)];
-  },
+ctx.ui.setFooter((tui, theme, footerData) => ({
   invalidate() {},
+  render(width: number): string[] {
+    // footerData.getGitBranch(): string | null
+    // footerData.getExtensionStatuses(): ReadonlyMap<string, string>
+    return [`${ctx.model?.id} (${footerData.getGitBranch() || "no git"})`];
+  },
+  dispose: footerData.onBranchChange(() => tui.requestRender()), // reactive
 }));
 
-// Restore default
-ctx.ui.setFooter(undefined);
+ctx.ui.setFooter(undefined); // restore default
 ```
+
+Token stats available via `ctx.sessionManager.getBranch()` and `ctx.model`.
 
 **Examples:** [custom-footer.ts](../examples/extensions/custom-footer.ts)
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -22,6 +22,7 @@ import type { BashResult } from "../bash-executor.js";
 import type { CompactionPreparation, CompactionResult } from "../compaction/index.js";
 import type { EventBus } from "../event-bus.js";
 import type { ExecOptions, ExecResult } from "../exec.js";
+import type { ReadonlyFooterDataProvider } from "../footer-data-provider.js";
 import type { KeybindingsManager } from "../keybindings.js";
 import type { CustomMessage } from "../messages.js";
 import type { ModelRegistry } from "../model-registry.js";
@@ -82,8 +83,17 @@ export interface ExtensionUIContext {
 	setWidget(key: string, content: string[] | undefined): void;
 	setWidget(key: string, content: ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined): void;
 
-	/** Set a custom footer component, or undefined to restore the built-in footer. */
-	setFooter(factory: ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined): void;
+	/** Set a custom footer component, or undefined to restore the built-in footer.
+	 *
+	 * The factory receives a FooterDataProvider for data not otherwise accessible:
+	 * git branch and extension statuses from setStatus(). Token stats, model info,
+	 * etc. are available via ctx.sessionManager and ctx.model.
+	 */
+	setFooter(
+		factory:
+			| ((tui: TUI, theme: Theme, footerData: ReadonlyFooterDataProvider) => Component & { dispose?(): void })
+			| undefined,
+	): void;
 
 	/** Set a custom header component (shown at startup, above chat), or undefined to restore the built-in header. */
 	setHeader(factory: ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined): void;

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -1,0 +1,121 @@
+import { existsSync, type FSWatcher, readFileSync, statSync, watch } from "fs";
+import { dirname, join, resolve } from "path";
+
+/**
+ * Find the git HEAD path by walking up from cwd.
+ * Handles both regular git repos (.git is a directory) and worktrees (.git is a file).
+ */
+function findGitHeadPath(): string | null {
+	let dir = process.cwd();
+	while (true) {
+		const gitPath = join(dir, ".git");
+		if (existsSync(gitPath)) {
+			try {
+				const stat = statSync(gitPath);
+				if (stat.isFile()) {
+					const content = readFileSync(gitPath, "utf8").trim();
+					if (content.startsWith("gitdir: ")) {
+						const gitDir = content.slice(8);
+						const headPath = resolve(dir, gitDir, "HEAD");
+						if (existsSync(headPath)) return headPath;
+					}
+				} else if (stat.isDirectory()) {
+					const headPath = join(gitPath, "HEAD");
+					if (existsSync(headPath)) return headPath;
+				}
+			} catch {
+				return null;
+			}
+		}
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+/**
+ * Provides git branch and extension statuses - data not otherwise accessible to extensions.
+ * Token stats, model info available via ctx.sessionManager and ctx.model.
+ */
+export class FooterDataProvider {
+	private extensionStatuses = new Map<string, string>();
+	private cachedBranch: string | null | undefined = undefined;
+	private gitWatcher: FSWatcher | null = null;
+	private branchChangeCallbacks = new Set<() => void>();
+
+	constructor() {
+		this.setupGitWatcher();
+	}
+
+	/** Current git branch, null if not in repo, "detached" if detached HEAD */
+	getGitBranch(): string | null {
+		if (this.cachedBranch !== undefined) return this.cachedBranch;
+
+		try {
+			const gitHeadPath = findGitHeadPath();
+			if (!gitHeadPath) {
+				this.cachedBranch = null;
+				return null;
+			}
+			const content = readFileSync(gitHeadPath, "utf8").trim();
+			this.cachedBranch = content.startsWith("ref: refs/heads/") ? content.slice(16) : "detached";
+		} catch {
+			this.cachedBranch = null;
+		}
+		return this.cachedBranch;
+	}
+
+	/** Extension status texts set via ctx.ui.setStatus() */
+	getExtensionStatuses(): ReadonlyMap<string, string> {
+		return this.extensionStatuses;
+	}
+
+	/** Subscribe to git branch changes. Returns unsubscribe function. */
+	onBranchChange(callback: () => void): () => void {
+		this.branchChangeCallbacks.add(callback);
+		return () => this.branchChangeCallbacks.delete(callback);
+	}
+
+	/** Internal: set extension status */
+	setExtensionStatus(key: string, text: string | undefined): void {
+		if (text === undefined) {
+			this.extensionStatuses.delete(key);
+		} else {
+			this.extensionStatuses.set(key, text);
+		}
+	}
+
+	/** Internal: cleanup */
+	dispose(): void {
+		if (this.gitWatcher) {
+			this.gitWatcher.close();
+			this.gitWatcher = null;
+		}
+		this.branchChangeCallbacks.clear();
+	}
+
+	private setupGitWatcher(): void {
+		if (this.gitWatcher) {
+			this.gitWatcher.close();
+			this.gitWatcher = null;
+		}
+
+		const gitHeadPath = findGitHeadPath();
+		if (!gitHeadPath) return;
+
+		try {
+			this.gitWatcher = watch(gitHeadPath, () => {
+				this.cachedBranch = undefined;
+				for (const cb of this.branchChangeCallbacks) cb();
+			});
+		} catch {
+			// Silently fail if we can't watch
+		}
+	}
+}
+
+/** Read-only view for extensions - excludes setExtensionStatus and dispose */
+export type ReadonlyFooterDataProvider = Pick<
+	FooterDataProvider,
+	"getGitBranch" | "getExtensionStatuses" | "onBranchChange"
+>;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -103,6 +103,8 @@ export {
 	wrapToolsWithExtensions,
 	wrapToolWithExtensions,
 } from "./core/extensions/index.js";
+// Footer data provider (git branch + extension statuses - data not otherwise available to extensions)
+export type { ReadonlyFooterDataProvider } from "./core/footer-data-provider.js";
 export { convertToLlm } from "./core/messages.js";
 export { ModelRegistry } from "./core/model-registry.js";
 // SDK for programmatic usage

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -40,6 +40,7 @@ import type {
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
 } from "../../core/extensions/index.js";
+import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
 import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { type SessionContext, SessionManager } from "../../core/session-manager.js";
@@ -127,6 +128,7 @@ export class InteractiveMode {
 	private autocompleteProvider: CombinedAutocompleteProvider | undefined;
 	private editorContainer: Container;
 	private footer: FooterComponent;
+	private footerDataProvider: FooterDataProvider;
 	private keybindings: KeybindingsManager;
 	private version: string;
 	private isInitialized = false;
@@ -225,7 +227,8 @@ export class InteractiveMode {
 		this.editor = this.defaultEditor;
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor as Component);
-		this.footer = new FooterComponent(session);
+		this.footerDataProvider = new FooterDataProvider();
+		this.footer = new FooterComponent(session, this.footerDataProvider);
 		this.footer.setAutoCompactEnabled(session.autoCompactionEnabled);
 
 		// Load hide thinking block setting
@@ -423,8 +426,8 @@ export class InteractiveMode {
 			this.ui.requestRender();
 		});
 
-		// Set up git branch watcher
-		this.footer.watchBranch(() => {
+		// Set up git branch watcher (uses provider instead of footer)
+		this.footerDataProvider.onBranchChange(() => {
 			this.ui.requestRender();
 		});
 	}
@@ -793,7 +796,7 @@ export class InteractiveMode {
 	 * Set extension status text in the footer.
 	 */
 	private setExtensionStatus(key: string, text: string | undefined): void {
-		this.footer.setExtensionStatus(key, text);
+		this.footerDataProvider.setExtensionStatus(key, text);
 		this.ui.requestRender();
 	}
 
@@ -853,7 +856,11 @@ export class InteractiveMode {
 	/**
 	 * Set a custom footer component, or restore the built-in footer.
 	 */
-	private setExtensionFooter(factory: ((tui: TUI, thm: Theme) => Component & { dispose?(): void }) | undefined): void {
+	private setExtensionFooter(
+		factory:
+			| ((tui: TUI, thm: Theme, footerData: ReadonlyFooterDataProvider) => Component & { dispose?(): void })
+			| undefined,
+	): void {
 		// Dispose existing custom footer
 		if (this.customFooter?.dispose) {
 			this.customFooter.dispose();
@@ -867,8 +874,8 @@ export class InteractiveMode {
 		}
 
 		if (factory) {
-			// Create and add custom footer
-			this.customFooter = factory(this.ui, theme);
+			// Create and add custom footer, passing the data provider
+			this.customFooter = factory(this.ui, theme, this.footerDataProvider);
 			this.ui.addChild(this.customFooter);
 		} else {
 			// Restore built-in footer
@@ -3335,6 +3342,7 @@ export class InteractiveMode {
 			this.loadingAnimation = undefined;
 		}
 		this.footer.dispose();
+		this.footerDataProvider.dispose();
 		if (this.unsubscribe) {
 			this.unsubscribe();
 		}


### PR DESCRIPTION
Added FooterDataProvider extension point

## Problem

Custom footers via `ctx.ui.setFooter()` couldn't access:
 - Git branch
 - Extension statuses from `ctx.ui.setStatus()`

 ## Solution

`FooterDataProvider` class with `Pick<>` read-only type (matches SessionManager pattern):

 ```typescript
 class FooterDataProvider {
   getGitBranch(): string | null
   getExtensionStatuses(): ReadonlyMap<string, string>
   onBranchChange(cb: () => void): () => void
   // internal: setExtensionStatus(), dispose()
 }

 type ReadonlyFooterDataProvider = Pick<FooterDataProvider,
   "getGitBranch" | "getExtensionStatuses" | "onBranchChange"
 >;
 ```

 ## Usage

 ```typescript
 ctx.ui.setFooter((tui, theme, footerData) => ({
   invalidate() {},
   render(width) {
     const branch = footerData.getGitBranch();
     return [`${ctx.model?.id} (${branch || "no git"})`];
   },
   dispose: footerData.onBranchChange(() => tui.requestRender()),
 }));
 ```
 
Could potentially move `getGitBranch()` and `getExtensionStatuses()` onto `ctx` directly, eliminating FooterDataProvider entirely. Would keep setFooter signature unchanged. Bigger refactor though since ctx would need to delegate to persistent state (git watcher lives across command invocations).