### PR TITLE
feat(tui): add character jump navigation (Ctrl+], Ctrl+Alt+])

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -27,6 +27,8 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, etc.
 | `cursorWordRight` | `alt+right`, `ctrl+right`, `alt+f` | Move cursor word right |
 | `cursorLineStart` | `home`, `ctrl+a` | Move to line start |
 | `cursorLineEnd` | `end`, `ctrl+e` | Move to line end |
+| `jumpForward` | `ctrl+]` | Jump forward to character |
+| `jumpBackward` | `ctrl+alt+]` | Jump backward to character |
 | `pageUp` | `pageUp` | Scroll up by page |
 | `pageDown` | `pageDown` | Scroll down by page |
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3948,6 +3948,8 @@ export class InteractiveMode {
 		const cursorWordRight = this.getEditorKeyDisplay("cursorWordRight");
 		const cursorLineStart = this.getEditorKeyDisplay("cursorLineStart");
 		const cursorLineEnd = this.getEditorKeyDisplay("cursorLineEnd");
+		const jumpForward = this.getEditorKeyDisplay("jumpForward");
+		const jumpBackward = this.getEditorKeyDisplay("jumpBackward");
 		const pageUp = this.getEditorKeyDisplay("pageUp");
 		const pageDown = this.getEditorKeyDisplay("pageDown");
 
@@ -3985,6 +3987,8 @@ export class InteractiveMode {
 | \`${cursorWordLeft}\` / \`${cursorWordRight}\` | Move by word |
 | \`${cursorLineStart}\` | Start of line |
 | \`${cursorLineEnd}\` | End of line |
+| \`${jumpForward}\` | Jump forward to character |
+| \`${jumpBackward}\` | Jump backward to character |
 | \`${pageUp}\` / \`${pageDown}\` | Scroll by page |
 
 **Editing**

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -298,8 +298,13 @@ editor.getPaddingX();  // Get current padding
 - `Enter` - Submit
 - `Shift+Enter`, `Ctrl+Enter`, or `Alt+Enter` - New line (terminal-dependent, Alt+Enter most reliable)
 - `Tab` - Autocomplete
-- `Ctrl+K` - Delete line
+- `Ctrl+K` - Delete to end of line
+- `Ctrl+U` - Delete to start of line
+- `Ctrl+W` or `Alt+Backspace` - Delete word backwards
+- `Alt+D` or `Alt+Delete` - Delete word forwards
 - `Ctrl+A` / `Ctrl+E` - Line start/end
+- `Ctrl+]` - Jump forward to character (awaits next keypress, then moves cursor to first occurrence)
+- `Ctrl+Alt+]` - Jump backward to character
 - Arrow keys, Backspace, Delete work as expected
 
 ### Markdown

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -13,6 +13,8 @@ export type EditorAction =
 	| "cursorWordRight"
 	| "cursorLineStart"
 	| "cursorLineEnd"
+	| "jumpForward"
+	| "jumpBackward"
 	| "pageUp"
 	| "pageDown"
 	// Deletion
@@ -72,6 +74,8 @@ export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = {
 	cursorWordRight: ["alt+right", "ctrl+right", "alt+f"],
 	cursorLineStart: ["home", "ctrl+a"],
 	cursorLineEnd: ["end", "ctrl+e"],
+	jumpForward: "ctrl+]",
+	jumpBackward: "ctrl+alt+]",
 	pageUp: "pageUp",
 	pageDown: "pageDown",
 	// Deletion


### PR DESCRIPTION
Add Bash/Readline-style character search:

- <kbd>Ctrl+]</kbd> enters forward jump mode, awaits next character, jumps to it
- <kbd>Ctrl+Alt+]</kbd> does the same but searches backward
- Multi-line search
- Case-sensitive matching
- Pressing the hotkey again cancels; control chars cancel and fall through

I find it very useful for navigating the sentences and code blocks.

https://github.com/user-attachments/assets/790fd632-7ce8-4a6b-8e97-ba61f647c09a
