### PR TITLE
fix(coding-agent): restore correct editor after /reload with custom editor

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3649,11 +3649,11 @@ export class InteractiveMode {
 		this.ui.setFocus(loader);
 		this.ui.requestRender();
 
-		const restoreEditor = () => {
+		const dismissLoader = (editor: Component) => {
 			loader.dispose();
 			this.editorContainer.clear();
-			this.editorContainer.addChild(previousEditor);
-			this.ui.setFocus(previousEditor as Component);
+			this.editorContainer.addChild(editor);
+			this.ui.setFocus(editor);
 			this.ui.requestRender();
 		};
 
@@ -3666,7 +3666,7 @@ export class InteractiveMode {
 				this.setupExtensionShortcuts(runner);
 			}
 			this.rebuildChatFromMessages();
-			restoreEditor();
+			dismissLoader(this.editor as Component);
 			this.showLoadedResources({ extensionPaths: runner?.getExtensionPaths() ?? [], force: true });
 			const modelsJsonError = this.session.modelRegistry.getError();
 			if (modelsJsonError) {
@@ -3674,7 +3674,7 @@ export class InteractiveMode {
 			}
 			this.showStatus("Reloaded extensions, skills, prompts, themes");
 		} catch (error) {
-			restoreEditor();
+			dismissLoader(previousEditor as Component);
 			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);
 		}
 	}


### PR DESCRIPTION
## Problem

When an extension uses `setEditorComponent()` to install a custom editor, the `/reload` command breaks the editor state:

- `getEditorText()` returns empty string
- Hotkeys like Ctrl+C stop working
- Some hotkeys (like Ctrl+A) still work

## Root Cause

The `handleReloadCommand()` had a bug where a wrong editor restored after reload. This caused a mismatch: `this.editor` pointed to the custom editor, but the container displayed `defaultEditor`. So `getEditorText()` read from the wrong editor, and focus was on the wrong component.

## Solution

1. **Use `this.editor` on success.** After reload, use whatever editor is current (may be custom editor from extension)

2. **Use fallback editor on failure.** If reload fails, restore the safe `defaultEditor` state

3. **Rename `restoreEditor` to `dismissLoader`.** The function no longer "restores" anything; it just dismisses the loader and shows the current editor
