### PR TITLE
example: add desktop notification extension (OSC 777)

### DIFF
--- a/packages/coding-agent/examples/extensions/notify.ts
+++ b/packages/coding-agent/examples/extensions/notify.ts
@@ -1,0 +1,25 @@
+/**
+ * Desktop Notification Extension
+ *
+ * Sends a native desktop notification when the agent finishes and is waiting for input.
+ * Uses OSC 777 escape sequence - no external dependencies.
+ *
+ * Supported terminals: Ghostty, iTerm2, WezTerm, rxvt-unicode
+ * Not supported: Kitty (uses OSC 99), Terminal.app, Windows Terminal, Alacritty
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+/**
+ * Send a desktop notification via OSC 777 escape sequence.
+ */
+function notify(title: string, body: string): void {
+	// OSC 777 format: ESC ] 777 ; notify ; title ; body BEL
+	process.stdout.write(`\x1b]777;notify;${title};${body}\x07`);
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.on("agent_end", async () => {
+		notify("Pi", "Ready for input");
+	});
+}


### PR DESCRIPTION
Adds a simple example extension that sends native desktop notifications when the agent finishes.

Uses OSC 777 escape sequence - no external dependencies.

**Supported terminals:** Ghostty, iTerm2, WezTerm, rxvt-unicode

**Not supported:** Kitty (uses OSC 99), Terminal.app, Windows Terminal, Alacritty

Clicking the notification focuses the terminal window/tab.