### PR TITLE
Add missing JSDoc params in sliceByColumn

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -753,6 +753,9 @@ export function truncateToWidth(
 
 /**
  * Extract a range of visible columns from a line. Handles ANSI codes and wide chars.
+ * @param line - Line of text (may contain ANSI codes)
+ * @param startCol - 0-indexed starting column
+ * @param length - Number of visible columns to extract
  * @param strict - If true, exclude wide chars at boundary that would extend past the range
  */
 export function sliceByColumn(line: string, startCol: number, length: number, strict = false): string {


### PR DESCRIPTION
I'm reading over your TUI implementation and noticed the missing params. 

Probably not worth opening an issue. Feel free to close it. 