### PR TITLE
feat(config): add PI_PACKAGE_DIR env var to override package path

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -31,6 +31,14 @@ export const isBunRuntime = !!process.versions.bun;
  * - For tsx (src/): returns parent directory (the package root)
  */
 export function getPackageDir(): string {
+	// Allow override via environment variable (useful for Nix/Guix where store paths tokenize poorly)
+	const envDir = process.env.PI_PACKAGE_DIR;
+	if (envDir) {
+		if (envDir === "~") return homedir();
+		if (envDir.startsWith("~/")) return homedir() + envDir.slice(1);
+		return envDir;
+	}
+
 	if (isBunBinary) {
 		// Bun binary: process.execPath points to the compiled executable
 		return dirname(process.execPath);


### PR DESCRIPTION
## Summary

Add `PI_PACKAGE_DIR` environment variable to override the detected package directory, following the existing pattern of `PI_CODING_AGENT_DIR`.

## Motivation

Content-addressed package managers (Nix, Guix) use hash-based paths like:
```
/nix/store/0vrx64vvx3in6ywz0zbxvb0h3gv5c1h5-pi-0.50.5/lib/node_modules/@mariozechner/pi-coding-agent
```

These paths appear 3× in the system prompt (README, docs, examples) and tokenize extremely poorly—nearly 1 token per character due to the random hash. A typical Nix path costs ~48 tokens vs ~5 tokens for a short symlink path.

| Install Method | Tokens (×3 paths) |
|----------------|-------------------|
| Nix store path | 144 |
| With override  | 15  |

With this env var, users can point to a stable symlink:
```bash
export PI_PACKAGE_DIR="~/.pi/pi-source"
```

Saving ~130 tokens per session.

## Changes

- 7 lines added to `getPackageDir()`, following exact pattern of `getAgentDir()`
- Supports `~` expansion like existing env var
- Zero impact for users who don't set it