### PR TITLE
surface error stacks stacks in output errorMessage

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -208,7 +208,17 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			stream.end();
 		} catch (error) {
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : String(error);
+			if (error instanceof Error && error.stack) {
+				console.error("[pi-ai] openai-codex-responses error stack:", error.stack);
+			} else {
+				console.error("[pi-ai] openai-codex-responses error:", error);
+			}
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			const stackSnippet =
+				error instanceof Error && error.stack
+					? `\n\`\`\`\n${error.stack.split("\n").slice(0, 6).join("\n")}\n\`\`\``
+					: "";
+			output.errorMessage = errorMessage + stackSnippet;
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -85,7 +85,17 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 		} catch (error) {
 			for (const block of output.content) delete (block as { index?: number }).index;
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			if (error instanceof Error && error.stack) {
+				console.error("[pi-ai] openai-responses error stack:", error.stack);
+			} else {
+				console.error("[pi-ai] openai-responses error:", error);
+			}
+			const errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			const stackSnippet =
+				error instanceof Error && error.stack
+					? `\n\`\`\`\n${error.stack.split("\n").slice(0, 6).join("\n")}\n\`\`\``
+					: "";
+			output.errorMessage = errorMessage + stackSnippet;
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Model } from "../src/types.js";
+
+let lastParams: unknown;
+
+class FakeOpenAI {
+	chat = {
+		completions: {
+			create: async (params: unknown) => {
+				lastParams = params;
+				return {
+					async *[Symbol.asyncIterator]() {
+						yield {
+							choices: [{ delta: {}, finish_reason: "stop" }],
+							usage: {
+								prompt_tokens: 1,
+								completion_tokens: 1,
+								prompt_tokens_details: { cached_tokens: 0 },
+								completion_tokens_details: { reasoning_tokens: 0 },
+							},
+						};
+					},
+				};
+			},
+		},
+	};
+}
+
+vi.mock("openai", () => ({ default: FakeOpenAI }));
+
+describe("openai-completions compat detection", () => {
+	it("handles undefined baseUrl without throwing", async () => {
+		const { streamSimple } = await import("../src/stream.js");
+		const { getModel } = await import("../src/models.js");
+		const baseModel = getModel("openai", "gpt-4o-mini");
+		if (!baseModel) {
+			throw new Error("Missing model fixture: openai/gpt-4o-mini");
+		}
+
+		const model = {
+			...baseModel,
+			api: "openai-completions",
+			baseUrl: undefined,
+		} as unknown as Model<"openai-completions">;
+
+		let payload: unknown;
+
+		await streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "hello",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? lastParams) as { store?: boolean };
+		expect(params.store).toBe(false);
+	});
+});


### PR DESCRIPTION
- guard openai-completions compat detection and OpenRouter routing when baseUrl is undefined
- include short stack snippets in errorMessage for openai providers
- add test to cover undefined baseUrl

when this is used in clawdbot we get this:
<img width="1690" height="723" alt="image" src="https://github.com/user-attachments/assets/7ff462d5-140b-4c1d-8a10-4a8ceb123cb6" />

instead of:
<img width="1452" height="378" alt="image" src="https://github.com/user-attachments/assets/8a7953c2-9b22-4dd1-9fe9-55029a9e46b2" />

which is like 1000x better error message than just `Cannot read properties of undefined (reading 'includes')`
