### PR TITLE
feat(coding-agent): export getAgentDir for extensions

### DIFF
--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -1,4 +1,7 @@
 // Core session management
+
+// Config paths
+export { getAgentDir } from "./config.js";
 export {
 	AgentSession,
 	type AgentSessionConfig,


### PR DESCRIPTION
**Problem**

Extensions that need to read/write files in the pi config directory (e.g., `~/.pi/agent/`) currently have to reimplement the path logic, including handling the `PI_CODING_AGENT_DIR` environment variable.

**Solution**

Export `getAgentDir()` from `@mariozechner/pi-coding-agent` so extensions can use the same path resolution as pi itself.

**Changes**

- `packages/coding-agent/src/index.ts`: Export `getAgentDir` from `./config.js`

**Example**

```typescript
import { getAgentDir } from "@mariozechner/pi-coding-agent";
import { join } from "node:path";

const envPath = join(getAgentDir(), "env.json");
```