### PR TITLE
fix(coding-agent): follow symlinked directories in prompt template loading

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Symlinked directories in `prompts/` folders are now followed when loading prompt templates ([#601](https://github.com/badlogic/pi-mono/pull/601) by [@aliou](https://github.com/aliou))
+
 ## [0.42.0] - 2026-01-09
 
 ### Added


### PR DESCRIPTION
Noticed this while moving stuff around: the symlink directories in `~/.pi/agent/prompts` and `.pi/prompts` are not followed. This matches what is done for skills

------

<details><summary>Summary by opus 4.5:</summary>
<p>

### Fix symlinked directories in prompt template loading

The `loadTemplatesFromDir` function in `prompt-templates.ts` was not following symlinked directories when scanning for `.md` template files.

**Problem**: If a user symlinked a directory into their `prompts/` folder (e.g., `~/.pi/agent/prompts/shared -> /path/to/shared-prompts/`), the symlinked directory was skipped entirely because `entry.isDirectory()` returns `false` for symlinks.

**Solution**: Applied the same pattern used in `skills.ts` - resolve symlinks using `statSync` before checking directory/file status:

```typescript
let isDirectory = entry.isDirectory();
let isFile = entry.isFile();
if (entry.isSymbolicLink()) {
    try {
        const stats = statSync(fullPath);
        isDirectory = stats.isDirectory();
        isFile = stats.isFile();
    } catch {
        // Broken symlink, skip it
        continue;
    }
}
```

This allows the function to correctly recurse into symlinked directories and load templates from them.

</p>
</details>