### PR TITLE
fix(coding-agent): show '(ctrl+o to collapse)' hint for bash output when expanded

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
@@ -166,7 +166,11 @@ export class BashExecutionComponent extends Container {
 
 			// Show how many lines are hidden (collapsed preview)
 			if (hiddenLineCount > 0) {
-				statusParts.push(theme.fg("dim", `... ${hiddenLineCount} more lines (ctrl+o to expand)`));
+				if (this.expanded) {
+					statusParts.push(theme.fg("dim", "(ctrl+o to collapse)"));
+				} else {
+					statusParts.push(theme.fg("dim", `... ${hiddenLineCount} more lines (ctrl+o to expand)`));
+				}
 			}
 
 			if (this.status === "cancelled") {


### PR DESCRIPTION
 before: It still says `... 3 more lines (ctrl+o to expand)` for full output.
 ```
 $ ls -a .

 .
 ..
 .git
 .github
 .gitignore
 .husky
 .pi
 AGENTS.md
 LEARNING_PLAN.md
 LICENSE
 README.md
 biome.json
 node_modules
 package-lock.json
 package.json
 packages
 pi-mono.code-workspace
 pi-test.sh
 scripts
 test.sh
 tsconfig.base.json
 tsconfig.json


 ... 3 more lines (ctrl+o to expand)
 ```

 after fix: It says `(ctrl+o to collapse)` for full output.

 ```
  $ ls -a .

 .
 ..
 .git
 .github
 .gitignore
 .husky
 .pi
 AGENTS.md
 LEARNING_PLAN.md
 LICENSE
 README.md
 biome.json
 node_modules
 package-lock.json
 package.json
 packages
 pi-mono.code-workspace
 pi-test.sh
 scripts
 test.sh
 tsconfig.base.json
 tsconfig.json


 (ctrl+o to collapse)
 ```