### PR TITLE
Fix install-from-source instructions

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -92,7 +92,7 @@ pi.exe
 
 ```bash
 git clone https://github.com/badlogic/pi-mono.git
-cd pi-mono && npm install
+cd pi-mono && npm install && npm run build
 cd packages/coding-agent && npm run build:binary
 ./dist/pi
 ```


### PR DESCRIPTION
Hopefully this change is reasonable. I'm not a web dev, just a passing scientific programmer who wanted to compile from source.

With the instructions as currently written, then the `npm run build:binary` commands returns an intimidatingly large number of errors that mostly look like:
```
src/cli/args.ts:5:36 - error TS2307: Cannot find module '@mariozechner/pi-agent-core' or its corresponding type declarations.
```

Asking our robot overlords for help, this was the suggested fix, and this seems to work. (Tested from a fresh clone.)

macOS Tahoe 26.2
node v21.6.2
npm 10.2.4
pi f1e225d9e7b3b614ca66c600dc011d81faaa9bba