### PR TITLE
fix(ai): handle undefined arguments in validateToolArguments

### DIFF
--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -62,7 +62,8 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): any {
 	const validate = ajv.compile(tool.parameters);
 
 	// Clone arguments so AJV can safely mutate for type coercion
-	const args = structuredClone(toolCall.arguments);
+	// Default undefined/null to {} for tools with empty object schemas (e.g. Type.Object({}))
+	const args = structuredClone(toolCall.arguments ?? {});
 
 	// Validate the arguments (AJV mutates args in-place for type coercion)
 	if (validate(args)) {


### PR DESCRIPTION
When a model calls a tool with an empty parameter schema (`Type.Object({})`), some models send `undefined` instead of `{}` for the arguments. This caused `structuredClone(undefined)` to return `undefined`, which fails AJV validation with:

```
Validation failed for tool "agents_list":
  - root: must be object

Received arguments:
undefined
```

**Fix:** Default undefined/null to `{}` before cloning.

Fixes #1115