### PR TITLE
Fix papercut: add some space below the final node to avoid scrollbar overlap (coding-agent)

### DIFF
--- a/packages/coding-agent/src/core/export-html/template.css
+++ b/packages/coding-agent/src/core/export-html/template.css
@@ -194,6 +194,10 @@
       color: var(--customMessageLabel);
     }
 
+    .tree-container > .tree-node:last-child {
+      margin-bottom: 1rem;
+    }
+
     .tree-status {
       padding: 4px 12px;
       font-size: 10px;


### PR DESCRIPTION
In my highly branched sessions like [this one](https://shittycodingagent.ai/session/?e24e6a4027c5d54c4b4d3b7e323c87d0) the bottom scrollbar overlaps the last tree node, making it extremely hard to select the session.
 
This is a screenshot from Firefox on macOS.

<img width="373" height="98" alt="image" src="https://github.com/user-attachments/assets/0c02bdcc-0fb9-47e4-9c48-ce5ffb81c296" />

This change adds a bottom margin to the final tree node so it stays clickable when the tree overflows horizontally and the scrollbar overlaps the last row.

Sharing my pi coding session that I used to work on this although tbh it's not very informative: https://shittycodingagent.ai/session/?fb3c212f74e81cc3eb466223b6c329b5

(I accidentally deleted my post-fix session file to share a screenshot after the fix, but you can imagine a 1 scrollbar width gap below that last node)