### PR TITLE
fix(build): add HTML templates and documentation to binary builds

### DIFF
--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -119,6 +119,8 @@ for platform in "${PLATFORMS[@]}"; do
     cp ../../node_modules/@silvia-odwyer/photon-node/photon_rs_bg.wasm binaries/$platform/
     mkdir -p binaries/$platform/theme
     cp dist/modes/interactive/theme/*.json binaries/$platform/theme/
+    cp -r dist/core/export-html binaries/$platform/
+    cp -r docs binaries/$platform/
     cp -r examples binaries/$platform/
 done
 


### PR DESCRIPTION
The binary archive was previously missing docs/ and export-html/, so pi couldn't answer questions about itself or generate HTML exports.