### PR TITLE
fix(ai): handle call arguments done on OpenAI-compatible endpoints

### DIFF
--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -231,6 +231,13 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 						});
 					}
 				}
+				// Handle function call arguments done (some providers send this instead of deltas)
+				else if (event.type === "response.function_call_arguments.done") {
+					if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
+						currentBlock.partialJson = event.arguments;
+						currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+					}
+				}
 				// Handle output item completion
 				else if (event.type === "response.output_item.done") {
 					const item = event.item;
@@ -256,13 +263,17 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 						});
 						currentBlock = null;
 					} else if (item.type === "function_call") {
+						const args =
+							currentBlock?.type === "toolCall" && currentBlock.partialJson
+								? JSON.parse(currentBlock.partialJson)
+								: JSON.parse(item.arguments);
 						const toolCall: ToolCall = {
 							type: "toolCall",
 							id: `${item.call_id}|${item.id}`,
 							name: item.name,
-							arguments: JSON.parse(item.arguments),
+							arguments: args,
 						};
-
+						currentBlock = null;
 						stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
 					}
 				}


### PR DESCRIPTION
fix bug encountered when running GLM-4.7-Flash hosted by LM Studio, in which the provider sends tool call arguments via
`response.function_call_arguments.done` events instead of streaming them via `response.function_call_arguments.delta` events. The final `response.output_item.done` event then contains empty `{}` arguments. The code only handled delta events, so tool calls failed with validation errors like `"must have required property 'command'"`.

Full disclosure, Opus triaged the bug and provided the fix (by adding logging statements to the req/resp to the upstream provider (LM Studio)). I'm happy to provide prompts/transcripts if you'd like, and acknowledge that I'm not an expert in Pi internals at this time.

Example output before fix:
<img width="425" height="808" alt="image" src="https://github.com/user-attachments/assets/f4cd3a64-f2c7-44ba-be21-3f5ef0a86aa9" />


and `models.json` config:

```json
{
    "providers": {
      "lmstudio": {
        "baseUrl": "http://localhost:1234/v1",
        "apiKey": "unused",
        "api": "openai-responses",
        "models": [
          ...
          {
            "id": "glm-4.7-flash",
            "name": "glm-4.7-flash",
            "reasoning": true,
            "input": ["text"],
            "compat": {
              "supportsDeveloperRole": false,
              "thinkingFormat": "zai"
            },
            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
            "contextWindow": 128000,
            "maxTokens": 32000
          }
        ]
      }
    }
  }
```

Other models, like Devstral Small 2, didn't show this issue.