### PR TITLE
feat(coding-agent): add Standard Schema support for extension tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3560,6 +3560,12 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"license": "MIT"
+		},
 		"node_modules/@tailwindcss/cli": {
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.18.tgz",
@@ -8690,6 +8696,7 @@
 				"@mariozechner/pi-ai": "^0.48.0",
 				"@mariozechner/pi-tui": "^0.48.0",
 				"@silvia-odwyer/photon-node": "^0.3.4",
+				"@standard-schema/spec": "^1.1.0",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
 				"diff": "^8.0.2",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Extension tools now support [Standard Schema](https://standardschema.dev/) for parameter definitions. Use Zod v4+, Valibot v1+, ArkType v2+, or any Standard Schema-compatible library instead of TypeBox. See [extensions.md](docs/extensions.md#tool-definition) for examples.
+
 ## [0.48.0] - 2026-01-16
 
 ### Added

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -162,7 +162,8 @@ The `package.json` approach enables:
 | Package | Purpose |
 |---------|---------|
 | `@mariozechner/pi-coding-agent` | Extension types (`ExtensionAPI`, `ExtensionContext`, events) |
-| `@sinclair/typebox` | Schema definitions for tool parameters |
+| `@sinclair/typebox` | Schema definitions for tool parameters (TypeBox) |
+| `@standard-schema/spec` | Standard Schema types (for Zod, Valibot, ArkType) |
 | `@mariozechner/pi-ai` | AI utilities (`StringEnum` for Google-compatible enums) |
 | `@mariozechner/pi-tui` | TUI components for custom rendering |
 
@@ -1050,6 +1051,31 @@ Register tools the LLM can call via `pi.registerTool()`. Tools appear in the sys
 
 ### Tool Definition
 
+The `parameters` field accepts **TypeBox** schemas or any [Standard Schema](https://standardschema.dev/) library (Zod v4+, Valibot v1+, ArkType v2+).
+
+```typescript
+// TypeBox (bundled)
+import { Type } from "@sinclair/typebox";
+parameters: Type.Object({ name: Type.String() })
+
+// Zod v4+ (npm install zod@4)
+import { z } from "zod";
+parameters: z.object({ name: z.string() })
+
+// Valibot v1+ (npm install valibot @valibot/to-json-schema)
+import * as v from "valibot";
+import { toStandardJsonSchema } from "@valibot/to-json-schema";
+parameters: toStandardJsonSchema(v.object({ name: v.string() }))
+
+// ArkType v2+ (npm install arktype)
+import { type } from "arktype";
+parameters: type({ name: "string" })
+```
+
+**Important:** Use `StringEnum` from `@mariozechner/pi-ai` for string enums with TypeBox. `Type.Union`/`Type.Literal` doesn't work with Google's API.
+
+### Full Example
+
 ```typescript
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
@@ -1060,7 +1086,7 @@ pi.registerTool({
   label: "My Tool",
   description: "What this tool does (shown to LLM)",
   parameters: Type.Object({
-    action: StringEnum(["list", "add"] as const),  // Use StringEnum for Google compatibility
+    action: StringEnum(["list", "add"] as const),
     text: Type.Optional(Type.String()),
   }),
 
@@ -1091,8 +1117,6 @@ pi.registerTool({
   renderResult(result, options, theme) { ... },
 });
 ```
-
-**Important:** Use `StringEnum` from `@mariozechner/pi-ai` for string enums. `Type.Union`/`Type.Literal` doesn't work with Google's API.
 
 ### Overriding Built-in Tools
 

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -137,7 +137,18 @@ export default function (pi: ExtensionAPI) {
 
 ## Key Patterns
 
-**Use StringEnum for string parameters** (required for Google API compatibility):
+**Schema libraries**: TypeBox or Standard Schema (Zod v4+, Valibot v1+, ArkType v2+):
+```typescript
+// TypeBox (bundled, no extra dependencies)
+import { Type } from "@sinclair/typebox";
+parameters: Type.Object({ name: Type.String() })
+
+// Zod v4+ (requires npm install zod@4)
+import { z } from "zod";
+parameters: z.object({ name: z.string() })
+```
+
+**Use StringEnum for string enums with TypeBox** (required for Google API compatibility):
 ```typescript
 import { StringEnum } from "@mariozechner/pi-ai";
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -44,6 +44,7 @@
 		"@mariozechner/pi-ai": "^0.48.0",
 		"@mariozechner/pi-tui": "^0.48.0",
 		"@silvia-odwyer/photon-node": "^0.3.4",
+		"@standard-schema/spec": "^1.1.0",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",
 		"diff": "^8.0.2",

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -16,6 +16,7 @@ export type {
 	ShutdownHandler,
 } from "./runner.js";
 export { ExtensionRunner } from "./runner.js";
+export { hasJSONSchemaConverter, isStandardSchema, toJSONSchema } from "./schema.js";
 export type {
 	AgentEndEvent,
 	AgentStartEvent,
@@ -57,10 +58,13 @@ export type {
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
 	FindToolResultEvent,
+	// Schema types (Standard Schema support)
+	FlexibleSchema,
 	GetActiveToolsHandler,
 	GetAllToolsHandler,
 	GetThinkingLevelHandler,
 	GrepToolResultEvent,
+	InferSchemaOutput,
 	// Events - Input
 	InputEvent,
 	InputEventResult,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -18,6 +18,7 @@ import * as _bundledPiTui from "@mariozechner/pi-tui";
 // These MUST be static so Bun bundles them into the compiled binary.
 // The virtualModules option then makes them available to extensions.
 import * as _bundledTypebox from "@sinclair/typebox";
+import * as _bundledStandardSchema from "@standard-schema/spec";
 import { getAgentDir, isBunBinary } from "../../config.js";
 // NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
 // avoiding a circular dependency. Extensions can import from @mariozechner/pi-coding-agent.
@@ -39,6 +40,7 @@ import type {
 /** Modules available to extensions via virtualModules (for compiled Bun binary) */
 const VIRTUAL_MODULES: Record<string, unknown> = {
 	"@sinclair/typebox": _bundledTypebox,
+	"@standard-schema/spec": _bundledStandardSchema,
 	"@mariozechner/pi-agent-core": _bundledPiAgentCore,
 	"@mariozechner/pi-tui": _bundledPiTui,
 	"@mariozechner/pi-ai": _bundledPiAi,
@@ -67,6 +69,7 @@ function getAliases(): Record<string, string> {
 		"@mariozechner/pi-tui": require.resolve("@mariozechner/pi-tui"),
 		"@mariozechner/pi-ai": require.resolve("@mariozechner/pi-ai"),
 		"@sinclair/typebox": typeboxRoot,
+		"@standard-schema/spec": require.resolve("@standard-schema/spec"),
 	};
 
 	return _aliases;

--- a/packages/coding-agent/src/core/extensions/schema.ts
+++ b/packages/coding-agent/src/core/extensions/schema.ts
@@ -1,0 +1,65 @@
+/**
+ * Schema utilities for Standard Schema support.
+ *
+ * Converts Standard Schema (Zod v4+, Valibot v1+, ArkType v2+) to JSON Schema
+ * for use with LLM tool definitions.
+ */
+
+import type { TSchema } from "@sinclair/typebox";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { FlexibleSchema } from "./types.js";
+
+/**
+ * Check if a schema is a Standard Schema (has ~standard property with validate).
+ */
+export function isStandardSchema(schema: unknown): schema is StandardSchemaV1 {
+	return (
+		typeof schema === "object" &&
+		schema !== null &&
+		"~standard" in schema &&
+		typeof (schema as StandardSchemaV1)["~standard"] === "object" &&
+		(schema as StandardSchemaV1)["~standard"] !== null &&
+		"validate" in (schema as StandardSchemaV1)["~standard"]
+	);
+}
+
+/**
+ * Check if a Standard Schema also implements Standard JSON Schema (has jsonSchema converter).
+ */
+export function hasJSONSchemaConverter(
+	schema: StandardSchemaV1,
+): schema is StandardSchemaV1 & { "~standard": { jsonSchema: { input: (opts: { target: string }) => unknown } } } {
+	const std = schema["~standard"] as unknown as Record<string, unknown>;
+	return (
+		"jsonSchema" in std &&
+		typeof std.jsonSchema === "object" &&
+		std.jsonSchema !== null &&
+		"input" in (std.jsonSchema as Record<string, unknown>)
+	);
+}
+
+/**
+ * Convert a flexible schema (TypeBox or Standard Schema) to a JSON Schema object.
+ *
+ * - TypeBox schemas are already JSON Schema compatible
+ * - Standard Schemas with jsonSchema converter use ~standard.jsonSchema.input()
+ * - Standard Schemas without jsonSchema converter throw an error
+ *
+ * @param schema - A TypeBox or Standard Schema
+ * @returns A JSON Schema object suitable for LLM tool definitions
+ */
+export function toJSONSchema(schema: FlexibleSchema): TSchema {
+	if (isStandardSchema(schema)) {
+		if (hasJSONSchemaConverter(schema)) {
+			return schema["~standard"].jsonSchema.input({ target: "draft-07" }) as TSchema;
+		}
+		throw new Error(
+			`Standard Schema from vendor "${schema["~standard"].vendor}" does not support JSON Schema conversion. ` +
+				`The schema must implement StandardJSONSchemaV1 (have a ~standard.jsonSchema.input method). ` +
+				`For Zod, use v4.2+. For Valibot, use @valibot/to-json-schema. For ArkType, use v2.1.28+.`,
+		);
+	}
+
+	// TypeBox schema - already JSON Schema compatible
+	return schema as TSchema;
+}

--- a/packages/coding-agent/src/core/extensions/wrapper.ts
+++ b/packages/coding-agent/src/core/extensions/wrapper.ts
@@ -4,11 +4,13 @@
 
 import type { AgentTool, AgentToolUpdateCallback } from "@mariozechner/pi-agent-core";
 import type { ExtensionRunner } from "./runner.js";
+import { toJSONSchema } from "./schema.js";
 import type { RegisteredTool, ToolCallEventResult, ToolResultEventResult } from "./types.js";
 
 /**
  * Wrap a RegisteredTool into an AgentTool.
  * Uses the runner's createContext() for consistent context across tools and event handlers.
+ * Converts Standard Schema parameters to JSON Schema for LLM compatibility.
  */
 export function wrapRegisteredTool(registeredTool: RegisteredTool, runner: ExtensionRunner): AgentTool {
 	const { definition } = registeredTool;
@@ -16,7 +18,7 @@ export function wrapRegisteredTool(registeredTool: RegisteredTool, runner: Exten
 		name: definition.name,
 		label: definition.label,
 		description: definition.description,
-		parameters: definition.parameters,
+		parameters: toJSONSchema(definition.parameters),
 		execute: (toolCallId, params, signal, onUpdate) =>
 			definition.execute(toolCallId, params, onUpdate, runner.createContext(), signal),
 	};

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -1,5 +1,7 @@
 // Core session management
 
+// Re-export Standard Schema types for extension authors
+export type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec";
 // Config paths
 export { getAgentDir } from "./config.js";
 export {
@@ -64,6 +66,8 @@ export type {
 	ExtensionShortcut,
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
+	FlexibleSchema,
+	InferSchemaOutput,
 	InputEvent,
 	InputEventResult,
 	InputSource,
@@ -95,13 +99,16 @@ export type {
 } from "./core/extensions/index.js";
 export {
 	ExtensionRunner,
+	hasJSONSchemaConverter,
 	isBashToolResult,
 	isEditToolResult,
 	isFindToolResult,
 	isGrepToolResult,
 	isLsToolResult,
 	isReadToolResult,
+	isStandardSchema,
 	isWriteToolResult,
+	toJSONSchema,
 	wrapRegisteredTool,
 	wrapRegisteredTools,
 	wrapToolsWithExtensions,


### PR DESCRIPTION
**Problem**

Extension authors are locked into TypeBox for tool parameter schemas. Other popular validation libraries (Zod, Valibot, ArkType) can't be used.

**Solution**

Add support for [Standard Schema](https://standardschema.dev/) - a common interface implemented by Zod v4+, Valibot v1+, ArkType v2+, and others.

**Changes**

- `packages/coding-agent/src/core/extensions/schema.ts`: New file with `toJSONSchema()` converter
- `packages/coding-agent/src/core/extensions/types.ts`: Add `FlexibleSchema` type accepting both TypeBox and Standard Schema
- `packages/coding-agent/src/core/extensions/wrapper.ts`: Convert schemas before passing to agent
- `packages/coding-agent/src/core/extensions/loader.ts`: Add `@standard-schema/spec` to virtual modules