### PR TITLE
chore: satisfy biome template literal lint

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/daxnuts.ts
+++ b/packages/coding-agent/src/modes/interactive/components/daxnuts.ts
@@ -46,7 +46,7 @@ function buildImage(): string[] {
 		for (let x = 0; x < WIDTH; x++) {
 			const top = pixels[row][x];
 			const bottom = pixels[row + 1]?.[x] ?? top;
-			line += rgb(bottom[0], bottom[1], bottom[2]) + rgb(top[0], top[1], top[2], true) + "▄";
+			line += `${rgb(bottom[0], bottom[1], bottom[2])}${rgb(top[0], top[1], top[2], true)}▄`;
 		}
 		line += RESET;
 		lines.push(line);

--- a/packages/tui/test/bug-regression-isimageline-startswith-bug.test.ts
+++ b/packages/tui/test/bug-regression-isimageline-startswith-bug.test.ts
@@ -76,7 +76,7 @@ describe("Bug regression: isImageLine() crash with image escape sequences", () =
 				"Suffix text \x1b_Ga=T,data...\x1b\\ suffix",
 				"Middle \x1b_Ga=T,data...\x1b\\ more text",
 				// Very long line (simulating 300KB+ crash scenario)
-				"Text before " + "\x1b_Ga=T,f=100" + "A".repeat(300000) + " text after",
+				`Text before \x1b_Ga=T,f=100${"A".repeat(300000)} text after`,
 			];
 
 			for (const line of scenarios) {
@@ -93,7 +93,7 @@ describe("Bug regression: isImageLine() crash with image escape sequences", () =
 				"Suffix text \x1b]1337;File=inline=1:data==\x07 suffix",
 				"Middle \x1b]1337;File=inline=1:data==\x07 more text",
 				// Very long line (simulating 304KB crash scenario)
-				"Text before " + "\x1b]1337;File=size=800,600;inline=1:" + "B".repeat(300000) + " text after",
+				`Text before \x1b]1337;File=size=800,600;inline=1:${"B".repeat(300000)} text after`,
 			];
 
 			for (const line of scenarios) {


### PR DESCRIPTION
Fixes the Biome lint/style/useTemplate infos (template literals preferred) in:

- packages/coding-agent/src/modes/interactive/components/daxnuts.ts
- packages/tui/test/bug-regression-isimageline-startswith-bug.test.ts

Fixes #1103.