### PR TITLE
fix(coding-agent): reset retry counter after each successful LLM response

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -105,6 +105,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 - Off-by-one error in bash output "earlier lines" count caused by counting spacing newline as hidden content ([#921](https://github.com/badlogic/pi-mono/issues/921))
 - User package filters now layer on top of manifest filters instead of replacing them ([#645](https://github.com/badlogic/pi-mono/issues/645))
 - Auto-retry now handles "terminated" errors from Codex API mid-stream failures
+- Fixed auto-retry counter accumulating across separate user prompts. Previously, if 2 retries failed and the session resumed, the next rate limit error would show "3/3" and fail immediately instead of starting fresh.
 - Follow-up queue (Alt+Enter) now sends full paste content instead of `[paste #N ...]` markers ([#912](https://github.com/badlogic/pi-mono/issues/912))
 - Fixed Alt-Up not restoring messages queued during compaction ([#923](https://github.com/badlogic/pi-mono/pull/923) by [@aliou](https://github.com/aliou))
 - Fixed session corruption when loading empty or invalid session files via `--session` flag ([#932](https://github.com/badlogic/pi-mono/issues/932) by [@armanddp](https://github.com/armanddp))

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -716,6 +716,13 @@ export class AgentSession {
 			);
 		}
 
+		// Reset retry counter for new user prompts (not retries)
+		// This prevents retry failures from accumulating across separate prompts
+		if (this._retryAttempt > 0) {
+			this._retryAttempt = 0;
+			this._resolveRetry();
+		}
+
 		// Check if we need to compact before sending (catches aborted responses)
 		const lastAssistant = this._findLastAssistantMessage();
 		if (lastAssistant) {


### PR DESCRIPTION
Fixes #1019

Previously, within a single tool-use turn, rate limit retries would accumulate across separate LLM calls. For example, if each of 3 tool calls hit a 429 and retried once, the counter would show '3/3' and fail even though each individual retry succeeded.

Now the counter resets immediately when a successful (non-error) assistant message arrives, so each LLM call gets a fresh set of retries.

## Changes
- Reset counter in `message_end` handler for successful assistant messages (key fix)
- Reset counter at start of `prompt()` for new user prompts (safety net)
- Reset counter unconditionally at `agent_end` (safety net)

## Testing
- Manual testing with rate-limited provider (Baseten) during multi-tool-call turns