### PR TITLE
fix(coding-agent): Title Case extension hotkeys in /hotkeys output

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4010,7 +4010,8 @@ export class InteractiveMode {
 `;
 				for (const [key, shortcut] of shortcuts) {
 					const description = shortcut.description ?? shortcut.extensionPath;
-					hotkeys += `| \`${key}\` | ${description} |\n`;
+					const keyDisplay = key.replace(/\b\w/g, (c) => c.toUpperCase());
+					hotkeys += `| \`${keyDisplay}\` | ${description} |\n`;
 				}
 			}
 		}


### PR DESCRIPTION
Extension hotkeys in the `/hotkeys` output are now displayed with Title Case keys for consistency with built-in hotkeys.

**Before:** `ctrl+x`
**After:** `Ctrl+X`