### PR TITLE
feat(ai): add OpenRouter provider routing support

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -413,6 +413,11 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 		params.reasoning_effort = options.reasoningEffort;
 	}
 
+	// OpenRouter provider routing preferences
+	if (model.baseUrl.includes("openrouter.ai") && model.compat?.openRouterRouting) {
+		(params as any).provider = model.compat.openRouterRouting;
+	}
+
 	return params;
 }
 
@@ -728,6 +733,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		requiresThinkingAsText: isMistral,
 		requiresMistralToolIds: isMistral,
 		thinkingFormat: isZai ? "zai" : "openai",
+		openRouterRouting: {},
 	};
 }
 
@@ -751,5 +757,6 @@ function getCompat(model: Model<"openai-completions">): Required<OpenAICompletio
 		requiresThinkingAsText: model.compat.requiresThinkingAsText ?? detected.requiresThinkingAsText,
 		requiresMistralToolIds: model.compat.requiresMistralToolIds ?? detected.requiresMistralToolIds,
 		thinkingFormat: model.compat.thinkingFormat ?? detected.thinkingFormat,
+		openRouterRouting: model.compat.openRouterRouting ?? {},
 	};
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -232,11 +232,25 @@ export interface OpenAICompletionsCompat {
 	requiresMistralToolIds?: boolean;
 	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "zai" uses thinking: { type: "enabled" }. Default: "openai". */
 	thinkingFormat?: "openai" | "zai";
+	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
+	openRouterRouting?: OpenRouterRouting;
 }
 
 /** Compatibility settings for OpenAI Responses APIs. */
 export interface OpenAIResponsesCompat {
 	// Reserved for future use
+}
+
+/**
+ * OpenRouter provider routing preferences.
+ * Controls which upstream providers OpenRouter routes requests to.
+ * @see https://openrouter.ai/docs/provider-routing
+ */
+export interface OpenRouterRouting {
+	/** List of provider slugs to exclusively use for this request (e.g., ["amazon-bedrock", "anthropic"]). */
+	only?: string[];
+	/** List of provider slugs to try in order (e.g., ["anthropic", "openai"]). */
+	order?: string[];
 }
 
 // Model interface for the unified model system

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -19,12 +19,19 @@ import type { AuthStorage } from "./auth-storage.js";
 
 const Ajv = (AjvModule as any).default || AjvModule;
 
+// Schema for OpenRouter routing preferences
+const OpenRouterRoutingSchema = Type.Object({
+	only: Type.Optional(Type.Array(Type.String())),
+	order: Type.Optional(Type.Array(Type.String())),
+});
+
 // Schema for OpenAI compatibility settings
 const OpenAICompletionsCompatSchema = Type.Object({
 	supportsStore: Type.Optional(Type.Boolean()),
 	supportsDeveloperRole: Type.Optional(Type.Boolean()),
 	supportsReasoningEffort: Type.Optional(Type.Boolean()),
 	maxTokensField: Type.Optional(Type.Union([Type.Literal("max_completion_tokens"), Type.Literal("max_tokens")])),
+	openRouterRouting: Type.Optional(OpenRouterRoutingSchema),
 });
 
 const OpenAIResponsesCompatSchema = Type.Object({


### PR DESCRIPTION
**What this is**

Following #843 , this adds support for OpenRouter provider selection as described in the issue.

**What it does**

These changes allow *custom* models to specify which upstream providers OpenRouter should route requests to via the `openRouterRouting` field in model definitions. Which model/provider combinations to use is completely up to you.

**Why it is so incomplete**

1. I wanted to keep it minimal.
2. Nobody else asked for it yet.
3. Probably nobody needs it aside from me and other secret OpenRouter provider sommeliers.
4. It's a tiny hint at how OpenRouter provider routing support could be extended in the future, if need be.

**Limitations**

⚠️ This is specifically designed to handle {one OR model} x {one provider} binding. No load balancing, priority selection or other OR features.

The idea is that for maintaining quality of inference and cache intact, you should stick to the single provider anyway, and routing between them is not desired.

**How it works**

The only introduced OpenRouter provider payload fields are:
- `only`: list of provider slugs to exclusively use
- `order`: list of provider slugs to try in order

Both of these should be used in tandem to ensure provider selection. In my testing, sometimes OpenRouter ignores the `only` parameter alone, but works when `only` *and* `order` are present.

So, the idea is that you:
- ask pi to create a custom openrouter config of your favorite model
- it will live in `~/.pi/models.json`
- it will look like this:

<img width="784" height="409" alt="Screenshot 2026-01-19 at 19 41 43" src="https://github.com/user-attachments/assets/f1f6c4d1-25cf-413c-8d6b-424a63bfaa83" />

... and the rest of the infrastructure would be handled by pi. It should correctly identify if you have OpenRouter API key for a model, it should work with /scoped-models and so on.

The only funky part of this code is the detection of a model by `baseUrl` and not `provider`, **but** it's intentional: it allows to create custom "virtually provided models" with openrouter-bedrock, openrouter-novita-fp8 etc labels in the UI and they all get the routing and API key pickup seamlessly.
