### PR TITLE
feat(ai): add support for MiniMax China (minimax-cn) provider

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -567,29 +567,36 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 		}
 
 		// Process MiniMax models
-		if (data.minimax?.models) {
-			for (const [modelId, model] of Object.entries(data.minimax.models)) {
-				const m = model as ModelsDevModel;
-				if (m.tool_call !== true) continue;
+		const minimaxVariants = [
+			{ key: "minimax", provider: "minimax", baseUrl: "https://api.minimax.io/anthropic" },
+			{ key: "minimax-cn", provider: "minimax-cn", baseUrl: "https://api.minimaxi.com/anthropic" },
+		] as const;
 
-				models.push({
-					id: modelId,
-					name: m.name || modelId,
-					api: "anthropic-messages",
-					provider: "minimax",
-					// MiniMax's Anthropic-compatible API - SDK appends /v1/messages
-					baseUrl: "https://api.minimax.io/anthropic",
-					reasoning: m.reasoning === true,
-					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
-					contextWindow: m.limit?.context || 4096,
-					maxTokens: m.limit?.output || 4096,
-				});
+		for (const { key, provider, baseUrl } of minimaxVariants) {
+			if (data[key]?.models) {
+				for (const [modelId, model] of Object.entries(data[key].models)) {
+					const m = model as ModelsDevModel;
+					if (m.tool_call !== true) continue;
+
+					models.push({
+						id: modelId,
+						name: m.name || modelId,
+						api: "anthropic-messages",
+						provider,
+						// MiniMax's Anthropic-compatible API - SDK appends /v1/messages
+						baseUrl,
+						reasoning: m.reasoning === true,
+						input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
+						cost: {
+							input: m.cost?.input || 0,
+							output: m.cost?.output || 0,
+							cacheRead: m.cost?.cache_read || 0,
+							cacheWrite: m.cost?.cache_write || 0,
+						},
+						contextWindow: m.limit?.context || 4096,
+						maxTokens: m.limit?.output || 4096,
+					});
+				}
 			}
 		}
 

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -2773,6 +2773,42 @@ export const MODELS = {
 			maxTokens: 131072,
 		} satisfies Model<"anthropic-messages">,
 	},
+	"minimax-cn": {
+		"MiniMax-M2": {
+			id: "MiniMax-M2",
+			name: "MiniMax-M2",
+			api: "anthropic-messages",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/anthropic",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 0.3,
+				output: 1.2,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 196608,
+			maxTokens: 128000,
+		} satisfies Model<"anthropic-messages">,
+		"MiniMax-M2.1": {
+			id: "MiniMax-M2.1",
+			name: "MiniMax-M2.1",
+			api: "anthropic-messages",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/anthropic",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 0.3,
+				output: 1.2,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 204800,
+			maxTokens: 131072,
+		} satisfies Model<"anthropic-messages">,
+	},
 	"mistral": {
 		"codestral-latest": {
 			id: "codestral-latest",

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -100,6 +100,7 @@ export function getEnvApiKey(provider: any): string | undefined {
 		zai: "ZAI_API_KEY",
 		mistral: "MISTRAL_API_KEY",
 		minimax: "MINIMAX_API_KEY",
+		"minimax-cn": "MINIMAX_CN_API_KEY",
 		opencode: "OPENCODE_API_KEY",
 	};
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -60,6 +60,7 @@ export type KnownProvider =
 	| "zai"
 	| "mistral"
 	| "minimax"
+	| "minimax-cn"
 	| "opencode";
 export type Provider = KnownProvider | string;
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -169,6 +169,7 @@ Add API keys to `~/.pi/agent/auth.json`:
 | Vercel AI Gateway | `vercel-ai-gateway` | `AI_GATEWAY_API_KEY` |
 | ZAI | `zai` | `ZAI_API_KEY` |
 | MiniMax | `minimax` | `MINIMAX_API_KEY` |
+| MiniMax (China) | `minimax-cn` | `MINIMAX_CN_API_KEY` |
 
 Auth file keys take priority over environment variables.
 
@@ -1153,7 +1154,7 @@ pi [options] [@files...] [messages...]
 
 | Option | Description |
 |--------|-------------|
-| `--provider <name>` | Provider: `anthropic`, `openai`, `openai-codex`, `google`, `google-vertex`, `amazon-bedrock`, `mistral`, `xai`, `groq`, `cerebras`, `openrouter`, `vercel-ai-gateway`, `zai`, `minimax`, `github-copilot`, `google-gemini-cli`, `google-antigravity`, or custom |
+| `--provider <name>` | Provider: `anthropic`, `openai`, `openai-codex`, `google`, `google-vertex`, `amazon-bedrock`, `mistral`, `xai`, `groq`, `cerebras`, `openrouter`, `vercel-ai-gateway`, `zai`, `minimax`, `minimax-cn`, `github-copilot`, `google-gemini-cli`, `google-antigravity`, or custom |
 | `--model <id>` | Model ID |
 | `--api-key <key>` | API key (overrides environment) |
 | `--system-prompt <text\|file>` | Custom system prompt (text or file path) |

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -28,6 +28,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	zai: "glm-4.6",
 	mistral: "devstral-medium-latest",
 	minimax: "MiniMax-M2.1",
+	"minimax-cn": "MiniMax-M2.1",
 	opencode: "claude-opus-4-5",
 };
 


### PR DESCRIPTION
Adds MiniMax China as a separate provider.

### Usage

Get api key from https://platform.minimaxi.com/docs/guides/quickstart .

```bash
export MINIMAX_CN_API_KEY=<api-key>
pi

# /model
→ MiniMax-M2.1 [minimax-cn] ✓
  MiniMax-M2 [minimax-cn]
```