### PR TITLE
feat(tui): auto-apply single suggestion in force file autocomplete

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1791,6 +1791,25 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 		);
 
 		if (suggestions && suggestions.items.length > 0) {
+			// If there's exactly one suggestion, apply it immediately
+			if (suggestions.items.length === 1) {
+				const item = suggestions.items[0]!;
+				this.pushUndoSnapshot();
+				this.lastAction = null;
+				const result = this.autocompleteProvider.applyCompletion(
+					this.state.lines,
+					this.state.cursorLine,
+					this.state.cursorCol,
+					item,
+					suggestions.prefix,
+				);
+				this.state.lines = result.lines;
+				this.state.cursorLine = result.cursorLine;
+				this.state.cursorCol = result.cursorCol;
+				if (this.onChange) this.onChange(this.getText());
+				return;
+			}
+
 			this.autocompletePrefix = suggestions.prefix;
 			this.autocompleteList = new SelectList(suggestions.items, 5, this.theme.selectList);
 			this.isAutocompleting = true;


### PR DESCRIPTION
### Problem

When using <kbd>Tab</kbd>-triggered file path completion, e.g. typing `~/Work` and pressing <kbd>Tab</kbd>, the autocomplete menu always appears even when there's only one matching suggestion. This requires an extra <kbd>Tab</kbd> press to confirm the selection, making path completion a bit slower than necessary.

### Solution

If there's exactly one item to suggest, apply it immediately without showing the menu. This behaves as if the user pressed Tab twice, but in a single keystroke.

Here's how it looks:

https://github.com/user-attachments/assets/08ab93b2-aa16-49a2-93ef-f2a62ba54e39
