### PR TITLE
feat(tui,coding-agent): add ctrl+b/ctrl+f cursor navigation keybindings

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -21,8 +21,8 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, etc.
 |--------|---------|-------------|
 | `cursorUp` | `up` | Move cursor up |
 | `cursorDown` | `down` | Move cursor down |
-| `cursorLeft` | `left` | Move cursor left |
-| `cursorRight` | `right` | Move cursor right |
+| `cursorLeft` | `left`, `ctrl+b` | Move cursor left |
+| `cursorRight` | `right`, `ctrl+f` | Move cursor right |
 | `cursorWordLeft` | `alt+left`, `ctrl+left`, `alt+b` | Move cursor word left |
 | `cursorWordRight` | `alt+right`, `ctrl+right`, `alt+f` | Move cursor word right |
 | `cursorLineStart` | `home`, `ctrl+a` | Move to line start |

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -66,8 +66,8 @@ export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = {
 	// Cursor movement
 	cursorUp: "up",
 	cursorDown: "down",
-	cursorLeft: "left",
-	cursorRight: "right",
+	cursorLeft: ["left", "ctrl+b"],
+	cursorRight: ["right", "ctrl+f"],
 	cursorWordLeft: ["alt+left", "ctrl+left", "alt+b"],
 	cursorWordRight: ["alt+right", "ctrl+right", "alt+f"],
 	cursorLineStart: ["home", "ctrl+a"],


### PR DESCRIPTION
Just adding a few more shell-style keybindings, following 81be813