### PR TITLE
feat(coding-agent): export getShellConfig for extensions

### DIFF
--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -280,3 +280,5 @@ export {
 	type ThemeColor,
 } from "./modes/interactive/theme/theme.js";
 export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.js";
+// Shell utilities
+export { getShellConfig } from "./utils/shell.js";


### PR DESCRIPTION
**Problem**

Extensions that need to spawn bash (e.g., for tab completions) currently have to reimplement shell detection logic, missing user's `shellPath` setting and Windows Git Bash detection.

**Solution**

Export `getShellConfig()` from `@mariozechner/pi-coding-agent` so extensions can use the same shell resolution as the core bash tool.

**Changes**

- `packages/coding-agent/src/index.ts`: Export `getShellConfig` from `./utils/shell.js`

**Example**

```ts
import { getShellConfig } from "@mariozechner/pi-coding-agent";

const { shell, args } = getShellConfig();
spawnSync(shell, [...args, script], { ... });
```

**Use case**

[bash-completion extension](https://github.com/dannote/dot-pi/tree/master/extensions/bash-completion)