### PR TITLE
fix(ai): coerce string numbers in tool argument validation

### DIFF
--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -19,6 +19,7 @@ if (!isBrowserExtension) {
 		ajv = new Ajv({
 			allErrors: true,
 			strict: false,
+			coerceTypes: true,
 		});
 		addFormats(ajv);
 	} catch (_e) {


### PR DESCRIPTION
**Problem**

LLMs sometimes output JSON with string values for numeric parameters (e.g., `"500"` instead of `500`). This causes tool argument validation to fail with errors like:

```
Validation failed for tool "read":
  - offset: must be number
  - limit: must be number
```

**Solution**

Enable AJV's `coerceTypes` option to automatically convert string numbers to actual numbers when the schema expects a number type.

**Changes**

- `packages/ai/src/utils/validation.ts`: Add `coerceTypes: true` to AJV configuration