### PR TITLE
fix(coding-agent): restore compaction-queued messages on Alt-Up

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Auto-retry now handles "terminated" errors from Codex API mid-stream failures
 - Follow-up queue (Alt+Enter) now sends full paste content instead of `[paste #N ...]` markers ([#912](https://github.com/badlogic/pi-mono/issues/912))
+- Fixed Alt-Up not restoring messages queued during compaction ([#923](https://github.com/badlogic/pi-mono/pull/923) by [@aliou](https://github.com/aliou))
 
 ## [0.49.3] - 2026-01-22
 


### PR DESCRIPTION
Hello!

When compaction is running and messages are queued (via Enter or Alt+Enter), pressing Alt-Up to restore them shows "No queued messages to restore" even though the messages are visible in the pending messages display.

Session: https://buildwithpi.ai/session/#5f351b6651ef1319ca2284bc115cbc7b

To reproduce, you can use this simple stalled-compaction extension : https://gist.github.com/aliou/3249be6c7d01683670c64f47f7164509 and install it with: 

```json
{
  "extensions": [
    "git:gist.github.com/aliou/3249be6c7d01683670c64f47f7164509"
  ]
}
```

<details><summary>Summary</summary>

## Problem

The coding agent maintains two separate message queues:
1. Session queue (`_steeringMessages` and `_followUpMessages`) - used during normal streaming
2. Compaction queue (`compactionQueuedMessages`) - used when compaction is in progress

`updatePendingMessagesDisplay()` correctly showed messages from both queues, but `restoreQueuedMessagesToEditor()` only checked the session queue via `session.clearQueue()`. When messages were queued during compaction, Alt-Up failed to restore them.

## Fix

Added helper methods to ensure consistency between display and restore:
- `getAllQueuedMessages()` - Read-only helper combining both queues
- `clearAllQueues()` - Destructive helper clearing both queues

Updated `updatePendingMessagesDisplay()` to use `getAllQueuedMessages()` and `restoreQueuedMessagesToEditor()` to use `clearAllQueues()`. This ensures the editor always restores the same messages shown in the pending display.

</details>