### PR TITLE
fix(coding-agent): use settings default when session has no thinking level entry

### DIFF
--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -409,7 +409,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	// If session has data, restore thinking level from it
 	if (thinkingLevel === undefined && hasExistingSession) {
-		thinkingLevel = existingSession.thinkingLevel as ThinkingLevel;
+		thinkingLevel = existingSession.thinkingLevel;
 	}
 
 	// Fall back to settings default

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -283,7 +283,7 @@ describe("buildSessionContext", () => {
 
 		const loaded = buildSessionContext(entries);
 		expect(loaded.messages.length).toBe(4);
-		expect(loaded.thinkingLevel).toBe("off");
+		expect(loaded.thinkingLevel).toBeUndefined();
 		expect(loaded.model).toEqual({ provider: "anthropic", modelId: "claude-sonnet-4-5" });
 	});
 

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -65,7 +65,7 @@ describe("buildSessionContext", () => {
 		it("empty entries returns empty context", () => {
 			const ctx = buildSessionContext([]);
 			expect(ctx.messages).toEqual([]);
-			expect(ctx.thinkingLevel).toBe("off");
+			expect(ctx.thinkingLevel).toBeUndefined();
 			expect(ctx.model).toBeNull();
 		});
 


### PR DESCRIPTION
## Summary

`buildSessionContext()` was returning `"off"` as default when no `thinking_level_change` entry existed in the session. This prevented the SDK from falling back to the user's `defaultThinkingLevel` setting on `--resume`.

Changed `SessionContext.thinkingLevel` to return `undefined` when no entry exists, allowing the SDK's existing fallback logic to work correctly.

## Impact

Affects sessions created before v0.31.0 (Jan 2, 2026), which added initial thinking level saving to new sessions. This is a defensive fix for legacy sessions that will naturally age out.

## Changes

- `session-manager.ts`: Changed `thinkingLevel` type to `string | undefined`, default to `undefined`
- Updated tests to expect `undefined` instead of `"off"` for sessions without thinking level entries