### PR TITLE
fix(coding-agent): prevent duplicate rendering of extension messages on startup

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -145,6 +145,7 @@ export class InteractiveMode {
 	private keybindings: KeybindingsManager;
 	private version: string;
 	private isInitialized = false;
+	private hasRenderedInitialMessages = false;
 	private onInputCallback?: (text: string) => void;
 	private loadingAnimation: Loader | undefined = undefined;
 	private readonly defaultWorkingMessage = "Working...";
@@ -619,7 +620,9 @@ export class InteractiveMode {
 					this.session
 						.sendCustomMessage(message, options)
 						.then(() => {
-							if (!wasStreaming && message.display) {
+							// Don't rebuild if initial render hasn't happened yet
+							// (renderInitialMessages will handle it)
+							if (!wasStreaming && message.display && this.hasRenderedInitialMessages) {
 								this.rebuildChatFromMessages();
 							}
 						})
@@ -2007,6 +2010,7 @@ export class InteractiveMode {
 	}
 
 	renderInitialMessages(): void {
+		this.hasRenderedInitialMessages = true;
 		// Get aligned messages and entries from session context
 		const context = this.sessionManager.buildSessionContext();
 		this.renderSessionContext(context, {


### PR DESCRIPTION
## Problem

Extensions that call `pi.sendMessage({ display: true })` during the `session_start` event have their messages rendered twice on startup.

## Cause

During initialization:
1. `initExtensions()` emits `session_start` event
2. Extension calls `pi.sendMessage({ display: true })`
3. The `sendMessage` handler's `.then()` callback calls `rebuildChatFromMessages()`
4. Then `renderInitialMessages()` is called after `init()` completes
5. Both render the same message

## Solution

Add a `hasRenderedInitialMessages` flag that prevents `rebuildChatFromMessages()` from being called before the initial render. The `renderInitialMessages()` method will handle rendering those messages.