### PR TITLE
Set CLI process name to 'pi'

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -5,6 +5,8 @@
  *
  * Test with: npx tsx src/cli-new.ts [args...]
  */
+process.title = "pi";
+
 import { main } from "./main.js";
 
 main(process.argv.slice(2));


### PR DESCRIPTION
Pi shows up as "node" in my tmux status line and when running `ps`.

This changes how it shows up in `ps` (on linux at least) and fixes my tmux status line.

Testing:
```
npm run build && node packages/coding-agent/dist/cli.js 
```

```
ps -eo pid,comm,args | rg -i '(^|\s)pi(\s|$)|/dist/cli\.js|@mariozechner/pi-coding-agent'                                                                                                                         5.859s

...other stuff
4133085 pi              pi
...other stuff
```

Not sure if `cli.ts` is the right place to set it? But seems ~sensible.