### PR TITLE
feat: export highlightCode and getLanguageFromPath for extensions

### DIFF
--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -264,9 +264,11 @@ export {
 } from "./modes/interactive/components/index.js";
 // Theme utilities for custom tools and extensions
 export {
+	getLanguageFromPath,
 	getMarkdownTheme,
 	getSelectListTheme,
 	getSettingsListTheme,
+	highlightCode,
 	initTheme,
 	Theme,
 	type ThemeColor,


### PR DESCRIPTION
Exports `highlightCode` and `getLanguageFromPath` from `@mariozechner/pi-coding-agent` to enable extensions to render code with syntax highlighting consistent with the rest of the UI.

### Rationale

Extensions that display code (e.g., code search tools, documentation fetchers, snippet viewers) currently have no way to apply syntax highlighting that matches pi's theme. They must either:
1. Show plain unstyled code
2. Bundle their own highlighting library and theme (which won't match pi's colors)

By exposing these two functions:
- **`highlightCode(code: string, lang?: string): string[]`** — Highlights code using pi's current theme colors
- **`getLanguageFromPath(filePath: string): string | undefined`** — Maps file extensions to language identifiers

Extensions can render code snippets with the same syntax highlighting used by built-in tools like `read`, `write`, and `edit`.