### PR TITLE
feat: add ctx.ui.setWorkingMessage() extension API

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ctx.ui.setWorkingMessage()` extension API to customize the "Working..." message during streaming
+
 ## [0.42.5] - 2026-01-11
 
 ### Fixed

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1170,6 +1170,7 @@ Extensions can interact with users via `ctx.ui` methods and customize how messag
 - Async operations with cancel (BorderedLoader)
 - Settings toggles (SettingsList)
 - Status indicators (setStatus)
+- Working message during streaming (setWorkingMessage)
 - Widgets above editor (setWidget)
 - Custom footers (setFooter)
 
@@ -1255,6 +1256,10 @@ See [examples/extensions/timed-confirm.ts](../examples/extensions/timed-confirm.
 // Status in footer (persistent until cleared)
 ctx.ui.setStatus("my-ext", "Processing...");
 ctx.ui.setStatus("my-ext", undefined);  // Clear
+
+// Working message (shown during streaming)
+ctx.ui.setWorkingMessage("Thinking deeply...");
+ctx.ui.setWorkingMessage();  // Restore default
 
 // Widget above editor (string array or factory function)
 ctx.ui.setWidget("my-widget", ["Line 1", "Line 2"]);

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -79,6 +79,7 @@ const noOpUIContext: ExtensionUIContext = {
 	input: async () => undefined,
 	notify: () => {},
 	setStatus: () => {},
+	setWorkingMessage: () => {},
 	setWidget: () => {},
 	setFooter: () => {},
 	setHeader: () => {},

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -79,6 +79,9 @@ export interface ExtensionUIContext {
 	/** Set status text in the footer/status bar. Pass undefined to clear. */
 	setStatus(key: string, text: string | undefined): void;
 
+	/** Set the working/loading message shown during streaming. Call with no argument to restore default. */
+	setWorkingMessage(message?: string): void;
+
 	/** Set a widget to display above the editor. Accepts string array or component factory. */
 	setWidget(key: string, content: string[] | undefined): void;
 	setWidget(key: string, content: ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined): void;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -135,6 +135,7 @@ export class InteractiveMode {
 	private isInitialized = false;
 	private onInputCallback?: (text: string) => void;
 	private loadingAnimation: Loader | undefined = undefined;
+	private readonly defaultWorkingMessage = "Working... (esc to interrupt)";
 
 	private lastSigintTime = 0;
 	private lastEscapeTime = 0;
@@ -948,6 +949,11 @@ export class InteractiveMode {
 			input: (title, placeholder, opts) => this.showExtensionInput(title, placeholder, opts),
 			notify: (message, type) => this.showExtensionNotify(message, type),
 			setStatus: (key, text) => this.setExtensionStatus(key, text),
+			setWorkingMessage: (message) => {
+				if (this.loadingAnimation) {
+					this.loadingAnimation.setMessage(message ?? this.defaultWorkingMessage);
+				}
+			},
 			setWidget: (key, content) => this.setExtensionWidget(key, content),
 			setFooter: (factory) => this.setExtensionFooter(factory),
 			setHeader: (factory) => this.setExtensionHeader(factory),
@@ -1559,7 +1565,7 @@ export class InteractiveMode {
 					this.ui,
 					(spinner) => theme.fg("accent", spinner),
 					(text) => theme.fg("muted", text),
-					"Working... (esc to interrupt)",
+					this.defaultWorkingMessage,
 				);
 				this.statusContainer.addChild(this.loadingAnimation);
 				this.ui.requestRender();

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -150,6 +150,10 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			} as RpcExtensionUIRequest);
 		},
 
+		setWorkingMessage(_message?: string): void {
+			// Working message not supported in RPC mode - requires TUI loader access
+		},
+
 		setWidget(key: string, content: unknown): void {
 			// Only support string arrays in RPC mode - factory functions are ignored
 			if (content === undefined || Array.isArray(content)) {


### PR DESCRIPTION
Update to allow extensions to customize the `⠼ Working... (esc to interrupt)` message during streaming.

```typescript
ctx.ui.setWorkingMessage("Pondering your regex...");
ctx.ui.setWorkingMessage();  // restore default
```

A typical extension would hook into the streaming events:

```typescript
pi.on("tool_call", async (event, ctx) => {
  if (event.toolName === "Read") {
    ctx.ui.setWorkingMessage(`Reading ${event.params.path}...`);
  } else if (event.toolName === "Bash") {
    ctx.ui.setWorkingMessage("Running command...");
  }
});

pi.on("tool_result", async (_event, ctx) => {
  ctx.ui.setWorkingMessage("Thinking...");
});
```

Safe to call when not streaming (no-op). RPC mode ignores it since there's no TUI loader to update. Only affects the main streaming loader, not the compaction or retry loaders.