### PR TITLE
feat(coding-agent): show release notes in update notification

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -25,6 +25,7 @@ export { ThemeSelectorComponent } from "./theme-selector.js";
 export { ThinkingSelectorComponent } from "./thinking-selector.js";
 export { ToolExecutionComponent, type ToolExecutionOptions } from "./tool-execution.js";
 export { TreeSelectorComponent } from "./tree-selector.js";
+export { UpdateNotificationComponent } from "./update-notification.js";
 export { UserMessageComponent } from "./user-message.js";
 export { UserMessageSelectorComponent } from "./user-message-selector.js";
 export { truncateToVisualLines, type VisualTruncateResult } from "./visual-truncate.js";

--- a/packages/coding-agent/src/modes/interactive/components/update-notification.ts
+++ b/packages/coding-agent/src/modes/interactive/components/update-notification.ts
@@ -1,0 +1,75 @@
+import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@mariozechner/pi-tui";
+import { isBunBinary, isBunRuntime } from "../../../config.js";
+import { getMarkdownTheme, theme } from "../theme/theme.js";
+import { DynamicBorder } from "./dynamic-border.js";
+import { editorKey } from "./keybinding-hints.js";
+
+/**
+ * Component that renders a version update notification with collapsed/expanded state.
+ * Collapsed: shows version and install command with borders
+ * Expanded: shows full release notes
+ */
+export class UpdateNotificationComponent extends Container {
+	private expanded = false;
+	private newVersion: string;
+	private releaseNotes: string | undefined;
+	private markdownTheme: MarkdownTheme;
+
+	constructor(newVersion: string, releaseNotes?: string, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
+		super();
+		this.newVersion = newVersion;
+		this.releaseNotes = releaseNotes;
+		this.markdownTheme = markdownTheme;
+		this.updateDisplay();
+	}
+
+	setExpanded(expanded: boolean): void {
+		this.expanded = expanded;
+		this.updateDisplay();
+	}
+
+	override invalidate(): void {
+		super.invalidate();
+		this.updateDisplay();
+	}
+
+	private getInstallCommand(): string {
+		if (isBunBinary) {
+			return `Download from: ${theme.fg("accent", "https://github.com/badlogic/pi-mono/releases/latest")}`;
+		}
+		return `Run: ${theme.fg("accent", `${isBunRuntime ? "bun" : "npm"} install -g @mariozechner/pi-coding-agent`)}`;
+	}
+
+	private updateDisplay(): void {
+		this.clear();
+
+		const borderColor = (text: string) => theme.fg("warning", text);
+
+		if (this.expanded && this.releaseNotes) {
+			this.addChild(new DynamicBorder(borderColor));
+			this.addChild(
+				new Text(`${theme.bold(theme.fg("warning", "Update Available"))} — ${this.getInstallCommand()}`, 1, 0),
+			);
+			this.addChild(new Spacer(1));
+			this.addChild(new Markdown(this.releaseNotes, 1, 0, this.markdownTheme));
+			this.addChild(new Spacer(1));
+			this.addChild(new DynamicBorder(borderColor));
+		} else {
+			const expandHint = this.releaseNotes
+				? ` (${theme.fg("dim", editorKey("expandTools"))} to see what's new)`
+				: "";
+			this.addChild(new DynamicBorder(borderColor));
+			this.addChild(
+				new Text(
+					`${theme.bold(theme.fg("warning", "Update Available"))}\n` +
+						theme.fg("muted", `New version ${this.newVersion} is available. `) +
+						this.getInstallCommand() +
+						expandHint,
+					1,
+					0,
+				),
+			);
+			this.addChild(new DynamicBorder(borderColor));
+		}
+	}
+}


### PR DESCRIPTION
**Problem**

The update notification only shows version number and install command - users don't know what changed.

**Solution**

Fetch release notes from GitHub Releases API and display them in the update notification. The notification is collapsible via Ctrl+O.

**Changes**

- `packages/coding-agent/src/modes/interactive/components/update-notification.ts`: New component with collapsed/expanded states
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: Fetch release notes alongside version check