### PR TITLE
Add direct filter shortcuts for Tree mode

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -750,9 +750,9 @@ class SearchLine implements Component {
 	render(width: number): string[] {
 		const query = this.treeList.getSearchQuery();
 		if (query) {
-			return [truncateToWidth(`  ${theme.fg("muted", "Search:")} ${theme.fg("accent", query)}`, width)];
+			return [truncateToWidth(`  ${theme.fg("muted", "Type to search:")} ${theme.fg("accent", query)}`, width)];
 		}
-		return [truncateToWidth(`  ${theme.fg("muted", "Search:")}`, width)];
+		return [truncateToWidth(`  ${theme.fg("muted", "Type to search:")}`, width)];
 	}
 
 	handleInput(_keyData: string): void {}
@@ -840,7 +840,7 @@ export class TreeSelectorComponent extends Container {
 		this.addChild(
 			new TruncatedText(
 				theme.fg("muted", "  ↑/↓: move. ←/→: page. l: label. ") +
-					theme.fg("dim", "^D/^T/^U/^L/^A: filters (^O/⇧^O cycle). Type to search"),
+					theme.fg("muted", "^D/^T/^U/^L/^A: filters (^O/⇧^O cycle)"),
 				0,
 				0,
 			),


### PR DESCRIPTION
While using `/tree` I was wishing I could filter for e.g. user messages a bit more conveniently, so this adds keyboard shortcuts to jump directly to specific filter modes in Tree mode. This is how it looks like:

<img width="1440" height="166" alt="CleanShot 2026-01-15 at 12 53 36@2x" src="https://github.com/user-attachments/assets/07a1e5d7-0ba4-447b-ba02-9a2f80845480" />

Let me know if it's too much for the shortcut bar and I'm happy to tweaks (or hide it, if you're fine with it being a secret feature :D)

The shortcuts are hardcoded for now like the cycling ones were, since I'm not sure they quite fit under editor shortcuts and adding a specific map for tree sounds more involved.

### Changes

- **`Ctrl+D`** - Set to `default` filter
- **`Ctrl+T`** - Toggle `no-tools` ↔ `default`
- **`Ctrl+U`** - Toggle `user-only` ↔ `default`
- **`Ctrl+L`** - Toggle `labeled-only` ↔ `default`
- **`Ctrl+A`** - Toggle `all` ↔ `default`
- Kept `Ctrl+O` / `Shift+Ctrl+O` cycle shortcuts
- Updated help text: `^D/^T/^U/^L/^A: filters (^O/⇧^O cycle)`
