### PR TITLE
fix(tui): ensure cursor moves to end of content on exit to prevent overwriting/artifacts

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -157,6 +157,18 @@ export class TUI extends Container {
 	}
 
 	stop(): void {
+		// Move cursor to the end of the content to prevent overwriting/artifacts on exit
+		if (this.previousLines.length > 0) {
+			const targetRow = this.previousLines.length; // Line after the last content
+			const lineDiff = targetRow - this.cursorRow;
+			if (lineDiff > 0) {
+				this.terminal.write(`\x1b[${lineDiff}B`);
+			} else if (lineDiff < 0) {
+				this.terminal.write(`\x1b[${-lineDiff}A`);
+			}
+			this.terminal.write("\r\n");
+		}
+
 		this.terminal.showCursor();
 		this.terminal.stop();
 	}


### PR DESCRIPTION

before: ctrl+c twice to exit, the last context usage status line got overwritten.
```
 1+1=?


 Thinking...

 1 + 1 = 2

───────────────────────────────────────────────────────────────────────────────

───────────────────────────────────────────────────────────────────────────────
~/workspace/pi-mono (main)
```

after fix: ctrl+c twice to exit, the status line is kept.
```
1+1=?


 Thinking...

 1 + 1 = 2

────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────
~/workspace/pi-mono (fix/cursor-on-exit)
↑695 ↓40 0.6%/128k                                        minimaxai/minimax-m2.1
```