### PR TITLE
feat: embedded sessions infrastructure for extensions

### DIFF
--- a/packages/coding-agent/examples/extensions/embedded-sessions/README.md
+++ b/packages/coding-agent/examples/extensions/embedded-sessions/README.md
@@ -1,0 +1,119 @@
+# Embedded Sessions Extension
+
+Child agent sessions that run in an overlay within the parent session. Useful for focused subtasks, exploration, or read-only review without polluting the main conversation.
+
+## Installation
+
+Copy this directory to your extensions folder:
+
+```bash
+cp -r embedded-sessions ~/.pi/agent/extensions/
+```
+
+Or symlink for development:
+
+```bash
+ln -s /path/to/pi-mono/packages/coding-agent/examples/extensions/embedded-sessions ~/.pi/agent/extensions/
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/embed [message]` | Open embedded session with optional initial message |
+| `/embed-context` | Session with recent parent conversation forked in |
+
+## Keybindings
+
+Inside the embedded session overlay:
+
+| Key | Action |
+|-----|--------|
+| Enter | Send message |
+| Escape | Abort (if streaming) or cancel session |
+| `/model` | Switch model |
+| `/done` | Complete session (generates summary) |
+| `/compact` | Compact session history |
+
+## Features
+
+- **Tool inheritance**: Inherits parent's tools by default
+- **Tool exclusion**: Exclude specific tools (e.g., `["write", "edit"]` for read-only)
+- **Parent context**: Optionally fork recent conversation history
+- **Persistence**: Sessions saved to `~/.pi/agent/sessions/embedded/{parent-id}/`
+- **Summary**: Extracts summary from last assistant response on `/done`
+- **File tracking**: Tracks files read and modified during session
+- **Session refs**: Reference stored in parent session showing completion status, duration, files, tokens
+
+## Programmatic Usage
+
+Extensions can create embedded sessions directly:
+
+```typescript
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { EmbeddedSessionComponent } from "./embedded-sessions/embedded-session-component.js";
+
+export default function myExtension(pi: ExtensionAPI) {
+  pi.registerCommand("my-embed", {
+    description: "Custom embedded session",
+    handler: async (args, ctx) => {
+      const result = await ctx.ui.custom(
+        async (tui, _theme, keybindings, done) => {
+          return EmbeddedSessionComponent.create({
+            tui,
+            parentSession: ctx.session,
+            options: {
+              title: "My Task",
+              initialMessage: args.trim() || undefined,
+              excludeTools: ["write"], // read-only
+            },
+            keybindings,
+            onClose: done,
+          });
+        },
+        { overlay: true },
+      );
+
+      if (!result.cancelled) {
+        ctx.ui.notify(`Completed: ${result.messageCount} messages`, "info");
+      }
+    },
+  });
+}
+```
+
+## Options
+
+```typescript
+interface EmbeddedSessionOptions {
+  title?: string;                    // Overlay title (default: "Embedded Session")
+  model?: Model;                     // Override model (default: inherit)
+  thinkingLevel?: ThinkingLevel;     // Override thinking (default: inherit)
+  inheritTools?: boolean;            // Include parent tools (default: true)
+  additionalTools?: AgentTool[];     // Extra tools for this session
+  excludeTools?: string[];           // Tools to exclude (e.g., ["write", "edit"])
+  initialMessage?: string;           // Auto-send on open
+  includeParentContext?: boolean;    // Fork parent messages (default: false)
+  parentContextDepth?: number;       // How many exchanges to fork (default: 5)
+  sessionFile?: string | false;      // Path, or false for in-memory
+  generateSummary?: boolean;         // Generate summary on close (default: true)
+  width?: number | `${number}%`;     // Overlay width (default: "90%")
+  maxHeight?: number | `${number}%`; // Overlay height (default: "85%")
+}
+```
+
+## Result
+
+```typescript
+interface EmbeddedSessionResult {
+  cancelled: boolean;       // true if Escape, false if /done
+  summary?: string;         // Last assistant response excerpt
+  sessionId: string;
+  sessionFile?: string;     // undefined for in-memory
+  durationMs: number;
+  filesRead: string[];
+  filesModified: string[];
+  messageCount: number;
+  tokens: { input, output, cacheRead, cacheWrite };
+}
+```

--- a/packages/coding-agent/examples/extensions/embedded-sessions/embedded-session-component.ts
+++ b/packages/coding-agent/examples/extensions/embedded-sessions/embedded-session-component.ts
@@ -1,0 +1,671 @@
+/**
+ * EmbeddedSessionComponent - Overlay UI for embedded sessions.
+ */
+
+import type { AgentMessage, AgentTool } from "@mariozechner/pi-agent-core";
+import { Agent } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, Model, TextContent } from "@mariozechner/pi-ai";
+import {
+	AgentSession,
+	type AgentSessionEvent,
+	AssistantMessageComponent,
+	CompactionSummaryMessageComponent,
+	CustomEditor,
+	getEditorTheme,
+	type KeybindingsManager,
+	ModelSelectorComponent,
+	SessionManager,
+	type ToolDefinition,
+	ToolExecutionComponent,
+	theme,
+	UserMessageComponent,
+} from "@mariozechner/pi-coding-agent";
+import type { CompactionSummaryMessage } from "@mariozechner/pi-coding-agent/core/messages.js";
+import { Container, Loader, Spacer, Text, type TUI, visibleWidth } from "@mariozechner/pi-tui";
+import type { EmbeddedSessionOptions, EmbeddedSessionResult } from "./types.js";
+
+export interface EmbeddedSessionComponentConfig {
+	tui: TUI;
+	parentSession: AgentSession;
+	options: EmbeddedSessionOptions;
+	keybindings: KeybindingsManager;
+	onClose: (result: EmbeddedSessionResult) => void;
+	getToolDefinition?: (name: string) => ToolDefinition | undefined;
+}
+
+/**
+ * Component that renders an embedded session in an overlay.
+ */
+export class EmbeddedSessionComponent extends Container {
+	private tui: TUI;
+	private parentSession: AgentSession;
+	private embeddedSession!: AgentSession;
+	private options: EmbeddedSessionOptions;
+	private keybindings: KeybindingsManager;
+	private onCloseCallback: (result: EmbeddedSessionResult) => void;
+	private getToolDefinitionFn: (name: string) => ToolDefinition | undefined;
+	private cwd: string;
+
+	// UI Components
+	private chatContainer!: Container;
+	private editor!: CustomEditor;
+	private statusLine!: Container;
+	private loadingIndicator: Loader | undefined;
+
+	// Overlay dimensions - use options if provided, otherwise defaults
+	get width(): number {
+		const opt = this.options.width;
+		if (typeof opt === "number") return opt;
+		if (typeof opt === "string" && opt.endsWith("%")) {
+			const pct = parseInt(opt, 10);
+			if (!Number.isNaN(pct) && pct > 0) {
+				return Math.floor(this.tui.terminal.columns * (pct / 100));
+			}
+		}
+		return Math.floor(this.tui.terminal.columns * 0.9);
+	}
+	get maxHeight(): number {
+		const opt = this.options.maxHeight;
+		if (typeof opt === "number") return opt;
+		if (typeof opt === "string" && opt.endsWith("%")) {
+			const pct = parseInt(opt, 10);
+			if (!Number.isNaN(pct) && pct > 0) {
+				return Math.floor(this.tui.terminal.rows * (pct / 100));
+			}
+		}
+		return Math.floor(this.tui.terminal.rows * 0.85);
+	}
+
+	// State
+	private startTime: number;
+	private filesRead = new Set<string>();
+	private filesModified = new Set<string>();
+	private closed = false;
+	private unsubscribe?: () => void;
+
+	// Streaming state
+	private streamingComponent: AssistantMessageComponent | undefined;
+	private pendingTools = new Map<string, ToolExecutionComponent>();
+	private toolArgsCache = new Map<string, Record<string, unknown>>();
+	private toolOutputExpanded = false;
+
+	private constructor(config: EmbeddedSessionComponentConfig) {
+		super();
+		this.tui = config.tui;
+		this.parentSession = config.parentSession;
+		this.options = config.options;
+		this.keybindings = config.keybindings;
+		this.onCloseCallback = config.onClose;
+		this.getToolDefinitionFn = config.getToolDefinition ?? (() => undefined);
+		this.cwd = config.parentSession.sessionManager.getCwd();
+		this.startTime = Date.now();
+	}
+
+	static async create(config: EmbeddedSessionComponentConfig): Promise<EmbeddedSessionComponent> {
+		const component = new EmbeddedSessionComponent(config);
+		await component.initialize();
+		return component;
+	}
+
+	private async initialize(): Promise<void> {
+		// 1. Create SessionManager
+		const sessionManager = this.createSessionManager();
+
+		// 2. Create tools
+		const tools = this.createTools();
+
+		// 3. Get system prompt from parent
+		const systemPrompt = this.parentSession.agent.state.systemPrompt;
+
+		// 4. Get model
+		const model = this.options.model ?? this.parentSession.model;
+		if (!model) {
+			throw new Error("Cannot create embedded session: no model specified and parent has no model");
+		}
+
+		// 5. Get initial messages
+		const initialMessages = this.buildInitialMessages();
+
+		// 6. Create Agent
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt,
+				tools,
+				messages: initialMessages,
+				thinkingLevel: this.options.thinkingLevel ?? this.parentSession.thinkingLevel,
+			},
+			getApiKey: (provider) => this.parentSession.modelRegistry.getApiKeyForProvider(provider),
+		});
+
+		// 7. Create AgentSession
+		this.embeddedSession = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager: this.parentSession.settingsManager,
+			modelRegistry: this.parentSession.modelRegistry,
+			promptTemplates: [...this.parentSession.promptTemplates],
+			skills: [...this.parentSession.skills],
+		});
+
+		// 8. Build UI
+		this.buildUI();
+
+		// 9. Subscribe to events
+		this.unsubscribe = this.embeddedSession.subscribe(this.handleEvent);
+
+		// 10. Send initial message if provided
+		if (this.options.initialMessage) {
+			this.embeddedSession.prompt(this.options.initialMessage).catch((err) => {
+				this.showError(err.message);
+			});
+		}
+	}
+
+	private createSessionManager(): SessionManager {
+		const parentId = this.parentSession.sessionManager.getSessionId();
+		const cwd = this.parentSession.sessionManager.getCwd();
+
+		if (this.options.sessionFile === false) {
+			return SessionManager.inMemory(cwd);
+		}
+
+		return SessionManager.createEmbedded(parentId, cwd, {
+			sessionFile: typeof this.options.sessionFile === "string" ? this.options.sessionFile : undefined,
+		});
+	}
+
+	private createTools(): AgentTool[] {
+		if (this.options.inheritTools === false) {
+			return this.options.additionalTools ?? [];
+		}
+
+		let tools = [...this.parentSession.agent.state.tools];
+
+		if (this.options.excludeTools?.length) {
+			const excluded = new Set(this.options.excludeTools);
+			tools = tools.filter((t) => !excluded.has(t.name));
+		}
+
+		if (this.options.additionalTools?.length) {
+			tools.push(...this.options.additionalTools);
+		}
+
+		return tools;
+	}
+
+	private buildInitialMessages(): AgentMessage[] {
+		if (!this.options.includeParentContext) {
+			return [];
+		}
+
+		const depth = this.options.parentContextDepth ?? 5;
+		const parentMessages = this.parentSession.agent.state.messages;
+		const totalUserMessages = parentMessages.filter((m) => m.role === "user").length;
+		const startAfterExchange = totalUserMessages - depth;
+
+		const relevantMessages: AgentMessage[] = [];
+		let userMessageCount = 0;
+
+		for (const msg of parentMessages) {
+			if (msg.role === "user") {
+				userMessageCount++;
+			}
+			if (userMessageCount > startAfterExchange) {
+				if (msg.role === "user" || msg.role === "assistant") {
+					relevantMessages.push(JSON.parse(JSON.stringify(msg)));
+				}
+			}
+		}
+
+		return relevantMessages;
+	}
+
+	private buildUI(): void {
+		this.chatContainer = new Container();
+		this.addChild(this.chatContainer);
+
+		this.editor = new CustomEditor(this.tui, getEditorTheme(), this.keybindings);
+		this.editor.onSubmit = (text) => this.handleSubmit(text);
+		this.editor.onEscape = () => {
+			if (this.embeddedSession.isStreaming) {
+				this.embeddedSession.abort();
+			} else {
+				this.close(true);
+			}
+		};
+		this.addChild(this.editor as any);
+
+		this.statusLine = new Container();
+		this.updateStatusLine();
+		this.addChild(this.statusLine);
+	}
+
+	private updateStatusLine(): void {
+		this.statusLine.clear();
+		const stats = this.embeddedSession.getSessionStats();
+		const tokens = `${this.formatTokens(stats.tokens.input)}in/${this.formatTokens(stats.tokens.output)}out`;
+
+		const hints = [
+			theme.fg("muted", `tokens: ${tokens}`),
+			theme.fg("dim", "│"),
+			theme.fg("dim", "Enter") + theme.fg("muted", " send"),
+			theme.fg("dim", "/model") + theme.fg("muted", " switch"),
+			theme.fg("dim", "/done") + theme.fg("muted", " complete"),
+			theme.fg("dim", "Esc") + theme.fg("muted", " cancel"),
+		].join("  ");
+
+		this.statusLine.addChild(new Text(hints, 0, 0));
+	}
+
+	private formatTokens(n: number): string {
+		return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+	}
+
+	private showModelSelector(initialSearchInput?: string): void {
+		const selector = new ModelSelectorComponent(
+			this.tui,
+			this.embeddedSession.model,
+			this.embeddedSession.settingsManager,
+			this.embeddedSession.modelRegistry,
+			[],
+			async (model: Model<any>) => {
+				try {
+					await this.embeddedSession.setModel(model);
+					this.tui.hideOverlay();
+					this.tui.setFocus(this.editor);
+					this.updateStatusLine();
+					this.tui.requestRender();
+				} catch (error) {
+					this.tui.hideOverlay();
+					this.tui.setFocus(this.editor);
+					this.showError(error instanceof Error ? error.message : String(error));
+				}
+			},
+			() => {
+				this.tui.hideOverlay();
+				this.tui.setFocus(this.editor);
+				this.tui.requestRender();
+			},
+			initialSearchInput,
+		);
+		this.tui.showOverlay(selector, { anchor: "center" });
+		this.tui.setFocus(selector);
+	}
+
+	handleInput(data: string): void {
+		this.editor.handleInput(data);
+	}
+
+	private handleSubmit(text: string): void {
+		const trimmed = text.trim();
+		if (!trimmed) return;
+
+		this.editor.setText("");
+
+		if (trimmed === "/done" || trimmed === "/close") {
+			this.close(false);
+			return;
+		}
+
+		if (trimmed === "/compact") {
+			this.embeddedSession.compact().catch((err) => this.showError(err.message));
+			return;
+		}
+
+		if (trimmed === "/model" || trimmed.startsWith("/model ")) {
+			const searchTerm = trimmed.startsWith("/model ") ? trimmed.slice(7).trim() : undefined;
+			this.showModelSelector(searchTerm);
+			return;
+		}
+
+		const behavior = this.embeddedSession.isStreaming ? "followUp" : undefined;
+		this.embeddedSession.prompt(trimmed, { streamingBehavior: behavior }).catch((err) => {
+			this.showError(err.message);
+		});
+	}
+
+	private handleEvent = (event: AgentSessionEvent): void => {
+		switch (event.type) {
+			case "agent_start":
+				this.showLoading();
+				break;
+			case "agent_end":
+				this.hideLoading();
+				this.updateStatusLine();
+				break;
+			case "message_start":
+				if (event.message.role === "user") {
+					this.renderUserMessage(event.message);
+				} else if (event.message.role === "assistant") {
+					this.startStreamingAssistant(event.message as AssistantMessage);
+				} else if (event.message.role === "compactionSummary") {
+					this.renderCompactionSummary(event.message as CompactionSummaryMessage);
+				}
+				break;
+			case "message_update":
+				if (event.message.role === "assistant") {
+					this.updateStreamingAssistant(event.message as AssistantMessage);
+				}
+				break;
+			case "message_end":
+				if (event.message.role === "assistant") {
+					this.endStreamingAssistant(event.message as AssistantMessage);
+				}
+				break;
+			case "tool_execution_start":
+				this.handleToolStart(event);
+				break;
+			case "tool_execution_update":
+				this.handleToolUpdate(event);
+				break;
+			case "tool_execution_end":
+				this.handleToolEnd(event);
+				break;
+		}
+		this.tui.requestRender();
+	};
+
+	private renderUserMessage(message: AgentMessage): void {
+		if (message.role !== "user" || !("content" in message)) return;
+		const textContent = this.extractTextFromContent(message.content);
+		if (textContent) {
+			this.chatContainer.addChild(new UserMessageComponent(textContent));
+			this.chatContainer.addChild(new Spacer(1));
+		}
+	}
+
+	private extractTextFromContent(content: any): string {
+		if (typeof content === "string") return content;
+		return content
+			.filter((c: any) => c.type === "text")
+			.map((c: any) => c.text)
+			.join(" ");
+	}
+
+	private renderCompactionSummary(message: CompactionSummaryMessage): void {
+		this.chatContainer.addChild(new Spacer(1));
+		const component = new CompactionSummaryMessageComponent(message);
+		component.setExpanded(this.toolOutputExpanded);
+		this.chatContainer.addChild(component);
+	}
+
+	private startStreamingAssistant(message: AssistantMessage): void {
+		this.streamingComponent = new AssistantMessageComponent(
+			message,
+			this.embeddedSession.settingsManager.getHideThinkingBlock(),
+		);
+		this.chatContainer.addChild(this.streamingComponent);
+		this.renderToolCallsFromMessage(message);
+	}
+
+	private updateStreamingAssistant(message: AssistantMessage): void {
+		if (this.streamingComponent) {
+			this.streamingComponent.updateContent(message);
+			this.renderToolCallsFromMessage(message);
+		}
+	}
+
+	private endStreamingAssistant(message: AssistantMessage): void {
+		if (this.streamingComponent) {
+			this.streamingComponent.updateContent(message);
+
+			if (message.stopReason === "aborted" || message.stopReason === "error") {
+				const errorMessage =
+					message.stopReason === "aborted" ? "Operation aborted" : message.errorMessage || "Error";
+				for (const [, component] of this.pendingTools) {
+					component.updateResult({ content: [{ type: "text", text: errorMessage }], isError: true });
+				}
+				this.pendingTools.clear();
+			} else {
+				for (const [, component] of this.pendingTools) {
+					component.setArgsComplete();
+				}
+			}
+
+			this.streamingComponent = undefined;
+			this.chatContainer.addChild(new Spacer(1));
+		}
+	}
+
+	private renderToolCallsFromMessage(message: AssistantMessage): void {
+		for (const content of message.content) {
+			if (content.type === "toolCall") {
+				if (!this.pendingTools.has(content.id)) {
+					const component = new ToolExecutionComponent(
+						content.name,
+						content.arguments,
+						{ showImages: this.parentSession.settingsManager.getShowImages() },
+						this.getToolDefinitionFn(content.name),
+						this.tui,
+						this.cwd,
+					);
+					component.setExpanded(this.toolOutputExpanded);
+					this.pendingTools.set(content.id, component);
+					this.chatContainer.addChild(component);
+					this.toolArgsCache.set(content.id, content.arguments as Record<string, unknown>);
+				} else {
+					const component = this.pendingTools.get(content.id);
+					if (component) {
+						component.updateArgs(content.arguments);
+						this.toolArgsCache.set(content.id, content.arguments as Record<string, unknown>);
+					}
+				}
+			}
+		}
+	}
+
+	private handleToolStart(event: { toolCallId: string; toolName: string; args: unknown }): void {
+		if (this.pendingTools.has(event.toolCallId)) return;
+
+		this.toolArgsCache.set(event.toolCallId, event.args as Record<string, unknown>);
+		const component = new ToolExecutionComponent(
+			event.toolName,
+			event.args,
+			{ showImages: this.parentSession.settingsManager.getShowImages() },
+			this.getToolDefinitionFn(event.toolName),
+			this.tui,
+			this.cwd,
+		);
+		component.setExpanded(this.toolOutputExpanded);
+		this.pendingTools.set(event.toolCallId, component);
+		this.chatContainer.addChild(component);
+	}
+
+	private handleToolUpdate(event: { toolCallId: string; partialResult: unknown }): void {
+		const component = this.pendingTools.get(event.toolCallId);
+		if (component) {
+			component.updateResult(event.partialResult as any);
+		}
+	}
+
+	private handleToolEnd(event: { toolCallId: string; toolName: string; result: any; isError: boolean }): void {
+		const component = this.pendingTools.get(event.toolCallId);
+		if (component) {
+			component.updateResult({ ...event.result, isError: event.isError });
+			this.pendingTools.delete(event.toolCallId);
+		}
+
+		const args = this.toolArgsCache.get(event.toolCallId);
+		this.toolArgsCache.delete(event.toolCallId);
+
+		if (args && typeof args.path === "string") {
+			if (event.toolName === "read") {
+				this.filesRead.add(args.path);
+			} else if (event.toolName === "write" || event.toolName === "edit") {
+				this.filesModified.add(args.path);
+			}
+		}
+	}
+
+	private showLoading(): void {
+		if (!this.loadingIndicator) {
+			this.loadingIndicator = new Loader(
+				this.tui,
+				(s) => theme.fg("accent", s),
+				(t) => theme.fg("muted", t),
+				"Working...",
+			);
+			this.statusLine.addChild(this.loadingIndicator);
+		}
+	}
+
+	private hideLoading(): void {
+		if (this.loadingIndicator) {
+			this.loadingIndicator.stop();
+			this.loadingIndicator = undefined;
+			this.statusLine.clear();
+			this.updateStatusLine();
+		}
+	}
+
+	private showError(message: string): void {
+		this.chatContainer.addChild(new Text(theme.fg("error", `Error: ${message}`), 1, 0));
+		this.chatContainer.addChild(new Spacer(1));
+	}
+
+	async close(cancelled: boolean): Promise<void> {
+		if (this.closed) return;
+		this.closed = true;
+
+		await this.embeddedSession.abort();
+		this.unsubscribe?.();
+
+		let summary: string | undefined;
+		if (!cancelled && this.options.generateSummary !== false) {
+			summary = await this.generateSummary();
+		}
+
+		const stats = this.embeddedSession.getSessionStats();
+		const result: EmbeddedSessionResult = {
+			cancelled,
+			summary,
+			sessionId: this.embeddedSession.sessionManager.getSessionId(),
+			sessionFile: this.embeddedSession.sessionManager.getSessionFile(),
+			durationMs: Date.now() - this.startTime,
+			filesRead: Array.from(this.filesRead),
+			filesModified: Array.from(this.filesModified),
+			messageCount: stats.totalMessages,
+			tokens: {
+				input: stats.tokens.input,
+				output: stats.tokens.output,
+				cacheRead: stats.tokens.cacheRead,
+				cacheWrite: stats.tokens.cacheWrite,
+			},
+		};
+
+		this.hideLoading();
+		this.onCloseCallback(result);
+	}
+
+	private async generateSummary(): Promise<string | undefined> {
+		const messages = this.embeddedSession.agent.state.messages;
+		if (messages.length === 0) return undefined;
+
+		const lastAssistant = messages.filter((m) => m.role === "assistant").pop() as AssistantMessage | undefined;
+		if (!lastAssistant) return undefined;
+
+		const text = lastAssistant.content
+			.filter((c): c is TextContent => c.type === "text")
+			.map((c) => c.text)
+			.join("\n")
+			.trim();
+
+		if (!text) return undefined;
+
+		const maxLength = 500;
+		return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+	}
+
+	invalidate(): void {
+		this.chatContainer?.invalidate?.();
+		this.statusLine?.invalidate?.();
+	}
+
+	render(_width: number): string[] {
+		const w = this.width;
+		const maxH = this.maxHeight;
+		const border = (s: string) => theme.fg("border", s);
+		const innerWidth = Math.max(1, w - 2);
+
+		const pad = (s: string, len: number) => {
+			const vis = visibleWidth(s);
+			return s + " ".repeat(Math.max(0, len - vis));
+		};
+
+		const row = (content: string) => border("│") + pad(content, innerWidth) + border("│");
+		const emptyRow = () => border("│") + " ".repeat(innerWidth) + border("│");
+		const separator = () => border(`├${"─".repeat(innerWidth)}┤`);
+
+		const editorLines = this.editor.render(innerWidth - 2);
+		const statusLines = this.statusLine.render(innerWidth - 2);
+
+		const hasModel = !!this.embeddedSession?.model;
+		const fixedLines = 1 + (hasModel ? 1 : 0) + 1 + 1 + 1 + editorLines.length + 1 + 1 + statusLines.length + 1;
+		const chatMaxHeight = Math.max(1, maxH - fixedLines);
+
+		let chatLines = this.chatContainer.render(innerWidth - 2);
+		if (chatLines.length > chatMaxHeight) {
+			chatLines = chatLines.slice(-chatMaxHeight);
+		}
+
+		const result: string[] = [];
+
+		// Top border with title
+		const title = this.options.title ?? "Embedded Session";
+		const model = this.embeddedSession?.model;
+		const modelStr = model ? `${model.provider}/${model.id}` : "";
+		let titleText = ` ${title} `;
+		let titleLen = visibleWidth(titleText);
+
+		// Truncate title if it's too long for the border
+		if (titleLen > innerWidth - 4) {
+			const maxTitleLen = innerWidth - 7; // Account for borders and ellipsis
+			titleText = ` ${title.slice(0, Math.max(0, maxTitleLen))}... `;
+			titleLen = visibleWidth(titleText);
+		}
+
+		const borderLen = Math.max(0, innerWidth - titleLen);
+		const leftBorder = Math.floor(borderLen / 2);
+		const rightBorder = borderLen - leftBorder;
+		result.push(
+			border(`╭${"─".repeat(leftBorder)}`) + theme.fg("accent", titleText) + border(`${"─".repeat(rightBorder)}╮`),
+		);
+
+		if (modelStr) {
+			result.push(row(` ${theme.fg("dim", modelStr)}`));
+		}
+
+		result.push(separator());
+
+		if (chatLines.length === 0) {
+			result.push(emptyRow());
+		} else {
+			for (const line of chatLines) {
+				result.push(row(` ${line}`));
+			}
+		}
+
+		result.push(separator());
+		result.push(emptyRow());
+
+		for (const line of editorLines) {
+			result.push(row(` ${line}`));
+		}
+
+		result.push(emptyRow());
+		result.push(separator());
+
+		for (const line of statusLines) {
+			result.push(row(` ${line}`));
+		}
+
+		result.push(border(`╰${"─".repeat(innerWidth)}╯`));
+
+		return result;
+	}
+
+	dispose(): void {
+		this.close(true);
+	}
+}

--- a/packages/coding-agent/examples/extensions/embedded-sessions/index.ts
+++ b/packages/coding-agent/examples/extensions/embedded-sessions/index.ts
@@ -1,0 +1,131 @@
+/**
+ * Embedded Sessions Extension
+ *
+ * Child agent sessions that run in an overlay within the parent session.
+ * Useful for focused subtasks, exploration, or read-only review.
+ *
+ * Commands:
+ *   /embed [message]   - Open embedded session with optional initial message
+ *   /embed-context     - Open embedded session with parent context included
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { EmbeddedSessionComponent } from "./embedded-session-component.js";
+import type { EmbeddedSessionOptions, EmbeddedSessionResult } from "./types.js";
+
+export default function embeddedSessions(pi: ExtensionAPI) {
+	/**
+	 * Create an embedded session in an overlay.
+	 */
+	async function createEmbeddedSession(
+		ctx: ExtensionCommandContext,
+		options: EmbeddedSessionOptions = {},
+	): Promise<EmbeddedSessionResult> {
+		const session = ctx.session;
+
+		const result = await ctx.ui.custom<EmbeddedSessionResult>(
+			async (tui, _theme, keybindings, done) => {
+				const component = await EmbeddedSessionComponent.create({
+					tui,
+					parentSession: session,
+					options,
+					keybindings,
+					onClose: done,
+				});
+				return component;
+			},
+			{
+				overlay: true,
+				overlayOptions: {
+					width: options.width ?? "90%",
+					maxHeight: options.maxHeight ?? "85%",
+					anchor: "center",
+				},
+			},
+		);
+
+		// Persist reference to parent session (if session had any activity)
+		if (!result.cancelled || result.messageCount > 0) {
+			session.sessionManager.appendEmbeddedSessionRef({
+				embeddedSessionId: result.sessionId,
+				embeddedSessionFile: result.sessionFile,
+				title: options.title,
+				summary: result.summary,
+				durationMs: result.durationMs,
+				messageCount: result.messageCount,
+				model: {
+					provider: (options.model ?? session.model)?.provider ?? "unknown",
+					modelId: (options.model ?? session.model)?.id ?? "unknown",
+				},
+				thinkingLevel: options.thinkingLevel ?? session.thinkingLevel,
+				cancelled: result.cancelled,
+				filesRead: result.filesRead,
+				filesModified: result.filesModified,
+				tokens: result.tokens,
+			});
+		}
+
+		return result;
+	}
+
+	// Basic embedded session
+	pi.registerCommand("embed", {
+		description: "Open an embedded session (optional: initial message)",
+		handler: async (args, ctx) => {
+			const title = args.trim() ? "Embedded Task" : "Embedded Session";
+			const result = await createEmbeddedSession(ctx, {
+				title,
+				initialMessage: args.trim() || undefined,
+				generateSummary: true,
+			});
+
+			if (!result.cancelled && result.summary) {
+				pi.sendMessage(
+					{
+						customType: "embedded_session_summary",
+						content: `Embedded session "${title}" completed.\n\nSummary:\n${result.summary}\n\nFiles read: ${result.filesRead.length > 0 ? result.filesRead.join(", ") : "none"}\nFiles modified: ${result.filesModified.length > 0 ? result.filesModified.join(", ") : "none"}`,
+						display: true,
+					},
+					{ triggerTurn: false },
+				);
+				ctx.ui.notify("Embedded session completed", "info");
+			} else if (result.cancelled) {
+				ctx.ui.notify("Embedded session cancelled", "warning");
+			}
+		},
+	});
+
+	// Embedded session with parent context
+	pi.registerCommand("embed-context", {
+		description: "Open embedded session with parent context forked in",
+		handler: async (args, ctx) => {
+			const title = "Context-Aware Session";
+			const result = await createEmbeddedSession(ctx, {
+				title,
+				includeParentContext: true,
+				parentContextDepth: 3,
+				initialMessage: args.trim() || "I have context from the parent session. How can I help?",
+				generateSummary: true,
+			});
+
+			if (!result.cancelled && result.summary) {
+				pi.sendMessage(
+					{
+						customType: "embedded_session_summary",
+						content: `Context-aware session completed.\n\nSummary:\n${result.summary}`,
+						display: true,
+					},
+					{ triggerTurn: false },
+				);
+				ctx.ui.notify("Embedded session completed", "info");
+			} else if (result.cancelled) {
+				ctx.ui.notify("Embedded session cancelled", "warning");
+			}
+		},
+	});
+}
+
+export type { EmbeddedSessionComponentConfig } from "./embedded-session-component.js";
+// Re-export for programmatic use by other extensions
+export { EmbeddedSessionComponent } from "./embedded-session-component.js";
+export type { EmbeddedSessionOptions, EmbeddedSessionResult } from "./types.js";

--- a/packages/coding-agent/examples/extensions/embedded-sessions/package.json
+++ b/packages/coding-agent/examples/extensions/embedded-sessions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pi-embedded-sessions",
+  "version": "1.0.0",
+  "description": "Embedded sessions extension for pi - create child agent sessions in overlays",
+  "main": "index.ts",
+  "type": "module",
+  "keywords": ["pi", "extension", "embedded-sessions"],
+  "author": "nicobailon",
+  "license": "MIT"
+}

--- a/packages/coding-agent/examples/extensions/embedded-sessions/types.ts
+++ b/packages/coding-agent/examples/extensions/embedded-sessions/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Types for embedded sessions.
+ */
+
+import type { AgentTool, ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { Model } from "@mariozechner/pi-ai";
+
+/**
+ * Options for creating an embedded session.
+ */
+export interface EmbeddedSessionOptions {
+	/** Display title for the overlay. Default: "Embedded Session" */
+	title?: string;
+
+	/** Override model. Default: inherit from parent */
+	model?: Model<any>;
+
+	/** Override thinking level. Default: inherit from parent */
+	thinkingLevel?: ThinkingLevel;
+
+	/** Include parent's tools. Default: true */
+	inheritTools?: boolean;
+
+	/** Additional tools for this embedded session only */
+	additionalTools?: AgentTool[];
+
+	/** Exclude specific tools from parent. E.g., ["write", "edit"] for read-only */
+	excludeTools?: string[];
+
+	/** Initial message to send automatically when session opens */
+	initialMessage?: string;
+
+	/** Include parent context (fork recent messages). Default: false */
+	includeParentContext?: boolean;
+
+	/** Number of recent parent exchanges to include. Default: 5 */
+	parentContextDepth?: number;
+
+	/**
+	 * Session file path.
+	 * - undefined: auto-generate in embedded/ directory
+	 * - false: in-memory only (no persistence)
+	 * - string: specific path
+	 */
+	sessionFile?: string | false;
+
+	/** Generate summary on close. Default: true */
+	generateSummary?: boolean;
+
+	/** Overlay width. Default: "90%" */
+	width?: number | `${number}%`;
+
+	/** Overlay max height. Default: "85%" */
+	maxHeight?: number | `${number}%`;
+}
+
+/**
+ * Result from an embedded session.
+ */
+export interface EmbeddedSessionResult {
+	/** Whether user cancelled (Escape) vs completed (/done) */
+	cancelled: boolean;
+
+	/** Generated summary (if generateSummary was true and not cancelled) */
+	summary?: string;
+
+	/** Embedded session ID */
+	sessionId: string;
+
+	/** Session file path (if persisted) */
+	sessionFile?: string;
+
+	/** Duration in ms */
+	durationMs: number;
+
+	/** Files read during session */
+	filesRead: string[];
+
+	/** Files modified during session */
+	filesModified: string[];
+
+	/** Message count */
+	messageCount: number;
+
+	/** Token usage */
+	tokens: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+	};
+}

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -117,6 +117,9 @@ export class ExtensionRunner {
 	private forkHandler: ForkHandler = async () => ({ cancelled: false });
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
 	private shutdownHandler: ShutdownHandler = () => {};
+	private getSessionFn: ExtensionContextActions["getSession"] = () => {
+		throw new Error("session not available yet");
+	};
 
 	constructor(
 		extensions: Extension[],
@@ -154,6 +157,7 @@ export class ExtensionRunner {
 
 		// Context actions (required)
 		this.getModel = contextActions.getModel;
+		this.getSessionFn = contextActions.getSession;
 		this.isIdleFn = contextActions.isIdle;
 		this.abortFn = contextActions.abort;
 		this.hasPendingMessagesFn = contextActions.hasPendingMessages;
@@ -324,6 +328,7 @@ export class ExtensionRunner {
 	 */
 	createContext(): ExtensionContext {
 		const getModel = this.getModel;
+		const getSession = this.getSessionFn;
 		return {
 			ui: this.uiContext,
 			hasUI: this.hasUI(),
@@ -332,6 +337,9 @@ export class ExtensionRunner {
 			modelRegistry: this.modelRegistry,
 			get model() {
 				return getModel();
+			},
+			get session() {
+				return getSession();
 			},
 			isIdle: () => this.isIdleFn(),
 			abort: () => this.abortFn(),
@@ -347,6 +355,8 @@ export class ExtensionRunner {
 			newSession: (options) => this.newSessionHandler(options),
 			fork: (entryId) => this.forkHandler(entryId),
 			navigateTree: (targetId, options) => this.navigateTreeHandler(targetId, options),
+			isEmbeddedSession: this.sessionManager.isEmbedded(),
+			parentSessionId: this.sessionManager.getParentSessionId(),
 		};
 	}
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -27,6 +27,7 @@ import type {
 } from "@mariozechner/pi-tui";
 import type { Static, TSchema } from "@sinclair/typebox";
 import type { Theme } from "../../modes/interactive/theme/theme.js";
+import type { AgentSession } from "../agent-session.js";
 import type { BashResult } from "../bash-executor.js";
 import type { CompactionPreparation, CompactionResult } from "../compaction/index.js";
 import type { EventBus } from "../event-bus.js";
@@ -209,6 +210,15 @@ export interface ExtensionContext {
 	modelRegistry: ModelRegistry;
 	/** Current model (may be undefined) */
 	model: Model<any> | undefined;
+	/**
+	 * The current AgentSession. Provides access to:
+	 * - `agent.state` (systemPrompt, tools, messages, model, thinkingLevel)
+	 * - `settingsManager`, `modelRegistry`, `promptTemplates`, `skills`
+	 * - `subscribe()` for event handling
+	 *
+	 * Use for advanced scenarios like creating embedded sessions.
+	 */
+	session: AgentSession;
 	/** Whether the agent is idle (not streaming) */
 	isIdle(): boolean;
 	/** Abort the current agent operation */
@@ -241,6 +251,12 @@ export interface ExtensionCommandContext extends ExtensionContext {
 		targetId: string,
 		options?: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string },
 	): Promise<{ cancelled: boolean }>;
+
+	/** Whether currently in an embedded session */
+	isEmbeddedSession: boolean;
+
+	/** Parent session ID (if in embedded session) */
+	parentSessionId?: string;
 }
 
 // ============================================================================
@@ -915,6 +931,7 @@ export interface ExtensionActions {
  */
 export interface ExtensionContextActions {
 	getModel: () => Model<any> | undefined;
+	getSession: () => AgentSession;
 	isIdle: () => boolean;
 	abort: () => void;
 	hasPendingMessages: () => boolean;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -148,6 +148,7 @@ export {
 	CURRENT_SESSION_VERSION,
 	type CustomEntry,
 	type CustomMessageEntry,
+	type EmbeddedSessionRefEntry,
 	type FileEntry,
 	getLatestCompactionEntry,
 	type ModelChangeEntry,
@@ -244,6 +245,8 @@ export {
 	CustomEditor,
 	CustomMessageComponent,
 	DynamicBorder,
+	EmbeddedSessionRefComponent,
+	type EmbeddedSessionRefComponentConfig,
 	ExtensionEditorComponent,
 	ExtensionInputComponent,
 	ExtensionSelectorComponent,
@@ -270,6 +273,7 @@ export {
 } from "./modes/interactive/components/index.js";
 // Theme utilities for custom tools and extensions
 export {
+	getEditorTheme,
 	getLanguageFromPath,
 	getMarkdownTheme,
 	getSelectListTheme,
@@ -278,6 +282,7 @@ export {
 	initTheme,
 	Theme,
 	type ThemeColor,
+	theme,
 } from "./modes/interactive/theme/theme.js";
 export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.js";
 // Shell utilities

--- a/packages/coding-agent/src/modes/interactive/components/embedded-session-ref.ts
+++ b/packages/coding-agent/src/modes/interactive/components/embedded-session-ref.ts
@@ -1,0 +1,91 @@
+import { Container, Text } from "@mariozechner/pi-tui";
+import type { EmbeddedSessionRefEntry } from "../../../core/session-manager.js";
+import { theme } from "../theme/theme.js";
+
+export interface EmbeddedSessionRefComponentConfig {
+	entry: EmbeddedSessionRefEntry;
+}
+
+/**
+ * Component that renders an embedded session reference in the parent chat.
+ * Shows a collapsible block with summary and metadata.
+ */
+export class EmbeddedSessionRefComponent extends Container {
+	private entry: EmbeddedSessionRefEntry;
+	private expanded = false;
+
+	constructor(config: EmbeddedSessionRefComponentConfig) {
+		super();
+		this.entry = config.entry;
+		this.renderContent();
+	}
+
+	private renderContent(): void {
+		this.clear();
+
+		const { entry } = this;
+		const icon = entry.cancelled ? "○" : "●";
+		const status = entry.cancelled ? "cancelled" : "completed";
+		const duration = this.formatDuration(entry.durationMs);
+
+		// Header line
+		const header = [
+			theme.fg(entry.cancelled ? "dim" : "accent", icon),
+			theme.fg("muted", " Embedded: "),
+			theme.bold(entry.title ?? "Session"),
+			theme.fg("dim", ` (${status}, ${duration}, ${entry.messageCount} messages)`),
+		].join("");
+
+		this.addChild(new Text(header, 1, 0));
+
+		// Summary (if present) - always show truncated in collapsed view
+		if (entry.summary) {
+			const summaryText = this.expanded ? entry.summary : entry.summary.slice(0, 200);
+			const ellipsis = !this.expanded && entry.summary.length > 200 ? "..." : "";
+			this.addChild(new Text(theme.fg("text", `  ${summaryText}${ellipsis}`), 1, 0));
+		}
+
+		// Files modified (collapsed view)
+		if (entry.filesModified?.length && !this.expanded) {
+			const count = entry.filesModified.length;
+			const preview = entry.filesModified
+				.slice(0, 3)
+				.map((f) => f.split("/").pop())
+				.join(", ");
+			const more = count > 3 ? ` +${count - 3} more` : "";
+			this.addChild(new Text(theme.fg("dim", `  Modified: ${preview}${more}`), 1, 0));
+		}
+
+		// Expanded details
+		if (this.expanded) {
+			if (entry.filesRead?.length) {
+				this.addChild(new Text(theme.fg("dim", `  Read: ${entry.filesRead.join(", ")}`), 1, 0));
+			}
+			if (entry.filesModified?.length) {
+				this.addChild(new Text(theme.fg("dim", `  Modified: ${entry.filesModified.join(", ")}`), 1, 0));
+			}
+			if (entry.tokens) {
+				const tokens = `${entry.tokens.input}/${entry.tokens.output}`;
+				this.addChild(new Text(theme.fg("dim", `  Tokens: ${tokens}`), 1, 0));
+			}
+		}
+	}
+
+	private formatDuration(ms: number): string {
+		const seconds = Math.floor(ms / 1000);
+		if (seconds < 60) return `${seconds}s`;
+		const minutes = Math.floor(seconds / 60);
+		const secs = seconds % 60;
+		return `${minutes}m ${secs}s`;
+	}
+
+	setExpanded(expanded: boolean): void {
+		if (this.expanded === expanded) return;
+		this.expanded = expanded;
+		this.renderContent();
+	}
+
+	invalidate(): void {
+		this.renderContent();
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -9,6 +9,7 @@ export { CustomEditor } from "./custom-editor.js";
 export { CustomMessageComponent } from "./custom-message.js";
 export { type RenderDiffOptions, renderDiff } from "./diff.js";
 export { DynamicBorder } from "./dynamic-border.js";
+export { EmbeddedSessionRefComponent, type EmbeddedSessionRefComponentConfig } from "./embedded-session-ref.js";
 export { ExtensionEditorComponent } from "./extension-editor.js";
 export { ExtensionInputComponent } from "./extension-input.js";
 export { ExtensionSelectorComponent } from "./extension-selector.js";

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -75,6 +75,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 			// ExtensionContextActions
 			{
 				getModel: () => session.model,
+				getSession: () => session,
 				isIdle: () => !session.isStreaming,
 				abort: () => session.abort(),
 				hasPendingMessages: () => session.pendingMessageCount > 0,

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -288,6 +288,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			// ExtensionContextActions
 			{
 				getModel: () => session.agent.state.model,
+				getSession: () => session,
 				isIdle: () => !session.isStreaming,
 				abort: () => session.abort(),
 				hasPendingMessages: () => session.pendingMessageCount > 0,

--- a/packages/coding-agent/test/compaction-extensions.test.ts
+++ b/packages/coding-agent/test/compaction-extensions.test.ts
@@ -120,6 +120,7 @@ describe.skipIf(!API_KEY)("Compaction extensions", () => {
 			// ExtensionContextActions
 			{
 				getModel: () => session.model,
+				getSession: () => session,
 				isIdle: () => !session.isStreaming,
 				abort: () => session.abort(),
 				hasPendingMessages: () => session.pendingMessageCount > 0,


### PR DESCRIPTION
I know you are busy with other priorities and this is a non critical thing so I don't expect this to be merged, but wanted to share anyway. Feel free to close.

This PR adds core primitives for extensions to create child agent sessions in overlays. Includes SessionManager.createEmbedded(), ctx.session in extension context, embedded session ref entries, and a full example extension.

<img width="1262" height="1136" alt="image" src="https://github.com/user-attachments/assets/5ebf8f21-1a76-41eb-9f9d-0f6cc3ccff61" />

**Core additions (~330 lines):**

- `SessionManager.createEmbedded(parentId, cwd)` - creates a session file under `~/.pi/agent/sessions/embedded/{parent-id}/`
- `SessionManager.getEntriesInPath()` - returns entries from root to current leaf (needed for rendering refs correctly after branching)
- `ctx.session` exposed in extension context - gives extensions access to the parent AgentSession
- `EmbeddedSessionRefEntry` type and `appendEmbeddedSessionRef()` - stores a "receipt" in the parent session when an embedded session closes
- `EmbeddedSessionRefComponent` - renders those receipts in the parent chat on session resume
- `isEmbeddedSession` / `parentSessionId` in command context
- Exports `theme` and `getEditorTheme` so extensions can style their overlays

**Example extension (~900 lines):**

Full working embedded session in overlay implementation at `examples/extensions/embedded-sessions/`.

**Testing**

```bash
# Copy to extensions folder
cp -r examples/extensions/embedded-sessions ~/.pi/agent/extensions/

# Then in pi
/embed What's in this codebase?
```

**I have manually tested:**
- Basic `/embed` and `/embed-context` flows
- Model switching within embedded session