### PR TITLE
feat(coding-agent): add Alt+Up hotkey to restore queued messages

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -26,7 +26,8 @@ export type AppAction =
 	| "expandTools"
 	| "toggleThinking"
 	| "externalEditor"
-	| "followUp";
+	| "followUp"
+	| "dequeue";
 
 /**
  * All configurable actions.
@@ -56,6 +57,7 @@ export const DEFAULT_APP_KEYBINDINGS: Record<AppAction, KeyId | KeyId[]> = {
 	toggleThinking: "ctrl+t",
 	externalEditor: "ctrl+g",
 	followUp: "alt+enter",
+	dequeue: "alt+up",
 };
 
 /**
@@ -80,6 +82,7 @@ const APP_ACTIONS: AppAction[] = [
 	"toggleThinking",
 	"externalEditor",
 	"followUp",
+	"dequeue",
 ];
 
 function isAppAction(action: string): action is AppAction {


### PR DESCRIPTION
Made with Codex - issue writeup and transcript in https://github.com/badlogic/pi-mono/issues/603

Codex writeup below, let me know feedback on implementation or hotkey

 ## Summary                                                                   
   Adds a new keybinding (`Alt+Up`) to restore queued steering/follow‑up        
 messages back into the editor without aborting the current run. Esc behavior   
 remains unchanged.                                                             
                                                                                
   ## Changes                                                                   
   - Add new app action `dequeue` with default keybinding `alt+up`.             
   - Wire the action to restore queued messages via                             
 `restoreQueuedMessagesToEditor()`.                                             
   - Update startup hints and `/hotkeys` help text to show the new shortcut.    
                                                                                
   ## Testing                                                                   
   - npm run check                                                              
                                                                                
   ## Notes                                                                     
   No slash command is added; only the hotkey. 