### PR TITLE
fix(ai): Fixed tool call ID normalization missing cross-provider cases

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tool call ID normalization missing cross-provider cases. Normalize when assistantMsg.api is openai-responses/openai-codex-responses and target isn't
+
 ## [0.43.0] - 2026-01-11
 
 ### Fixed
@@ -41,6 +45,8 @@
 - Added OpenCode Zen provider support with 26 models (Claude, GPT, Gemini, Grok, Kimi, GLM, Qwen, etc.). Set `OPENCODE_API_KEY` env var to use.
 
 ## [0.41.0] - 2026-01-09
+
+## [0.40.1] - 2026-01-09
 
 ## [0.40.1] - 2026-01-09
 


### PR DESCRIPTION
Normalize when assistantMsg.api is `openai-responses`/`openai-codex-responses` and target isn't.

## Technical details
The problematic `|` character and 450+ char IDs come from openai-ish API.
Both [openai-responses](https://github.com/badlogic/pi-mono/blob/6730b4fa59f0f8f0d2dbc3f8fbb3285a3a4f2caf/packages/ai/src/providers/openai-codex-responses.ts#L193) and [openai-codex-responses](https://github.com/badlogic/pi-mono/blob/6730b4fa59f0f8f0d2dbc3f8fbb3285a3a4f2caf/packages/ai/src/providers/openai-responses.ts#L114) generate IDs like `${call_id}|${item.id}`.

## Test
npm check & manual
[Issue thread](https://shittycodingagent.ai/session?41f8a2013e117853c190622a7e9266c5)
[fixed](https://shittycodingagent.ai/session?4668351f1a006597d3aa27f3ae381deb)
