### PR TITLE
Add Codex retry parity for pi

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -77,6 +77,9 @@ export interface AgentOptions {
 	 * Custom token budgets for thinking levels (token-based providers only).
 	 */
 	thinkingBudgets?: ThinkingBudgets;
+	requestMaxRetries?: number;
+	requestBaseDelayMs?: number;
+	streamIdleTimeoutMs?: number;
 }
 
 export class Agent {
@@ -106,6 +109,9 @@ export class Agent {
 	private runningPrompt?: Promise<void>;
 	private resolveRunningPrompt?: () => void;
 	private _thinkingBudgets?: ThinkingBudgets;
+	private _requestMaxRetries?: number;
+	private _requestBaseDelayMs?: number;
+	private _streamIdleTimeoutMs?: number;
 
 	constructor(opts: AgentOptions = {}) {
 		this._state = { ...this._state, ...opts.initialState };
@@ -117,6 +123,9 @@ export class Agent {
 		this._sessionId = opts.sessionId;
 		this.getApiKey = opts.getApiKey;
 		this._thinkingBudgets = opts.thinkingBudgets;
+		this._requestMaxRetries = opts.requestMaxRetries;
+		this._requestBaseDelayMs = opts.requestBaseDelayMs;
+		this._streamIdleTimeoutMs = opts.streamIdleTimeoutMs;
 	}
 
 	/**
@@ -333,6 +342,9 @@ export class Agent {
 			reasoning,
 			sessionId: this._sessionId,
 			thinkingBudgets: this._thinkingBudgets,
+			requestMaxRetries: this._requestMaxRetries,
+			requestBaseDelayMs: this._requestBaseDelayMs,
+			streamIdleTimeoutMs: this._streamIdleTimeoutMs,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
 			getApiKey: this.getApiKey,

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed OpenCode provider's `/v1` endpoint to use `system` role instead of `developer` role, fixing `400 Incorrect role information` error for models using `openai-completions` API ([#755](https://github.com/badlogic/pi-mono/pull/755) by [@melihmucuk](https://github.com/melihmucuk))
+- OpenAI Codex responses now retry transport failures, add session routing headers, and classify stream disconnects/rate limits with idle timeouts for retry handling.
 
 ## [0.46.0] - 2026-01-15
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -212,6 +212,9 @@ function mapOptionsForApi<TApi extends Api>(
 		signal: options?.signal,
 		apiKey: apiKey || options?.apiKey,
 		sessionId: options?.sessionId,
+		requestMaxRetries: options?.requestMaxRetries,
+		requestBaseDelayMs: options?.requestBaseDelayMs,
+		streamIdleTimeoutMs: options?.streamIdleTimeoutMs,
 	};
 
 	// Helper to clamp xhigh to high for providers that don't support it

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -86,6 +86,9 @@ export interface StreamOptions {
 	 * session-aware features. Ignored by providers that don't support it.
 	 */
 	sessionId?: string;
+	requestMaxRetries?: number;
+	requestBaseDelayMs?: number;
+	streamIdleTimeoutMs?: number;
 }
 
 // Unified options with reasoning passed to streamSimple() and completeSimple()
@@ -145,6 +148,12 @@ export interface Usage {
 
 export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
 
+export interface ErrorDetails {
+	retryable?: boolean;
+	retryAfterMs?: number;
+	kind?: string;
+}
+
 export interface UserMessage {
 	role: "user";
 	content: string | (TextContent | ImageContent)[];
@@ -160,6 +169,7 @@ export interface AssistantMessage {
 	usage: Usage;
 	stopReason: StopReason;
 	errorMessage?: string;
+	errorDetails?: ErrorDetails;
 	timestamp: number; // Unix timestamp in milliseconds
 }
 

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -86,16 +86,21 @@ const OVERFLOW_PATTERNS = [
  */
 export function isContextOverflow(message: AssistantMessage, contextWindow?: number): boolean {
 	// Case 1: Check error message patterns
-	if (message.stopReason === "error" && message.errorMessage) {
-		// Check known patterns
-		if (OVERFLOW_PATTERNS.some((p) => p.test(message.errorMessage!))) {
+	if (message.stopReason === "error") {
+		if (message.errorDetails?.kind === "context_length_exceeded") {
 			return true;
 		}
+		if (message.errorMessage) {
+			// Check known patterns
+			if (OVERFLOW_PATTERNS.some((p) => p.test(message.errorMessage!))) {
+				return true;
+			}
 
-		// Cerebras and Mistral return 400/413/429 with no body - check for status code pattern
-		// 429 can indicate token-based rate limiting which correlates with context overflow
-		if (/^4(00|13|29)\s*(status code)?\s*\(no body\)/i.test(message.errorMessage)) {
-			return true;
+			// Cerebras and Mistral return 400/413/429 with no body - check for status code pattern
+			// 429 can indicate token-based rate limiting which correlates with context overflow
+			if (/^4(00|13|29)\s*(status code)?\s*\(no body\)/i.test(message.errorMessage)) {
+				return true;
+			}
 		}
 	}
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `retry.streamMaxRetries` and `retry.streamIdleTimeoutMs` settings for Codex stream reconnect handling.
+
 ### Fixed
 
 - Session tree now preserves branch connectors and indentation when filters hide intermediate entries so descendants attach to the nearest visible ancestor and sibling branches align. Fixed in both TUI and HTML export ([#739](https://github.com/badlogic/pi-mono/pull/739) by [@w-winter](https://github.com/w-winter))
+- Auto-retry now treats Codex stream disconnects and rate limits as retryable, honoring retry-after delays when provided.
 
 ## [0.46.0] - 2026-01-15
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -752,7 +752,9 @@ Global `~/.pi/agent/settings.json` stores persistent preferences:
   "retry": {
     "enabled": true,
     "maxRetries": 3,
-    "baseDelayMs": 2000
+    "baseDelayMs": 2000,
+    "streamMaxRetries": 5,
+    "streamIdleTimeoutMs": 300000
   },
   "terminal": {
     "showImages": true
@@ -784,6 +786,8 @@ Global `~/.pi/agent/settings.json` stores persistent preferences:
 | `retry.enabled` | Auto-retry on transient errors | `true` |
 | `retry.maxRetries` | Maximum retry attempts | `3` |
 | `retry.baseDelayMs` | Base delay for exponential backoff | `2000` |
+| `retry.streamMaxRetries` | Maximum stream reconnect attempts | `5` |
+| `retry.streamIdleTimeoutMs` | Stream idle timeout before retry (ms) | `300000` |
 | `terminal.showImages` | Render images inline (supported terminals) | `true` |
 | `images.autoResize` | Auto-resize images to 2000x2000 max for better model compatibility | `true` |
 | `images.blockImages` | Prevent images from being sent to LLM providers | `false` |

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -437,6 +437,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const contextFiles = options.contextFiles ?? discoverContextFiles(cwd, agentDir);
 	time("discoverContextFiles");
 
+	const retrySettings = settingsManager.getRetrySettings();
+	const requestRetryOverrides = retrySettings.enabled ? {} : { requestMaxRetries: 0 };
 	const autoResizeImages = settingsManager.getImageAutoResize();
 	// Create ALL built-in tools for the registry (extensions can enable any of them)
 	const allBuiltInToolsMap = createAllTools(cwd, { read: { autoResizeImages } });
@@ -628,6 +630,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		steeringMode: settingsManager.getSteeringMode(),
 		followUpMode: settingsManager.getFollowUpMode(),
 		thinkingBudgets: settingsManager.getThinkingBudgets(),
+		streamIdleTimeoutMs: retrySettings.streamIdleTimeoutMs,
+		...requestRetryOverrides,
 		getApiKey: async (provider) => {
 			// Use the provider argument from the in-flight request;
 			// agent.state.model may already be switched mid-turn.

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -16,6 +16,8 @@ export interface RetrySettings {
 	enabled?: boolean; // default: true
 	maxRetries?: number; // default: 3
 	baseDelayMs?: number; // default: 2000 (exponential backoff: 2s, 4s, 8s)
+	streamMaxRetries?: number;
+	streamIdleTimeoutMs?: number;
 }
 
 export interface SkillsSettings {
@@ -320,11 +322,19 @@ export class SettingsManager {
 		this.save();
 	}
 
-	getRetrySettings(): { enabled: boolean; maxRetries: number; baseDelayMs: number } {
+	getRetrySettings(): {
+		enabled: boolean;
+		maxRetries: number;
+		baseDelayMs: number;
+		streamMaxRetries: number;
+		streamIdleTimeoutMs: number;
+	} {
 		return {
 			enabled: this.getRetryEnabled(),
 			maxRetries: this.settings.retry?.maxRetries ?? 3,
 			baseDelayMs: this.settings.retry?.baseDelayMs ?? 2000,
+			streamMaxRetries: this.settings.retry?.streamMaxRetries ?? 5,
+			streamIdleTimeoutMs: this.settings.retry?.streamIdleTimeoutMs ?? 300000,
 		};
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1821,11 +1821,13 @@ export class InteractiveMode {
 				// Show retry indicator
 				this.statusContainer.clear();
 				const delaySeconds = Math.round(event.delayMs / 1000);
+				const isStreamRetry = event.errorKind === "stream_disconnect" || event.errorKind === "stream_idle_timeout";
+				const retryLabel = isStreamRetry ? "Reconnecting" : "Retrying";
 				this.retryLoader = new Loader(
 					this.ui,
 					(spinner) => theme.fg("warning", spinner),
 					(text) => theme.fg("muted", text),
-					`Retrying (${event.attempt}/${event.maxAttempts}) in ${delaySeconds}s... (${appKey(this.keybindings, "interrupt")} to cancel)`,
+					`${retryLabel} (${event.attempt}/${event.maxAttempts}) in ${delaySeconds}s... (${appKey(this.keybindings, "interrupt")} to cancel)`,
 				);
 				this.statusContainer.addChild(this.retryLoader);
 				this.ui.requestRender();


### PR DESCRIPTION
## Summary
- add Codex transport retry + stream disconnect/idle classification with retry metadata
- propagate retry metadata to AgentSession/UI and expose stream retry settings
- extend Codex streaming tests for retries and usage limits

## Testing
- npm run check