### PR TITLE
fix(web-ui): export ProviderKeyInput component

### DIFF
--- a/packages/web-ui/src/index.ts
+++ b/packages/web-ui/src/index.ts
@@ -30,6 +30,7 @@ export {
 	registerMessageRenderer,
 	renderMessage,
 } from "./components/message-renderer-registry.js";
+export { ProviderKeyInput } from "./components/ProviderKeyInput.js";
 export {
 	type SandboxFile,
 	SandboxIframe,


### PR DESCRIPTION
## Summary

- Exports the `ProviderKeyInput` component from `@mariozechner/pi-web-ui`

## Rationale

The `ProviderKeyInput` component provides a reusable API key input field with:
- Built-in validation
- API key testing against provider endpoints
- Visual feedback for key status (valid/invalid)

It was used internally by dialogs (`SettingsDialog`, `ProvidersModelsTab`, `ApiKeyPromptDialog`) but not exported from the package, making it unavailable to consumers who may want to use it in their own UI.

## Test plan

- [ ] Verify `ProviderKeyInput` is importable from `@mariozechner/pi-web-ui`
- [ ] Verify existing dialogs still work correctly