### PR TITLE
fix(coding-agent): use dynamic paths in error messages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed error messages showing hardcoded `~/.pi/agent/` paths instead of respecting `PI_CODING_AGENT_DIR` ([#887](https://github.com/badlogic/pi-mono/pull/887) by [@aliou](https://github.com/aliou))
 - Fixed `write` tool not displaying errors in the UI when execution fails ([#856](https://github.com/badlogic/pi-mono/issues/856))
 - Fixed HTML export using default theme instead of user's active theme
 - Show session name in the footer and terminal / tab title

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -23,7 +23,7 @@
 import { Agent, type AgentMessage, type AgentTool, type ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { Message, Model } from "@mariozechner/pi-ai";
 import { join } from "path";
-import { getAgentDir } from "../config.js";
+import { getAgentDir, getAuthPath } from "../config.js";
 import { AgentSession } from "./agent-session.js";
 import { AuthStorage } from "./auth-storage.js";
 import { createEventBus, type EventBus } from "./event-bus.js";
@@ -401,7 +401,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 		} else {
 			// No models available - set message so user knows to /login or configure keys
-			modelFallbackMessage = "No models available. Use /login or set an API key environment variable.";
+			modelFallbackMessage = `No models available. Use /login, set an API key environment variable, or create ${getAuthPath()}`;
 		}
 	}
 

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { spawn, spawnSync } from "child_process";
+import { getSettingsPath } from "../config.js";
 import { SettingsManager } from "../core/settings-manager.js";
 
 let cachedShellConfig: { shell: string; args: string[] } | null = null;
@@ -45,7 +46,7 @@ export function getShellConfig(): { shell: string; args: string[] } {
 			return cachedShellConfig;
 		}
 		throw new Error(
-			`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ~/.pi/agent/settings.json`,
+			`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ${getSettingsPath()}`,
 		);
 	}
 
@@ -79,7 +80,7 @@ export function getShellConfig(): { shell: string; args: string[] } {
 			`No bash shell found. Options:\n` +
 				`  1. Install Git for Windows: https://git-scm.com/download/win\n` +
 				`  2. Add your bash to PATH (Cygwin, MSYS2, etc.)\n` +
-				`  3. Set shellPath in ~/.pi/agent/settings.json\n\n` +
+				`  3. Set shellPath in ${getSettingsPath()}\n\n` +
 				`Searched Git Bash in:\n${paths.map((p) => `  ${p}`).join("\n")}`,
 		);
 	}


### PR DESCRIPTION
Hello!

When `PI_CODING_AGENT_DIR` is set to a custom path, error messages still referenced the hardcoded `~/.pi/agent/` paths for `auth.json` and `settings.json`. This was confusing when trying to debug credential issues in non-default configurations.

Session: https://buildwithpi.ai/session/#45233e584148cc671c855b3fc22e2ee1

<details><summary>Summary</summary>

## Problem

Error messages in `sdk.ts` and `shell.ts` used hardcoded `~/.pi/agent/` paths instead of the dynamic path functions that respect `PI_CODING_AGENT_DIR`.

## Fix

- `sdk.ts`: Use `getAuthPath()` in the "No models available" message
- `shell.ts`: Use `getSettingsPath()` in shell configuration error messages

</details>