### PR TITLE
Fix orphaned tool calls for Bedrock

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -38,6 +38,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { transformMessages } from "./transform-messages.js";
 
 export interface BedrockOptions extends StreamOptions {
 	region?: string;
@@ -307,10 +308,10 @@ function buildSystemPrompt(
 
 function convertMessages(context: Context, model: Model<"bedrock-converse-stream">): Message[] {
 	const result: Message[] = [];
-	const messages = context.messages;
+	const transformedMessages = transformMessages(context.messages, model);
 
-	for (let i = 0; i < messages.length; i++) {
-		const m = messages[i];
+	for (let i = 0; i < transformedMessages.length; i++) {
+		const m = transformedMessages[i];
 
 		switch (m.role) {
 			case "user":
@@ -393,8 +394,8 @@ function convertMessages(context: Context, model: Model<"bedrock-converse-stream
 
 				// Look ahead for consecutive toolResult messages
 				let j = i + 1;
-				while (j < messages.length && messages[j].role === "toolResult") {
-					const nextMsg = messages[j] as ToolResultMessage;
+				while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
+					const nextMsg = transformedMessages[j] as ToolResultMessage;
 					toolResults.push({
 						toolResult: {
 							toolUseId: nextMsg.toolCallId,


### PR DESCRIPTION
## Summary
- apply transformMessages before Bedrock message conversion to insert synthetic tool results

## Problem
Aborted tool-use streams can leave orphaned tool calls without tool results. Bedrock did not run the shared message transform, so the orphan fix never ran and the next request failed validation.

## Error
The model returned the following errors: messages.N: tool_use ids were found without tool_result blocks immediately after: tooluse_XXXX. Each tool_use block must have a corresponding tool_result block in the next message.

## Repro
1) start a tool call, then abort mid-stream
2) the assistant message persists with tool_use but no tool_result
3) send a new user message → Bedrock rejects the history (missing tool_result)

## Why Bedrock only
Other providers already run transformMessages; Bedrock skipped it, so orphaned tool_use were unhandled.

## Fix
Reuse existing transformMessages logic in the Bedrock provider before conversion.

## Testing
- npm run check
