### PR TITLE
feat(coding-agent): /reload now re-renders entire scrollback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Changed
 
+- `/reload` now re-renders the entire scrollback so updated extension components are visible immediately
 - Skill, prompt template, and theme discovery now use settings and CLI path arrays instead of legacy filters ([#645](https://github.com/badlogic/pi-mono/issues/645))
 
 ### Fixed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3361,6 +3361,7 @@ export class InteractiveMode {
 			if (runner) {
 				this.setupExtensionShortcuts(runner);
 			}
+			this.rebuildChatFromMessages();
 			restoreEditor();
 			this.showLoadedResources({ extensionPaths: runner?.getExtensionPaths() ?? [], force: true });
 			const modelsJsonError = this.session.modelRegistry.getError();

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -297,19 +297,6 @@ describe("extensions discovery", () => {
 		expect(result.extensions[0].path).toContain("my-ext.ts");
 	});
 
-	it("resolves 3rd party npm dependencies (chalk)", async () => {
-		// Load the real chalk-logger extension from examples
-		const chalkLoggerPath = path.resolve(__dirname, "../examples/extensions/chalk-logger.ts");
-
-		const result = await discoverAndLoadExtensions([chalkLoggerPath], tempDir, tempDir);
-
-		expect(result.errors).toHaveLength(0);
-		expect(result.extensions).toHaveLength(1);
-		expect(result.extensions[0].path).toContain("chalk-logger.ts");
-		// The extension registers event handlers, not commands/tools
-		expect(result.extensions[0].handlers.size).toBeGreaterThan(0);
-	});
-
 	it("resolves dependencies from extension's own node_modules", async () => {
 		// Load extension that has its own package.json and node_modules with 'ms' package
 		const extPath = path.resolve(__dirname, "../examples/extensions/with-deps");


### PR DESCRIPTION
For extension development, reloading now rebuilds the full chat history so updated component rendering is visible immediately, not just in new messages.

This helps when iterating on extension components - after `/reload`, you can see how your changes affect the entire conversation history rather than only new messages.

Also fixes a pre-existing CI failure by removing the broken test for deleted `chalk-logger.ts` extension (npm dependency resolution is already covered by the `with-deps` test).