### PR TITLE
Add support for /model autocomplete

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -154,7 +154,7 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	private filterModels(query: string): void {
-		this.filteredModels = fuzzyFilter(this.allModels, query, ({ id, provider }) => `${id} ${provider}`);
+		this.filteredModels = fuzzyFilter(this.allModels, query, ({ id }) => id);
 		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredModels.length - 1));
 		this.updateList();
 	}


### PR DESCRIPTION
I think this is a nice QOL improvement. /model will now auto complete and when I write "opus45" it gives me the right proposal first.

https://github.com/user-attachments/assets/d977692c-3a41-4ca4-b41d-2e1d75060f64


