### PR TITLE
fix(ai): add DeepSeek to non-standard providers

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -765,6 +765,8 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		baseUrl.includes("chutes.ai") ||
 		isZai ||
 		provider === "opencode" ||
+		provider === "deepseek" ||
+		baseUrl.includes("api.deepseek.com") ||
 		baseUrl.includes("opencode.ai");
 
 	const useMaxTokens = provider === "mistral" || baseUrl.includes("mistral.ai") || baseUrl.includes("chutes.ai");


### PR DESCRIPTION
## Summary

DeepSeek API does not support the `developer` role, only `system`, `user`, `assistant`, and `tool`.

## Problem

When using DeepSeek models, the API returns:

```
400 Failed to deserialize the JSON body into the target type: 
messages[0].role: unknown variant `developer`, expected one of `system`, `user`, `assistant`, `tool`
```

## Solution

Add DeepSeek to the `isNonStandard` check in `detectCompat()` so that `supportsDeveloperRole` returns `false`, causing the code to use `system` role instead of `developer`.

## Changes

**File:** `packages/ai/src/providers/openai-completions.ts`

```typescript
const isNonStandard =
    // ... existing providers ...
    provider === "opencode" ||
    provider === "deepseek" ||                    // Added
    baseUrl.includes("api.deepseek.com") ||       // Added
    baseUrl.includes("opencode.ai");
```

## Testing

Tested locally with moltbot/clawdbot - DeepSeek Chat works correctly after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)