### PR TITLE
fix(tui): numbered list items showing "1." when code blocks break list continuity

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Numbered list items showing "1." for all items when code blocks break list continuity ([#660](https://github.com/badlogic/pi-mono/pull/660) by [@ogulcancelik](https://github.com/ogulcancelik))
+
 ## [0.43.0] - 2026-01-11
 
 ### Added

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -418,13 +418,15 @@ export class Markdown implements Component {
 	/**
 	 * Render a list with proper nesting support
 	 */
-	private renderList(token: Token & { items: any[]; ordered: boolean }, depth: number): string[] {
+	private renderList(token: Token & { items: any[]; ordered: boolean; start?: number }, depth: number): string[] {
 		const lines: string[] = [];
 		const indent = "  ".repeat(depth);
+		// Use the list's start property (defaults to 1 for ordered lists)
+		const startNumber = token.start ?? 1;
 
 		for (let i = 0; i < token.items.length; i++) {
 			const item = token.items[i];
-			const bullet = token.ordered ? `${i + 1}. ` : "- ";
+			const bullet = token.ordered ? `${startNumber + i}. ` : "- ";
 
 			// Process item tokens to handle nested lists
 			const itemLines = this.renderListItem(item.tokens || [], depth);

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -108,6 +108,43 @@ describe("Markdown component", () => {
 			assert.ok(plainLines.some((line) => line.includes("  - Unordered nested")));
 			assert.ok(plainLines.some((line) => line.includes("2. Second ordered")));
 		});
+
+		it("should maintain numbering when code blocks are not indented (LLM output)", () => {
+			// When code blocks aren't indented, marked parses each item as a separate list.
+			// We use token.start to preserve the original numbering.
+			const markdown = new Markdown(
+				`1. First item
+
+\`\`\`typescript
+// code block
+\`\`\`
+
+2. Second item
+
+\`\`\`typescript
+// another code block
+\`\`\`
+
+3. Third item`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80);
+			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trim());
+
+			// Find all lines that start with a number and period
+			const numberedLines = plainLines.filter((line) => /^\d+\./.test(line));
+
+			// Should have 3 numbered items
+			assert.strictEqual(numberedLines.length, 3, `Expected 3 numbered items, got: ${numberedLines.join(", ")}`);
+
+			// Check the actual numbers
+			assert.ok(numberedLines[0].startsWith("1."), `First item should be "1.", got: ${numberedLines[0]}`);
+			assert.ok(numberedLines[1].startsWith("2."), `Second item should be "2.", got: ${numberedLines[1]}`);
+			assert.ok(numberedLines[2].startsWith("3."), `Third item should be "3.", got: ${numberedLines[2]}`);
+		});
 	});
 
 	describe("Tables", () => {


### PR DESCRIPTION
## Summary
When LLMs output numbered lists with code blocks that aren't properly indented, the markdown parser (marked) treats each item as a separate list starting at 1.

## Root Cause
`renderList()` was using `i + 1` for bullet numbers, but `i` is the index within each list token's items. When marked splits lists, each token has only 1 item, so all bullets showed "1.".

## Fix
Use the list's `start` property that marked preserves:
```typescript
const startNumber = token.start ?? 1;
const bullet = token.ordered ? `${startNumber + i}. ` : "- ";
```

## Testing
Added test case for the specific scenario.