### PR TITLE
feat(ai):Add resume scope toggle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-
+- `/resume` selector now toggles between current-folder and all sessions with Tab, showing the session cwd in the All view.
 - `/models` command to enable/disable models for Ctrl+P cycling. Changes persist to `enabledModels` in settings.json and take effect immediately. ([#626](https://github.com/badlogic/pi-mono/pull/626) by [@CarlosGtrz](https://github.com/CarlosGtrz))
 - `model_select` extension hook fires when model changes via `/model`, model cycling, or session restore with `source` field and `previousModel` ([#628](https://github.com/badlogic/pi-mono/pull/628) by [@marckrenn](https://github.com/marckrenn))
 - `ctx.ui.setWorkingMessage()` extension API to customize the "Working..." message during streaming ([#625](https://github.com/badlogic/pi-mono/pull/625) by [@nicobailon](https://github.com/nicobailon))

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -7,13 +7,17 @@ import type { SessionInfo } from "../core/session-manager.js";
 import { SessionSelectorComponent } from "../modes/interactive/components/session-selector.js";
 
 /** Show TUI session selector and return selected session path or null if cancelled */
-export async function selectSession(sessions: SessionInfo[]): Promise<string | null> {
+export async function selectSession(
+	currentSessions: SessionInfo[],
+	allSessions: SessionInfo[],
+): Promise<string | null> {
 	return new Promise((resolve) => {
 		const ui = new TUI(new ProcessTerminal());
 		let resolved = false;
 
 		const selector = new SessionSelectorComponent(
-			sessions,
+			currentSessions,
+			allSessions,
 			(path: string) => {
 				if (!resolved) {
 					resolved = true;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -317,13 +317,14 @@ export async function main(args: string[]) {
 		// Initialize keybindings so session picker respects user config
 		KeybindingsManager.create();
 
-		const sessions = SessionManager.list(cwd, parsed.sessionDir);
+		const currentSessions = SessionManager.list(cwd, parsed.sessionDir);
+		const allSessions = SessionManager.listAll();
 		time("SessionManager.list");
-		if (sessions.length === 0) {
+		if (currentSessions.length === 0 && allSessions.length === 0) {
 			console.log(chalk.dim("No sessions found"));
 			return;
 		}
-		const selectedPath = await selectSession(sessions);
+		const selectedPath = await selectSession(currentSessions, allSessions);
 		time("selectSession");
 		if (!selectedPath) {
 			console.log(chalk.dim("No session selected"));

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 import {
 	type Component,
 	Container,
@@ -5,12 +6,67 @@ import {
 	getEditorKeybindings,
 	Input,
 	Spacer,
-	Text,
 	truncateToWidth,
+	visibleWidth,
 } from "@mariozechner/pi-tui";
 import type { SessionInfo } from "../../../core/session-manager.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
+
+type SessionScope = "current" | "all";
+
+function shortenPath(path: string): string {
+	const home = os.homedir();
+	if (!path) return path;
+	if (path.startsWith(home)) {
+		return `~${path.slice(home.length)}`;
+	}
+	return path;
+}
+
+function formatSessionDate(date: Date): string {
+	const now = new Date();
+	const diffMs = now.getTime() - date.getTime();
+	const diffMins = Math.floor(diffMs / 60000);
+	const diffHours = Math.floor(diffMs / 3600000);
+	const diffDays = Math.floor(diffMs / 86400000);
+
+	if (diffMins < 1) return "just now";
+	if (diffMins < 60) return `${diffMins} minute${diffMins !== 1 ? "s" : ""} ago`;
+	if (diffHours < 24) return `${diffHours} hour${diffHours !== 1 ? "s" : ""} ago`;
+	if (diffDays === 1) return "1 day ago";
+	if (diffDays < 7) return `${diffDays} days ago`;
+
+	return date.toLocaleDateString();
+}
+
+class SessionSelectorHeader implements Component {
+	private scope: SessionScope;
+
+	constructor(scope: SessionScope) {
+		this.scope = scope;
+	}
+
+	setScope(scope: SessionScope): void {
+		this.scope = scope;
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const title = this.scope === "current" ? "Resume Session (Current Folder)" : "Resume Session (All)";
+		const leftText = theme.bold(title);
+		const scopeText =
+			this.scope === "current"
+				? `${theme.fg("accent", "◉ Current Folder")}${theme.fg("muted", " | ○ All")}`
+				: `${theme.fg("muted", "○ Current Folder | ")}${theme.fg("accent", "◉ All")}`;
+		const rightText = truncateToWidth(scopeText, width, "");
+		const availableLeft = Math.max(0, width - visibleWidth(rightText) - 1);
+		const left = truncateToWidth(leftText, availableLeft, "");
+		const spacing = Math.max(0, width - visibleWidth(left) - visibleWidth(rightText));
+		return [`${left}${" ".repeat(spacing)}${rightText}`];
+	}
+}
 
 /**
  * Custom session list component with multi-line items and search
@@ -20,15 +76,18 @@ class SessionList implements Component {
 	private filteredSessions: SessionInfo[] = [];
 	private selectedIndex: number = 0;
 	private searchInput: Input;
+	private showCwd = false;
 	public onSelect?: (sessionPath: string) => void;
 	public onCancel?: () => void;
 	public onExit: () => void = () => {};
+	public onToggleScope?: () => void;
 	private maxVisible: number = 5; // Max sessions visible (each session is 3 lines: msg + metadata + blank)
 
-	constructor(sessions: SessionInfo[]) {
+	constructor(sessions: SessionInfo[], showCwd: boolean) {
 		this.allSessions = sessions;
 		this.filteredSessions = sessions;
 		this.searchInput = new Input();
+		this.showCwd = showCwd;
 
 		// Handle Enter in search input - select current item
 		this.searchInput.onSubmit = () => {
@@ -41,18 +100,22 @@ class SessionList implements Component {
 		};
 	}
 
+	setSessions(sessions: SessionInfo[], showCwd: boolean): void {
+		this.allSessions = sessions;
+		this.showCwd = showCwd;
+		this.filterSessions(this.searchInput.getValue());
+	}
+
 	private filterSessions(query: string): void {
 		this.filteredSessions = fuzzyFilter(
 			this.allSessions,
 			query,
-			(session) => `${session.id} ${session.allMessagesText}`,
+			(session) => `${session.id} ${session.allMessagesText} ${session.cwd}`,
 		);
 		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredSessions.length - 1));
 	}
 
-	invalidate(): void {
-		// No cached state to invalidate currently
-	}
+	invalidate(): void {}
 
 	render(width: number): string[] {
 		const lines: string[] = [];
@@ -65,23 +128,6 @@ class SessionList implements Component {
 			lines.push(theme.fg("muted", "  No sessions found"));
 			return lines;
 		}
-
-		// Format dates
-		const formatDate = (date: Date): string => {
-			const now = new Date();
-			const diffMs = now.getTime() - date.getTime();
-			const diffMins = Math.floor(diffMs / 60000);
-			const diffHours = Math.floor(diffMs / 3600000);
-			const diffDays = Math.floor(diffMs / 86400000);
-
-			if (diffMins < 1) return "just now";
-			if (diffMins < 60) return `${diffMins} minute${diffMins !== 1 ? "s" : ""} ago`;
-			if (diffHours < 24) return `${diffHours} hour${diffHours !== 1 ? "s" : ""} ago`;
-			if (diffDays === 1) return "1 day ago";
-			if (diffDays < 7) return `${diffDays} days ago`;
-
-			return date.toLocaleDateString();
-		};
 
 		// Calculate visible range with scrolling
 		const startIndex = Math.max(
@@ -105,9 +151,13 @@ class SessionList implements Component {
 			const messageLine = cursor + (isSelected ? theme.bold(truncatedMsg) : truncatedMsg);
 
 			// Second line: metadata (dimmed) - also truncate for safety
-			const modified = formatDate(session.modified);
+			const modified = formatSessionDate(session.modified);
 			const msgCount = `${session.messageCount} message${session.messageCount !== 1 ? "s" : ""}`;
-			const metadata = `  ${modified} · ${msgCount}`;
+			const metadataParts = [modified, msgCount];
+			if (this.showCwd && session.cwd) {
+				metadataParts.push(shortenPath(session.cwd));
+			}
+			const metadata = `  ${metadataParts.join(" · ")}`;
 			const metadataLine = theme.fg("dim", truncateToWidth(metadata, width, ""));
 
 			lines.push(messageLine);
@@ -127,6 +177,12 @@ class SessionList implements Component {
 
 	handleInput(keyData: string): void {
 		const kb = getEditorKeybindings();
+		if (kb.matches(keyData, "tab")) {
+			if (this.onToggleScope) {
+				this.onToggleScope();
+			}
+			return;
+		}
 		// Up arrow
 		if (kb.matches(keyData, "selectUp")) {
 			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
@@ -161,27 +217,36 @@ class SessionList implements Component {
  */
 export class SessionSelectorComponent extends Container {
 	private sessionList: SessionList;
+	private header: SessionSelectorHeader;
+	private scope: SessionScope = "current";
+	private currentSessions: SessionInfo[];
+	private allSessions: SessionInfo[];
 
 	constructor(
-		sessions: SessionInfo[],
+		currentSessions: SessionInfo[],
+		allSessions: SessionInfo[],
 		onSelect: (sessionPath: string) => void,
 		onCancel: () => void,
 		onExit: () => void,
 	) {
 		super();
+		this.currentSessions = currentSessions;
+		this.allSessions = allSessions;
+		this.header = new SessionSelectorHeader(this.scope);
 
 		// Add header
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.bold("Resume Session"), 1, 0));
+		this.addChild(this.header);
 		this.addChild(new Spacer(1));
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
 
 		// Create session list
-		this.sessionList = new SessionList(sessions);
+		this.sessionList = new SessionList(this.currentSessions, this.scope === "all");
 		this.sessionList.onSelect = onSelect;
 		this.sessionList.onCancel = onCancel;
 		this.sessionList.onExit = onExit;
+		this.sessionList.onToggleScope = () => this.toggleScope();
 
 		this.addChild(this.sessionList);
 
@@ -190,9 +255,16 @@ export class SessionSelectorComponent extends Container {
 		this.addChild(new DynamicBorder());
 
 		// Auto-cancel if no sessions
-		if (sessions.length === 0) {
+		if (currentSessions.length === 0 && allSessions.length === 0) {
 			setTimeout(() => onCancel(), 100);
 		}
+	}
+
+	private toggleScope(): void {
+		this.scope = this.scope === "current" ? "all" : "current";
+		const sessions = this.scope === "current" ? this.currentSessions : this.allSessions;
+		this.sessionList.setSessions(sessions, this.scope === "all");
+		this.header.setScope(this.scope);
 	}
 
 	getSessionList(): SessionList {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2876,9 +2876,11 @@ export class InteractiveMode {
 
 	private showSessionSelector(): void {
 		this.showSelector((done) => {
-			const sessions = SessionManager.list(this.sessionManager.getCwd(), this.sessionManager.getSessionDir());
+			const currentSessions = SessionManager.list(this.sessionManager.getCwd(), this.sessionManager.getSessionDir());
+			const allSessions = SessionManager.listAll();
 			const selector = new SessionSelectorComponent(
-				sessions,
+				currentSessions,
+				allSessions,
 				async (sessionPath) => {
 					done();
 					await this.handleResumeSession(sessionPath);


### PR DESCRIPTION
Writeup in https://github.com/badlogic/pi-mono/issues/619
Made with codex, session transcript [here](https://shittycodingagent.ai/session?e85cfb263be8c545007bfda28e10c465)

Add a second screen in /resume that shows all sessions. For example, for cases where you start a session in the wrong wd and then cd into a different one; or just want to search more broadly than pwd. Works well locally, I want to clean up code.

## Summary
- add current vs all sessions toggle to /resume selector
- show cwd metadata in All scope
- centralize session listing helpers

## Notes
- `SessionInfo.cwd` is now optional to avoid a breaking type change; runtime still fills it when present.
- `listAll` intentionally scans only the default `~/.pi/agent/sessions` root (not custom `--session-dir` overrides).
- Does not include sessions from custom --session-dir locations

## Testing
- npm run check
- Manual testing locally
- CI failure unrelated to this change

## AI Review
- Generated with Codex; please review carefully
