### PR TITLE
feat(coding-agent): add --verbose CLI flag to override quietStartup setting

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -34,6 +34,7 @@ export interface Args {
 	noSkills?: boolean;
 	skills?: string[];
 	listModels?: string | true;
+	verbose?: boolean;
 	messages: string[];
 	fileArgs: string[];
 	/** Unknown flags (potentially extension flags) - map of flag name to value */
@@ -134,6 +135,8 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			} else {
 				result.listModels = true;
 			}
+		} else if (arg === "--verbose") {
+			result.verbose = true;
 		} else if (arg.startsWith("@")) {
 			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
 		} else if (arg.startsWith("--") && extensionFlags) {
@@ -187,6 +190,7 @@ ${chalk.bold("Options:")}
   --skills <patterns>            Comma-separated glob patterns to filter skills (e.g., git-*,docker)
   --export <file>                Export session file to HTML and exit
   --list-models [search]         List available models (with optional fuzzy search)
+  --verbose                      Force verbose startup (overrides quietStartup setting)
   --help, -h                     Show this help
   --version, -v                  Show version number
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -363,6 +363,11 @@ export async function main(args: string[]) {
 	const parsed = parseArgs(args, extensionFlags);
 	time("parseArgs");
 
+	// Apply CLI verbose flag to settings manager
+	if (parsed.verbose) {
+		settingsManager.setVerboseFromCli();
+	}
+
 	// Pass flag values to extensions via runtime
 	for (const [name, value] of parsed.unknownFlags) {
 		extensionsResult.runtime.flagValues.set(name, value);
@@ -465,6 +470,7 @@ export async function main(args: string[]) {
 	);
 	sessionOptions.authStorage = authStorage;
 	sessionOptions.modelRegistry = modelRegistry;
+	sessionOptions.settingsManager = settingsManager;
 	sessionOptions.eventBus = eventBus;
 
 	// Handle CLI --api-key as runtime override (not persisted)

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2625,7 +2625,7 @@ export class InteractiveMode {
 					doubleEscapeAction: this.settingsManager.getDoubleEscapeAction(),
 					showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
 					editorPaddingX: this.settingsManager.getEditorPaddingX(),
-					quietStartup: this.settingsManager.getQuietStartup(),
+					quietStartup: this.settingsManager.getStoredQuietStartup(),
 				},
 				{
 					onAutoCompactChange: (enabled) => {

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -170,6 +170,13 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("--verbose flag", () => {
+		test("parses --verbose flag", () => {
+			const result = parseArgs(["--verbose"]);
+			expect(result.verbose).toBe(true);
+		});
+	});
+
 	describe("--no-tools flag", () => {
 		test("parses --no-tools flag", () => {
 			const result = parseArgs(["--no-tools"]);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -106,6 +106,61 @@ describe("SettingsManager", () => {
 		});
 	});
 
+	describe("quietStartup and --verbose CLI override", () => {
+		it("should return false (verbose) by default", () => {
+			const manager = SettingsManager.inMemory({});
+			expect(manager.getQuietStartup()).toBe(false);
+		});
+
+		it("should return true when quietStartup is set in settings", () => {
+			const manager = SettingsManager.inMemory({ quietStartup: true });
+			expect(manager.getQuietStartup()).toBe(true);
+		});
+
+		it("should return false when setVerboseFromCli is called", () => {
+			const manager = SettingsManager.inMemory({ quietStartup: true });
+			expect(manager.getQuietStartup()).toBe(true);
+
+			manager.setVerboseFromCli();
+			expect(manager.getQuietStartup()).toBe(false);
+		});
+
+		it("should preserve CLI override when setQuietStartup is called", () => {
+			const manager = SettingsManager.inMemory({ quietStartup: false });
+			manager.setVerboseFromCli();
+
+			// Try to set quiet via the normal setter
+			manager.setQuietStartup(true);
+
+			// Should still be verbose because CLI override is active
+			expect(manager.getQuietStartup()).toBe(false);
+		});
+
+		it("should allow setQuietStartup to change state when not CLI-overridden", () => {
+			const manager = SettingsManager.inMemory({ quietStartup: false });
+			expect(manager.getQuietStartup()).toBe(false);
+
+			manager.setQuietStartup(true);
+			expect(manager.getQuietStartup()).toBe(true);
+
+			manager.setQuietStartup(false);
+			expect(manager.getQuietStartup()).toBe(false);
+		});
+
+		it("getStoredQuietStartup should return stored value even when CLI-overridden", () => {
+			const manager = SettingsManager.inMemory({ quietStartup: true });
+			expect(manager.getStoredQuietStartup()).toBe(true);
+			expect(manager.getQuietStartup()).toBe(true);
+
+			manager.setVerboseFromCli();
+
+			// getQuietStartup returns effective value (verbose due to CLI)
+			expect(manager.getQuietStartup()).toBe(false);
+			// getStoredQuietStartup returns stored value (still quiet in settings)
+			expect(manager.getStoredQuietStartup()).toBe(true);
+		});
+	});
+
 	describe("shellCommandPrefix", () => {
 		it("should load shellCommandPrefix from settings", () => {
 			const settingsPath = join(agentDir, "settings.json");


### PR DESCRIPTION
This is an implementation of #867. I made a couple of key decisions:

- Named the flag `--verbose` and not `--no-quiet`, mainly because `--verbose` is universally recognized across CLI tools.
- In `/settings`, show the value as it's stored on disk. For example, if `quietStartup` is `true` in settings.json and `--verbose` is passed making the effective value `false`, `/settings` still shows `true`.