### PR TITLE
fix: update Antigravity User-Agent version to 1.15.8

### DIFF
--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -73,7 +73,7 @@ const GEMINI_CLI_HEADERS = {
 
 // Headers for Antigravity (sandbox endpoint) - requires specific User-Agent
 const ANTIGRAVITY_HEADERS = {
-	"User-Agent": "antigravity/1.11.5 darwin/arm64",
+	"User-Agent": "antigravity/1.15.8 darwin/arm64",
 	"X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
 	"Client-Metadata": JSON.stringify({
 		ideType: "IDE_UNSPECIFIED",

--- a/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
+++ b/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
@@ -50,7 +50,7 @@ type SaveMode = (typeof SAVE_MODES)[number];
 const ANTIGRAVITY_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 
 const ANTIGRAVITY_HEADERS = {
-	"User-Agent": "antigravity/1.11.5 darwin/arm64",
+	"User-Agent": "antigravity/1.15.8 darwin/arm64",
 	"X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
 	"Client-Metadata": JSON.stringify({
 		ideType: "IDE_UNSPECIFIED",


### PR DESCRIPTION
## Summary

Google has started rejecting requests with older Antigravity client versions, causing the error:

> "This version of Antigravity is no longer supported. Please update to receive the latest features!"

This PR updates the User-Agent header from `antigravity/1.11.5` to `antigravity/1.15.8` to fix authentication failures with the `cloudcode-pa.googleapis.com` API.

## Changes

- Updated `packages/ai/src/providers/google-gemini-cli.ts`: User-Agent version bump
- Updated `packages/coding-agent/examples/extensions/antigravity-image-gen.ts`: User-Agent version bump

## Related Issues

- https://github.com/badrisnarayanan/antigravity-claude-proxy/issues/213

## Test Plan

- [x] Verified locally that requests to cloudcode-pa.googleapis.com succeed with the updated User-Agent