### PR TITLE
feat(coding-agent): extension command argument autocomplete

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - New `input` event in extension system for intercepting, transforming, or handling user input before the agent processes it. Supports three result types: `continue` (pass through), `transform` (modify text/images), `handled` (respond without LLM). Handlers chain transforms and short-circuit on handled.
 - Extension example: `input-transform.ts` demonstrating input interception patterns (quick mode, instant commands, source routing)
+- Extension commands can provide argument auto-completions via `getArgumentCompletions` in `pi.registerCommand()`.
 
 ### Fixed
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -856,6 +856,25 @@ pi.registerCommand("stats", {
 });
 ```
 
+Optional: add argument auto-completion for `/command ...`:
+
+```typescript
+import type { AutocompleteItem } from "@mariozechner/pi-tui";
+
+pi.registerCommand("deploy", {
+  description: "Deploy to an environment",
+  getArgumentCompletions: (prefix: string): AutocompleteItem[] | null => {
+    const envs = ["dev", "staging", "prod"];
+    const items = envs.map((e) => ({ value: e, label: e }));
+    const filtered = items.filter((i) => i.value.startsWith(prefix));
+    return filtered.length > 0 ? filtered : null;
+  },
+  handler: async (args, ctx) => {
+    ctx.ui.notify(`Deploying: ${args}`, "info");
+  },
+});
+```
+
 **Examples:** [custom-footer.ts](../examples/extensions/custom-footer.ts), [custom-header.ts](../examples/extensions/custom-header.ts), [handoff.ts](../examples/extensions/handoff.ts), [pirate.ts](../examples/extensions/pirate.ts), [plan-mode/index.ts](../examples/extensions/plan-mode/index.ts), [preset.ts](../examples/extensions/preset.ts), [qna.ts](../examples/extensions/qna.ts), [send-user-message.ts](../examples/extensions/send-user-message.ts), [snake.ts](../examples/extensions/snake.ts), [summarize.ts](../examples/extensions/summarize.ts), [todo.ts](../examples/extensions/todo.ts), [tools.ts](../examples/extensions/tools.ts)
 
 ### pi.registerMessageRenderer(customType, renderer)

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -150,7 +150,7 @@ function createExtensionAPI(
 			});
 		},
 
-		registerCommand(name: string, options: { description?: string; handler: RegisteredCommand["handler"] }): void {
+		registerCommand(name: string, options: Omit<RegisteredCommand, "name">): void {
 			extension.commands.set(name, { name, ...options });
 		},
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -16,6 +16,7 @@ import type {
 } from "@mariozechner/pi-agent-core";
 import type { ImageContent, Model, TextContent, ToolResultMessage } from "@mariozechner/pi-ai";
 import type {
+	AutocompleteItem,
 	Component,
 	EditorComponent,
 	EditorTheme,
@@ -655,6 +656,7 @@ export type MessageRenderer<T = unknown> = (
 export interface RegisteredCommand {
 	name: string;
 	description?: string;
+	getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null;
 	handler: (args: string, ctx: ExtensionCommandContext) => Promise<void>;
 }
 
@@ -714,7 +716,7 @@ export interface ExtensionAPI {
 	// =========================================================================
 
 	/** Register a custom command. */
-	registerCommand(name: string, options: { description?: string; handler: RegisteredCommand["handler"] }): void;
+	registerCommand(name: string, options: Omit<RegisteredCommand, "name">): void;
 
 	/** Register a keyboard shortcut. */
 	registerShortcut(

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -319,6 +319,7 @@ export class InteractiveMode {
 			(cmd) => ({
 				name: cmd.name,
 				description: cmd.description ?? "(extension command)",
+				getArgumentCompletions: cmd.getArgumentCompletions,
 			}),
 		);
 


### PR DESCRIPTION
I've added a new optional `getArgumentCompletions()` method to `pi.registerCommand()`. This exposes the existing autocomplete mechanism, currently used by the built-in `/model` command, to extensions.

- Motivation: I wanted to enable "git-like" commands for extensions, where the system provides suggestions not just for the primary slash command, but for its parameters as well. Currently, extension commands lack this discovery layer, making complex subcommands harder to use compared to built-in features.

- Changes:
    - Updated `RegisteredCommand` to support the optional `getArgumentCompletions(argumentPrefix)` callback.
    - Tweaked the extension loader so it actually holds onto this callback alongside the main command handler.
    - Wired the interactive mode's autocomplete logic to pull suggestions from extensions when a user starts typing arguments.
    - Brushed up the docs and changelog to reflect the new API option.

- Testing:
    - Created a dummy extension with nested subcommands and verified that suggestions appear correctly after the initial slash command.
    - Double-checked that I didn't break the existing `/model` autocomplete—everything there is still working smoothly.
