### PR TITLE
fix(coding-agent): expand tilde in PI_CODING_AGENT_DIR env var

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fixed extension messages rendering twice on startup when `pi.sendMessage({ display: true })` is called during `session_start` ([#765](https://github.com/badlogic/pi-mono/pull/765) by [@dannote](https://github.com/dannote))
+- Fixed `PI_CODING_AGENT_DIR` env var not expanding tilde (`~`) to home directory ([#768](https://github.com/badlogic/pi-mono/pull/778) by [@aliou](https://github.com/aliou))
 
 ## [0.47.0] - 2026-01-16
 

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -122,7 +122,14 @@ export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
 
 /** Get the agent config directory (e.g., ~/.pi/agent/) */
 export function getAgentDir(): string {
-	return process.env[ENV_AGENT_DIR] || join(homedir(), CONFIG_DIR_NAME, "agent");
+	const envDir = process.env[ENV_AGENT_DIR];
+	if (envDir) {
+		// Expand tilde to home directory
+		if (envDir === "~") return homedir();
+		if (envDir.startsWith("~/")) return homedir() + envDir.slice(1);
+		return envDir;
+	}
+	return join(homedir(), CONFIG_DIR_NAME, "agent");
 }
 
 /** Get path to user's custom themes directory */


### PR DESCRIPTION
Hello! 

Noticed that the `~` isn't expanded when using it with `PI_CODING_AGENT_DIR`. This meant that the skills in that directory weren't discovered.

<details><summary>Summary by Opus:</summary>
<p>


## Problem

When setting `PI_CODING_AGENT_DIR=~/custom/path/`, skills and other resources in that directory weren't discovered. The tilde was treated as a literal character instead of being expanded to the home directory.

## Investigation

Traced the issue to `getAgentDir()` in `config.ts` which returns the env var value as-is without tilde expansion:

```typescript
export function getAgentDir(): string {
    return process.env[ENV_AGENT_DIR] || join(homedir(), CONFIG_DIR_NAME, "agent");
}
```

This is inconsistent with other path handling in the codebase:

- `path-utils.ts:expandPath()` - expands `~` for tool paths
- `extensions/loader.ts:expandPath()` - expands `~` for extension paths
- `skills.ts` custom directories - expands `~` via `customDir.replace(/^~(?=$|[\\/])/, homedir())`

## Fix

Added tilde expansion to `getAgentDir()` matching the pattern used elsewhere.


</p>
</details>