### PR TITLE
fix(coding-agent): remember last selected model when using scoped models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Scoped models (`--models` or `enabledModels`) now remember the last selected model across sessions instead of always starting with the first model in the scope ([#736](https://github.com/badlogic/pi-mono/pull/736) by [@ogulcancelik](https://github.com/ogulcancelik))
 - Show `bun install` instead of `npm install` in update notification when running under Bun ([#714](https://github.com/badlogic/pi-mono/pull/714) by [@dannote](https://github.com/dannote))
 - `/skill` prompts now include the skill path ([#711](https://github.com/badlogic/pi-mono/pull/711) by [@jblwilliams](https://github.com/jblwilliams))
 - Use configurable `expandTools` keybinding instead of hardcoded Ctrl+O ([#717](https://github.com/badlogic/pi-mono/pull/717) by [@dannote](https://github.com/dannote))


### PR DESCRIPTION
When using scoped models (`--models` or `enabledModels` in settings), switching models mid-session would save the selection, but the next new session would always start with the first model in the scope instead of the saved default.

This fix checks if the saved default model is within the scoped models list. If yes, it uses the saved default; otherwise falls back to the first scoped model.

**Before:** New sessions always started with the first scoped model, ignoring saved selection.
**After:** New sessions start with the last selected model (if it's in scope), matching the behavior outside of scoped models.