### PR TITLE
fix(web-ui): export AbortedMessage and ToolMessageDebugView

### DIFF
--- a/packages/web-ui/src/index.ts
+++ b/packages/web-ui/src/index.ts
@@ -14,12 +14,14 @@ export { MessageList } from "./components/MessageList.js";
 // Message components
 export type { ArtifactMessage, UserMessageWithAttachments } from "./components/Messages.js";
 export {
+	AbortedMessage,
 	AssistantMessage,
 	convertAttachments,
 	defaultConvertToLlm,
 	isArtifactMessage,
 	isUserMessageWithAttachments,
 	ToolMessage,
+	ToolMessageDebugView,
 	UserMessage,
 } from "./components/Messages.js";
 // Message renderer registry


### PR DESCRIPTION
## Summary

- Exports `AbortedMessage` and `ToolMessageDebugView` components from `@mariozechner/pi-web-ui`

## Rationale

These utility components were defined in `Messages.ts` but not exported:

- **AbortedMessage**: A simple component that displays "Request aborted" text in a styled format
- **ToolMessageDebugView**: A debugging component that displays tool call arguments and results in a formatted view

Both can be useful for consumers building custom chat UIs who want consistent styling for these message types.

## Test plan

- [ ] Verify both components are importable from `@mariozechner/pi-web-ui`
- [ ] Verify existing message rendering is not affected