### PR TITLE
Add fuzzy search to settings list

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -309,6 +309,7 @@ export class SettingsSelectorComponent extends Container {
 				}
 			},
 			callbacks.onCancel,
+			{ enableSearch: true },
 		);
 
 		this.addChild(this.settingsList);


### PR DESCRIPTION
# Add fuzzy search to settings list

## Summary
- Added fuzzy search support to the TUI settings list and enabled it for `/settings`.
- Search matches only setting labels, mirroring model selector behavior.
- Space remains a confirm key and is not added to the search query.

## Technical Details
- Introduced `SettingsListOptions` with `enableSearch` and wired an `Input` for filtering.
- `SettingsList` now uses `fuzzyFilter` on labels and resets selection to the first match on filter updates.
- `/settings` passes `{ enableSearch: true }` when constructing the settings list.
