### PR TITLE
fix(coding-agent): remove -- from registerFlag calls

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -1041,7 +1041,7 @@ Register custom CLI flags (parsed automatically, shown in `--help`):
 
 ```typescript
 export default function (pi: ExtensionAPI) {
-  pi.registerFlag("--dry-run", {
+  pi.registerFlag("dry-run", {
     description: "Run without making changes",
     type: "boolean",
   });

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -190,7 +190,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({ ... });
   pi.registerCommand("name", { ... });
   pi.registerShortcut("ctrl+x", { ... });
-  pi.registerFlag("--my-flag", { ... });
+  pi.registerFlag("my-flag", { ... });
 }
 ```
 
@@ -809,7 +809,7 @@ pi.registerShortcut("ctrl+shift+p", {
 Register a CLI flag.
 
 ```typescript
-pi.registerFlag("--plan", {
+pi.registerFlag("plan", {
   description: "Start in plan mode",
   type: "boolean",
   default: false,

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -429,7 +429,7 @@ describe("extensions discovery", () => {
 	it("loads extension with flags", async () => {
 		const extCode = `
 			export default function(pi) {
-				pi.registerFlag("--my-flag", {
+				pi.registerFlag("my-flag", {
 					description: "My custom flag",
 					handler: async (value) => {},
 				});

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -213,7 +213,7 @@ describe("ExtensionRunner", () => {
 		it("collects flags from extensions", async () => {
 			const extCode = `
 				export default function(pi) {
-					pi.registerFlag("--my-flag", {
+					pi.registerFlag("my-flag", {
 						description: "My flag",
 						handler: async () => {},
 					});
@@ -231,7 +231,7 @@ describe("ExtensionRunner", () => {
 		it("can set flag values", async () => {
 			const extCode = `
 				export default function(pi) {
-					pi.registerFlag("--test-flag", {
+					pi.registerFlag("test-flag", {
 						description: "Test flag",
 						handler: async () => {},
 					});


### PR DESCRIPTION
This was causing the agent sometimes to pick up on the incorrect syntax when asked to write extensions with flags