### PR TITLE
fix: lowercase OpenAI Responses tool call ids

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -80,8 +80,8 @@ export function convertResponsesMessages<TApi extends Api>(
 		if (!allowedToolCallProviders.has(model.provider)) return id;
 		if (!id.includes("|")) return id;
 		const [callId, itemId] = id.split("|");
-		const sanitizedCallId = callId.replace(/[^a-zA-Z0-9_-]/g, "_");
-		let sanitizedItemId = itemId.replace(/[^a-zA-Z0-9_-]/g, "_");
+		const sanitizedCallId = callId.replace(/[^a-zA-Z0-9_-]/g, "_").toLowerCase();
+		let sanitizedItemId = itemId.replace(/[^a-zA-Z0-9_-]/g, "_").toLowerCase();
 		// OpenAI Responses API requires item id to start with "fc"
 		if (!sanitizedItemId.startsWith("fc")) {
 			sanitizedItemId = `fc_${sanitizedItemId}`;


### PR DESCRIPTION
## Summary
- normalize OpenAI Responses tool call IDs to lowercase after sanitization

## Problem
OpenAI Responses/Codex APIs reject tool/item IDs containing uppercase characters. This surfaced as:
"Invalid 'input[i].id' ... Expected an ID that contains letters, numbers, underscores, or dashes".

## Fix
Lowercase sanitizedCallId and sanitizedItemId in openai-responses-shared.ts.

## Test
- not run (logic change only)
