### PR TITLE
fix(ai): update codex stream originator test

### DIFF
--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -81,7 +81,7 @@ describe("openai-codex streaming", () => {
 				expect(headers?.get("Authorization")).toBe(`Bearer ${token}`);
 				expect(headers?.get("chatgpt-account-id")).toBe("acc_test");
 				expect(headers?.get("OpenAI-Beta")).toBe("responses=experimental");
-				expect(headers?.get("originator")).toBe("codex_cli_rs");
+				expect(headers?.get("originator")).toBe("pi");
 				expect(headers?.get("accept")).toBe("text/event-stream");
 				expect(headers?.has("x-api-key")).toBe(false);
 				return new Response(stream, {


### PR DESCRIPTION
CI fix to update Codex streaming test to expect `originator=pi` instead of `codex_cli_rs`.
- Why: The provider header changed in 0.42.3; the test mock was out of sync, causing fetch to throw and stream events to fail.
- Impact: Test aligns with current provider behavior; no production logic changes.
- Testing: npm run check