### PR TITLE
fix(coding-agent): inline ALT+UP UI hint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Inline hint for queued messages showing the `Alt+Up` restore shortcut.
+
 ## [0.43.0] - 2026-01-11
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -421,7 +421,7 @@ export class InteractiveMode {
 			theme.fg("muted", " to queue follow-up") +
 			"\n" +
 			theme.fg("dim", dequeue) +
-			theme.fg("muted", " to restore queued messages") +
+			theme.fg("muted", " to edit all queued messages") +
 			"\n" +
 			theme.fg("dim", "ctrl+v") +
 			theme.fg("muted", " to paste image") +
@@ -2328,6 +2328,9 @@ export class InteractiveMode {
 				const text = theme.fg("dim", `Follow-up: ${message}`);
 				this.pendingMessagesContainer.addChild(new TruncatedText(text, 1, 0));
 			}
+			const dequeueHint = this.getAppKeyDisplay("dequeue");
+			const hintText = theme.fg("dim", `↳ ${dequeueHint} to edit all queued messages`);
+			this.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}
 	}
 


### PR DESCRIPTION
Tiny polish to show UI hint for ALT+UP queue restore so users know it's there.

<img width="301" height="92" alt="Screenshot 2026-01-12 at 14 12 55" src="https://github.com/user-attachments/assets/b2b8c296-9014-4287-ad21-56bbb2a0afe4" />

Small update - amended text so it's "to edit all" (clearer), not "to restore"
Tests
- npm run check
- manual testing locally