### PR TITLE
feat: Add skill slash commands feature

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -25,6 +25,7 @@ export interface SkillsSettings {
 	enableClaudeProject?: boolean; // default: true
 	enablePiUser?: boolean; // default: true
 	enablePiProject?: boolean; // default: true
+	enableSkillCommands?: boolean; // default: true - register loaded skills as slash commands
 	customDirectories?: string[]; // default: []
 	ignoredSkills?: string[]; // default: [] (glob patterns to exclude; takes precedence over includeSkills)
 	includeSkills?: string[]; // default: [] (empty = include all; glob patterns to filter)
@@ -375,6 +376,14 @@ export class SettingsManager {
 		this.save();
 	}
 
+	setEnableSkillCommands(enabled: boolean): void {
+		if (!this.globalSettings.skills) {
+			this.globalSettings.skills = {};
+		}
+		this.globalSettings.skills.enableSkillCommands = enabled;
+		this.save();
+	}
+
 	getSkillsSettings(): Required<SkillsSettings> {
 		return {
 			enabled: this.settings.skills?.enabled ?? true,
@@ -383,6 +392,7 @@ export class SettingsManager {
 			enableClaudeProject: this.settings.skills?.enableClaudeProject ?? true,
 			enablePiUser: this.settings.skills?.enablePiUser ?? true,
 			enablePiProject: this.settings.skills?.enablePiProject ?? true,
+			enableSkillCommands: this.settings.skills?.enableSkillCommands ?? true,
 			customDirectories: [...(this.settings.skills?.customDirectories ?? [])],
 			ignoredSkills: [...(this.settings.skills?.ignoredSkills ?? [])],
 			includeSkills: [...(this.settings.skills?.includeSkills ?? [])],

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -26,6 +26,7 @@ export interface SettingsConfig {
 	showImages: boolean;
 	autoResizeImages: boolean;
 	blockImages: boolean;
+	enableSkillCommands: boolean;
 	steeringMode: "all" | "one-at-a-time";
 	followUpMode: "all" | "one-at-a-time";
 	thinkingLevel: ThinkingLevel;
@@ -42,6 +43,7 @@ export interface SettingsCallbacks {
 	onShowImagesChange: (enabled: boolean) => void;
 	onAutoResizeImagesChange: (enabled: boolean) => void;
 	onBlockImagesChange: (blocked: boolean) => void;
+	onEnableSkillCommandsChange: (enabled: boolean) => void;
 	onSteeringModeChange: (mode: "all" | "one-at-a-time") => void;
 	onFollowUpModeChange: (mode: "all" | "one-at-a-time") => void;
 	onThinkingLevelChange: (level: ThinkingLevel) => void;
@@ -255,6 +257,15 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
+		// Skill commands toggle
+		items.splice(items.findIndex((item) => item.id === "steering-mode"), 0, {
+			id: "skill-commands",
+			label: "Skill commands",
+			description: "Register loaded skills as slash commands for quick access",
+			currentValue: config.enableSkillCommands ? "true" : "false",
+			values: ["true", "false"],
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -275,6 +286,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "block-images":
 						callbacks.onBlockImagesChange(newValue === "true");
+						break;
+					case "skill-commands":
+						callbacks.onEnableSkillCommandsChange(newValue === "true");
 						break;
 					case "steering-mode":
 						callbacks.onSteeringModeChange(newValue as "all" | "one-at-a-time");


### PR DESCRIPTION
## Summary

This PR adds a new feature to automatically register loaded skills as slash commands with a `skill:` prefix.

## Changes

### 1. Skill Slash Commands ()
- Load skills from configured directories
- Register each skill as a slash command with `skill:` prefix (e.g., `/skill:test-skill`)
- Execute skill content when the command is invoked
- Command name format: `skill:<skill-name>` (spaces and special chars replaced with hyphens)

### 2. Settings UI ()
- Add `Skill commands` toggle in settings menu (default: enabled)
- Users can enable/disable the feature via Settings > Skill commands

### 3. Settings Management ()
- Add `enableSkillCommands` setting to `SkillsSettings` interface
- Add `setEnableSkillCommands()` method to persist the setting

## Usage



## Files Changed

- `packages/coding-agent/src/core/settings-manager.ts`
- `packages/coding-agent/src/modes/interactive/components/settings-selector.ts`
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`