### PR TITLE
fix: skip common dependency and build directories when indexing skills

### DIFF
--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -25,6 +25,20 @@ const MAX_NAME_LENGTH = 64;
 /** Max description length per spec */
 const MAX_DESCRIPTION_LENGTH = 1024;
 
+/** Common dependency and build directories to skip */
+const SKIP_DIRS = new Set([
+	"node_modules",
+	".venv",
+	"venv",
+	"__pycache__",
+	".git",
+	"dist",
+	"build",
+	".cache",
+	".npm",
+	".pnpm",
+]);
+
 export interface SkillFrontmatter {
 	name?: string;
 	description?: string;
@@ -139,8 +153,8 @@ function loadSkillsFromDirInternal(dir: string, source: string, includeRootFiles
 				continue;
 			}
 
-			// Skip node_modules to avoid scanning dependencies
-			if (entry.name === "node_modules") {
+			// Skip common dependency and build directories
+			if (SKIP_DIRS.has(entry.name)) {
 				continue;
 			}
 


### PR DESCRIPTION
Skills indexing was scanning into dependency directories.
This caused slow indexing and potential issues with large dependency trees.
The fix adds a SKIP_DIRS set to exclude common dependency/build directories like node_modules, .venv, dist, etc.