### PR TITLE
perf(tui): optimized extractCursorPosition to scan lines in reverse order

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -772,7 +772,7 @@ export class TUI extends Container {
 	 * @returns Cursor position { row, col } or null if no marker found
 	 */
 	private extractCursorPosition(lines: string[]): { row: number; col: number } | null {
-		for (let row = 0; row < lines.length; row++) {
+		for (let row = lines.length - 1; row >= 0; row--) {
 			const line = lines[row];
 			const markerIndex = line.indexOf(CURSOR_MARKER);
 			if (markerIndex !== -1) {


### PR DESCRIPTION
Optimized extractCursorPosition to scan lines in reverse order for improved performance.

Turns out this is one of the slowest functions during a regular session.
<img width="516" height="147" alt="image" src="https://github.com/user-attachments/assets/1eac4596-a988-4810-93fc-96ac2d4b43de" />

Mostly because it scans from the head instead of the tail.