### PR TITLE
fix(plan-mode): change shortcut from Shift+P to Ctrl+Alt+P

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Changed
 
 - Replaced `wasm-vips` with `@silvia-odwyer/photon-node` for image processing ([#710](https://github.com/badlogic/pi-mono/pull/710) by [@can1357](https://github.com/can1357))
+- Extension example: `plan-mode/` shortcut changed from Shift+P to Ctrl+Alt+P to avoid conflict with typing capital P ([#746](https://github.com/badlogic/pi-mono/pull/746) by [@ferologics](https://github.com/ferologics))
 
 ## [0.45.7] - 2026-01-13
 

--- a/packages/coding-agent/examples/extensions/plan-mode/README.md
+++ b/packages/coding-agent/examples/extensions/plan-mode/README.md
@@ -15,7 +15,7 @@ Read-only exploration mode for safe code analysis.
 
 - `/plan` - Toggle plan mode
 - `/todos` - Show current plan progress
-- `Shift+P` - Toggle plan mode (shortcut)
+- `Ctrl+Alt+P` - Toggle plan mode (shortcut)
 
 ## Usage
 

--- a/packages/coding-agent/examples/extensions/plan-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/plan-mode/index.ts
@@ -5,7 +5,7 @@
  * When enabled, only read-only tools are available.
  *
  * Features:
- * - /plan command or Shift+P to toggle
+ * - /plan command or Ctrl+Alt+P to toggle
  * - Bash restricted to allowlisted read-only commands
  * - Extracts numbered plan steps from "Plan:" sections
  * - [DONE:n] markers to complete steps during execution
@@ -113,7 +113,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		},
 	});
 
-	pi.registerShortcut(Key.shift("p"), {
+	pi.registerShortcut(Key.ctrlAlt("p"), {
 		description: "Toggle plan mode",
 		handler: async (ctx) => togglePlanMode(ctx),
 	});


### PR DESCRIPTION
## Problem

`Shift+P` conflicts with typing capital P, making the shortcut unusable in practice.

## Solution

Changed to `Ctrl+Alt+P` which is cross-platform safe and doesn't conflict with:
- `Ctrl+Shift+P` - command palette on Windows/VS Code
- `Shift+Alt+P` / `Option+Shift+P` - types π on macOS

## Changes

- `index.ts`: `Key.shift("p")" → `Key.ctrlAlt("p")`
- `README.md`: Updated shortcut documentation
- `CHANGELOG.md`: Added entry under `[Unreleased]`