### PR TITLE
fix: enable image input for kimi-coding k2p5 model

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1180,7 +1180,7 @@ async function generateModels() {
 			provider: "kimi-coding",
 			baseUrl: KIMI_CODING_BASE_URL,
 			reasoning: true,
-			input: ["text"],
+			input: ["text", "image"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 262144,
 			maxTokens: 32768,


### PR DESCRIPTION
## Summary
- Kimi K2.5 (`k2p5`) is a native multimodal model that supports image input, but the `kimi-coding` provider hardcodes `input: ["text"]`
- This causes downstream consumers (e.g. OpenClaw) to skip sending images to the model even though it can process them
- Changed `input` from `["text"]` to `["text", "image"]` for the `k2p5` model definition

## Test plan
- [x] Tested with OpenClaw gateway using `kimi-code/kimi-for-coding` model
- [x] Confirmed image input works correctly after changing the input declaration
- [x] Verified the model successfully describes images sent via Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)