### PR TITLE
fix(web-ui): export CustomProviderCard component

### DIFF
--- a/packages/web-ui/src/index.ts
+++ b/packages/web-ui/src/index.ts
@@ -7,6 +7,7 @@ export { ChatPanel } from "./ChatPanel.js";
 export { AgentInterface } from "./components/AgentInterface.js";
 export { AttachmentTile } from "./components/AttachmentTile.js";
 export { ConsoleBlock } from "./components/ConsoleBlock.js";
+export { CustomProviderCard } from "./components/CustomProviderCard.js";
 export { ExpandableSection } from "./components/ExpandableSection.js";
 export { Input } from "./components/Input.js";
 export { MessageEditor } from "./components/MessageEditor.js";


### PR DESCRIPTION
## Summary

- Exports the `CustomProviderCard` component from `@mariozechner/pi-web-ui`

## Rationale

The `CustomProviderCard` component is used internally (by `ProvidersModelsTab`) but was not exported from the package index. This makes it unavailable to consumers who may want to use or extend it.

## Test plan

- [ ] Verify `CustomProviderCard` is importable from `@mariozechner/pi-web-ui`
- [ ] Verify existing functionality is not affected