### PR TITLE
Add pi.getToolInfo() extension API

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `pi.getToolInfo()` extension API to get tool names and descriptions ([#647](https://github.com/badlogic/pi-mono/issues/647))
+
 ## [0.43.0] - 2026-01-11
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -862,12 +862,14 @@ const result = await pi.exec("git", ["status"], { signal, timeout: 5000 });
 
 **Examples:** [auto-commit-on-exit.ts](../examples/extensions/auto-commit-on-exit.ts), [dirty-repo-guard.ts](../examples/extensions/dirty-repo-guard.ts), [git-checkpoint.ts](../examples/extensions/git-checkpoint.ts)
 
-### pi.getActiveTools() / pi.getAllTools() / pi.setActiveTools(names)
+### pi.getActiveTools() / pi.getAllTools() / pi.getToolInfo() / pi.setActiveTools(names)
 
 Manage active tools.
 
 ```typescript
 const active = pi.getActiveTools();  // ["read", "bash", "edit", "write"]
+const all = pi.getAllTools();        // All tool names
+const info = pi.getToolInfo();       // [{ name: "read", description: "Read file contents..." }, ...]
 pi.setActiveTools(["read", "bash"]); // Switch to read-only
 ```
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -466,6 +466,16 @@ export class AgentSession {
 	}
 
 	/**
+	 * Get tool info (name and description) for all configured tools.
+	 */
+	getToolInfo(): Array<{ name: string; description: string }> {
+		return Array.from(this._toolRegistry.values()).map((t) => ({
+			name: t.name,
+			description: t.description,
+		}));
+	}
+
+	/**
 	 * Set active tools by name.
 	 * Only tools in the registry can be enabled. Unknown tool names are ignored.
 	 * Also rebuilds the system prompt to reflect the new tool set.

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -60,6 +60,7 @@ export type {
 	GetActiveToolsHandler,
 	GetAllToolsHandler,
 	GetThinkingLevelHandler,
+	GetToolInfoHandler,
 	GrepToolResultEvent,
 	KeybindingsManager,
 	LoadExtensionsResult,
@@ -99,6 +100,7 @@ export type {
 	ToolCallEventResult,
 	// Tools
 	ToolDefinition,
+	ToolInfo,
 	ToolRenderResultOptions,
 	ToolResultEvent,
 	ToolResultEventResult,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -92,6 +92,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
 		getThinkingLevel: notInitialized,
 		setThinkingLevel: notInitialized,
+		getToolInfo: notInitialized,
 		flagValues: new Map(),
 	};
 }
@@ -179,6 +180,10 @@ function createExtensionAPI(
 
 		getAllTools(): string[] {
 			return runtime.getAllTools();
+		},
+
+		getToolInfo() {
+			return runtime.getToolInfo();
 		},
 
 		setActiveTools(toolNames: string[]): void {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -736,6 +736,9 @@ export interface ExtensionAPI {
 	/** Get all configured tools (built-in + extension tools). */
 	getAllTools(): string[];
 
+	/** Get tool info (name and description) for all configured tools. */
+	getToolInfo(): ToolInfo[];
+
 	/** Set the active tools by name. */
 	setActiveTools(toolNames: string[]): void;
 
@@ -801,6 +804,11 @@ export type GetActiveToolsHandler = () => string[];
 
 export type GetAllToolsHandler = () => string[];
 
+/** Simplified tool info for extensions */
+export type ToolInfo = Pick<ToolDefinition, "name" | "description">;
+
+export type GetToolInfoHandler = () => ToolInfo[];
+
 export type SetActiveToolsHandler = (toolNames: string[]) => void;
 
 export type SetModelHandler = (model: Model<any>) => Promise<boolean>;
@@ -831,6 +839,7 @@ export interface ExtensionActions {
 	setModel: SetModelHandler;
 	getThinkingLevel: GetThinkingLevelHandler;
 	setThinkingLevel: SetThinkingLevelHandler;
+	getToolInfo: GetToolInfoHandler;
 }
 
 /**

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -678,6 +678,7 @@ export class InteractiveMode {
 				},
 				getActiveTools: () => this.session.getActiveToolNames(),
 				getAllTools: () => this.session.getAllToolNames(),
+				getToolInfo: () => this.session.getToolInfo(),
 				setActiveTools: (toolNames) => this.session.setActiveToolsByName(toolNames),
 				setModel: async (model) => {
 					const key = await this.session.modelRegistry.getApiKey(model);

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -50,6 +50,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 				},
 				getActiveTools: () => session.getActiveToolNames(),
 				getAllTools: () => session.getAllToolNames(),
+				getToolInfo: () => session.getToolInfo(),
 				setActiveTools: (toolNames: string[]) => session.setActiveToolsByName(toolNames),
 				setModel: async (model) => {
 					const key = await session.modelRegistry.getApiKey(model);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -269,6 +269,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				},
 				getActiveTools: () => session.getActiveToolNames(),
 				getAllTools: () => session.getAllToolNames(),
+				getToolInfo: () => session.getToolInfo(),
 				setActiveTools: (toolNames: string[]) => session.setActiveToolsByName(toolNames),
 				setModel: async (model) => {
 					const key = await session.modelRegistry.getApiKey(model);

--- a/packages/coding-agent/test/compaction-extensions.test.ts
+++ b/packages/coding-agent/test/compaction-extensions.test.ts
@@ -110,6 +110,7 @@ describe.skipIf(!API_KEY)("Compaction extensions", () => {
 				appendEntry: async () => {},
 				getActiveTools: () => [],
 				getAllTools: () => [],
+				getToolInfo: () => [],
 				setActiveTools: () => {},
 				setModel: async () => false,
 				getThinkingLevel: () => "off",


### PR DESCRIPTION
Expose tool names and descriptions to extensions via `pi.getToolInfo()`.
Previously extensions could only get tool names via `pi.getAllTools()`.

## Changes

- Added `ToolInfo` interface and `GetToolInfoHandler` type
- Added `getToolInfo()` to `ExtensionAPI` and `ExtensionActions`
- Added `getToolInfo()` method to `AgentSession`
- Wired up in interactive, print, and rpc modes
- Updated docs and changelog

Fixes #647