### PR TITLE
fix: load keybindings before --resume session picker

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -347,6 +347,10 @@ All keyboard shortcuts can be customized via `~/.pi/agent/keybindings.json`. Eac
 | `toggleThinking` | `ctrl+t` | Toggle thinking |
 | `externalEditor` | `ctrl+g` | Open external editor |
 | `followUp` | `alt+enter` | Queue follow-up message |
+| `selectUp` | `up` | Move selection up in lists (session picker, model selector) |
+| `selectDown` | `down` | Move selection down in lists |
+| `selectConfirm` | `enter` | Confirm selection |
+| `selectCancel` | `escape`, `ctrl+c` | Cancel selection |
 
 **Example (Emacs-style):**
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -17,6 +17,7 @@ import { CONFIG_DIR_NAME, getAgentDir, getModelsPath, VERSION } from "./config.j
 import { createEventBus } from "./core/event-bus.js";
 import { exportFromFile } from "./core/export-html/index.js";
 import { discoverAndLoadExtensions, type LoadExtensionsResult, loadExtensions } from "./core/extensions/index.js";
+import { KeybindingsManager } from "./core/keybindings.js";
 import type { ModelRegistry } from "./core/model-registry.js";
 import { resolveModelScope, type ScopedModel } from "./core/model-resolver.js";
 import { type CreateAgentSessionOptions, createAgentSession, discoverAuthStorage, discoverModels } from "./core/sdk.js";
@@ -313,6 +314,9 @@ export async function main(args: string[]) {
 
 	// Handle --resume: show session picker
 	if (parsed.resume) {
+		// Initialize keybindings so session picker respects user config
+		KeybindingsManager.create();
+
 		const sessions = SessionManager.list(cwd, parsed.sessionDir);
 		time("SessionManager.list");
 		if (sessions.length === 0) {


### PR DESCRIPTION
The problem: I wanted to be able to select my session (either from `/resume` or `--resume`) with different keybindings.

The issue: when running `pi --resume`, custom keybindings from `~/.pi/agent/keybindings.json` were not being applied to the session picker. This happened because `KeybindingsManager.create()` was only called when `InteractiveMode` initialized, but the session picker runs before that.

The session picker uses `getEditorKeybindings()` for navigation (selectUp/selectDown etc.), which returns the global default keybindings if `setEditorKeybindings()` hasn't been called yet.

Fix: call `KeybindingsManager.create()` inside the `--resume` block before showing the session picker. This loads user keybindings and sets them globally.

The current fix results in double-init of keybindings when entering interactive mode which _should_ be harmless, since it's the same same config loaded twice, but is minimal and only affects the `--resume` path.

I considered passing keybindings from `main()` to `InteractiveMode` - it's cleaner but requires API changes so I'll let you decide if that's appropriate :-)

Also documented the `select*` keybindings in README.md.