### PR TITLE
Add regression test for viewport cursor overwrite bug

### DIFF
--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -196,4 +196,81 @@ describe("TUI differential rendering", () => {
 
 		tui.stop();
 	});
+
+	it("preserves earlier lines when appending content that exceeds viewport (viewport cursor fix)", async () => {
+		// Regression test for the viewport cursor overwrite bug (fixed in a6f9c3c).
+		//
+		// Bug scenario: When content exceeds viewport height and new lines are appended
+		// (e.g., tool output arriving after initial streaming), earlier lines could be
+		// overwritten. This happened because hardwareCursorRow (a content index) was
+		// used directly for CSI A/B cursor movement, but cursor movement clamps at
+		// viewport boundaries — causing writes to land on wrong lines.
+		//
+		// This test simulates the real-world pattern: streaming content that exceeds
+		// viewport, followed by tool output, followed by more streaming. All phases
+		// must be preserved in the scroll buffer without overwrites.
+
+		const terminal = new VirtualTerminal(40, 10); // Small viewport: 10 rows
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		// Phase 1: Render "pre-tool" content that exceeds viewport (20 lines > 10 rows)
+		const preLines = Array.from({ length: 20 }, (_, i) => `PRE-TOOL-${String(i + 1).padStart(2, "0")}`);
+		component.lines = [...preLines];
+		tui.start();
+		await terminal.flush();
+
+		// Phase 2: Simulate "tool output" — append more lines
+		const toolLines = Array.from({ length: 15 }, (_, i) => `TOOL-OUT-${String(i + 1).padStart(2, "0")}`);
+		component.lines = [...preLines, ...toolLines];
+		tui.requestRender();
+		await terminal.flush();
+
+		// Phase 3: Simulate "post-tool streaming" — append even more lines
+		const postLines = Array.from({ length: 5 }, (_, i) => `POST-TOOL-${String(i + 1).padStart(2, "0")}`);
+		component.lines = [...preLines, ...toolLines, ...postLines];
+		tui.requestRender();
+		await terminal.flush();
+
+		// Verify: ALL lines from all phases must be preserved in the scroll buffer.
+		// The bug caused some PRE-TOOL lines to be overwritten by later content.
+		const scrollBuffer = terminal.getScrollBuffer();
+		const scrollText = scrollBuffer.join("\n");
+
+		for (let i = 1; i <= 20; i++) {
+			const expectedLine = `PRE-TOOL-${String(i).padStart(2, "0")}`;
+			assert.ok(
+				scrollText.includes(expectedLine),
+				`PRE-TOOL line ${i} should be preserved in scroll buffer. Missing: ${expectedLine}`,
+			);
+		}
+
+		for (let i = 1; i <= 15; i++) {
+			const expectedLine = `TOOL-OUT-${String(i).padStart(2, "0")}`;
+			assert.ok(
+				scrollText.includes(expectedLine),
+				`TOOL-OUT line ${i} should be in scroll buffer. Missing: ${expectedLine}`,
+			);
+		}
+
+		for (let i = 1; i <= 5; i++) {
+			const expectedLine = `POST-TOOL-${String(i).padStart(2, "0")}`;
+			assert.ok(
+				scrollText.includes(expectedLine),
+				`POST-TOOL line ${i} should be in scroll buffer. Missing: ${expectedLine}`,
+			);
+		}
+
+		// Verify line ordering: all lines should appear in correct sequence
+		const expectedSequence = [...preLines, ...toolLines, ...postLines];
+		let lastIndex = -1;
+		for (const line of expectedSequence) {
+			const idx = scrollBuffer.indexOf(line);
+			assert.ok(idx > lastIndex, `Expected "${line}" to appear after the previous line in scroll buffer`);
+			lastIndex = idx;
+		}
+
+		tui.stop();
+	});
 });


### PR DESCRIPTION
## Summary

Adds a regression test for the scrollback overwrite bug GH954 which was fixed in a6f9c3c.

I ran into this bug while using pi and tracked it down independently. By the time I had a fix ready, I saw you'd already committed one — so I'm contributing the regression test, in case that might be useful.

## What this test does

The test simulates the exact usage pattern that triggered the bug:

1. Stream content that exceeds viewport height (20 lines into a 10-row viewport)
2. Append "tool output" (15 more lines)
3. Append "post-tool streaming" (5 more lines)

It then verifies that **all 40 lines** are present in the scroll buffer in the correct order — no overwrites, no missing content.

## Why?

This is non-interactive regression test.

The fix involves subtle cursor coordinate translation logic (content indices vs. viewport-relative rows), and future refactoring could accidentally break it.

The test:
- **Fails on fa8b26a** (pre-fix): `PRE-TOOL line 20 should be preserved in scroll buffer. Missing: PRE-TOOL-20`
- **Passes on a6f9c3c** (post-fix) and later

## authorship

I algal used AI to assist in authoring this.