### PR TITLE
fix: custom footer extensions now see model changes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Session picker respects custom keybindings when using `--resume` ([#633](https://github.com/badlogic/pi-mono/pull/633) by [@aos](https://github.com/aos))
+- Custom footer extensions now see model changes: `ctx.model` is now a getter that returns the current model instead of a snapshot from when the context was created ([#634](https://github.com/badlogic/pi-mono/pull/634) by [@ogulcancelik](https://github.com/ogulcancelik))
 
 ## [0.42.5] - 2026-01-11
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -307,13 +307,16 @@ export class ExtensionRunner {
 	 * Context values are resolved at call time, so changes via initialize() are reflected.
 	 */
 	createContext(): ExtensionContext {
+		const getModel = this.getModel;
 		return {
 			ui: this.uiContext,
 			hasUI: this.hasUI(),
 			cwd: this.cwd,
 			sessionManager: this.sessionManager,
 			modelRegistry: this.modelRegistry,
-			model: this.getModel(),
+			get model() {
+				return getModel();
+			},
 			isIdle: () => this.isIdleFn(),
 			abort: () => this.abortFn(),
 			hasPendingMessages: () => this.hasPendingMessagesFn(),


### PR DESCRIPTION
Extensions using `ctx.ui.setFooter()` that read `ctx.model` in their render function were showing stale model info after `/model` changes.

**Root cause:** `createContext()` evaluated `model: this.getModel()` once, creating a snapshot. Extensions capturing `ctx` at `session_start` would always see the model from that moment.

**Fix:** Made `model` a getter that returns the current model on each access.