### PR TITLE
feat(coding-agent): add PI_SHARE_VIEWER_URL env var for custom share viewer

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -252,6 +252,7 @@ ${chalk.bold("Environment Variables:")}
   AWS_BEARER_TOKEN_BEDROCK - Bedrock API key (bearer token)
   AWS_REGION              - AWS region for Amazon Bedrock (e.g., us-east-1)
   ${ENV_AGENT_DIR.padEnd(23)} - Session storage directory (default: ~/${CONFIG_DIR_NAME}/agent)
+  PI_SHARE_VIEWER_URL     - Base URL for /share command (default: https://buildwithpi.ai/session/)
 
 ${chalk.bold("Available Tools (default: read, bash, edit, write):")}
   read   - Read file contents

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -116,6 +116,14 @@ export const VERSION: string = pkg.version;
 // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
 export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
 
+const DEFAULT_SHARE_VIEWER_URL = "https://buildwithpi.ai/session/";
+
+/** Get the share viewer URL for a gist ID */
+export function getShareViewerUrl(gistId: string): string {
+	const baseUrl = process.env.PI_SHARE_VIEWER_URL || DEFAULT_SHARE_VIEWER_URL;
+	return `${baseUrl}#${gistId}`;
+}
+
 // =============================================================================
 // User Config Paths (~/.pi/agent/*)
 // =============================================================================

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -43,7 +43,15 @@ import {
 	visibleWidth,
 } from "@mariozechner/pi-tui";
 import { spawn, spawnSync } from "child_process";
-import { APP_NAME, getAuthPath, getDebugLogPath, isBunBinary, isBunRuntime, VERSION } from "../../config.js";
+import {
+	APP_NAME,
+	getAuthPath,
+	getDebugLogPath,
+	getShareViewerUrl,
+	isBunBinary,
+	isBunRuntime,
+	VERSION,
+} from "../../config.js";
 import type { AgentSession, AgentSessionEvent } from "../../core/agent-session.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type {
@@ -3364,7 +3372,7 @@ export class InteractiveMode {
 			}
 
 			// Create the preview URL
-			const previewUrl = `https://buildwithpi.ai/session/#${gistId}`;
+			const previewUrl = getShareViewerUrl(gistId);
 			this.showStatus(`Share URL: ${previewUrl}\nGist: ${gistUrl}`);
 		} catch (error: unknown) {
 			if (!loader.signal.aborted) {


### PR DESCRIPTION
Add a PI_SHARE_VIEWER_URL environment variable to customize the base URL used by the /share command. Defaults to https://buildwithpi.ai/session/ when not set.

#880