### PR TITLE
feat(ai,agent): add tool_exec_* events for custom providers

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Forward `tool_exec_start`, `tool_exec_update`, `tool_exec_end` provider events as `tool_execution_*` agent events in `streamAssistantResponse`
+
 ## [0.50.7] - 2026-01-31
 
 ## [0.50.6] - 2026-01-30

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -268,6 +268,35 @@ async function streamAssistantResponse(
 				}
 				break;
 
+			case "tool_exec_start":
+				stream.push({
+					type: "tool_execution_start",
+					toolCallId: event.toolCallId,
+					toolName: event.toolName,
+					args: event.args,
+				});
+				break;
+
+			case "tool_exec_update":
+				stream.push({
+					type: "tool_execution_update",
+					toolCallId: event.toolCallId,
+					toolName: event.toolName,
+					args: event.args,
+					partialResult: event.partialResult,
+				});
+				break;
+
+			case "tool_exec_end":
+				stream.push({
+					type: "tool_execution_end",
+					toolCallId: event.toolCallId,
+					toolName: event.toolName,
+					result: event.result,
+					isError: event.isError,
+				});
+				break;
+
 			case "done":
 			case "error": {
 				const finalMessage = await response.result();

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ToolExecResult` interface and `tool_exec_start`, `tool_exec_update`, `tool_exec_end` event variants to `AssistantMessageEvent` for custom providers that execute tools inside `streamSimple`
+
 ## [0.50.7] - 2026-01-31
 
 ## [0.50.6] - 2026-01-30

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -177,6 +177,11 @@ export interface Context {
 	tools?: Tool[];
 }
 
+export interface ToolExecResult {
+	content: (TextContent | ImageContent)[];
+	details?: unknown;
+}
+
 export type AssistantMessageEvent =
 	| { type: "start"; partial: AssistantMessage }
 	| { type: "text_start"; contentIndex: number; partial: AssistantMessage }
@@ -188,6 +193,15 @@ export type AssistantMessageEvent =
 	| { type: "toolcall_start"; contentIndex: number; partial: AssistantMessage }
 	| { type: "toolcall_delta"; contentIndex: number; delta: string; partial: AssistantMessage }
 	| { type: "toolcall_end"; contentIndex: number; toolCall: ToolCall; partial: AssistantMessage }
+	| { type: "tool_exec_start"; toolCallId: string; toolName: string; args: Record<string, unknown> }
+	| {
+			type: "tool_exec_update";
+			toolCallId: string;
+			toolName: string;
+			args: Record<string, unknown>;
+			partialResult: ToolExecResult;
+	  }
+	| { type: "tool_exec_end"; toolCallId: string; toolName: string; result: ToolExecResult; isError: boolean }
 	| { type: "done"; reason: Extract<StopReason, "stop" | "length" | "toolUse">; message: AssistantMessage }
 	| { type: "error"; reason: Extract<StopReason, "aborted" | "error">; error: AssistantMessage };
 


### PR DESCRIPTION
This PR lets custom providers registered via `streamSimple` emit tool execution events during streaming, so the TUI shows full results just like built-in tool calls.

Previously, `AssistantMessageEventStream` only carried LLM-level events. Providers that use bidirectional protocols where the server requests tool execution mid-stream and blocks until results come back had no way to surface what happened. Certain custom provider integrations that shall remain unmentioned would show tool names and args but never the output.

The agent loop forwards these to the existing `tool_execution_*` events the TUI already handles.

```typescript
stream.push({
  type: "tool_exec_start",
  toolCallId: "exec-1",
  toolName: "read",
  args: { path: "src/index.ts" },
});

// ... provider executes tool on behalf of remote server ...

stream.push({
  type: "tool_exec_end",
  toolCallId: "exec-1",
  toolName: "read",
  result: {
    content: [{ type: "text", text: fileContents }],
    details: { totalLines: 42 },
  },
  isError: false,
});
```
