### PR TITLE
fix(tui): skip key release check for bracketed paste content

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - TUI renders with wrong dimensions after suspend/resume if terminal was resized while suspended ([#599](https://github.com/badlogic/pi-mono/issues/599))
+- Pasted content containing Kitty key release patterns (e.g., `:3F` in MAC addresses) was incorrectly filtered out ([#623](https://github.com/badlogic/pi-mono/pull/623) by [@ogulcancelik](https://github.com/ogulcancelik))
 
 ## [0.42.4] - 2026-01-10
 

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -314,6 +314,12 @@ let _lastEventType: KeyEventType = "press";
  * Only meaningful when Kitty keyboard protocol with flag 2 is active.
  */
 export function isKeyRelease(data: string): boolean {
+	// Don't treat bracketed paste content as key release, even if it contains
+	// patterns like ":3F" (e.g., bluetooth MAC addresses like "90:62:3F:A5")
+	if (data.includes("\x1b[200~")) {
+		return false;
+	}
+
 	// Quick check: release events with flag 2 contain ":3"
 	// Format: \x1b[<codepoint>;<modifier>:3u
 	if (


### PR DESCRIPTION
Pasted content containing Kitty key release patterns (e.g., `:3F` in bluetooth MAC addresses like `90:62:3F:A5:AC:3F`) was incorrectly detected as a key release event and silently dropped.

The `isKeyRelease()` check uses `data.includes(":3F")` which matches arbitrary text, not just actual Kitty sequences. The fix checks for bracketed paste markers (`\x1b[200~`) before running the pattern check.

Found this while trying to paste bluetooth MAC addresses - spent half an hour debugging Ghostty and tmux before realizing the text was being dropped inside pi.