### PR TITLE
perf(tui): optimize image line detection and rendering cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6084,6 +6084,15 @@
 			],
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -9051,6 +9060,7 @@
 				"diff": "^8.0.2",
 				"file-type": "^21.1.1",
 				"glob": "^11.0.3",
+				"ignore": "^7.0.5",
 				"marked": "^15.0.12",
 				"minimatch": "^10.1.1",
 				"proper-lockfile": "^4.1.2",

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1,4 +1,5 @@
 import { marked, type Token } from "marked";
+import { isImageLine } from "../terminal-image.js";
 import type { Component } from "../tui.js";
 import { applyBackgroundToLine, visibleWidth, wrapTextWithAnsi } from "../utils.js";
 
@@ -121,7 +122,11 @@ export class Markdown implements Component {
 		// Wrap lines (NO padding, NO background yet)
 		const wrappedLines: string[] = [];
 		for (const line of renderedLines) {
-			wrappedLines.push(...wrapTextWithAnsi(line, contentWidth));
+			if (isImageLine(line)) {
+				wrappedLines.push(line);
+			} else {
+				wrappedLines.push(...wrapTextWithAnsi(line, contentWidth));
+			}
 		}
 
 		// Add margins and background to each wrapped line
@@ -131,6 +136,11 @@ export class Markdown implements Component {
 		const contentLines: string[] = [];
 
 		for (const line of wrappedLines) {
+			if (isImageLine(line)) {
+				contentLines.push(line);
+				continue;
+			}
+
 			const lineWithMargins = leftMargin + line + rightMargin;
 
 			if (bgFn) {

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -79,6 +79,24 @@ export function getCapabilities(): TerminalCapabilities {
 
 export function resetCapabilitiesCache(): void {
 	cachedCapabilities = null;
+	imageEscapePrefix = undefined;
+}
+
+let imageEscapePrefix: string | null | undefined;
+
+function getImageEscapePrefix(): string | null {
+	if (imageEscapePrefix === undefined) {
+		const protocol = getCapabilities().images;
+		if (protocol === "kitty") imageEscapePrefix = "\x1b_G";
+		else if (protocol === "iterm2") imageEscapePrefix = "\x1b]1337;File=";
+		else imageEscapePrefix = null;
+	}
+	return imageEscapePrefix;
+}
+
+export function isImageLine(line: string): boolean {
+	const prefix = getImageEscapePrefix();
+	return prefix !== null && line.startsWith(prefix);
 }
 
 /**


### PR DESCRIPTION
**Description:**

Eliminates several hot paths identified in profiling of a 300s session, reducing total CPU time by ~20%:

| Function | Before | After |
|----------|--------|-------|
| `containsImage` | 43s | ~1s (startsWith) |
| `join` (cache key) | 14s | 0 (direct array comparison) |
| `applyLineResets` | 3s | ~0 (in-place mutation) |

### Changes

**terminal-image.ts**
- Add `isImageLine()` with single `startsWith` check based on detected terminal protocol
- Lazily cache the escape prefix, reset with `resetCapabilitiesCache()`

**tui.ts**
- Replace `containsImage()` (dual `includes()` scan) with imported `isImageLine()`
- In-place mutation in `applyLineResets()` instead of `map()` allocation

**markdown.ts**  
- Skip margins/background for image lines (must output raw)

**box.ts**
- Replace `join("\n")` key with direct array comparison via `matchCache()`

<img width="675" height="554" alt="image" src="https://github.com/user-attachments/assets/b7430086-54cf-4fe4-8449-8c976b7dc60a" />