### PR TITLE
fix(coding-agent): show cursor after exiting selectors

### DIFF
--- a/packages/coding-agent/src/cli/config-selector.ts
+++ b/packages/coding-agent/src/cli/config-selector.ts
@@ -20,23 +20,14 @@ export async function selectConfig(options: ConfigSelectorOptions): Promise<void
 	// Initialize theme before showing TUI
 	initTheme(options.settingsManager.getTheme(), true);
 
-	return new Promise((resolve) => {
+	return new Promise(() => {
 		const ui = new TUI(new ProcessTerminal());
-		let resolved = false;
 
 		const selector = new ConfigSelectorComponent(
 			options.resolvedPaths,
 			options.settingsManager,
 			options.cwd,
 			options.agentDir,
-			() => {
-				if (!resolved) {
-					resolved = true;
-					ui.stop();
-					stopThemeWatcher();
-					resolve();
-				}
-			},
 			() => {
 				ui.stop();
 				stopThemeWatcher();

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -28,13 +28,6 @@ export async function selectSession(
 				}
 			},
 			() => {
-				if (!resolved) {
-					resolved = true;
-					ui.stop();
-					resolve(null);
-				}
-			},
-			() => {
 				ui.stop();
 				process.exit(0);
 			},

--- a/packages/coding-agent/src/modes/interactive/components/config-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector.ts
@@ -184,7 +184,6 @@ class ResourceList implements Component, Focusable {
 	private agentDir: string;
 
 	public onCancel?: () => void;
-	public onExit?: () => void;
 	public onToggle?: (item: ResourceItem, newEnabled: boolean) => void;
 
 	private _focused = false;
@@ -391,10 +390,6 @@ class ResourceList implements Component, Focusable {
 			this.onCancel?.();
 			return;
 		}
-		if (matchesKey(data, "ctrl+c")) {
-			this.onExit?.();
-			return;
-		}
 		if (data === " " || kb.matches(data, "selectConfirm")) {
 			const entry = this.filteredItems[this.selectedIndex];
 			if (entry?.type === "item") {
@@ -559,8 +554,7 @@ export class ConfigSelectorComponent extends Container implements Focusable {
 		settingsManager: SettingsManager,
 		cwd: string,
 		agentDir: string,
-		onClose: () => void,
-		onExit: () => void,
+		onCancel: () => void,
 		requestRender: () => void,
 	) {
 		super();
@@ -576,8 +570,7 @@ export class ConfigSelectorComponent extends Container implements Focusable {
 
 		// Resource list
 		this.resourceList = new ResourceList(groups, settingsManager, cwd, agentDir);
-		this.resourceList.onCancel = onClose;
-		this.resourceList.onExit = onExit;
+		this.resourceList.onCancel = onCancel;
 		this.resourceList.onToggle = () => requestRender();
 		this.addChild(this.resourceList);
 

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -188,7 +188,6 @@ class SessionList implements Component, Focusable {
 	private currentSessionFilePath?: string;
 	public onSelect?: (sessionPath: string) => void;
 	public onCancel?: () => void;
-	public onExit: () => void = () => {};
 	public onToggleScope?: () => void;
 	public onToggleSort?: () => void;
 	public onTogglePath?: (showPath: boolean) => void;
@@ -573,7 +572,6 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		allSessionsLoader: SessionsLoader,
 		onSelect: (sessionPath: string) => void,
 		onCancel: () => void,
-		onExit: () => void,
 		requestRender: () => void,
 		options?: {
 			renameSession?: (sessionPath: string, currentName: string | undefined) => Promise<void>;
@@ -610,10 +608,6 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		this.sessionList.onCancel = () => {
 			clearStatusMessage();
 			onCancel();
-		};
-		this.sessionList.onExit = () => {
-			clearStatusMessage();
-			onExit();
 		};
 		this.sessionList.onToggleScope = () => this.toggleScope();
 		this.sessionList.onToggleSort = () => this.toggleSortMode();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3486,9 +3486,6 @@ export class InteractiveMode {
 					done();
 					this.ui.requestRender();
 				},
-				() => {
-					void this.shutdown();
-				},
 				() => this.ui.requestRender(),
 				{
 					renameSession: async (sessionFilePath: string, nextName: string | undefined) => {

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -56,7 +56,6 @@ describe("session selector path/delete interactions", () => {
 			() => {},
 			() => {},
 			() => {},
-			() => {},
 		);
 		await flushPromises();
 
@@ -79,7 +78,6 @@ describe("session selector path/delete interactions", () => {
 			() => {},
 			() => {},
 			() => {},
-			() => {},
 		);
 		await flushPromises();
 
@@ -99,7 +97,6 @@ describe("session selector path/delete interactions", () => {
 		const selector = new SessionSelectorComponent(
 			async () => sessions,
 			async () => [],
-			() => {},
 			() => {},
 			() => {},
 			() => {},
@@ -137,7 +134,6 @@ describe("session selector path/delete interactions", () => {
 			() => {},
 			() => {},
 			() => {},
-			() => {},
 		);
 		await flushPromises();
 
@@ -165,7 +161,6 @@ describe("session selector path/delete interactions", () => {
 				allLoadCalls++;
 				return allDeferred.promise;
 			},
-			() => {},
 			() => {},
 			() => {},
 			() => {},

--- a/packages/coding-agent/test/session-selector-rename.test.ts
+++ b/packages/coding-agent/test/session-selector-rename.test.ts
@@ -39,7 +39,6 @@ describe("session selector rename", () => {
 			() => {},
 			() => {},
 			() => {},
-			() => {},
 			{ showRenameHint: true },
 		);
 		await flushPromises();
@@ -54,7 +53,6 @@ describe("session selector rename", () => {
 		const selector = new SessionSelectorComponent(
 			async () => sessions,
 			async () => [],
-			() => {},
 			() => {},
 			() => {},
 			() => {},
@@ -74,7 +72,6 @@ describe("session selector rename", () => {
 		const selector = new SessionSelectorComponent(
 			async () => sessions,
 			async () => [],
-			() => {},
 			() => {},
 			() => {},
 			() => {},


### PR DESCRIPTION
The terminal cursor remains hidden after exiting the sessions selector (`pi --resume`) and the config selector (`pi config`).

This occurs because `SessionList` and `ResourceList` always invoke the `onCancel()` callback on exit, and the `tui` continues running and re-renders after that.

This PR removes the unused `onExit` callback, and ensures the process exits in the input handler after `tui` stops.

before:
<img width="1176" height="617" alt="screenshot-2026-01-31_00-21-01" src="https://github.com/user-attachments/assets/9d9966f7-eed6-48ef-8fa5-079707523df9" />
<img width="1200" height="571" alt="screenshot-2026-01-31_00-22-24" src="https://github.com/user-attachments/assets/ad15bd38-9810-4c34-ad0b-331bcb93fa75" />

after:
<img width="1186" height="555" alt="screenshot-2026-01-31_00-22-56" src="https://github.com/user-attachments/assets/cd764971-2e95-4b01-8ef6-57b1bf30e40f" />
<img width="1190" height="599" alt="screenshot-2026-01-31_00-23-19" src="https://github.com/user-attachments/assets/5bc1b1ff-7549-4a3f-8f66-bedcb50ae995" />
