### PR TITLE
fix(coding-agent): fall back to 256color in Terminal.app

### DIFF
--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -166,8 +166,12 @@ function detectColorMode(): ColorMode {
 		return "truecolor";
 	}
 	const term = process.env.TERM || "";
-	// Only fall back to 256color for truly limited terminals
+	// Fall back to 256color for truly limited terminals
 	if (term === "dumb" || term === "" || term === "linux") {
+		return "256color";
+	}
+	// Terminal.app also doesn't support truecolor
+	if (process.env.TERM_PROGRAM === "Apple_Terminal") {
 		return "256color";
 	}
 	// Assume truecolor for everything else - virtually all modern terminals support it


### PR DESCRIPTION
This adds an exception from the truecolor rule for Terminal.app.

Without the fallback, the app looks pretty jarring:

| Original | Fixed |
|---|---|
| <img width="977" height="651" alt="Screenshot 2026-01-20 at 13 08 03" src="https://github.com/user-attachments/assets/1be2179c-f207-42e0-b2c5-dacc55ca208e" /> | <img width="977" height="651" alt="Screenshot 2026-01-20 at 13 08 37" src="https://github.com/user-attachments/assets/f4621094-657f-4db6-9846-ad9d23551ea5" /> |
| <img width="977" height="651" alt="Screenshot 2026-01-20 at 13 05 54" src="https://github.com/user-attachments/assets/3fa25081-b4e6-472e-986b-6a9cd31ceedd" /> | <img width="977" height="651" alt="Screenshot 2026-01-20 at 13 06 06" src="https://github.com/user-attachments/assets/6987c29c-a39f-4e29-8ff8-fc3ad40104bf" /> |
