### PR TITLE
doc: add link to termux port repo

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -11,7 +11,7 @@
 
 A terminal-based coding agent with multi-model support, mid-session model switching, and a simple CLI for headless coding tasks.
 
-Works on Linux, macOS, and Windows (requires bash; see [Windows Setup](#windows-setup)).
+Works on Linux, macOS, and Windows (requires bash; see [Windows Setup](#windows-setup)). [Separately maintained port](https://github.com/VaclavSynacek/pi-coding-agent-termux) works on Termux/Android.
 
 ## Table of Contents
 


### PR DESCRIPTION
Hello Mario, as a followup to #758 : the port is done, works at least on my phones, is published on npm. Adding the link to it.

PS: I hope pi can maintain the port themselves - I have tested with a few versions and the readme and attached ssh session to termux is generally enough for them to figure out the rebasing, testing, publishing, pushing in one session. So yep, this might actually work longterm, although cannot be fully automated unless i dedicate some always charged always connected phone to this.