### PR TITLE
fix(tui): keep overlays centered across resizes, overlay docs update

### DIFF
--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -152,6 +152,27 @@ const result = await ctx.ui.custom<string | null>(
 );
 ```
 
+### Overlay Lifecycle
+
+Overlay components are disposed when closed. Don't reuse references - create fresh instances:
+
+```typescript
+// Wrong - stale reference
+let menu: MenuComponent;
+await ctx.ui.custom((_, __, ___, done) => {
+  menu = new MenuComponent(done);
+  return menu;
+}, { overlay: true });
+setActiveComponent(menu);  // Disposed
+
+// Correct - re-call to re-show
+const showMenu = () => ctx.ui.custom((_, __, ___, done) => 
+  new MenuComponent(done), { overlay: true });
+
+await showMenu();  // First show
+await showMenu();  // "Back" = just call again
+```
+
 See [overlay-qa-tests.ts](../examples/extensions/overlay-qa-tests.ts) for comprehensive examples covering anchors, margins, stacking, responsive visibility, and animation.
 
 ## Built-in Components

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Slash command menu now only triggers when the editor input is otherwise empty ([#904](https://github.com/badlogic/pi-mono/issues/904))
+- Center-anchored overlays now stay vertically centered when resizing the terminal taller after a shrink
 
 ## [0.49.3] - 2026-01-22
 


### PR DESCRIPTION
Overlays drifted during resize because cursor movements were calculated using absolute line positions instead of screen-relative positions. The fix tracks where the viewport starts and does the math in screen space.

When anchored to `center` overlays could “ratchet” upward (or downward) as the window height changed because our diff rendering cursor moves didn’t account for viewport shifts and we weren’t reliably extending the terminal working area when content grew.

Tracks viewport top across renders and computes cursor deltas relative to the current viewport (fixes height-resize alignment issues). Forces rendering of newly-appended lines when the rendered buffer grows (ensures the working area actually expands, so overlays stay centered).

Reproduce by: open a centered overlay at half-height, then resize taller/shorter — overlay stays centered throughout.

Before:

https://github.com/user-attachments/assets/79935bca-6502-442c-be5a-110f2f3447fe



After:

https://github.com/user-attachments/assets/e4e0440f-f1e8-41a3-bdf0-21c164a7e7e7



Also added docs on overlay lifecycle semantics. Armin ran into bugs where overlays became unresponsive but turned out he was holding references to disposed components and trying to reuse them. The docs now clarify that overlays are disposed on close, so you should create fresh instances when re-showing. Agents pointed at the docs will get this guidance upfront.

<img width="870" height="201" alt="image" src="https://github.com/user-attachments/assets/70e79ea9-ce2e-43db-b5ee-10b9d9a8d0b7" />




