### PR TITLE
fix(coding-agent): hide provider in footer when terminal is narrow

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -159,22 +159,7 @@ export class FooterComponent implements Component {
 		// Add model name on the right side, plus thinking level if model supports it
 		const modelName = state.model?.id || "no-model";
 
-		// Add thinking level hint if model supports reasoning and thinking is enabled
-		let rightSide = modelName;
-		if (state.model?.reasoning) {
-			const thinkingLevel = state.thinkingLevel || "off";
-			if (thinkingLevel !== "off") {
-				rightSide = `${modelName} • ${thinkingLevel}`;
-			}
-		}
-
-		// Prepend the provider in parenthesis to the right side if there's multiple providers
-		if (this.footerData.getAvailableProviderCount() > 1 && state.model) {
-			rightSide = `(${state.model.provider}) ${rightSide}`;
-		}
-
 		let statsLeftWidth = visibleWidth(statsLeft);
-		const rightSideWidth = visibleWidth(rightSide);
 
 		// If statsLeft is too wide, truncate it
 		if (statsLeftWidth > width) {
@@ -186,6 +171,27 @@ export class FooterComponent implements Component {
 
 		// Calculate available space for padding (minimum 2 spaces between stats and model)
 		const minPadding = 2;
+
+		// Add thinking level hint if model supports reasoning and thinking is enabled
+		let rightSideWithoutProvider = modelName;
+		if (state.model?.reasoning) {
+			const thinkingLevel = state.thinkingLevel || "off";
+			if (thinkingLevel !== "off") {
+				rightSideWithoutProvider = `${modelName} • ${thinkingLevel}`;
+			}
+		}
+
+		// Prepend the provider in parentheses if there are multiple providers and there's enough room
+		let rightSide = rightSideWithoutProvider;
+		if (this.footerData.getAvailableProviderCount() > 1 && state.model) {
+			rightSide = `(${state.model!.provider}) ${rightSideWithoutProvider}`;
+			if (statsLeftWidth + minPadding + visibleWidth(rightSide) > width) {
+				// Too wide, fall back
+				rightSide = rightSideWithoutProvider;
+			}
+		}
+
+		const rightSideWidth = visibleWidth(rightSide);
 		const totalNeeded = statsLeftWidth + minPadding + rightSideWidth;
 
 		let statsLine: string;


### PR DESCRIPTION
### Problem

This is a follow-up to #920, which shows the provider prefix, e.g. `(anthropic)`, in the footer when multiple providers are available. On narrow terminals, e.g. around 80 characters, the right side of the footer may be truncated mid-text, making it difficult to read the model name and thinking level.

### Solution

Instead of truncating characters when the footer is too wide, try hiding the provider prefix first. This keeps the most important information (model name and thinking level) visible on narrow terminals while still showing the provider when there's enough room.

https://github.com/user-attachments/assets/fb1cbf1a-0d78-4630-abec-d9f2ee07d616

cc: @enisdenjo, @marckrenn