### PR TITLE
feat(coding-agent): show model name instead of id in status bar and model selector

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Model display is now consistent across the status bar, model cycling, and model selector. The model name is shown everywhere instead of the identifier, with the model selector also showing `[provider:id]` for additional context.
+
 ## [0.42.2] - 2026-01-10
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -151,7 +151,7 @@ export class FooterComponent implements Component {
 		let statsLeft = statsParts.join(" ");
 
 		// Add model name on the right side, plus thinking level if model supports it
-		const modelName = state.model?.id || "no-model";
+		const modelName = state.model?.name || state.model?.id || "no-model";
 
 		// Add thinking level hint if model supports reasoning and thinking is enabled
 		let rightSide = modelName;

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -154,7 +154,11 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	private filterModels(query: string): void {
-		this.filteredModels = fuzzyFilter(this.allModels, query, ({ id, provider }) => `${id} ${provider}`);
+		this.filteredModels = fuzzyFilter(
+			this.allModels,
+			query,
+			({ id, provider, model }) => `${model.name || ""} ${id} ${provider}`,
+		);
 		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredModels.length - 1));
 		this.updateList();
 	}
@@ -180,13 +184,13 @@ export class ModelSelectorComponent extends Container {
 			let line = "";
 			if (isSelected) {
 				const prefix = theme.fg("accent", "→ ");
-				const modelText = `${item.id}`;
-				const providerBadge = theme.fg("muted", `[${item.provider}]`);
+				const modelText = `${item.model.name || item.id}`;
+				const providerBadge = theme.fg("muted", `[${item.provider}:${item.id}]`);
 				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
 				line = `${prefix + theme.fg("accent", modelText)} ${providerBadge}${checkmark}`;
 			} else {
-				const modelText = `  ${item.id}`;
-				const providerBadge = theme.fg("muted", `[${item.provider}]`);
+				const modelText = `  ${item.model.name || item.id}`;
+				const providerBadge = theme.fg("muted", `[${item.provider}:${item.id}]`);
 				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
 				line = `${modelText} ${providerBadge}${checkmark}`;
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2518,7 +2518,7 @@ export class InteractiveMode {
 				await this.session.setModel(model);
 				this.footer.invalidate();
 				this.updateEditorBorderColor();
-				this.showStatus(`Model: ${model.id}`);
+				this.showStatus(`Model: ${model.name || model.id}`);
 			} catch (error) {
 				this.showError(error instanceof Error ? error.message : String(error));
 			}
@@ -2582,7 +2582,7 @@ export class InteractiveMode {
 						this.footer.invalidate();
 						this.updateEditorBorderColor();
 						done();
-						this.showStatus(`Model: ${model.id}`);
+						this.showStatus(`Model: ${model.name || model.id}`);
 					} catch (error) {
 						done();
 						this.showError(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
The display of models was inconsistent across the different places, so this make it more aligned. The fuzzy fiterring also takes the name into consideration now.

<img width="656" height="276" alt="CleanShot 2026-01-10 at 13 04 23@2x" src="https://github.com/user-attachments/assets/6e337dd3-4836-48f9-bed0-2f7106abea95" />

<img width="1234" height="686" alt="CleanShot 2026-01-10 at 13 04 35@2x" src="https://github.com/user-attachments/assets/0fa06445-ef44-4443-86b8-a2ff031c6dcf" />
