### PR TITLE
fix(coding-agent): use dynamic import for photon module in ESM context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Fixed photon module failing to load in ESM context with "require is not defined" error
 - Fixed crash during auto-compaction when summarization fails (e.g., quota exceeded). Now displays error message instead of crashing ([#792](https://github.com/badlogic/pi-mono/issues/792))
 - Fixed `--no-extensions` flag not preventing extension discovery ([#776](https://github.com/badlogic/pi-mono/issues/776))
 - Fixed extension messages rendering twice on startup when `pi.sendMessage({ display: true })` is called during `session_start` ([#765](https://github.com/badlogic/pi-mono/pull/765) by [@dannote](https://github.com/dannote))

--- a/packages/coding-agent/src/utils/image-resize.ts
+++ b/packages/coding-agent/src/utils/image-resize.ts
@@ -1,5 +1,5 @@
 import type { ImageContent } from "@mariozechner/pi-ai";
-import { getPhoton } from "./photon.js";
+import { loadPhoton } from "./photon.js";
 
 export interface ImageResizeOptions {
 	maxWidth?: number; // Default: 2000
@@ -53,7 +53,7 @@ export async function resizeImage(img: ImageContent, options?: ImageResizeOption
 	const opts = { ...DEFAULT_OPTIONS, ...options };
 	const inputBuffer = Buffer.from(img.data, "base64");
 
-	const photon = getPhoton();
+	const photon = await loadPhoton();
 	if (!photon) {
 		// Photon not available, return original image
 		return {

--- a/packages/coding-agent/src/utils/photon.ts
+++ b/packages/coding-agent/src/utils/photon.ts
@@ -8,8 +8,8 @@
  * The challenge: photon-node's CJS entry uses fs.readFileSync(__dirname + '/photon_rs_bg.wasm')
  * which bakes the build machine's absolute path into Bun compiled binaries.
  *
- * Solution: Lazy-load photon and gracefully handle failures. Image processing functions
- * already have fallbacks that return original images when photon isn't available.
+ * Solution: Lazy-load photon via dynamic import and gracefully handle failures.
+ * Image processing functions have fallbacks that return original images when photon isn't available.
  */
 
 // Re-export types from the main package
@@ -17,43 +17,29 @@ export type { PhotonImage as PhotonImageType } from "@silvia-odwyer/photon-node"
 
 // Lazy-loaded photon module
 let photonModule: typeof import("@silvia-odwyer/photon-node") | null = null;
-let loadAttempted = false;
-let loadError: Error | null = null;
+let loadPromise: Promise<typeof import("@silvia-odwyer/photon-node") | null> | null = null;
 
 /**
- * Get the photon module, loading it lazily on first access.
- * Returns null if loading fails (e.g., in broken Bun binary).
+ * Load the photon module asynchronously.
+ * Returns cached module on subsequent calls.
  */
-export function getPhoton(): typeof import("@silvia-odwyer/photon-node") | null {
-	if (loadAttempted) {
+export async function loadPhoton(): Promise<typeof import("@silvia-odwyer/photon-node") | null> {
+	if (photonModule) {
 		return photonModule;
 	}
 
-	loadAttempted = true;
-
-	try {
-		// Dynamic require to defer loading until actually needed
-		// This also allows the error to be caught gracefully
-		photonModule = require("@silvia-odwyer/photon-node");
-	} catch (e) {
-		loadError = e as Error;
-		photonModule = null;
+	if (loadPromise) {
+		return loadPromise;
 	}
 
-	return photonModule;
-}
+	loadPromise = (async () => {
+		try {
+			photonModule = await import("@silvia-odwyer/photon-node");
+		} catch {
+			photonModule = null;
+		}
+		return photonModule;
+	})();
 
-/**
- * Check if photon is available and working.
- */
-export function isPhotonAvailable(): boolean {
-	return getPhoton() !== null;
-}
-
-/**
- * Get the error that occurred during photon loading, if any.
- */
-export function getPhotonLoadError(): Error | null {
-	getPhoton(); // Ensure load was attempted
-	return loadError;
+	return loadPromise;
 }


### PR DESCRIPTION
**Problem**

Photon module fails to load with "require is not defined" error when running in ESM context.

**Solution**

Replace synchronous `require()` with async `import()` in photon.ts.

**Changes**

- `packages/coding-agent/src/utils/photon.ts`: Replace `getPhoton()` with async `loadPhoton()`
- `packages/coding-agent/src/utils/image-convert.ts`: Use `await loadPhoton()`
- `packages/coding-agent/src/utils/image-resize.ts`: Use `await loadPhoton()`