### PR TITLE
feat(coding-agent): Add session name

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -130,7 +130,7 @@ class SessionList implements Component {
 		this.filteredSessions = fuzzyFilter(
 			this.allSessions,
 			query,
-			(session) => `${session.id} ${session.allMessagesText} ${session.cwd}`,
+			(session) => `${session.id} ${session.name ?? ""} ${session.allMessagesText} ${session.cwd}`,
 		);
 		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredSessions.length - 1));
 	}
@@ -162,7 +162,8 @@ class SessionList implements Component {
 			const isSelected = i === this.selectedIndex;
 
 			// Normalize first message to single line
-			const normalizedMessage = session.firstMessage.replace(/\n/g, " ").trim();
+			const displayName = session.name?.trim() ?? session.firstMessage;
+			const normalizedMessage = displayName.replace(/\n/g, " ").trim();
 
 			// First line: cursor + message (truncate to visible width)
 			const cursor = isSelected ? theme.fg("accent", "› ") : "  ";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -286,6 +286,7 @@ export class InteractiveMode {
 			{ name: "export", description: "Export session to HTML file" },
 			{ name: "share", description: "Share session as a secret GitHub gist" },
 			{ name: "copy", description: "Copy last agent message to clipboard" },
+			{ name: "name", description: "Set session name" },
 			{ name: "session", description: "Show session info and stats" },
 			{ name: "changelog", description: "Show changelog entries" },
 			{ name: "hotkeys", description: "Show all keyboard shortcuts" },
@@ -674,6 +675,14 @@ export class InteractiveMode {
 					});
 				},
 				appendEntry: (customType, data) => {
+					if (customType === "session_info") {
+						if (typeof data !== "string") {
+							this.showError("Session name must be a string");
+							return;
+						}
+						this.sessionManager.appendSessionInfo(data);
+						return;
+					}
 					this.sessionManager.appendCustomEntry(customType, data);
 				},
 				getActiveTools: () => this.session.getActiveToolNames(),
@@ -1438,6 +1447,11 @@ export class InteractiveMode {
 			}
 			if (text === "/copy") {
 				this.handleCopyCommand();
+				this.editor.setText("");
+				return;
+			}
+			if (text === "/name" || text.startsWith("/name ")) {
+				this.handleNameCommand(text);
 				this.editor.setText("");
 				return;
 			}
@@ -3252,6 +3266,19 @@ export class InteractiveMode {
 		} catch (error) {
 			this.showError(error instanceof Error ? error.message : String(error));
 		}
+	}
+
+	private handleNameCommand(text: string): void {
+		const name = text.replace(/^\/name\b/, "").trim();
+		if (!name) {
+			this.showWarning("Usage: /name <name>");
+			return;
+		}
+
+		this.sessionManager.appendSessionInfo(name);
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(new Text(theme.fg("dim", `Session name set: ${name}`), 1, 0));
+		this.ui.requestRender();
 	}
 
 	private handleSessionCommand(): void {

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -46,6 +46,14 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 					});
 				},
 				appendEntry: (customType, data) => {
+					if (customType === "session_info") {
+						if (typeof data !== "string") {
+							console.error("Session name must be a string");
+							return;
+						}
+						session.sessionManager.appendSessionInfo(data);
+						return;
+					}
 					session.sessionManager.appendCustomEntry(customType, data);
 				},
 				getActiveTools: () => session.getActiveToolNames(),

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -265,6 +265,14 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 					});
 				},
 				appendEntry: (customType, data) => {
+					if (customType === "session_info") {
+						if (typeof data !== "string") {
+							output(error(undefined, "append_entry", "Session name must be a string"));
+							return;
+						}
+						session.sessionManager.appendSessionInfo(data);
+						return;
+					}
 					session.sessionManager.appendCustomEntry(customType, data);
 				},
 				getActiveTools: () => session.getActiveToolNames(),


### PR DESCRIPTION
Adds a way to name a session.

This appends a new `SessionInfoEntry` object to the session file, which has a name. SessionManager was updated to append session info entries. The RPC, interactive and print mode APIs have also been updated.

I've also added a `/name <some-name>` command, and an extension API for extensions to use LLMs to generate session names.

When set, the name is used in the `--resume` session listing instead of the truncated first message. This makes it easier to sessions, especially when they were forked (which often have the same first message)!