### PR TITLE
fix: use bash completions for !/!! autocomplete

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Session tree now preserves branch connectors and indentation when filters hide intermediate entries so descendants attach to the nearest visible ancestor and sibling branches align. Fixed in both TUI and HTML export ([#739](https://github.com/badlogic/pi-mono/pull/739) by [@w-winter](https://github.com/w-winter))
+- Bash mode tab completion now uses bash completions for `!`/`!!` commands when available
 
 ## [0.46.0] - 2026-01-15
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -60,6 +60,7 @@ import type { TruncationResult } from "../../core/tools/truncate.js";
 import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/changelog.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.js";
+import { getShellConfig } from "../../utils/shell.js";
 
 import { ensureTool } from "../../utils/tools-manager.js";
 import { ArminComponent } from "./components/armin.js";
@@ -334,10 +335,18 @@ export class InteractiveMode {
 		}
 
 		// Setup autocomplete
+		let shellPath: string | undefined;
+		try {
+			shellPath = getShellConfig().shell;
+		} catch {
+			shellPath = undefined;
+		}
+
 		this.autocompleteProvider = new CombinedAutocompleteProvider(
 			[...slashCommands, ...templateCommands, ...extensionCommands, ...skillCommandList],
 			process.cwd(),
 			fdPath,
+			shellPath,
 		);
 		this.defaultEditor.setAutocompleteProvider(this.autocompleteProvider);
 	}

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Shell command tab completion now uses bash completions for `!`/`!!` commands when available
+
 ## [0.46.0] - 2026-01-15
 
 ### Fixed

--- a/packages/tui/src/bash-completion-script.ts
+++ b/packages/tui/src/bash-completion-script.ts
@@ -1,0 +1,93 @@
+export const bashCompletionScript = `set -o pipefail
+shopt -s progcomp
+completion_file=""
+for candidate in "\${BASH_COMPLETION_COMPAT_DIR:-}/bash_completion" "/usr/local/etc/bash_completion" "/opt/homebrew/etc/bash_completion" "/usr/share/bash-completion/bash_completion" "/usr/local/share/bash-completion/bash_completion" "/opt/homebrew/share/bash-completion/bash_completion" "/usr/local/etc/profile.d/bash_completion.sh" "/opt/homebrew/etc/profile.d/bash_completion.sh" "/etc/bash_completion"; do
+  if [[ -n "$candidate" && -r "$candidate" ]]; then
+    completion_file="$candidate"
+    break
+  fi
+done
+if [[ -n "$completion_file" ]]; then
+  source "$completion_file"
+fi
+
+load_command_completion() {
+  local cmd="$1"
+  local -a candidates
+  candidates=(
+    "/etc/bash_completion.d/$cmd"
+    "/usr/local/etc/bash_completion.d/$cmd"
+    "/opt/homebrew/etc/bash_completion.d/$cmd"
+    "/usr/share/bash-completion/completions/$cmd"
+    "/usr/local/share/bash-completion/completions/$cmd"
+    "/opt/homebrew/share/bash-completion/completions/$cmd"
+  )
+
+  if [[ "$cmd" = "git" ]]; then
+    local exec_path=""
+    if command -v git >/dev/null 2>&1; then
+      exec_path=$(git --exec-path 2>/dev/null)
+    fi
+    if [[ -n "$exec_path" ]]; then
+      candidates+=("\${exec_path%/git-core}/../share/git-core/git-completion.bash")
+      candidates+=("\${exec_path%/libexec/git-core}/share/git-core/git-completion.bash")
+    fi
+    candidates+=(
+      "/usr/share/git-core/git-completion.bash"
+      "/usr/local/share/git-core/git-completion.bash"
+      "/opt/homebrew/share/git-core/git-completion.bash"
+      "/Applications/Xcode.app/Contents/Developer/usr/share/git-core/git-completion.bash"
+    )
+  fi
+
+  local candidate
+  for candidate in "\${candidates[@]}"; do
+    if [[ -n "$candidate" && -r "$candidate" ]]; then
+      source "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+line="$PI_BASH_COMPLETION_LINE"
+point="$PI_BASH_COMPLETION_POINT"
+if [[ -z "$line" ]]; then exit 0; fi
+COMP_LINE="$line"
+COMP_POINT=$point
+read -ra COMP_WORDS <<< "$line"
+word_index=0
+in_word=0
+for ((i=0; i<point; i++)); do
+  ch="\${line:i:1}"
+  if [[ "$ch" =~ [[:space:]] ]]; then
+    if (( in_word )); then
+      in_word=0
+      word_index=$((word_index+1))
+    fi
+  else
+    in_word=1
+  fi
+done
+COMP_CWORD=$word_index
+if (( COMP_CWORD >= \${#COMP_WORDS[@]} )); then
+  COMP_WORDS+=("")
+fi
+cmd="\${COMP_WORDS[0]}"
+if [[ -z "$cmd" ]]; then exit 0; fi
+if type _completion_loader >/dev/null 2>&1; then
+  _completion_loader "$cmd" >/dev/null 2>&1
+fi
+completion=$(complete -p "$cmd" 2>/dev/null | head -n 1)
+if [[ -z "$completion" ]]; then
+  load_command_completion "$cmd"
+  completion=$(complete -p "$cmd" 2>/dev/null | head -n 1)
+fi
+if [[ -z "$completion" ]]; then exit 0; fi
+cur="\${COMP_WORDS[COMP_CWORD]}"
+comp_cmd=\${completion#complete }
+comp_cmd=\${comp_cmd% $cmd}
+comp_cmd=\${comp_cmd% --}
+eval "compgen \${comp_cmd} -- \\"$cur\\""
+`;


### PR DESCRIPTION
**Problem**

Bash-mode tab completion (`!` / `!!`) falls back to file paths and ignores command-specific completions (e.g., `!git comm` + <kbd>Tab</kbd> shows directories instead of `commit`).

**Solution**

Run bash completion scripts for shell-mode suggestions and filter results by the typed prefix.

**Changes**

- `packages/tui/src/bash-completion-script.ts`: load bash completion sources and per-command fallbacks
- `packages/tui/src/autocomplete.ts`: invoke bash completion script, filter results by prefix
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: pass resolved shell path to autocomplete
- `packages/tui/test/autocomplete.test.ts`: add shell completion coverage for `!` paths/commands

**Tests**

- `npm run check`
- `npm run test`
- Manual: verified `!git` completion works
