### PR TITLE
feat(coding-agent): show loaded prompt templates in init

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -596,6 +596,14 @@ export class InteractiveMode {
 			this.chatContainer.addChild(new Spacer(1));
 		}
 
+		// Show loaded prompt templates
+		const templates = this.session.promptTemplates;
+		if (templates.length > 0) {
+			const templateList = templates.map((t) => theme.fg("dim", `  /${t.name} ${t.source}`)).join("\n");
+			this.chatContainer.addChild(new Text(theme.fg("muted", "Loaded prompt templates:\n") + templateList, 0, 0));
+			this.chatContainer.addChild(new Spacer(1));
+		}
+
 		const extensionRunner = this.session.extensionRunner;
 		if (!extensionRunner) {
 			return; // No extensions loaded


### PR DESCRIPTION
Init UI example:
```
Loaded context:
  /Users/admin/.pi/agent/AGENTS.md

Loaded skills:
  /Users/admin/.claude/skills/typo-checker/SKILL.md

Loaded prompt templates:
  /git-commit (user:git)

Loaded extensions:
  /Users/admin/.pi/agent/extensions/custom-header.ts
```