### PR TITLE
Generate OpenCode Zen models automatically

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -57,6 +57,7 @@ Unified LLM API with automatic model discovery, provider configuration, token an
 - **xAI**
 - **OpenRouter**
 - **Vercel AI Gateway**
+- **OpenCode Zen**
 - **MiniMax**
 - **GitHub Copilot** (requires OAuth, see below)
 - **Google Gemini CLI** (requires OAuth, see below)
@@ -865,6 +866,7 @@ In Node.js environments, you can set environment variables to avoid passing API 
 | xAI | `XAI_API_KEY` |
 | OpenRouter | `OPENROUTER_API_KEY` |
 | Vercel AI Gateway | `AI_GATEWAY_API_KEY` |
+| OpenCode Zen | `OPENCODE_API_KEY` |
 | zAI | `ZAI_API_KEY` |
 | MiniMax | `MINIMAX_API_KEY` |
 | GitHub Copilot | `COPILOT_GITHUB_TOKEN` or `GH_TOKEN` or `GITHUB_TOKEN` |

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -3907,9 +3907,9 @@ export const MODELS = {
 		"alpha-gd4": {
 			id: "alpha-gd4",
 			name: "Alpha GD4",
-			api: "anthropic-messages",
+			api: "openai-completions",
 			provider: "opencode",
-			baseUrl: "https://opencode.ai/zen",
+			baseUrl: "https://opencode.ai/zen/v1",
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -3920,7 +3920,7 @@ export const MODELS = {
 			},
 			contextWindow: 262144,
 			maxTokens: 32768,
-		} satisfies Model<"anthropic-messages">,
+		} satisfies Model<"openai-completions">,
 		"alpha-glm-4.7": {
 			id: "alpha-glm-4.7",
 			name: "Alpha GLM-4.7",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -32,11 +32,12 @@ export interface ApiOptionsMap {
 }
 
 // Compile-time exhaustiveness check - this will fail if ApiOptionsMap doesn't have all KnownApi keys
-type _CheckExhaustive = ApiOptionsMap extends Record<Api, StreamOptions>
-	? Record<Api, StreamOptions> extends ApiOptionsMap
-		? true
-		: ["ApiOptionsMap is missing some KnownApi values", Exclude<Api, keyof ApiOptionsMap>]
-	: ["ApiOptionsMap doesn't extend Record<KnownApi, StreamOptions>"];
+type _CheckExhaustive =
+	ApiOptionsMap extends Record<Api, StreamOptions>
+		? Record<Api, StreamOptions> extends ApiOptionsMap
+			? true
+			: ["ApiOptionsMap is missing some KnownApi values", Exclude<Api, keyof ApiOptionsMap>]
+		: ["ApiOptionsMap doesn't extend Record<KnownApi, StreamOptions>"];
 const _exhaustive: _CheckExhaustive = true;
 
 // Helper type to get options for a specific API


### PR DESCRIPTION
I tried this out locally and it worked okay.

It fetches their models from their API endpoint and merge the metadata grabbed from models.dev that matches the OpenCode Zen provider.