### PR TITLE
feat(coding-agent): add pi.registerProvider() for dynamic provider registration

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1054,6 +1054,43 @@ pi.events.on("my:event", (data) => { ... });
 pi.events.emit("my:event", { ... });
 ```
 
+### pi.registerProvider(name, config)
+
+Register or override a model provider dynamically. Useful for proxies, custom endpoints, or team-wide model configurations.
+
+```typescript
+// Register a new provider with custom models
+pi.registerProvider("my-proxy", {
+  baseUrl: "https://proxy.example.com",
+  apiKey: "PROXY_API_KEY",  // env var name or literal
+  api: "anthropic-messages",
+  models: [
+    {
+      id: "claude-sonnet-4-20250514",
+      name: "Claude 4 Sonnet (proxy)",
+      reasoning: false,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 16384
+    }
+  ]
+});
+
+// Override baseUrl for an existing provider (keeps all models)
+pi.registerProvider("anthropic", {
+  baseUrl: "https://proxy.example.com"
+});
+```
+
+**Config options:**
+- `baseUrl` - API endpoint URL. Required when defining models.
+- `apiKey` - API key or environment variable name. Required when defining models.
+- `api` - API type: `"anthropic-messages"`, `"openai-completions"`, `"openai-responses"`, etc.
+- `headers` - Custom headers to include in requests.
+- `authHeader` - If true, adds `Authorization: Bearer` header automatically.
+- `models` - Array of model definitions. If provided, replaces all existing models for this provider.
+
 ## State Management
 
 Extensions with state should store it in tool result `details` for proper branching support:

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -76,6 +76,9 @@ export type {
 	MessageRenderOptions,
 	ModelSelectEvent,
 	ModelSelectSource,
+	// Provider Registration
+	ProviderConfig,
+	ProviderModelConfig,
 	ReadToolResultEvent,
 	// Commands
 	RegisteredCommand,

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -856,6 +856,100 @@ export interface ExtensionAPI {
 
 	/** Shared event bus for extension communication. */
 	events: EventBus;
+
+	// =========================================================================
+	// Provider Registration
+	// =========================================================================
+
+	/**
+	 * Register or override a model provider.
+	 *
+	 * If `models` is provided: replaces all existing models for this provider.
+	 * If only `baseUrl` is provided: overrides the URL for existing models.
+	 *
+	 * @example
+	 * // Register a new provider with custom models
+	 * pi.registerProvider("my-proxy", {
+	 *   baseUrl: "https://proxy.example.com",
+	 *   apiKey: "PROXY_API_KEY",
+	 *   api: "anthropic-messages",
+	 *   models: [
+	 *     {
+	 *       id: "claude-sonnet-4-20250514",
+	 *       name: "Claude 4 Sonnet (proxy)",
+	 *       reasoning: false,
+	 *       input: ["text", "image"],
+	 *       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	 *       contextWindow: 200000,
+	 *       maxTokens: 16384
+	 *     }
+	 *   ]
+	 * });
+	 *
+	 * @example
+	 * // Override baseUrl for an existing provider
+	 * pi.registerProvider("anthropic", {
+	 *   baseUrl: "https://proxy.example.com"
+	 * });
+	 */
+	registerProvider(name: string, config: ProviderConfig): void;
+}
+
+/** Configuration for registering a provider. */
+export interface ProviderConfig {
+	/** Base URL for the API endpoint. Required when defining models. */
+	baseUrl?: string;
+	/** API key or environment variable name. Required when defining models. */
+	apiKey?: string;
+	/** API type. Required at provider or model level when defining models. */
+	api?:
+		| "openai-completions"
+		| "openai-responses"
+		| "openai-codex-responses"
+		| "anthropic-messages"
+		| "google-generative-ai"
+		| "bedrock-converse-stream";
+	/** Custom headers to include in requests. */
+	headers?: Record<string, string>;
+	/** If true, adds Authorization: Bearer header with the resolved API key. */
+	authHeader?: boolean;
+	/** Models to register. If provided, replaces all existing models for this provider. */
+	models?: ProviderModelConfig[];
+}
+
+/** Configuration for a model within a provider. */
+export interface ProviderModelConfig {
+	/** Model ID (e.g., "claude-sonnet-4-20250514"). */
+	id: string;
+	/** Display name (e.g., "Claude 4 Sonnet"). */
+	name: string;
+	/** API type override for this model. */
+	api?:
+		| "openai-completions"
+		| "openai-responses"
+		| "openai-codex-responses"
+		| "anthropic-messages"
+		| "google-generative-ai"
+		| "bedrock-converse-stream";
+	/** Whether the model supports extended thinking. */
+	reasoning: boolean;
+	/** Supported input types. */
+	input: ("text" | "image")[];
+	/** Cost per token (for tracking, can be 0). */
+	cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+	/** Maximum context window size in tokens. */
+	contextWindow: number;
+	/** Maximum output tokens. */
+	maxTokens: number;
+	/** Custom headers for this model. */
+	headers?: Record<string, string>;
+	/** OpenAI compatibility settings. */
+	compat?: {
+		supportsStore?: boolean;
+		supportsDeveloperRole?: boolean;
+		supportsReasoningEffort?: boolean;
+		maxTokensField?: "max_completion_tokens" | "max_tokens";
+	};
 }
 
 /** Extension factory function type. Supports both sync and async initialization. */

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -469,7 +469,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	} else {
 		// Discover extensions, merging with additional paths
 		const configuredPaths = [...settingsManager.getExtensionPaths(), ...(options.additionalExtensionPaths ?? [])];
-		extensionsResult = await discoverAndLoadExtensions(configuredPaths, cwd, agentDir, eventBus);
+		extensionsResult = await discoverAndLoadExtensions(configuredPaths, cwd, agentDir, eventBus, modelRegistry);
 		time("discoverAndLoadExtensions");
 		for (const { path, error } of extensionsResult.errors) {
 			console.error(`Failed to load extension "${path}": ${error}`);
@@ -486,6 +486,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				eventBus,
 				extensionsResult.runtime,
 				`<inline-${i}>`,
+				modelRegistry,
 			);
 			extensionsResult.extensions.push(loaded);
 		}

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -74,6 +74,8 @@ export type {
 	LoadExtensionsResult,
 	MessageRenderer,
 	MessageRenderOptions,
+	ProviderConfig,
+	ProviderModelConfig,
 	RegisteredCommand,
 	RegisteredTool,
 	SessionBeforeCompactEvent,


### PR DESCRIPTION
**Problem**

Extensions cannot dynamically configure model providers. The only way to add providers is through `models.json`, which doesn't support:
- Fetching config from external servers at runtime
- Conditional registration based on environment (e.g., local Ollama)
- Team/corporate provider distribution via extensions

**Solution**

Add `pi.registerProvider(name, config)` to ExtensionAPI for runtime provider registration.

**Use cases**

- Fetch provider config from corporate/team server dynamically
- Conditionally register local models (e.g., Ollama if running)
- Override baseUrl for existing providers (proxies, private endpoints)
- Project-specific model configurations

**Example**

```typescript
// Fetch config from server
const config = await fetch('https://internal.company.com/ai-config').then(r => r.json());
pi.registerProvider('company-ai', config);

// Override existing provider's baseUrl  
pi.registerProvider('anthropic', {
  baseUrl: 'https://private-ai.company.com'
});
```

**Changes**

- `model-registry.ts`: Add `registerProvider()` method
- `types.ts`: Add `ProviderConfig`, `ProviderModelConfig` types, extend `ExtensionAPI`
- `loader.ts`: Pass `ModelRegistry` to extensions, implement API method
- `sdk.ts`: Thread `modelRegistry` through extension loading
- `extensions.md`: Document new API
- Tests for new functionality