### PR TITLE
fix(ai): skip zen tests when OPENCODE_API_KEY is not set

### DIFF
--- a/packages/ai/test/zen.test.ts
+++ b/packages/ai/test/zen.test.ts
@@ -3,7 +3,7 @@ import { MODELS } from "../src/models.generated.js";
 import { complete } from "../src/stream.js";
 import type { Model } from "../src/types.js";
 
-describe("OpenCode Zen Models Smoke Test", () => {
+describe.skipIf(!process.env.OPENCODE_API_KEY)("OpenCode Zen Models Smoke Test", () => {
 	const zenModels = Object.values(MODELS.opencode);
 
 	zenModels.forEach((model) => {


### PR DESCRIPTION
I think this is the fix for CI failure

Pi writeup:
The `zen.test.ts` file was added in commit 97d0189e without the standard `skipIf` guard, causing CI to fail on all PRs since no `OPENCODE_API_KEY` is configured in GitHub Actions.

This follows the same pattern used by other API-dependent tests (e.g., `abort.test.ts`, `context-overflow.test.ts`).

## Changes
- Add `describe.skipIf(!process.env.OPENCODE_API_KEY)` to skip the OpenCode Zen smoke tests when no API key is available

## Testing
- `npm run check` passes
- Tests will be skipped in CI (no API key) but can still run locally with `OPENCODE_API_KEY` set