### PR TITLE
fix(coding-agent): delegate extension shortcuts instead of copying

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1575,7 +1575,7 @@ export class InteractiveMode {
 				customEditor.onEscape = this.defaultEditor.onEscape;
 				customEditor.onCtrlD = this.defaultEditor.onCtrlD;
 				customEditor.onPasteImage = this.defaultEditor.onPasteImage;
-				customEditor.onExtensionShortcut = this.defaultEditor.onExtensionShortcut;
+				customEditor.onExtensionShortcut = (data: string) => this.defaultEditor.onExtensionShortcut?.(data);
 				// Copy action handlers (clear, suspend, model switching, etc.)
 				for (const [action, handler] of this.defaultEditor.actionHandlers) {
 					(customEditor.actionHandlers as Map<string, () => void>).set(action, handler);


### PR DESCRIPTION
### Problem

Extension shortcuts registered via `registerShortcut()` were not firing when the extension also used `setEditorComponent()`. This happened because `setEditorComponent()` copied `onExtensionShortcut` from `defaultEditor` at creation time, capturing `undefined` because `setupExtensionShortcuts()` hadn't run yet.

This regression was introduced in commit b846a4bf #645.

An excerpt of the extension:

```typescript
export default function (pi: ExtensionAPI) {
	pi.on("session_start", (_event, ctx) => {
		ctx.ui.setEditorComponent((tui, theme, keybindings) => {
			return new MyEditor(tui, theme, keybindings);
		});
	});

	pi.registerShortcut(Key.ctrl("x"), {
		description: "Copy prompt to clipboard",
		handler: async (ctx) => {
			// ...
		},
	});
}
```

Here's the flow:

1. `InteractiveMode.initExtensions()` runs
2. `bindExtensions()` emits `session_start`
3. Extension's `session_start` handler calls `ctx.ui.setEditorComponent(factory)`
4. `setCustomEditorComponent()` runs:
    
    ```
    // Line 1580 in interactive-mode.ts
    customEditor.onExtensionShortcut = this.defaultEditor.onExtensionShortcut;
    //                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    //                                  This is UNDEFINED at this point!
    ```
    
5. `this.editor = customEditor` (now using custom editor)
6. `setupExtensionShortcuts()` sets `defaultEditor.onExtensionShortcut = handler`
    - But we're not using `defaultEditor` anymore!
7. User presses shortcut → `customEditor.onExtensionShortcut(key)` → `undefined(key)` → nothing happens ✗

### Solution

The fix is to delegate to `defaultEditor.onExtensionShortcut` at call time.
