### PR TITLE
Use hash fragments instead of query strings for share URLs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Share URLs now use hash fragments (`#`) instead of query strings (`?`) to prevent session IDs from being sent to buildwithpi.ai ([#828](https://github.com/badlogic/pi-mono/issues/828))
+
 ## [0.49.0] - 2026-01-17
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3297,7 +3297,7 @@ export class InteractiveMode {
 			}
 
 			// Create the preview URL
-			const previewUrl = `https://buildwithpi.ai/session?${gistId}`;
+			const previewUrl = `https://buildwithpi.ai/session/#${gistId}`;
 			this.showStatus(`Share URL: ${previewUrl}\nGist: ${gistUrl}`);
 		} catch (error: unknown) {
 			if (!loader.signal.aborted) {


### PR DESCRIPTION
Fixes #828

## Summary

Changes share URL format from `?SESSION_ID` to `#SESSION_ID`. URL fragments are not sent to the server in HTTP requests, so session IDs stay client-side.

## Changes

- `interactive-mode.ts`: Updated share URL template from `session?${gistId}` to `session/#${gistId}`

## Backward Compatibility

The buildwithpi.ai frontend (https://github.com/badlogic/shittycodingagent.ai/pull/4) parses the hash first and falls back to query string, so:
- New pi versions generate `#`-based URLs
- Old `?`-based URLs continue to work

---

*hash hides the secret*
*query string tells the server*
*fragments stay home*

🌸