### PR TITLE
Allow setting service tier for OpenAI models via `streamSimple()`

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `streamSimple()` ignoring `serviceTier` for OpenAI Responses requests.
+
 ## [0.45.3] - 2026-01-13
 
 ## [0.45.2] - 2026-01-13

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -268,6 +268,7 @@ function mapOptionsForApi<TApi extends Api>(
 			return {
 				...base,
 				reasoningEffort: supportsXhigh(model) ? options?.reasoning : clampReasoning(options?.reasoning),
+				...(options?.serviceTier !== undefined ? { serviceTier: options.serviceTier } : {}),
 			} satisfies OpenAIResponsesOptions;
 
 		case "openai-codex-responses":

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -91,6 +91,8 @@ export interface SimpleStreamOptions extends StreamOptions {
 	reasoning?: ThinkingLevel;
 	/** Custom token budgets for thinking levels (token-based providers only) */
 	thinkingBudgets?: ThinkingBudgets;
+	/** OpenAI Responses-specific: request a specific service tier (latency/pricing). */
+	serviceTier?: OpenAIResponsesOptions["serviceTier"];
 }
 
 // Generic StreamFunction with typed options


### PR DESCRIPTION
Makes it possible to keep using `streamSimple()` while being able to set the service tier for OpenAI models.