### PR TITLE
fix: handle empty/corrupted session files in setSessionFile

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -648,6 +648,16 @@ export class SessionManager {
 		this.sessionFile = resolve(sessionFile);
 		if (existsSync(this.sessionFile)) {
 			this.fileEntries = loadEntriesFromFile(this.sessionFile);
+
+			// If file was empty or corrupted (no valid header), start fresh to avoid
+			// appending messages without a session header (which breaks the session)
+			if (this.fileEntries.length === 0) {
+				const explicitPath = this.sessionFile;
+				this.newSession();
+				this.sessionFile = explicitPath;
+				return;
+			}
+
 			const header = this.fileEntries.find((e) => e.type === "session") as SessionHeader | undefined;
 			this.sessionId = header?.id ?? randomUUID();
 


### PR DESCRIPTION
## Problem

When `SessionManager.setSessionFile()` loads an existing file that is empty or has an invalid/missing header, it sets `flushed = true` even though `fileEntries` is empty. This causes subsequent messages to be appended **without a session header**, permanently corrupting the session file.

## Solution

Check if `fileEntries` is empty after loading and, if so, start a fresh session while preserving the explicit file path.

```typescript
if (this.fileEntries.length === 0) {
  const explicitPath = this.sessionFile;
  this.newSession();
  this.sessionFile = explicitPath;
  return;
}
```

## Testing

Added 4 new tests covering:
- Loading an empty file creates a new session with valid header
- Loading a file without valid header creates a new session  
- Writing after loading corrupted file produces valid session structure
- Explicit file path is preserved when recovering from corruption

All existing tests continue to pass.

## Evidence

Example of corrupted session file (messages without header, orphaned parentIds):
https://gist.github.com/armanddp/a62986a0e01480af0339b28c818eadfb

Fixes #932