### PR TITLE
fix(tui): decode Kitty CSI-u shifted symbols

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `PI_NO_HARDWARE_CURSOR=1` environment variable to disable hardware cursor positioning for terminals with limited escape sequence support (e.g., IntelliJ IDEA's built-in terminal)
 
+### Fixed
+
+- Decode Kitty CSI-u printable sequences in the editor so shifted symbol keys (e.g., `@`, `?`) work in terminals that enable Kitty keyboard protocol
+
 ## [0.47.0] - 2026-01-16
 
 ### Breaking Changes


### PR DESCRIPTION
## Issue
When WezTerm has Kitty keyboard protocol enabled, shifted symbol keys (for example Shift+2 → `@`, Shift+/ → `?`) were not inserted in pi’s editor. Letters still worked, but symbols were dropped.

This PR fixes WezTerm + Kitty keyboard protocol input so shifted symbols (e.g., `@`, `?`) are inserted correctly in the editor.

## Background
With Kitty flag 4 enabled, WezTerm sends CSI‑u sequences that include both the base key and the shifted key codepoint. The editor only accepted raw printable characters, so shifted symbols were dropped. This regressed in v0.46.0 (commit `15a9670`) when Kitty alternate key reporting was enabled to support non‑Latin shortcuts.

## Changes
- Decode CSI‑u printable sequences in `packages/tui/src/components/editor.ts` and insert the shifted key codepoint when Shift is set.
- Add a changelog entry in `packages/tui/CHANGELOG.md`.
