### PR TITLE
fix(coding-agent): resolve api keys by provider

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Extension example: `summarize.ts` for summarizing conversations using custom UI and an external model
 - Vercel AI Gateway provider support: set `AI_GATEWAY_API_KEY` and use `--provider vercel-ai-gateway` ([#689](https://github.com/badlogic/pi-mono/pull/689) by [@timolins](https://github.com/timolins))
 
+### Fixed
+
+- Fix API key resolution after model switches by using provider argument.
+
 ## [0.45.3] - 2026-01-13
 
 ## [0.45.2] - 2026-01-13

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -628,14 +628,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		steeringMode: settingsManager.getSteeringMode(),
 		followUpMode: settingsManager.getFollowUpMode(),
 		thinkingBudgets: settingsManager.getThinkingBudgets(),
-		getApiKey: async () => {
-			const currentModel = agent.state.model;
-			if (!currentModel) {
+		getApiKey: async (provider) => {
+			// Use the provider argument from the in-flight request;
+			// agent.state.model may already be switched mid-turn.
+			const resolvedProvider = provider || agent.state.model?.provider;
+			if (!resolvedProvider) {
 				throw new Error("No model selected");
 			}
-			const key = await modelRegistry.getApiKey(currentModel);
+			const key = await modelRegistry.authStorage.getApiKey(resolvedProvider);
 			if (!key) {
-				throw new Error(`No API key found for provider "${currentModel.provider}"`);
+				throw new Error(`No API key found for provider "${resolvedProvider}"`);
 			}
 			return key;
 		},

--- a/packages/coding-agent/test/sdk-api-key.test.ts
+++ b/packages/coding-agent/test/sdk-api-key.test.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getModel } from "@mariozechner/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { createAgentSession } from "../src/core/sdk.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+
+describe("createAgentSession getApiKey", () => {
+	let tempDir: string;
+	let agentDir: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-test-sdk-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		agentDir = join(tempDir, "agent");
+		projectDir = join(tempDir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("uses the provider argument after model switches", async () => {
+		const authStorage = new AuthStorage(join(agentDir, "auth.json"));
+		authStorage.set("anthropic", { type: "api_key", key: "anthropic-key" });
+		authStorage.set("openai-codex", { type: "api_key", key: "codex-key" });
+
+		const modelRegistry = new ModelRegistry(authStorage, join(agentDir, "models.json"));
+		const settingsManager = SettingsManager.create(projectDir, agentDir);
+		const sessionManager = SessionManager.inMemory(projectDir);
+
+		const anthropicModel = getModel("anthropic", "claude-opus-4-5");
+		const codexModel = getModel("openai-codex", "gpt-5.2-codex");
+
+		const { session } = await createAgentSession({
+			cwd: projectDir,
+			agentDir,
+			authStorage,
+			modelRegistry,
+			settingsManager,
+			sessionManager,
+			model: anthropicModel,
+		});
+
+		await session.setModel(codexModel);
+
+		const key = await session.agent.getApiKey?.("anthropic");
+		expect(key).toBe("anthropic-key");
+	});
+});


### PR DESCRIPTION
Hey Mario, I found a bug when switching models mid-flight. I know you have high standards for PRs, so I've tried my best to make it high quality and slop free - please let me know if anything is missing or needs improvement :)

Session log: https://shittycodingagent.ai/session/?c33197b6427065f81fbd85d803e6f978
Model used: gpt-5.2-codex-high

## Summary
- resolve API keys using the provider argument to prevent model-switch 401s mid-run
- add regression test for provider-specific key resolution
- update coding-agent changelog

## Why (Human-written, verbatim)
- When switching models from opus 4.5 to codex, I got an error, interrupting first request to the model; I suspected that the access token was not adequately refreshed. It was annoying, so I asked codex to fix it for me :) The aim of this change is to ensure that you can seamlessly switch to/from OpenAI models without getting any errors.

## Proof (LLM-generated)
- The session log shows a `model_change` to `openai-codex/gpt-5.2-codex`, then an Anthropic `401 invalid x-api-key` error on the next assistant message. That’s the failure that triggered this fix.
- Session log: `~/.pi/agent/sessions/--Users-josh-code-lawbot-hub--/2026-01-12T22-55-39-082Z_cf315833-388d-4a28-9c2f-f20f51e7cde3.jsonl` (lines 694-699)
- Full excerpt (verbatim from session log):
```
{"type":"model_change","id":"c44c9a39","parentId":"a2a08f77","timestamp":"2026-01-13T10:11:35.989Z","provider":"openai-codex","modelId":"gpt-5.2-codex"}
{"type":"thinking_level_change","id":"097d62e4","parentId":"c44c9a39","timestamp":"2026-01-13T10:11:35.989Z","thinkingLevel":"high"}
{"type":"message","id":"8e1bb8eb","parentId":"097d62e4","timestamp":"2026-01-13T10:11:36.879Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"No output - pi might be timing out or waiting for something. Let me try with explicit model","thinkingSignature":"EoMCCkYICxgCKkBRiJ/Np0QC0xAvO1s8RZKJvE99E0Xb9ZR/eokHlNC8c8Eye6HzDkBLT9NUrqOnNQCmtQMZVLYi2XsJPIeRqsEPEgyn7GljPX2N69R7AiYaDKVMoeSEGE1DU8mQ6yIwLMPA7cOI3kV8FIa6/s1BxtuNqSf1Jv7IcbVfz7rTd6Yxr+Q8ZW+souZ4gzu3LbK3KmtSvNujeTEz8dsCEGo9Bqq7VPQOjwHYKiRk+lGgTmOYdzqtZKyZ+U/ERCLgFwAVq1K6eWfLJuDIYn4ciKbVUyJ/Vx3BrcmL+nF0JI9AXD0inyj/staPRPAlffv4McxM3VODr1ERzm99moYHUBgB"},{"type":"toolCall","id":"toolu_01Hcuy17wTKrmcaHzKshD9LF","name":"bash","arguments":{"command":"pi --print --no-session \"say hi\" 2>&1 | head -10","timeout":30}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-opus-4-5","usage":{"input":8,"output":115,"cacheRead":117837,"cacheWrite":138,"totalTokens":118098,"cost":{"input":0.00004,"output":0.002875,"cacheRead":0.0589185,"cacheWrite":0.0008625000000000001,"total":0.062696}},"stopReason":"toolUse","timestamp":1768299092273}}
{"type":"message","id":"67cdb318","parentId":"8e1bb8eb","timestamp":"2026-01-13T10:11:39.121Z","message":{"role":"toolResult","toolCallId":"toolu_01Hcuy17wTKrmcaHzKshD9LF","toolName":"bash","content":[{"type":"text","text":"Hi Josh — glad to be here; let’s make solid progress today.\n"}],"isError":false,"timestamp":1768299099119}}
{"type":"message","id":"63ce2a0d","parentId":"67cdb318","timestamp":"2026-01-13T10:11:39.349Z","message":{"role":"assistant","content":[],"api":"anthropic-messages","provider":"anthropic","model":"claude-opus-4-5","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"error","timestamp":1768299099121,"errorMessage":"401 {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key\"},\"request_id\":\"req_011CX5CQPwvfz2TfNUHh8aii\"}"}}
{"type":"message","id":"8e686d98","parentId":"63ce2a0d","timestamp":"2026-01-13T10:12:11.433Z","message":{"role":"user","content":[{"type":"text","text":"continue"}],"timestamp":1768299131429}}
```


## Analysis (LLM-generated)
- Turn start snapshots `config.model` (provider stays Anthropic for the in-flight turn).
- `/model` immediately updates `agent.state.model` and writes the `model_change` entry.
- The LLM call resolves the API key via `getApiKey(config.model.provider)`.
- SDK `getApiKey` ignored its provider argument and read `agent.state.model`, so it returned the new provider’s key.
- Result: Anthropic request sent with Codex key → 401. Deterministic mismatch, not token expiry.
- The session log ordering reflects this: `model_change` to Codex, then an Anthropic tool call, then the Anthropic 401.

## Testing (LLM-generated)
- npm run check
