### PR TITLE
fix(tui): remove backslash input buffering

### DIFF
--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -19,7 +19,6 @@ export class Input implements Component, Focusable {
 	// Bracketed paste mode buffering
 	private pasteBuffer: string = "";
 	private isInPaste: boolean = false;
-	private pendingShiftEnter: boolean = false;
 
 	getValue(): string {
 		return this.value;
@@ -65,22 +64,6 @@ export class Input implements Component, Focusable {
 					this.handleInput(remaining);
 				}
 			}
-			return;
-		}
-
-		if (this.pendingShiftEnter) {
-			if (data === "\r") {
-				this.pendingShiftEnter = false;
-				if (this.onSubmit) this.onSubmit(this.value);
-				return;
-			}
-			this.pendingShiftEnter = false;
-			this.value = `${this.value.slice(0, this.cursor)}\\${this.value.slice(this.cursor)}`;
-			this.cursor += 1;
-		}
-
-		if (data === "\\") {
-			this.pendingShiftEnter = true;
 			return;
 		}
 

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -3,23 +3,28 @@ import { describe, it } from "node:test";
 import { Input } from "../src/components/input.js";
 
 describe("Input component", () => {
-	it("treats split VS Code Shift+Enter as submit", () => {
+	it("submits value including backslash on Enter", () => {
 		const input = new Input();
 		let submitted: string | undefined;
 
-		input.setValue("hello");
 		input.onSubmit = (value) => {
 			submitted = value;
 		};
 
+		// Type hello, then backslash, then Enter
+		input.handleInput("h");
+		input.handleInput("e");
+		input.handleInput("l");
+		input.handleInput("l");
+		input.handleInput("o");
 		input.handleInput("\\");
 		input.handleInput("\r");
 
-		assert.strictEqual(submitted, "hello");
-		assert.strictEqual(input.getValue(), "hello");
+		// Input is single-line, no backslash+Enter workaround
+		assert.strictEqual(submitted, "hello\\");
 	});
 
-	it("inserts a literal backslash when not followed by Enter", () => {
+	it("inserts backslash as regular character", () => {
 		const input = new Input();
 
 		input.handleInput("\\");


### PR DESCRIPTION
### Problem

Previously, pressing `\` would buffer the character and wait for the next key press. If followed by <kbd>Enter</kbd>, it would insert a newline, <kbd>Shift+Enter</kbd> equivalent. If followed by any other key, both characters would be inserted. This caused a noticeable input delay when typing backslashes.

### Cause

The feature was added in commit 178a3a56 "fix(tui): handle split Shift+Enter in VS Code".

I believe the purpose was supporting an old Claude Code VS Code keybinding. The `/terminal-setup` command used to add:

```json
{
  "key": "shift+enter",
  "command": "workbench.action.terminal.sendSequence",
  "args": { "text": "\\\r\n" }
}
```

This sent a literal backslash + CR + LF when pressing <kbd>Shift+Enter</kbd>. The buffering detected this pattern and converted it to a newline. Newer Claude Code versions changed this to `"\u001b\r"` <kbd>Alt+Enter</kbd>, and Pi's docs now recommend the Kitty sequence `"\u001b[13;2u"`.

### Solution

I decided to keep this behavior because I believe a few people have developed muscle memory for the `\+Enter` combination. Instead of buffering, let `\` be inserted immediately. On <kbd>Enter</kbd>, check if the character before the cursor is `\`. If so, delete it and insert a newline instead of submitting.

I removed the backslash handling entirely from the Input component. These are single-line inputs (search boxes, rename fields); there's no need to insert new lines there.


https://github.com/user-attachments/assets/41707307-db5e-4b7b-b6de-074a1bff5cf4

