### PR TITLE
fix(coding-agent): display extension loading errors to user

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Session picker respects custom keybindings when using `--resume` ([#633](https://github.com/badlogic/pi-mono/pull/633) by [@aos](https://github.com/aos))
 - Custom footer extensions now see model changes: `ctx.model` is now a getter that returns the current model instead of a snapshot from when the context was created ([#634](https://github.com/badlogic/pi-mono/pull/634) by [@ogulcancelik](https://github.com/ogulcancelik))
+- Extension loading errors are now displayed to the user instead of being silently ignored ([#639](https://github.com/badlogic/pi-mono/pull/639) by [@aliou](https://github.com/aliou))
 
 ## [0.42.5] - 2026-01-11
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -238,6 +238,11 @@ export async function main(args: string[]) {
 		time("discoverExtensionFlags");
 	}
 
+	// Log extension loading errors
+	for (const { path, error } of extensionsResult.errors) {
+		console.error(chalk.red(`Failed to load extension "${path}": ${error}`));
+	}
+
 	// Collect all extension flags
 	const extensionFlags = new Map<string, { type: "boolean" | "string" }>();
 	for (const ext of extensionsResult.extensions) {


### PR DESCRIPTION
Noticed this issue while trying my config on another setup: the extensions defined in the `~/.pi/agent/settings.json` where i forgot to run `npm install` where not being loaded and i couldn't figure out why. It's the same issue when loading extensions via the `-e` flag.


Session: https://shittycodingagent.ai/session/?39da28353eed673d5f35e43c2c82d48e
<details><summary>Summary by opus</summary>
<p>



**Problem**

When extensions fail to load (e.g., typo in path with `-e`, missing `node_modules` for an extension with dependencies, syntax errors), the user receives no feedback. The extension silently fails to load.

**Root cause**

In `packages/coding-agent/src/core/extensions/loader.ts`, the `loadExtensions()` function correctly catches errors and returns them in the result object:

```ts
return {
  extensions,
  errors,  // Array<{ path: string; error: string }>
  setUIContext(...) { ... },
};
```

However, in `packages/coding-agent/src/main.ts` (the CLI entry point), only `extensions` was destructured:

```ts
const { extensions: loadedExtensions } = await discoverAndLoadExtensions(...);
```

The `errors` array was never extracted or displayed. Note that `sdk.ts` already handled this correctly with:

```ts
for (const { path, error } of result.errors) {
  console.error(`Failed to load extension "${path}": ${error}`);
}
```

**Fix**

Extract and display errors in `main.ts`, matching the pattern used in `sdk.ts`:

```ts
const { extensions: loadedExtensions, errors: extensionErrors } = await discoverAndLoadExtensions(...);
for (const { path, error } of extensionErrors) {
  console.error(chalk.red(`Failed to load extension "${path}": ${error}`));
}
```

</p>
</details> 

