### PR TITLE
feat(coding-agent): improve /scoped-models cycling UX

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- `/scoped-models`: Ctrl+R resets to the initial model selection, and Ctrl+T cycles per-model thinking overrides (persisted via `:level` suffixes).
+
+### Changed
+
+- Ctrl+P model cycling status now includes the provider name.
+- `/scoped-models` now shows ✓ for enabled models even when all models are enabled.
+
 ## [0.49.1] - 2026-01-18
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7,7 +7,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import {
 	type AssistantMessage,
 	getOAuthProviders,
@@ -2244,7 +2244,9 @@ export class InteractiveMode {
 				this.updateEditorBorderColor();
 				const thinkingStr =
 					result.model.reasoning && result.thinkingLevel !== "off" ? ` (thinking: ${result.thinkingLevel})` : "";
-				this.showStatus(`Switched to ${result.model.name || result.model.id}${thinkingStr}`);
+				this.showStatus(
+					`Switched to ${result.model.name || result.model.id}${thinkingStr} [${result.model.provider}]`,
+				);
 			}
 		} catch (error) {
 			this.showError(error instanceof Error ? error.message : String(error));
@@ -2746,46 +2748,75 @@ export class InteractiveMode {
 		const sessionScopedModels = this.session.scopedModels;
 		const hasSessionScope = sessionScopedModels.length > 0;
 
-		// Build enabled model IDs from session state or settings
-		const enabledModelIds = new Set<string>();
-		let hasFilter = false;
+		let enabledIds: string[] | null = null;
+		const thinkingOverrides = new Map<string, ThinkingLevel>();
 
 		if (hasSessionScope) {
-			// Use current session's scoped models
-			for (const sm of sessionScopedModels) {
-				enabledModelIds.add(`${sm.model.provider}/${sm.model.id}`);
+			// Prefer extracting explicit thinking overrides from settings patterns when the session scope
+			// matches the settings scope. This preserves explicit :level suffixes even if the level equals
+			// the current session default thinking level.
+			const settingsPatterns = this.settingsManager.getEnabledModels();
+			if (settingsPatterns !== undefined && settingsPatterns.length > 0) {
+				const scopedFromSettings = await resolveModelScope(settingsPatterns, this.session.modelRegistry);
+				const settingsIds = scopedFromSettings.map((sm) => `${sm.model.provider}/${sm.model.id}`);
+				const sessionIds = sessionScopedModels.map((sm) => `${sm.model.provider}/${sm.model.id}`);
+				const matchesSettingsScope =
+					sessionIds.length === settingsIds.length && sessionIds.every((id, i) => id === settingsIds[i]);
+
+				if (matchesSettingsScope) {
+					enabledIds = settingsIds;
+					for (const sm of scopedFromSettings) {
+						const fullId = `${sm.model.provider}/${sm.model.id}`;
+						if (sm.thinkingLevel && sm.thinkingLevel !== "off") {
+							thinkingOverrides.set(fullId, sm.thinkingLevel);
+						}
+					}
+				} else {
+					enabledIds = sessionIds;
+					for (const sm of sessionScopedModels) {
+						const fullId = `${sm.model.provider}/${sm.model.id}`;
+						if (sm.thinkingLevel !== "off") {
+							thinkingOverrides.set(fullId, sm.thinkingLevel);
+						}
+					}
+				}
+			} else {
+				enabledIds = sessionScopedModels.map((sm) => `${sm.model.provider}/${sm.model.id}`);
+				for (const sm of sessionScopedModels) {
+					const fullId = `${sm.model.provider}/${sm.model.id}`;
+					if (sm.thinkingLevel !== "off") {
+						thinkingOverrides.set(fullId, sm.thinkingLevel);
+					}
+				}
 			}
-			hasFilter = true;
 		} else {
 			// Fall back to settings
 			const patterns = this.settingsManager.getEnabledModels();
 			if (patterns !== undefined && patterns.length > 0) {
-				hasFilter = true;
 				const scopedModels = await resolveModelScope(patterns, this.session.modelRegistry);
+				enabledIds = scopedModels.map((sm) => `${sm.model.provider}/${sm.model.id}`);
 				for (const sm of scopedModels) {
-					enabledModelIds.add(`${sm.model.provider}/${sm.model.id}`);
+					const fullId = `${sm.model.provider}/${sm.model.id}`;
+					if (sm.thinkingLevel && sm.thinkingLevel !== "off") {
+						thinkingOverrides.set(fullId, sm.thinkingLevel);
+					}
 				}
 			}
 		}
 
-		// Track current enabled state (session-only until persisted)
-		const currentEnabledIds = new Set(enabledModelIds);
-		let currentHasFilter = hasFilter;
-
-		// Helper to update session's scoped models (session-only, no persist)
-		const updateSessionModels = async (enabledIds: Set<string>) => {
-			if (enabledIds.size > 0 && enabledIds.size < allModels.length) {
-				// Use current session thinking level, not settings default
+		const applySessionScope = async (patterns: string[] | null) => {
+			if (patterns && patterns.length > 0) {
+				// Use current session thinking level as default for models without explicit thinking suffix
 				const currentThinkingLevel = this.session.thinkingLevel;
-				const newScopedModels = await resolveModelScope(Array.from(enabledIds), this.session.modelRegistry);
+				const scopedModels = await resolveModelScope(patterns, this.session.modelRegistry);
 				this.session.setScopedModels(
-					newScopedModels.map((sm) => ({
+					scopedModels.map((sm) => ({
 						model: sm.model,
 						thinkingLevel: sm.thinkingLevel ?? currentThinkingLevel,
 					})),
 				);
 			} else {
-				// All enabled or none enabled = no filter
+				// No models enabled = clear scope
 				this.session.setScopedModels([]);
 			}
 		};
@@ -2794,50 +2825,15 @@ export class InteractiveMode {
 			const selector = new ScopedModelsSelectorComponent(
 				{
 					allModels,
-					enabledModelIds: currentEnabledIds,
-					hasEnabledModelsFilter: currentHasFilter,
+					enabledIds,
+					thinkingOverrides,
 				},
 				{
-					onModelToggle: async (modelId, enabled) => {
-						if (enabled) {
-							currentEnabledIds.add(modelId);
-						} else {
-							currentEnabledIds.delete(modelId);
-						}
-						currentHasFilter = true;
-						await updateSessionModels(currentEnabledIds);
+					onChange: async (patterns) => {
+						await applySessionScope(patterns);
 					},
-					onEnableAll: async (allModelIds) => {
-						currentEnabledIds.clear();
-						for (const id of allModelIds) {
-							currentEnabledIds.add(id);
-						}
-						currentHasFilter = false;
-						await updateSessionModels(currentEnabledIds);
-					},
-					onClearAll: async () => {
-						currentEnabledIds.clear();
-						currentHasFilter = true;
-						await updateSessionModels(currentEnabledIds);
-					},
-					onToggleProvider: async (_provider, modelIds, enabled) => {
-						for (const id of modelIds) {
-							if (enabled) {
-								currentEnabledIds.add(id);
-							} else {
-								currentEnabledIds.delete(id);
-							}
-						}
-						currentHasFilter = true;
-						await updateSessionModels(currentEnabledIds);
-					},
-					onPersist: (enabledIds) => {
-						// Persist to settings
-						const newPatterns =
-							enabledIds.length === allModels.length
-								? undefined // All enabled = clear filter
-								: enabledIds;
-						this.settingsManager.setEnabledModels(newPatterns);
+					onPersist: (patterns) => {
+						this.settingsManager.setEnabledModels(patterns === null ? undefined : patterns);
 						this.showStatus("Model selection saved to settings");
 					},
 					onCancel: () => {

--- a/packages/coding-agent/test/scoped-models-selector.test.ts
+++ b/packages/coding-agent/test/scoped-models-selector.test.ts
@@ -1,0 +1,119 @@
+import type { Model } from "@mariozechner/pi-ai";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { ScopedModelsSelectorComponent } from "../src/modes/interactive/components/scoped-models-selector.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+const mockModels: Model<"anthropic-messages">[] = [
+	{
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+	},
+	{
+		id: "gpt-4o",
+		name: "GPT-4o",
+		api: "anthropic-messages",
+		provider: "openai",
+		baseUrl: "https://api.openai.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 5, output: 15, cacheRead: 0.5, cacheWrite: 5 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	},
+];
+
+function renderAll(selector: ScopedModelsSelectorComponent, width = 120): string {
+	return selector.render(width).join("\n");
+}
+
+describe("ScopedModelsSelectorComponent", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("shows ✓ for enabled models even when all models are enabled", () => {
+		const selector = new ScopedModelsSelectorComponent(
+			{ allModels: mockModels, enabledIds: null },
+			{ onChange: vi.fn(), onPersist: vi.fn(), onCancel: vi.fn() },
+		);
+
+		const out = renderAll(selector);
+		expect(out).toContain("claude-sonnet-4-5");
+		expect(out).toContain("gpt-4o");
+		expect(out).toMatch(/✓/);
+	});
+
+	test("Ctrl+T cycles thinking overrides and shows :level suffix", () => {
+		const onChange = vi.fn();
+		const selector = new ScopedModelsSelectorComponent(
+			{ allModels: mockModels, enabledIds: ["anthropic/claude-sonnet-4-5"] },
+			{ onChange, onPersist: vi.fn(), onCancel: vi.fn() },
+		);
+
+		// Ctrl+T (\x14) should set first override to :minimal
+		selector.handleInput("\x14");
+		let out = renderAll(selector);
+		expect(out).toContain("claude-sonnet-4-5:minimal");
+
+		// Next cycle -> :low
+		selector.handleInput("\x14");
+		out = renderAll(selector);
+		expect(out).toContain("claude-sonnet-4-5:low");
+
+		// Ensure it emitted at least one change
+		expect(onChange).toHaveBeenCalled();
+	});
+
+	test("Ctrl+T is ignored when all models are enabled (no filter)", () => {
+		const selector = new ScopedModelsSelectorComponent(
+			{ allModels: mockModels, enabledIds: null },
+			{ onChange: vi.fn(), onPersist: vi.fn(), onCancel: vi.fn() },
+		);
+
+		selector.handleInput("\x14");
+		const out = renderAll(selector);
+		expect(out).not.toContain(":minimal");
+	});
+
+	test("Ctrl+T works when all models are explicitly selected", () => {
+		const selector = new ScopedModelsSelectorComponent(
+			{ allModels: mockModels, enabledIds: ["anthropic/claude-sonnet-4-5", "openai/gpt-4o"] },
+			{ onChange: vi.fn(), onPersist: vi.fn(), onCancel: vi.fn() },
+		);
+
+		selector.handleInput("\x14");
+		const out = renderAll(selector);
+		expect(out).toContain("claude-sonnet-4-5:minimal");
+	});
+
+	test("Ctrl+R resets selection and thinking overrides", () => {
+		const selector = new ScopedModelsSelectorComponent(
+			{ allModels: mockModels, enabledIds: ["anthropic/claude-sonnet-4-5"] },
+			{ onChange: vi.fn(), onPersist: vi.fn(), onCancel: vi.fn() },
+		);
+
+		// Set override
+		selector.handleInput("\x14"); // Ctrl+T
+		let out = renderAll(selector);
+		expect(out).toContain("claude-sonnet-4-5:minimal");
+
+		// Toggle off the model (Enter = \r)
+		selector.handleInput("\r");
+		out = renderAll(selector);
+		expect(out).toMatch(/claude-sonnet-4-5/);
+
+		// Reset (Ctrl+R = \x12)
+		selector.handleInput("\x12");
+		out = renderAll(selector);
+		expect(out).toContain("claude-sonnet-4-5");
+		expect(out).not.toContain("claude-sonnet-4-5:minimal");
+	});
+});


### PR DESCRIPTION
Some improvements to `/scoped-models` vibecoded with gpt 5.2. Take it as feature requests if too much code is changed.

- Add Ctrl+R reset to restore the initial model selection
- Add Ctrl+T per-model thinking overrides, persisted via :level suffix
- Include provider name in Ctrl+P model cycling status
- Show ✓ for enabled models even when all models are enabled