### PR TITLE
fix: include skill path in /skill prompts

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3357,7 +3357,10 @@ export class InteractiveMode {
 			const content = fs.readFileSync(skillPath, "utf-8");
 			// Strip YAML frontmatter if present
 			const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
-			const message = args ? `${body}\n\n---\n\nUser: ${args}` : body;
+			const skillDir = path.dirname(skillPath);
+			const header = `Skill location: ${skillPath}\nReferences are relative to ${skillDir}.`;
+			const skillMessage = `${header}\n\n${body}`;
+			const message = args ? `${skillMessage}\n\n---\n\nUser: ${args}` : skillMessage;
 			await this.session.prompt(message);
 		} catch (err) {
 			this.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
When loading skills with the slash command with codex, I noticed that the agent was initially unable to find the references directory but eventually found it through a few iterations of `rg` in my home directory. This prefixes the message with the relative path and the agent looked in the right place immediately.