### PR TITLE
feat(coding-agent): export VERSION to make it available for use in the custom header

### DIFF
--- a/packages/coding-agent/examples/extensions/custom-header.ts
+++ b/packages/coding-agent/examples/extensions/custom-header.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent";
+import { VERSION } from "@mariozechner/pi-coding-agent";
 
 // --- PI MASCOT ---
 // Based on pi_mascot.ts - the pi agent character
@@ -52,7 +53,7 @@ export default function (pi: ExtensionAPI) {
 					render(_width: number): string[] {
 						const mascotLines = getPiMascot(theme);
 						// Add a subtitle with hint
-						const subtitle = theme.fg("muted", "   shitty coding agent");
+						const subtitle = `${theme.fg("muted", "   shitty coding agent")}${theme.fg("dim", ` v${VERSION}`)}`;
 						return [...mascotLines, subtitle];
 					},
 					invalidate() {},

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -1,7 +1,7 @@
 // Core session management
 
 // Config paths
-export { getAgentDir } from "./config.js";
+export { getAgentDir, VERSION } from "./config.js";
 export {
 	AgentSession,
 	type AgentSessionConfig,


### PR DESCRIPTION
```
➜  pi-mono git:(feat/app-version) pi


     █▌  █▌
  ██████████████
     ██    ██
     ██    ██
     ██    ██
     ██    ██

   shitty coding agent v0.48.0
```