### PR TITLE
fix(coding-agent): propagate paddingX to custom editors

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1555,6 +1555,9 @@ export class InteractiveMode {
 			if (newEditor.borderColor !== undefined) {
 				newEditor.borderColor = this.defaultEditor.borderColor;
 			}
+			if (newEditor.setPaddingX !== undefined) {
+				newEditor.setPaddingX(this.defaultEditor.getPaddingX());
+			}
 
 			// Set autocomplete if supported
 			if (newEditor.setAutocompleteProvider && this.autocompleteProvider) {
@@ -3030,6 +3033,9 @@ export class InteractiveMode {
 					onEditorPaddingXChange: (padding) => {
 						this.settingsManager.setEditorPaddingX(padding);
 						this.defaultEditor.setPaddingX(padding);
+						if (this.editor !== this.defaultEditor && this.editor.setPaddingX !== undefined) {
+							this.editor.setPaddingX(padding);
+						}
 					},
 					onCancel: () => {
 						done();

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -62,4 +62,7 @@ export interface EditorComponent extends Component {
 
 	/** Border color function */
 	borderColor?: (str: string) => string;
+
+	/** Set horizontal padding */
+	setPaddingX?(padding: number): void;
 }


### PR DESCRIPTION
The issue was that when `setCustomEditorComponent()` creates a new editor from the factory that an extension provides, it copies a bunch of stuff (callbacks, border color, autocomplete, action handlers), but it doesn't copy the `paddingX` setting.