### PR TITLE
fix(coding-agent): send correct follow-up paste content

### DIFF
--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -49,6 +49,12 @@ export interface EditorComponent extends Component {
 	 */
 	getExpandedText?(): string;
 
+	/**
+	 * Consume the current text as if it was submitted.
+	 * Returns the trimmed text with markers expanded and clears editor state.
+	 */
+	consumeText?(): string;
+
 	// =========================================================================
 	// Autocomplete support (optional)
 	// =========================================================================


### PR DESCRIPTION
Per https://github.com/badlogic/pi-mono/issues/912

- Ensures queued follow-up messages send paste content rather than literal paste marker
- Changes:
  - Introduced `Editor.consumeText()` (expands `[paste #N …]` markers, trims, and resets editor state).
  - Enter submit now calls `consumeText()`; before, it duplicated expansion/reset logic.*
  - Follow‑up queueing uses `consumeText()` (or `getExpandedText()` fallback) and only clears the editor when not already consumed.
- Testing
  - npm run check
  - ./test.sh
  - manual testing locally
  
Built with PI:
- Share URL: https://buildwithpi.ai/session/#ca35c68178b6d6267d21ab7848c4360b
- Gist: https://gist.github.com/tmustier/ca35c68178b6d6267d21ab7848c4360b

**History note: Duplication was introduced when follow‑up queueing was added in `InteractiveMode.handleFollowUp()` (commit 8f268257, Jan 2 2026). That path read `editor.getText().trim()` directly instead of reusing the editor submit logic that expands paste markers.*