### PR TITLE
fix: use AWS_BEARER_TOKEN_BEDROCK for Bedrock authentication

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -94,6 +94,12 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 		if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
 			config.region = config.region || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
 
+			// Support bearer token authentication via AWS_BEARER_TOKEN_BEDROCK
+			const bearerToken = process.env.AWS_BEARER_TOKEN_BEDROCK?.trim();
+			if (bearerToken) {
+				config.token = { token: bearerToken };
+			}
+
 			if (
 				process.env.HTTP_PROXY ||
 				process.env.HTTPS_PROXY ||


### PR DESCRIPTION
Closes: https://github.com/badlogic/pi-mono/issues/974

When `AWS_BEARER_TOKEN_BEDROCK` is set, pass it to the BedrockRuntimeClient config for bearer token authentication.

Previously, this env var was only checked for credential detection in `env-api-keys.ts` but never actually used when creating the client.
