### PR TITLE
fix(openai-completions): fall back to non-streaming when tools present on Ollama

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -216,6 +216,14 @@ export interface OpenAICompletionsCompat {
 	requiresMistralToolIds?: boolean;
 	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "zai" uses thinking: { type: "enabled" }. Default: "openai". */
 	thinkingFormat?: "openai" | "zai";
+	/**
+	 * Whether the provider supports tool_calls in streaming responses.
+	 * When false and tools are present, the request is sent with stream:false
+	 * and the response is converted to the event stream format.
+	 * Default: true. Auto-detected as false for Ollama.
+	 * See: https://github.com/ollama/ollama/issues/9632
+	 */
+	supportsStreamingToolCalls?: boolean;
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;
 	/** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */


### PR DESCRIPTION
## Problem

Ollama's streaming implementation silently drops `tool_calls` from responses. When `stream: true` and the model decides to call a tool, the streaming chunks return empty content with `finish_reason: "stop"` — the tool call is completely lost.

This affects **all models** served via Ollama (Mistral, Qwen, Llama, etc.) and breaks tool calling for any downstream consumer (OpenClaw, LangChain, etc.).

**Non-streaming mode works perfectly** — proper `tool_calls` array with `finish_reason: "tool_calls"`.

This is a known Ollama limitation:
- https://github.com/ollama/ollama/issues/9632 (March 2025)
- https://github.com/ollama/ollama/issues/12557 (October 2025)

Still unfixed in Ollama v0.15.1 (latest as of Feb 2026).

## Solution

- Add `supportsStreamingToolCalls` field to `OpenAICompletionsCompat`
- Auto-detect Ollama via provider name (`"ollama"`) or baseUrl (`:11434`)
- When tools are present and `supportsStreamingToolCalls === false`, send `stream: false`
- Convert the `ChatCompletion` response into the `AssistantMessageEventStream` format (text blocks, tool calls, usage)
- Allow manual override via `model.compat.supportsStreamingToolCalls`

## Changes

- `packages/ai/src/types.ts`: Add `supportsStreamingToolCalls` to `OpenAICompletionsCompat`
- `packages/ai/src/providers/openai-completions.ts`:
  - Add `isOllamaProvider()` detection
  - Conditional streaming in `buildParams()` 
  - Non-streaming response handler in `streamOpenAICompletions()`
  - Pass through in `getCompat()`

## Testing

Verified with Ollama v0.15.1 + Mistral Small 3.2 24B:

```bash
# Non-streaming (works) — this is what the fix does
curl -s http://localhost:11434/v1/chat/completions \
  -d '{"model":"mistral-small:24b","messages":[...],"tools":[...]}"'
# → proper tool_calls, finish_reason: "tool_calls" ✅

# Streaming (broken) — this is what happens without the fix
curl -s http://localhost:11434/v1/chat/completions \
  -d '{"model":"mistral-small:24b","stream":true,"messages":[...],"tools":[...]}"'
# → empty content, finish_reason: "stop", no tool_calls ❌
```

Related issue: https://github.com/openclaw/openclaw/issues/5769