### PR TITLE
docs(coding-agent): document vscode shift+enter for multi-line input

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -138,6 +138,17 @@ config.enable_kitty_keyboard = true
 return config
 ```
 
+**VS Code (Integrated Terminal):** Add to `keybindings.json` to enable `Shift+Enter` for multi-line input:
+
+```json
+{
+  "key": "shift+enter",
+  "command": "workbench.action.terminal.sendSequence",
+  "args": { "text": "\u001b[13;2u" },
+  "when": "terminalFocus"
+}
+```
+
 **Windows Terminal:** Does not support the Kitty keyboard protocol. Shift+Enter cannot be distinguished from Enter. Use Ctrl+Enter for multi-line input instead. All other keybindings work correctly.
 
 ### API Keys & OAuth


### PR DESCRIPTION

Add instructions to configure `keybindings.json` for Shift+Enter support in VS Code integrated terminal.

<img width="629" height="189" alt="image" src="https://github.com/user-attachments/assets/0d68ad2f-b0d8-4fe6-ade4-73fd1dd4e38c" />