### PR TITLE
Add keybinding actions for /tree, /fork, and /new

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -76,6 +76,14 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, etc.
 | `suspend` | `ctrl+z` | Suspend to background |
 | `externalEditor` | `ctrl+g` | Open in external editor (`$VISUAL` or `$EDITOR`) |
 
+### Session
+
+| Action | Default | Description |
+|--------|---------|-------------|
+| `newSession` | *(none)* | Start a new session (`/new`) |
+| `tree` | *(none)* | Open session tree navigator (`/tree`) |
+| `fork` | *(none)* | Fork current session (`/fork`) |
+
 ### Models & Thinking
 
 | Action | Default | Description |

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -28,7 +28,10 @@ export type AppAction =
 	| "externalEditor"
 	| "followUp"
 	| "dequeue"
-	| "pasteImage";
+	| "pasteImage"
+	| "newSession"
+	| "tree"
+	| "fork";
 
 /**
  * All configurable actions.
@@ -60,6 +63,9 @@ export const DEFAULT_APP_KEYBINDINGS: Record<AppAction, KeyId | KeyId[]> = {
 	followUp: "alt+enter",
 	dequeue: "alt+up",
 	pasteImage: "ctrl+v",
+	newSession: [],
+	tree: [],
+	fork: [],
 };
 
 /**
@@ -86,6 +92,9 @@ const APP_ACTIONS: AppAction[] = [
 	"followUp",
 	"dequeue",
 	"pasteImage",
+	"newSession",
+	"tree",
+	"fork",
 ];
 
 function isAppAction(action: string): action is AppAction {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1776,6 +1776,9 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("externalEditor", () => this.openExternalEditor());
 		this.defaultEditor.onAction("followUp", () => this.handleFollowUp());
 		this.defaultEditor.onAction("dequeue", () => this.handleDequeue());
+		this.defaultEditor.onAction("newSession", () => this.handleClearCommand());
+		this.defaultEditor.onAction("tree", () => this.showTreeSelector());
+		this.defaultEditor.onAction("fork", () => this.showUserMessageSelector());
 
 		this.defaultEditor.onChange = (text: string) => {
 			const wasBashMode = this.isBashMode;


### PR DESCRIPTION
Add three new configurable keybinding actions: `newSession`, `tree`, and `fork`. All are unbound by default. Example config:

```json
{
  "newSession": "ctrl+n",
  "tree": "ctrl+shift+t",
  "fork": "ctrl+shift+f"
}
```

The keybinding handlers don't clear the editor, unlike the `/` commands which clear to remove the command text. This means you can draft a message, then start a new session or navigate the tree without losing your text. For `tree` and `fork`, if you navigate to a user message the editor gets that message's text; if you navigate to an assistant message the editor is left as-is. I chose to do this way because the code looks more sane, but of course it's open for discussion.

Closes #1088