### PR TITLE
fix(tui): stop slash skill completion from auto-submitting

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -605,15 +605,9 @@ export class Editor implements Component, Focusable {
 					this.state.lines = result.lines;
 					this.state.cursorLine = result.cursorLine;
 					this.state.cursorCol = result.cursorCol;
-
-					if (this.autocompletePrefix.startsWith("/")) {
-						this.cancelAutocomplete();
-						// Fall through to submit
-					} else {
-						this.cancelAutocomplete();
-						if (this.onChange) this.onChange(this.getText());
-						return;
-					}
+					this.cancelAutocomplete();
+					if (this.onChange) this.onChange(this.getText());
+					return;
 				}
 			}
 		}


### PR DESCRIPTION
## Stop slash skill autocomplete from auto-submitting

### What was happening
Selecting a /skill from autocomplete was auto-submitting the message, so you couldn't add any context afterward.

### What this fixes
Now /skill completions work like @file mentions - they insert the text and let you keep typing instead of immediately sending. This lets you do things like `/skill <do X with Y>` without workarounds.

### The change
Removed the special case for /-prefixed completions in the autocomplete handler. All completions now just insert text and close the menu without auto-submitting.