### PR TITLE
feat(coding-agent): add Ctrl+L for clear screen and move model selector to Ctrl+X

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -364,7 +364,8 @@ Both modes are configurable via `/settings`: "one-at-a-time" delivers messages o
 | Ctrl+Z | Suspend to background (use `fg` in shell to resume) |
 | Shift+Tab | Cycle thinking level |
 | Ctrl+P / Shift+Ctrl+P | Cycle models forward/backward (scoped by `--models`) |
-| Ctrl+L | Open model selector |
+| Ctrl+L | Clear screen |
+| Ctrl+X | Open model selector |
 | Ctrl+O | Toggle tool output expansion |
 | Ctrl+T | Toggle thinking block visibility |
 | Ctrl+G | Edit message in external editor (`$VISUAL` or `$EDITOR`) |
@@ -403,13 +404,14 @@ All keyboard shortcuts can be customized via `~/.pi/agent/keybindings.json`. Eac
 | `submit` | `enter` | Submit input |
 | `tab` | `tab` | Tab/autocomplete |
 | `interrupt` | `escape` | Interrupt operation |
-| `clear` | `ctrl+c` | Clear editor |
+| `clear` | `ctrl+c` | Clear editor (first) / exit (second) |
+| `clearScreen` | `ctrl+l` | Clear screen |
 | `exit` | `ctrl+d` | Exit (when empty) |
 | `suspend` | `ctrl+z` | Suspend process |
 | `cycleThinkingLevel` | `shift+tab` | Cycle thinking level |
 | `cycleModelForward` | `ctrl+p` | Next model |
 | `cycleModelBackward` | `shift+ctrl+p` | Previous model |
-| `selectModel` | `ctrl+l` | Open model selector |
+| `selectModel` | `ctrl+x` | Open model selector |
 | `expandTools` | `ctrl+o` | Expand tool output |
 | `toggleThinking` | `ctrl+t` | Toggle thinking |
 | `externalEditor` | `ctrl+g` | Open external editor |

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -224,6 +224,7 @@ export class ExtensionRunner {
 		"ctrl+k",
 		"ctrl+p",
 		"ctrl+l",
+		"ctrl+x",
 		"ctrl+o",
 		"ctrl+t",
 		"ctrl+g",

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -17,6 +17,7 @@ import { getAgentDir } from "../config.js";
 export type AppAction =
 	| "interrupt"
 	| "clear"
+	| "clearScreen"
 	| "exit"
 	| "suspend"
 	| "cycleThinkingLevel"
@@ -48,12 +49,13 @@ export type KeybindingsConfig = {
 export const DEFAULT_APP_KEYBINDINGS: Record<AppAction, KeyId | KeyId[]> = {
 	interrupt: "escape",
 	clear: "ctrl+c",
+	clearScreen: "ctrl+l",
 	exit: "ctrl+d",
 	suspend: "ctrl+z",
 	cycleThinkingLevel: "shift+tab",
 	cycleModelForward: "ctrl+p",
 	cycleModelBackward: "shift+ctrl+p",
-	selectModel: "ctrl+l",
+	selectModel: "ctrl+x",
 	expandTools: "ctrl+o",
 	toggleThinking: "ctrl+t",
 	externalEditor: "ctrl+g",
@@ -74,6 +76,7 @@ export const DEFAULT_KEYBINDINGS: Required<KeybindingsConfig> = {
 const APP_ACTIONS: AppAction[] = [
 	"interrupt",
 	"clear",
+	"clearScreen",
 	"exit",
 	"suspend",
 	"cycleThinkingLevel",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -369,6 +369,7 @@ export class InteractiveMode {
 			const instructions = [
 				hint("interrupt", "to interrupt"),
 				hint("clear", "to clear"),
+				hint("clearScreen", "to clear screen"),
 				rawKeyHint(`${appKey(kb, "clear")} twice`, "to exit"),
 				hint("exit", "to exit (empty)"),
 				hint("suspend", "to suspend"),
@@ -1377,6 +1378,7 @@ export class InteractiveMode {
 
 		// Register app action handlers
 		this.defaultEditor.onAction("clear", () => this.handleCtrlC());
+		this.defaultEditor.onAction("clearScreen", () => this.handleClearScreen());
 		this.defaultEditor.onCtrlD = () => this.handleCtrlD();
 		this.defaultEditor.onAction("suspend", () => this.handleCtrlZ());
 		this.defaultEditor.onAction("cycleThinkingLevel", () => this.cycleThinkingLevel());
@@ -2178,6 +2180,11 @@ export class InteractiveMode {
 		} else {
 			this.showStatus(`Restored ${restored} queued message${restored > 1 ? "s" : ""} to editor`);
 		}
+	}
+
+	private handleClearScreen(): void {
+		this.chatContainer.clear();
+		this.ui.requestRender(true);
 	}
 
 	private updateEditorBorderColor(): void {
@@ -3414,6 +3421,9 @@ export class InteractiveMode {
 		const suspend = this.getAppKeyDisplay("suspend");
 		const cycleThinkingLevel = this.getAppKeyDisplay("cycleThinkingLevel");
 		const cycleModelForward = this.getAppKeyDisplay("cycleModelForward");
+		const cycleModelBackward = this.getAppKeyDisplay("cycleModelBackward");
+		const selectModel = this.getAppKeyDisplay("selectModel");
+		const clearScreen = this.getAppKeyDisplay("clearScreen");
 		const expandTools = this.getAppKeyDisplay("expandTools");
 		const toggleThinking = this.getAppKeyDisplay("toggleThinking");
 		const externalEditor = this.getAppKeyDisplay("externalEditor");
@@ -3444,10 +3454,12 @@ export class InteractiveMode {
 | \`${tab}\` | Path completion / accept autocomplete |
 | \`${interrupt}\` | Cancel autocomplete / abort streaming |
 | \`${clear}\` | Clear editor (first) / exit (second) |
+| \`${clearScreen}\` | Clear screen |
 | \`${exit}\` | Exit (when editor is empty) |
 | \`${suspend}\` | Suspend to background |
 | \`${cycleThinkingLevel}\` | Cycle thinking level |
-| \`${cycleModelForward}\` | Cycle models |
+| \`${cycleModelForward}\` / \`${cycleModelBackward}\` | Cycle models |
+| \`${selectModel}\` | Open model selector |
 | \`${expandTools}\` | Toggle tool output expansion |
 | \`${toggleThinking}\` | Toggle thinking block visibility |
 | \`${externalEditor}\` | Edit message in external editor |


### PR DESCRIPTION
### Description
This PR aligns the CLI behavior with standard Unix-like terminals by introducing a new **Clear Screen** action mapped to `Ctrl+L`.
Previously, `Ctrl+L` was used for the **Model Selector**. To accommodate this new behavior, the **Model Selector** shortcut has been remapped to `Ctrl+X`.

### Changes
  - Added a new `clearScreen` action, bound to `Ctrl+L` by default.
  - Remapped the `selectModel` keybinding from `Ctrl+L` to `Ctrl+X`.
  - Updated UI startup hints, keybinding configurations, and documentation to reflect the new shortcuts.