### PR TITLE
feat(ai): Add cacheControlTtl option for Anthropic prompt caching

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `headers` option to `StreamOptions` for custom HTTP headers in API requests. Supported by all providers except Amazon Bedrock (which uses AWS SDK auth). Headers are merged with provider defaults and `model.headers`, with `options.headers` taking precedence.
+- Added `cacheControlTtl` option to customize Anthropic-style prompt cache TTL (`"5m"` or `"1h"`).
 
 ## [0.49.2] - 2026-01-19
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -218,6 +218,7 @@ function mapOptionsForApi<TApi extends Api>(
 		signal: options?.signal,
 		apiKey: apiKey || options?.apiKey,
 		sessionId: options?.sessionId,
+		cacheControlTtl: options?.cacheControlTtl,
 		headers: options?.headers,
 		onPayload: options?.onPayload,
 	};

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -87,6 +87,11 @@ export interface StreamOptions {
 	 */
 	sessionId?: string;
 	/**
+	 * Optional TTL for Anthropic-style prompt caching when cache_control is used.
+	 * Allowed values: "5m" (default) or "1h".
+	 */
+	cacheControlTtl?: "5m" | "1h";
+	/**
 	 * Optional callback for inspecting provider payloads before sending.
 	 */
 	onPayload?: (payload: unknown) => void;


### PR DESCRIPTION
## Summary

  - Add cacheControlTtl to StreamOptions to control Anthropic prompt cache TTL ("5m" or "1h").
  - Apply the TTL to Anthropic cache_control blocks (system + last user) while preserving existing defaults.
  - Propagate the same TTL to OpenRouter’s Anthropic path via the OpenAI-compatible provider for consistent behavior.

  ## Motivation

  Clawdbot relies on @mariozechner/pi-ai for Anthropic prompt caching and needs to control TTL to manage cache reuse behavior. The current library
  only supports the default 5-minute TTL; Clawdbot requires 1-hour cache windows for longer-running workflows.

  ## Notes

  - Backward compatible: when cacheControlTtl is not set, requests use the existing cache_control: { type: "ephemeral" }.
  - No behavioral change for non-Anthropic providers.