### PR TITLE
fix(coding-agent): prevent session selector from closing immediately when current folder has no sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Extension example: `notify.ts` for desktop notifications via OSC 777 escape sequence ([#658](https://github.com/badlogic/pi-mono/pull/658) by [@ferologics](https://github.com/ferologics))
 
+### Fixed
+
+- Session selector now stays open when current folder has no sessions, allowing Tab to switch to "all" scope ([#661](https://github.com/badlogic/pi-mono/pull/661) by [@aliou](https://github.com/aliou))
+
 ## [0.43.0] - 2026-01-11
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -145,7 +145,13 @@ class SessionList implements Component {
 		lines.push(""); // Blank line after search
 
 		if (this.filteredSessions.length === 0) {
-			lines.push(theme.fg("muted", "  No sessions found"));
+			if (this.showCwd) {
+				// "All" scope - no sessions anywhere that match filter
+				lines.push(theme.fg("muted", "  No sessions found"));
+			} else {
+				// "Current folder" scope - hint to try "all"
+				lines.push(theme.fg("muted", "  No sessions in current folder. Press Tab to view all."));
+			}
 			return lines;
 		}
 
@@ -298,10 +304,6 @@ export class SessionSelectorComponent extends Container {
 			this.header.setLoading(false);
 			this.sessionList.setSessions(sessions, false);
 			this.requestRender();
-			// If no sessions found, cancel
-			if (sessions.length === 0) {
-				this.onCancel();
-			}
 		});
 	}
 


### PR DESCRIPTION
Hello!

When using `/resume` or `--resume` in a directory with no sessions, the session selector immediately closes instead of staying open and allowing the user to press Tab to switch to "all" scope (which shows sessions from all directories).

This makes it impossible to resume sessions from other directories when the current directory has no sessions - the selector just flashes and disappears.

For `--resume`, it also broke the ui of the selector completely.

**Root cause**: `loadCurrentSessions()` had an auto-cancel that fired when `sessions.length === 0`, closing the selector before the user could interact with it.

Session: https://shittycodingagent.ai/session/?339c6380f4231fbe786ed7d0e6661de0

---
<details><summary>Summary:</summary>

## Problem

The session selector component auto-cancelled when no sessions existed in the current directory scope:

```typescript
// In loadCurrentSessions()
if (sessions.length === 0) {
    this.onCancel();
}
```

This prevented users from pressing Tab to toggle to "all" scope, which would show sessions from other directories.

## Fix

1. Removed the premature auto-cancel in `loadCurrentSessions()`
2. Added context-aware empty state messages:
   - Current folder scope: "No sessions in current folder. Press Tab to view all."
   - All scope: "No sessions found"

The selector now only closes when both scopes are empty (existing logic in `toggleScope()` already handled this correctly).

## Changes

- `packages/coding-agent/src/modes/interactive/components/session-selector.ts`: Remove auto-cancel, add scope-aware empty messages

</details>