### PR TITLE
feat(coding-agent): display timeout in bash tool UI

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -341,10 +341,16 @@ export class ToolExecutionComponent extends Container {
 	 */
 	private renderBashContent(): void {
 		const command = this.args?.command || "";
+		const timeout = this.args?.timeout as number | undefined;
 
 		// Header
+		const timeoutSuffix = timeout ? theme.fg("muted", ` (timeout ${timeout}s)`) : "";
 		this.contentBox.addChild(
-			new Text(theme.fg("toolTitle", theme.bold(`$ ${command || theme.fg("toolOutput", "...")}`)), 0, 0),
+			new Text(
+				theme.fg("toolTitle", theme.bold(`$ ${command || theme.fg("toolOutput", "...")}`)) + timeoutSuffix,
+				0,
+				0,
+			),
 		);
 
 		if (this.result) {


### PR DESCRIPTION
**Problem**

When the LLM uses the bash tool with a timeout, there's no visual indication of the timeout in the UI.

**Solution**

Display the timeout in the bash command header:

```
$ sleep 60 (timeout 30s)
```

**Changes**

- `packages/coding-agent/src/modes/interactive/components/tool-execution.ts`: Add timeout suffix to bash header in `renderBashContent()`

**Note**

Checked if this could be done via extension — it can't. Extensions can only provide custom renderers for their own tools, not override built-in tool rendering.