### PR TITLE
feat(ui): Add Retro CRT/Phosphor Effect Layer

### DIFF
--- a/packages/web-ui/src/app.css
+++ b/packages/web-ui/src/app.css
@@ -9,6 +9,9 @@
 /* biome-ignore lint/correctness/noInvalidPositionAtImportRule: fuck you */
 @import "tailwindcss";
 
+/* CRT / Phosphor overlay effect */
+@import "./components/CRTOverlay.module.css";
+
 body {
 	font-size: 16px;
 	-webkit-font-smoothing: antialiased;

--- a/packages/web-ui/src/components/CRTOverlay.module.css
+++ b/packages/web-ui/src/components/CRTOverlay.module.css
@@ -1,0 +1,175 @@
+/* =============================================================================
+   CRT / Phosphor Monitor Effect
+   Retro scanlines, flicker, vignette, and glow for that Fallout-terminal vibe.
+   ============================================================================= */
+
+/* -----------------------------------------------------------------------------
+   Color Mode Variables
+   ----------------------------------------------------------------------------- */
+
+/* Default: Green phosphor (P1/P39 style) */
+crt-container,
+crt-container[color-mode="green"] {
+	--crt-phosphor: #33ff33;
+	--crt-phosphor-dim: #1a8c1a;
+	--crt-phosphor-glow: rgba(51, 255, 51, 0.4);
+	--crt-scanline-dark: rgba(0, 0, 0, 0.15);
+	--crt-vignette-color: rgba(0, 0, 0, 0.5);
+}
+
+/* Amber phosphor (P3 style) */
+crt-container[color-mode="amber"] {
+	--crt-phosphor: #ffb347;
+	--crt-phosphor-dim: #cc8a30;
+	--crt-phosphor-glow: rgba(255, 179, 71, 0.4);
+	--crt-scanline-dark: rgba(0, 0, 0, 0.12);
+	--crt-vignette-color: rgba(20, 10, 0, 0.5);
+}
+
+/* Blue phosphor (cool terminal) */
+crt-container[color-mode="blue"] {
+	--crt-phosphor: #66ccff;
+	--crt-phosphor-dim: #3399cc;
+	--crt-phosphor-glow: rgba(102, 204, 255, 0.4);
+	--crt-scanline-dark: rgba(0, 0, 0, 0.12);
+	--crt-vignette-color: rgba(0, 10, 20, 0.5);
+}
+
+/* -----------------------------------------------------------------------------
+   Wrapper & Content
+   ----------------------------------------------------------------------------- */
+
+.crt-wrapper {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	background: #0a0a0a;
+}
+
+.crt-content {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	z-index: 1;
+}
+
+/* -----------------------------------------------------------------------------
+   Curvature Effect (optional 3D transform)
+   ----------------------------------------------------------------------------- */
+
+.crt-curvature {
+	perspective: 1000px;
+	border-radius: 20px;
+	overflow: hidden;
+}
+
+.crt-curvature .crt-content {
+	transform: rotateX(1deg) rotateY(0deg);
+	transform-origin: center center;
+}
+
+.crt-curvature .crt-overlay {
+	border-radius: 20px;
+}
+
+/* -----------------------------------------------------------------------------
+   Overlay Layer (scanlines + vignette + flicker)
+   pointer-events: none so it doesn't block interaction
+   ----------------------------------------------------------------------------- */
+
+.crt-overlay {
+	position: absolute;
+	inset: 0;
+	z-index: 1000;
+	pointer-events: none;
+
+	/* Scanlines: horizontal repeating dark lines */
+	background:
+		/* Scanlines */
+		repeating-linear-gradient(
+			to bottom,
+			transparent 0px,
+			transparent 2px,
+			var(--crt-scanline-dark) 2px,
+			var(--crt-scanline-dark) 4px
+		),
+		/* Vignette: radial gradient darkening corners */
+		radial-gradient(
+			ellipse at center,
+			transparent 0%,
+			transparent 60%,
+			var(--crt-vignette-color) 100%
+		);
+
+	/* Subtle flicker animation */
+	animation: crt-flicker 0.1s infinite;
+}
+
+/* -----------------------------------------------------------------------------
+   Flicker Animation
+   Very subtle opacity variation to simulate 60Hz CRT hum
+   ----------------------------------------------------------------------------- */
+
+@keyframes crt-flicker {
+	0% {
+		opacity: 0.97;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0.98;
+	}
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+	.crt-overlay {
+		animation: none;
+		opacity: 1;
+	}
+}
+
+/* -----------------------------------------------------------------------------
+   Text Glow (Phosphor Bloom Effect)
+   Applied to common text elements within the CRT container
+   ----------------------------------------------------------------------------- */
+
+crt-container {
+	color: var(--crt-phosphor);
+}
+
+crt-container p,
+crt-container span,
+crt-container div,
+crt-container h1,
+crt-container h2,
+crt-container h3,
+crt-container h4,
+crt-container h5,
+crt-container h6,
+crt-container li,
+crt-container td,
+crt-container th,
+crt-container label,
+crt-container button,
+crt-container a,
+crt-container input,
+crt-container textarea,
+crt-container pre,
+crt-container code {
+	text-shadow:
+		0 0 2px var(--crt-phosphor-glow),
+		0 0 4px var(--crt-phosphor-glow);
+}
+
+/* Slightly stronger glow for headings */
+crt-container h1,
+crt-container h2,
+crt-container h3 {
+	text-shadow:
+		0 0 3px var(--crt-phosphor-glow),
+		0 0 6px var(--crt-phosphor-glow),
+		0 0 10px var(--crt-phosphor-glow);
+}

--- a/packages/web-ui/src/components/CRTOverlay.ts
+++ b/packages/web-ui/src/components/CRTOverlay.ts
@@ -1,0 +1,67 @@
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+/**
+ * Phosphor color mode for the CRT effect.
+ */
+export type CRTColorMode = "green" | "amber" | "blue";
+
+/**
+ * A wrapper component that applies a retro CRT/phosphor monitor effect
+ * to its children. Includes scanlines, flicker, vignette, and optional
+ * screen curvature.
+ *
+ * @example
+ * ```html
+ * <crt-container color-mode="green" curvature>
+ *   <div>Your app content here</div>
+ * </crt-container>
+ * ```
+ */
+@customElement("crt-container")
+export class CRTContainer extends LitElement {
+	/**
+	 * The phosphor color mode: "green" (classic), "amber" (warm), or "blue" (cool).
+	 */
+	@property({ type: String, attribute: "color-mode", reflect: true })
+	colorMode: CRTColorMode = "green";
+
+	/**
+	 * Whether to apply a subtle curved screen effect via CSS 3D transforms.
+	 */
+	@property({ type: Boolean, reflect: true })
+	curvature = false;
+
+	// Render into light DOM to inherit Tailwind styles
+	createRenderRoot() {
+		return this;
+	}
+
+	override connectedCallback() {
+		super.connectedCallback();
+		this.style.display = "block";
+		this.style.width = "100%";
+		this.style.height = "100%";
+		this.style.position = "relative";
+	}
+
+	override render() {
+		const curvatureClass = this.curvature ? "crt-curvature" : "";
+
+		return html`
+			<div class="crt-wrapper ${curvatureClass}">
+				<!-- Content slot -->
+				<div class="crt-content">
+					<slot></slot>
+				</div>
+				<!-- Overlay layer: scanlines + vignette + flicker -->
+				<div class="crt-overlay" aria-hidden="true"></div>
+			</div>
+		`;
+	}
+}
+
+// Guard against duplicate registration
+if (!customElements.get("crt-container")) {
+	customElements.define("crt-container", CRTContainer);
+}

--- a/packages/web-ui/src/index.ts
+++ b/packages/web-ui/src/index.ts
@@ -7,6 +7,7 @@ export { ChatPanel } from "./ChatPanel.js";
 export { AgentInterface } from "./components/AgentInterface.js";
 export { AttachmentTile } from "./components/AttachmentTile.js";
 export { ConsoleBlock } from "./components/ConsoleBlock.js";
+export { type CRTColorMode, CRTContainer } from "./components/CRTOverlay.js";
 export { ExpandableSection } from "./components/ExpandableSection.js";
 export { Input } from "./components/Input.js";
 export { MessageEditor } from "./components/MessageEditor.js";


### PR DESCRIPTION
## Summary

- Add `<crt-container>` web component that wraps content with a classic CRT monitor aesthetic
- Includes scanlines, subtle 60Hz flicker, vignette, and phosphor text glow
- Supports three color modes: green (classic), amber (warm), and blue (cool)
- Optional `curvature` prop for curved screen effect via CSS 3D transforms

## Technical Details

- Pure CSS implementation (no JS animations) for optimal performance
- Uses `pointer-events: none` on overlay to avoid blocking touch/click interactions
- Respects `prefers-reduced-motion` for accessibility (disables flicker)
- Exports `CRTContainer` component and `CRTColorMode` type from package index

## Test plan

- [ ] Verify the example app renders with green phosphor effect by default
- [ ] Test color modes: change `color-mode="green"` to `"amber"` or `"blue"` 
- [ ] Test curvature: add `curvature` attribute to see 3D curved screen
- [ ] Verify dialogs/overlays still work (z-index layering)
- [ ] Verify touch/click interactions are not blocked by overlay
- [ ] Test with `prefers-reduced-motion` enabled (flicker should be disabled)