### PR TITLE
feat(coding-agent): add support for APPEND_SYSTEM.md to make it easier to append instructions to system prompt

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -573,7 +573,7 @@ Use these for:
 
 ### Custom System Prompt
 
-Replace the default system prompt entirely by creating a `SYSTEM.md` file:
+Replace the default system prompt **entirely** by creating a `SYSTEM.md` file:
 
 1. **Project-local:** `.pi/SYSTEM.md` (takes precedence)
 2. **Global:** `~/.pi/agent/SYSTEM.md` (fallback)
@@ -589,7 +589,16 @@ Focus on:
 - Proper formatting
 ```
 
-The `--system-prompt` CLI flag overrides both files. Use `--append-system-prompt` to add to (rather than replace) the prompt.
+The `--system-prompt` CLI flag overrides both files.
+
+### Appending to the System Prompt
+
+To add instructions to the system prompt **without** replacing the default (preserving automatic loading of `AGENTS.md` context files, skills, and tools guidelines), create an `APPEND_SYSTEM.md` file:
+
+1. **Project-local:** `.pi/APPEND_SYSTEM.md` (takes precedence)
+2. **Global:** `~/.pi/agent/APPEND_SYSTEM.md` (fallback)
+
+The `--append-system-prompt` CLI flag overrides both files.
 
 ### Custom Models and Providers
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -116,6 +116,23 @@ function discoverSystemPromptFile(): string | undefined {
 	return undefined;
 }
 
+/** Discover APPEND_SYSTEM.md file if no CLI append system prompt was provided */
+function discoverAppendSystemPromptFile(): string | undefined {
+	// Check project-local first: .pi/APPEND_SYSTEM.md
+	const projectPath = join(process.cwd(), CONFIG_DIR_NAME, "APPEND_SYSTEM.md");
+	if (existsSync(projectPath)) {
+		return projectPath;
+	}
+
+	// Fall back to global: ~/.pi/agent/APPEND_SYSTEM.md
+	const globalPath = join(getAgentDir(), "APPEND_SYSTEM.md");
+	if (existsSync(globalPath)) {
+		return globalPath;
+	}
+
+	return undefined;
+}
+
 function buildSessionOptions(
 	parsed: Args,
 	scopedModels: ScopedModel[],
@@ -128,8 +145,11 @@ function buildSessionOptions(
 
 	// Auto-discover SYSTEM.md if no CLI system prompt provided
 	const systemPromptSource = parsed.systemPrompt ?? discoverSystemPromptFile();
+	// Auto-discover APPEND_SYSTEM.md if no CLI append system prompt provided
+	const appendSystemPromptSource = parsed.appendSystemPrompt ?? discoverAppendSystemPromptFile();
+
 	const resolvedSystemPrompt = resolvePromptInput(systemPromptSource, "system prompt");
-	const resolvedAppendPrompt = resolvePromptInput(parsed.appendSystemPrompt, "append system prompt");
+	const resolvedAppendPrompt = resolvePromptInput(appendSystemPromptSource, "append system prompt");
 
 	if (sessionManager) {
 		options.sessionManager = sessionManager;


### PR DESCRIPTION
Currently custom `SYSTEM.md` file will replace the default system prompt entirely without loading `AGENTS.md` context files, skills, etc., which may not be expected sometimes. 
Providing the `APPEND_SYSTEM.md` file makes it easier to add more instructions to the system prompt without having to pass `--append-system-prompt` every time.
