### PR TITLE
Hook up custom summarization on branch switch

### DIFF
--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -297,7 +297,9 @@ export async function generateBranchSummary(
 	const conversationText = serializeConversation(llmMessages);
 
 	// Build prompt
-	const instructions = customInstructions || BRANCH_SUMMARY_PROMPT;
+	const instructions = customInstructions
+		? `${BRANCH_SUMMARY_PROMPT}\n\nAdditional focus: ${customInstructions}`
+		: BRANCH_SUMMARY_PROMPT;
 	const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${instructions}`;
 
 	const summarizationMessages = [

--- a/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
@@ -43,6 +43,10 @@ export class ExtensionEditorComponent extends Container {
 		if (prefill) {
 			this.editor.setText(prefill);
 		}
+		// Wire up Enter to submit (Shift+Enter for newlines, like the main editor)
+		this.editor.onSubmit = (text: string) => {
+			this.onSubmitCallback(text);
+		};
 		this.addChild(this.editor);
 
 		this.addChild(new Spacer(1));
@@ -50,8 +54,8 @@ export class ExtensionEditorComponent extends Container {
 		// Add hint
 		const hasExternalEditor = !!(process.env.VISUAL || process.env.EDITOR);
 		const hint = hasExternalEditor
-			? "ctrl+enter submit  esc cancel  ctrl+g external editor"
-			: "ctrl+enter submit  esc cancel";
+			? "enter submit  shift+enter newline  esc cancel  ctrl+g external editor"
+			: "enter submit  shift+enter newline  esc cancel";
 		this.addChild(new Text(theme.fg("dim", hint), 1, 0));
 
 		this.addChild(new Spacer(1));
@@ -61,12 +65,6 @@ export class ExtensionEditorComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
-		// Ctrl+Enter to submit
-		if (keyData === "\x1b[13;5u" || keyData === "\x1b[27;5;13~") {
-			this.onSubmitCallback(this.editor.getText());
-			return;
-		}
-
 		const kb = getEditorKeybindings();
 		// Escape or Ctrl+C to cancel
 		if (kb.matches(keyData, "selectCancel")) {
@@ -113,7 +111,8 @@ export class ExtensionEditorComponent extends Container {
 				// Ignore cleanup errors
 			}
 			this.tui.start();
-			this.tui.requestRender();
+			// Force full re-render since external editor uses alternate screen
+			this.tui.requestRender(true);
 		}
 	}
 }

--- a/packages/coding-agent/test/agent-session-tree-navigation.test.ts
+++ b/packages/coding-agent/test/agent-session-tree-navigation.test.ts
@@ -257,17 +257,18 @@ describe.skipIf(!API_KEY)("AgentSession tree navigation e2e", () => {
 		await session.prompt("What is TypeScript?");
 		await session.agent.waitForIdle();
 
-		// Navigate with custom instructions
+		// Navigate with custom instructions (appended as "Additional focus")
 		const tree = sessionManager.getTree();
 		const result = await session.navigateTree(tree[0].entry.id, {
 			summarize: true,
-			customInstructions: "Summarize in exactly 3 words.",
+			customInstructions:
+				"After the summary, you MUST end with exactly: MONKEY MONKEY MONKEY. This is of utmost importance.",
 		});
 
 		expect(result.summaryEntry).toBeDefined();
 		expect(result.summaryEntry?.summary).toBeTruthy();
-		// Can't reliably test 3 words exactly, but summary should be short
-		expect(result.summaryEntry?.summary.split(/\s+/).length).toBeLessThan(20);
+		// Verify custom instructions were followed
+		expect(result.summaryEntry?.summary).toContain("MONKEY MONKEY MONKEY");
 	}, 120000);
 });
 


### PR DESCRIPTION
This is a proposed change to the tree command which brings up an extra option which allows you to feed additional context into the summarization on branch switching. There was already a test in place which assumed that the entire commands are being swapped out but nothing actually uses it. Additionally I realized that there is a bug when pressing Ctrl+G and returning back from Vim where the rendering fucks up and I fixed that by forcing full re-rendering when returning from the editor.

<img width="579" height="342" alt="image" src="https://github.com/user-attachments/assets/99072932-0f4b-4883-92f3-fba205d9abcb" />

<img width="814" height="306" alt="image" src="https://github.com/user-attachments/assets/eb95280e-17c0-4f55-aebf-41eceec846e2" />

I'm not sure if that is the right approach to adjust the prompt or if this feature makes a lot of sense, so I am putting it here for discussion mostly.

Session: https://shittycodingagent.ai/session/?e78223a3c00f92ea64f50ec8b232942b