### PR TITLE
feat(coding-agent): add hotkey support to extension selector and y/n …

### DIFF
--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -77,6 +77,8 @@ export interface ExtensionUIDialogOptions {
 	signal?: AbortSignal;
 	/** Timeout in milliseconds. Dialog auto-dismisses with live countdown display. */
 	timeout?: number;
+	/** Optional hotkey mapping (e.g., { "y": "Yes", "n": "No" }). Keys are case-sensitive. */
+	hotkeys?: Record<string, string>;
 }
 
 /** Placement for extension widgets. */

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1421,7 +1421,7 @@ export class InteractiveMode {
 					this.hideExtensionSelector();
 					resolve(undefined);
 				},
-				{ tui: this.ui, timeout: opts?.timeout },
+				{ tui: this.ui, timeout: opts?.timeout, hotkeys: opts?.hotkeys },
 			);
 
 			this.editorContainer.clear();
@@ -1451,7 +1451,10 @@ export class InteractiveMode {
 		message: string,
 		opts?: ExtensionUIDialogOptions,
 	): Promise<boolean> {
-		const result = await this.showExtensionSelector(`${title}\n${message}`, ["Yes", "No"], opts);
+		const result = await this.showExtensionSelector(`${title}\n${message}`, ["Yes", "No"], {
+			...opts,
+			hotkeys: { y: "Yes", Y: "Yes", n: "No", N: "No" },
+		});
 		return result === "Yes";
 	}
 


### PR DESCRIPTION
Adds single-character hotkey support (e.g., y/n) to selection and confirmation dialogs.

 ### Why?

 This is specifically needed for easier control of pi when running inside tmux, where arrow key navigation can be cumbersome. It allows for quick one-key responses to extension prompts and confirmation dialogs.

 ### Key Changes

 - Added hotkeys support to ExtensionUIDialogOptions.
 - Implemented y/n (case-insensitive) mapping for all standard confirmation dialogs.
 - Updated UI hints to display available hotkeys in the footer.