### PR TITLE
exit on invalid settings.json to prevent overwrite

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- exits with an error when settings.json has syntax errors, preventing data loss from save operations overwriting the user content.
+
 ## [0.50.3] - 2026-01-29
 
 ### New Features

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -164,8 +164,9 @@ export class SettingsManager {
 			const settings = JSON.parse(content);
 			return SettingsManager.migrateSettings(settings);
 		} catch (error) {
-			console.error(`Warning: Could not read settings file ${path}: ${error}`);
-			return {};
+			console.error(`Error: Could not read settings file ${path}: ${error}`);
+			console.error(`\nPlease fix error in ${path} and try again.`);
+			process.exit(1);
 		}
 	}
 


### PR DESCRIPTION
My settings.json got overwriting when pi tries to save lastChangelogVersion because a missing comma, that's a lot of pain and therefore we have a new PR.