### PR TITLE
fix(export): use active theme instead of default for HTML export

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed `write` tool not displaying errors in the UI when execution fails ([#856](https://github.com/badlogic/pi-mono/issues/856))
+- Fixed HTML export using default theme instead of user's active theme
 
 ## [0.49.2] - 2026-01-19
 

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -786,7 +786,7 @@ function ansi256ToHex(index: number): string {
  * Used by HTML export to generate CSS custom properties.
  */
 export function getResolvedThemeColors(themeName?: string): Record<string, string> {
-	const name = themeName ?? getDefaultTheme();
+	const name = themeName ?? currentThemeName ?? getDefaultTheme();
 	const isLight = name === "light";
 	const themeJson = loadThemeJson(name);
 	const resolved = resolveThemeColors(themeJson.colors, themeJson.vars);
@@ -825,7 +825,7 @@ export function getThemeExportColors(themeName?: string): {
 	cardBg?: string;
 	infoBg?: string;
 } {
-	const name = themeName ?? getDefaultTheme();
+	const name = themeName ?? currentThemeName ?? getDefaultTheme();
 	try {
 		const themeJson = loadThemeJson(name);
 		const exportSection = themeJson.export;


### PR DESCRIPTION
`getResolvedThemeColors` and `getThemeExportColors` now fall back to `currentThemeName` before `getDefaultTheme()`, so HTML exports respect the user's selected theme.