### PR TITLE
fix: allow pi-test.sh to run from any directory

### DIFF
--- a/pi-test.sh
+++ b/pi-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-npx tsx packages/coding-agent/src/cli.ts "$@"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+npx tsx "$SCRIPT_DIR/packages/coding-agent/src/cli.ts" "$@"


### PR DESCRIPTION
The script used a relative path to `packages/coding-agent/src/cli.ts`, which only worked when running from the repo root.

Now resolves the script's directory and uses an absolute path, so you can run it from anywhere:

```bash
/path/to/pi-mono/pi-test.sh
```