### PR TITLE
fix(ai): batch tool-result images to fix Claude/Gemini 400 errors on multi-image reads

### DIFF
--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.js";
+import { convertMessages } from "../src/providers/openai-completions.js";
+import type {
+	AssistantMessage,
+	Context,
+	Model,
+	OpenAICompletionsCompat,
+	ToolResultMessage,
+	Usage,
+} from "../src/types.js";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const compat: Required<OpenAICompletionsCompat> = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresMistralToolIds: false,
+	thinkingFormat: "openai",
+};
+
+function buildToolResult(toolCallId: string, timestamp: number): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "read",
+		content: [
+			{ type: "text", text: "Read image file [image/png]" },
+			{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+		],
+		isError: false,
+		timestamp,
+	};
+}
+
+describe("openai-completions convertMessages", () => {
+	it("batches tool-result images after consecutive tool results", () => {
+		const baseModel = getModel("openai", "gpt-4o-mini");
+		const model: Model<"openai-completions"> = {
+			...baseModel,
+			api: "openai-completions",
+			input: ["text", "image"],
+		};
+
+		const now = Date.now();
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "img-1.png" } },
+				{ type: "toolCall", id: "tool-2", name: "read", arguments: { path: "img-2.png" } },
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: now,
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Read the images", timestamp: now - 2 },
+				assistantMessage,
+				buildToolResult("tool-1", now + 1),
+				buildToolResult("tool-2", now + 2),
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+		const roles = messages.map((message) => message.role);
+		expect(roles).toEqual(["user", "assistant", "tool", "tool", "user"]);
+
+		const imageMessage = messages[messages.length - 1];
+		expect(imageMessage.role).toBe("user");
+		expect(Array.isArray(imageMessage.content)).toBe(true);
+
+		const imageParts = (imageMessage.content as Array<{ type?: string }>).filter(
+			(part) => part?.type === "image_url",
+		);
+		expect(imageParts.length).toBe(2);
+	});
+});


### PR DESCRIPTION
## Problem

When reading multiple images in a single turn via the OpenAI-completions adapter, Claude and Gemini models fail with 400 errors:

- GitHub Copilot Claude (`claude-opus-4.5`, `claude-sonnet-4.5`): `tool_use ids were found without tool_result blocks immediately after`
- GitHub Copilot Gemini (`gemini-3-pro-preview`): `400 invalid request body`

GPT and Grok models were unaffected by this particular issue.

## Root Cause

The OpenAI-completions adapter was inserting a `user` message containing images after *each* tool result:

```
assistant(tool_calls: [read img1, read img2])
tool(result for img1)
user(image1)          ← breaks adjacency
tool(result for img2)
user(image2)
```

Claude strictly requires that `tool_use` blocks are immediately followed by their `tool_result` blocks with no interleaved messages. Gemini also rejects this structure.

## Solution

Batch consecutive `toolResult` messages and emit a single `user` message with all images at the end:

```
assistant(tool_calls: [read img1, read img2])
tool(result for img1)
tool(result for img2)
user([image1, image2])   ← single message after all tool results
```

This matches how the native Anthropic provider already handles tool results.

## Changes

- `packages/ai/src/providers/openai-completions.ts`: Refactored `convertMessages` to batch consecutive tool results and collect images, emitting one combined user message afterward
- `packages/ai/test/openai-completions-tool-result-images.test.ts`: Added test verifying message structure `[user, assistant, tool, tool, user(images)]`
- Exported `convertMessages` for unit testing

## Testing

```bash
npx vitest run packages/ai/test/openai-completions-tool-result-images.test.ts
```