### PR TITLE
feat(coding-agent): add ctx.getSystemPrompt() to extension context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ctx.getSystemPrompt()` in extension context to access the current system prompt
+
 ## [0.50.5] - 2026-01-30
 
 ## [0.50.4] - 2026-01-30

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -654,6 +654,22 @@ ctx.compact({
 });
 ```
 
+### ctx.getSystemPrompt()
+
+Returns the current system prompt. Useful for custom headers, debugging, or inspection.
+
+```typescript
+pi.on("session_start", async (_event, ctx) => {
+  ctx.ui.setHeader((_tui, theme) => ({
+    render(width) {
+      const prompt = ctx.getSystemPrompt();
+      return [`System prompt: ${prompt.length} chars`];
+    },
+    invalidate() {},
+  }));
+});
+```
+
 ## ExtensionCommandContext
 
 Command handlers receive `ExtensionCommandContext`, which extends `ExtensionContext` with session control methods. These are only available in commands because they can deadlock if called from event handlers.

--- a/packages/coding-agent/examples/extensions/system-prompt-header.ts
+++ b/packages/coding-agent/examples/extensions/system-prompt-header.ts
@@ -1,0 +1,86 @@
+/**
+ * System Prompt Header Extension
+ *
+ * Demonstrates ctx.getSystemPrompt() by displaying system prompt in a styled box
+ * with markdown rendering. Shows a preview by default, toggle with /toggle-full-prompt.
+ */
+
+import { type ExtensionAPI, type ExtensionContext, getMarkdownTheme } from "@mariozechner/pi-coding-agent";
+import { Box, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
+
+const MAX_PREVIEW_LINES = 5;
+
+export default function (pi: ExtensionAPI) {
+	// Track expanded state
+	let expanded = false;
+
+	// Helper to update the header
+	function updateHeader(ctx: ExtensionContext) {
+		if (!ctx.hasUI) return;
+
+		ctx.ui.setHeader((_tui, theme) => {
+			// Create a Box with background color (like tool calls)
+			const box = new Box(
+				1, // paddingX
+				1, // paddingY
+				(text: string) => theme.bg("customMessageBg", text),
+			);
+
+			const prompt = ctx.getSystemPrompt();
+			const lines = prompt.split("\n");
+			const nonEmptyLines = lines.filter((l) => l.trim().length > 0);
+
+			// Title with stats
+			const title = theme.fg("accent", theme.bold(" System Prompt "));
+			const stats = theme.fg("muted", ` (${nonEmptyLines.length} lines, ${prompt.length} chars)`);
+			const toggle = theme.fg("dim", " [/toggle-full-prompt]");
+			box.addChild(new Text(title + stats + toggle, 0, 0));
+			box.addChild(new Spacer(1));
+
+			// Content with markdown rendering
+			const mdTheme = getMarkdownTheme();
+
+			if (expanded) {
+				// Show full prompt with markdown rendering
+				box.addChild(new Markdown(prompt, 0, 0, mdTheme));
+			} else {
+				// Show preview (first N lines) with markdown rendering
+				const previewText = lines.slice(0, MAX_PREVIEW_LINES).join("\n");
+				box.addChild(new Markdown(previewText, 0, 0, mdTheme));
+
+				if (lines.length > MAX_PREVIEW_LINES) {
+					const remaining = lines.length - MAX_PREVIEW_LINES;
+					box.addChild(new Spacer(1));
+					box.addChild(new Text(theme.fg("dim", `... (${remaining} more lines)`), 0, 0));
+				}
+			}
+
+			// Add spacer after box
+			const container = {
+				render(width: number): string[] {
+					const boxLines = box.render(width);
+					const spacer = new Spacer(1);
+					return [...boxLines, ...spacer.render(width)];
+				},
+				invalidate() {
+					box.invalidate();
+				},
+			};
+
+			return container;
+		});
+	}
+
+	pi.on("session_start", async (_event, ctx) => {
+		updateHeader(ctx);
+	});
+
+	// Command to toggle expanded/collapsed
+	pi.registerCommand("toggle-full-prompt", {
+		description: "Toggle system prompt header between preview and full view",
+		handler: async (_args, ctx) => {
+			expanded = !expanded;
+			updateHeader(ctx);
+		},
+	});
+}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -514,6 +514,11 @@ export class AgentSession {
 		return this.agent.state.isStreaming;
 	}
 
+	/** Current system prompt (base prompt before per-turn extension modifications) */
+	get systemPrompt(): string {
+		return this._baseSystemPrompt;
+	}
+
 	/** Current retry attempt (0 if not retrying) */
 	get retryAttempt(): number {
 		return this._retryAttempt;
@@ -1756,6 +1761,7 @@ export class AgentSession {
 						}
 					})();
 				},
+				getSystemPrompt: () => this._baseSystemPrompt,
 			},
 		);
 	}

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -159,6 +159,7 @@ export class ExtensionRunner {
 	private hasPendingMessagesFn: () => boolean = () => false;
 	private getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	private compactFn: (options?: CompactOptions) => void = () => {};
+	private getSystemPromptFn: () => string = () => "";
 	private newSessionHandler: NewSessionHandler = async () => ({ cancelled: false });
 	private forkHandler: ForkHandler = async () => ({ cancelled: false });
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
@@ -203,6 +204,7 @@ export class ExtensionRunner {
 		this.shutdownHandler = contextActions.shutdown;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
+		this.getSystemPromptFn = contextActions.getSystemPrompt;
 
 		// Process provider registrations queued during extension loading
 		for (const { name, config } of this.runtime.pendingProviderRegistrations) {
@@ -421,6 +423,7 @@ export class ExtensionRunner {
 			shutdown: () => this.shutdownHandler(),
 			getContextUsage: () => this.getContextUsageFn(),
 			compact: (options) => this.compactFn(options),
+			getSystemPrompt: () => this.getSystemPromptFn(),
 		};
 	}
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -260,6 +260,8 @@ export interface ExtensionContext {
 	getContextUsage(): ContextUsage | undefined;
 	/** Trigger compaction without awaiting completion. */
 	compact(options?: CompactOptions): void;
+	/** Get the current system prompt */
+	getSystemPrompt(): string;
 }
 
 /**
@@ -1084,6 +1086,7 @@ export interface ExtensionContextActions {
 	shutdown: () => void;
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
+	getSystemPrompt: () => string;
 }
 
 /**

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1120,6 +1120,7 @@ export class InteractiveMode {
 					}
 				})();
 			},
+			getSystemPrompt: () => this.session.systemPrompt,
 		});
 
 		// Set up the extension shortcut handler on the default editor


### PR DESCRIPTION
Hey, so since seeing `/share` I had this idea of making the system prompt visible and inspectable in the TUI as well. 

I personally think it's nice to be able to see it more often to get familiar with how things are structured, checking if custom prompts load correctly, etc. So I propose we make it available for extensions to read it. 

Also added a vibeslopped example extension that adds an expandable system prompt box to the top of the built-in header with a command to toggle the full contents:

<img width="1560" height="722" alt="CleanShot 2026-01-30 at 15 02 16@2x" src="https://github.com/user-attachments/assets/383cd7c9-781e-4cf9-bdad-32d5a4f44af3" />

## Opus description

Expose the system prompt to extensions via ctx.getSystemPrompt(). This enables custom headers, debugging, logging, and other use cases that need access to the system prompt.

- Add getSystemPrompt() to ExtensionContext interface
- Add getSystemPrompt to ExtensionContextActions interface
- Wire up the getter in ExtensionRunner and AgentSession
- Document in extensions.md
- Add system-prompt-header.ts example extension