### PR TITLE
feat(coding-agent): add named-only filter toggle to /resume picker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `newSession`, `tree`, and `fork` keybinding actions for `/new`, `/tree`, and `/fork` commands. All unbound by default. ([#1114](https://github.com/badlogic/pi-mono/pull/1114) by [@juanibiapina](https://github.com/juanibiapina))
 - Added `retry.maxDelayMs` setting to cap maximum server-requested retry delay. When a provider requests a longer delay (e.g., Google's "quota will reset after 5h"), the request fails immediately with an informative error instead of waiting silently. Default: 60000ms (60 seconds). ([#1123](https://github.com/badlogic/pi-mono/issues/1123))
 - `/resume` session picker: new "Threaded" sort mode (now default) displays sessions in a tree structure based on fork relationships. Compact one-line format with message count and age on the right. ([#1124](https://github.com/badlogic/pi-mono/pull/1124) by [@pasky](https://github.com/pasky))
+- `/resume` session picker now supports named-only filter toggle (default Ctrl+N, configurable via `toggleSessionNamedFilter`) to show only named sessions ([#862](https://github.com/badlogic/pi-mono/issues/862))
 - Added Qwen CLI OAuth provider extension example. ([#940](https://github.com/badlogic/pi-mono/pull/940) by [@4h9fbZ](https://github.com/4h9fbZ))
 - Added OAuth `modifyModels` hook support for extension-registered providers at registration time. ([#940](https://github.com/badlogic/pi-mono/pull/940) by [@4h9fbZ](https://github.com/4h9fbZ))
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -124,6 +124,7 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, etc.
 |--------|---------|-------------|
 | `toggleSessionPath` | `ctrl+p` | Toggle path display |
 | `toggleSessionSort` | `ctrl+s` | Toggle sort mode |
+| `toggleSessionNamedFilter` | `ctrl+n` | Toggle named-only filter |
 | `renameSession` | `ctrl+r` | Rename session |
 | `deleteSession` | `ctrl+d` | Delete session |
 | `deleteSessionNoninvasive` | `ctrl+backspace` | Delete session (when query empty) |

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -3,6 +3,7 @@
  */
 
 import { ProcessTerminal, TUI } from "@mariozechner/pi-tui";
+import { KeybindingsManager } from "../core/keybindings.js";
 import type { SessionInfo, SessionListProgress } from "../core/session-manager.js";
 import { SessionSelectorComponent } from "../modes/interactive/components/session-selector.js";
 
@@ -15,6 +16,7 @@ export async function selectSession(
 ): Promise<string | null> {
 	return new Promise((resolve) => {
 		const ui = new TUI(new ProcessTerminal());
+		const keybindings = KeybindingsManager.create();
 		let resolved = false;
 
 		const selector = new SessionSelectorComponent(
@@ -39,7 +41,7 @@ export async function selectSession(
 				process.exit(0);
 			},
 			() => ui.requestRender(),
-			{ showRenameHint: false },
+			{ showRenameHint: false, keybindings },
 		);
 
 		ui.addChild(selector);

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -25,6 +25,7 @@ export type AppAction =
 	| "selectModel"
 	| "expandTools"
 	| "toggleThinking"
+	| "toggleSessionNamedFilter"
 	| "externalEditor"
 	| "followUp"
 	| "dequeue"
@@ -59,6 +60,7 @@ export const DEFAULT_APP_KEYBINDINGS: Record<AppAction, KeyId | KeyId[]> = {
 	selectModel: "ctrl+l",
 	expandTools: "ctrl+o",
 	toggleThinking: "ctrl+t",
+	toggleSessionNamedFilter: "ctrl+n",
 	externalEditor: "ctrl+g",
 	followUp: "alt+enter",
 	dequeue: "alt+up",
@@ -88,6 +90,7 @@ const APP_ACTIONS: AppAction[] = [
 	"selectModel",
 	"expandTools",
 	"toggleThinking",
+	"toggleSessionNamedFilter",
 	"externalEditor",
 	"followUp",
 	"dequeue",

--- a/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
@@ -3,6 +3,8 @@ import type { SessionInfo } from "../../../core/session-manager.js";
 
 export type SortMode = "threaded" | "recent" | "relevance";
 
+export type NameFilter = "all" | "named";
+
 export interface ParsedSearchQuery {
 	mode: "tokens" | "regex";
 	tokens: { kind: "fuzzy" | "phrase"; value: string }[];
@@ -23,6 +25,15 @@ function normalizeWhitespaceLower(text: string): string {
 
 function getSessionSearchText(session: SessionInfo): string {
 	return `${session.id} ${session.name ?? ""} ${session.allMessagesText} ${session.cwd}`;
+}
+
+function hasSessionName(session: SessionInfo): boolean {
+	return Boolean(session.name?.trim());
+}
+
+function matchesNameFilter(session: SessionInfo, filter: NameFilter): boolean {
+	if (filter === "all") return true;
+	return hasSessionName(session);
 }
 
 export function parseSearchQuery(query: string): ParsedSearchQuery {
@@ -142,9 +153,16 @@ export function matchSession(session: SessionInfo, parsed: ParsedSearchQuery): M
 	return { matches: true, score: totalScore };
 }
 
-export function filterAndSortSessions(sessions: SessionInfo[], query: string, sortMode: SortMode): SessionInfo[] {
+export function filterAndSortSessions(
+	sessions: SessionInfo[],
+	query: string,
+	sortMode: SortMode,
+	nameFilter: NameFilter = "all",
+): SessionInfo[] {
+	const nameFiltered =
+		nameFilter === "all" ? sessions : sessions.filter((session) => matchesNameFilter(session, nameFilter));
 	const trimmed = query.trim();
-	if (!trimmed) return sessions;
+	if (!trimmed) return nameFiltered;
 
 	const parsed = parseSearchQuery(query);
 	if (parsed.error) return [];
@@ -152,7 +170,7 @@ export function filterAndSortSessions(sessions: SessionInfo[], query: string, so
 	// Recent mode: filter only, keep incoming order.
 	if (sortMode === "recent") {
 		const filtered: SessionInfo[] = [];
-		for (const s of sessions) {
+		for (const s of nameFiltered) {
 			const res = matchSession(s, parsed);
 			if (res.matches) filtered.push(s);
 		}
@@ -161,7 +179,7 @@ export function filterAndSortSessions(sessions: SessionInfo[], query: string, so
 
 	// Relevance mode: sort by score, tie-break by modified desc.
 	const scored: { session: SessionInfo; score: number }[] = [];
-	for (const s of sessions) {
+	for (const s of nameFiltered) {
 		const res = matchSession(s, parsed);
 		if (!res.matches) continue;
 		scored.push({ session: s, score: res.score });

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -14,11 +14,12 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@mariozechner/pi-tui";
+import { KeybindingsManager } from "../../../core/keybindings.js";
 import type { SessionInfo, SessionListProgress } from "../../../core/session-manager.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
-import { keyHint } from "./keybinding-hints.js";
-import { filterAndSortSessions, type SortMode } from "./session-selector-search.js";
+import { appKey, appKeyHint, keyHint } from "./keybinding-hints.js";
+import { filterAndSortSessions, type NameFilter, type SortMode } from "./session-selector-search.js";
 
 type SessionScope = "current" | "all";
 
@@ -47,9 +48,15 @@ function formatSessionDate(date: Date): string {
 	return `${Math.floor(diffDays / 365)}y`;
 }
 
+function hasSessionName(session: SessionInfo): boolean {
+	return Boolean(session.name?.trim());
+}
+
 class SessionSelectorHeader implements Component {
 	private scope: SessionScope;
 	private sortMode: SortMode;
+	private nameFilter: NameFilter;
+	private keybindings: KeybindingsManager;
 	private requestRender: () => void;
 	private loading = false;
 	private loadProgress: { loaded: number; total: number } | null = null;
@@ -59,9 +66,17 @@ class SessionSelectorHeader implements Component {
 	private statusTimeout: ReturnType<typeof setTimeout> | null = null;
 	private showRenameHint = false;
 
-	constructor(scope: SessionScope, sortMode: SortMode, requestRender: () => void) {
+	constructor(
+		scope: SessionScope,
+		sortMode: SortMode,
+		nameFilter: NameFilter,
+		keybindings: KeybindingsManager,
+		requestRender: () => void,
+	) {
 		this.scope = scope;
 		this.sortMode = sortMode;
+		this.nameFilter = nameFilter;
+		this.keybindings = keybindings;
 		this.requestRender = requestRender;
 	}
 
@@ -71,6 +86,10 @@ class SessionSelectorHeader implements Component {
 
 	setSortMode(sortMode: SortMode): void {
 		this.sortMode = sortMode;
+	}
+
+	setNameFilter(nameFilter: NameFilter): void {
+		this.nameFilter = nameFilter;
 	}
 
 	setLoading(loading: boolean): void {
@@ -122,6 +141,9 @@ class SessionSelectorHeader implements Component {
 		const sortLabel = this.sortMode === "threaded" ? "Threaded" : this.sortMode === "recent" ? "Recent" : "Fuzzy";
 		const sortText = theme.fg("muted", "Sort: ") + theme.fg("accent", sortLabel);
 
+		const nameLabel = this.nameFilter === "all" ? "All" : "Named";
+		const nameText = theme.fg("muted", "Name: ") + theme.fg("accent", nameLabel);
+
 		let scopeText: string;
 		if (this.loading) {
 			const progressText = this.loadProgress ? `${this.loadProgress.loaded}/${this.loadProgress.total}` : "...";
@@ -132,7 +154,7 @@ class SessionSelectorHeader implements Component {
 			scopeText = `${theme.fg("muted", "○ Current Folder | ")}${theme.fg("accent", "◉ All")}`;
 		}
 
-		const rightText = truncateToWidth(`${scopeText}  ${sortText}`, width, "");
+		const rightText = truncateToWidth(`${scopeText}  ${nameText}  ${sortText}`, width, "");
 		const availableLeft = Math.max(0, width - visibleWidth(rightText) - 1);
 		const left = truncateToWidth(leftText, availableLeft, "");
 		const spacing = Math.max(0, width - visibleWidth(left) - visibleWidth(rightText));
@@ -154,6 +176,7 @@ class SessionSelectorHeader implements Component {
 			const hint1 = keyHint("tab", "scope") + sep + theme.fg("muted", 're:<pattern> regex · "phrase" exact');
 			const hint2Parts = [
 				keyHint("toggleSessionSort", "sort"),
+				appKeyHint(this.keybindings, "toggleSessionNamedFilter", "named"),
 				keyHint("deleteSession", "delete"),
 				keyHint("toggleSessionPath", `path ${pathState}`),
 			];
@@ -258,6 +281,8 @@ class SessionList implements Component, Focusable {
 	private searchInput: Input;
 	private showCwd = false;
 	private sortMode: SortMode = "threaded";
+	private nameFilter: NameFilter = "all";
+	private keybindings: KeybindingsManager;
 	private showPath = false;
 	private confirmingDeletePath: string | null = null;
 	private currentSessionFilePath?: string;
@@ -266,6 +291,7 @@ class SessionList implements Component, Focusable {
 	public onExit: () => void = () => {};
 	public onToggleScope?: () => void;
 	public onToggleSort?: () => void;
+	public onToggleNameFilter?: () => void;
 	public onTogglePath?: (showPath: boolean) => void;
 	public onDeleteConfirmationChange?: (path: string | null) => void;
 	public onDeleteSession?: (sessionPath: string) => Promise<void>;
@@ -283,12 +309,21 @@ class SessionList implements Component, Focusable {
 		this.searchInput.focused = value;
 	}
 
-	constructor(sessions: SessionInfo[], showCwd: boolean, sortMode: SortMode, currentSessionFilePath?: string) {
+	constructor(
+		sessions: SessionInfo[],
+		showCwd: boolean,
+		sortMode: SortMode,
+		nameFilter: NameFilter,
+		keybindings: KeybindingsManager,
+		currentSessionFilePath?: string,
+	) {
 		this.allSessions = sessions;
 		this.filteredSessions = [];
 		this.searchInput = new Input();
 		this.showCwd = showCwd;
 		this.sortMode = sortMode;
+		this.nameFilter = nameFilter;
+		this.keybindings = keybindings;
 		this.currentSessionFilePath = currentSessionFilePath;
 		this.filterSessions("");
 
@@ -308,6 +343,11 @@ class SessionList implements Component, Focusable {
 		this.filterSessions(this.searchInput.getValue());
 	}
 
+	setNameFilter(nameFilter: NameFilter): void {
+		this.nameFilter = nameFilter;
+		this.filterSessions(this.searchInput.getValue());
+	}
+
 	setSessions(sessions: SessionInfo[], showCwd: boolean): void {
 		this.allSessions = sessions;
 		this.showCwd = showCwd;
@@ -316,14 +356,16 @@ class SessionList implements Component, Focusable {
 
 	private filterSessions(query: string): void {
 		const trimmed = query.trim();
+		const nameFiltered =
+			this.nameFilter === "all" ? this.allSessions : this.allSessions.filter((session) => hasSessionName(session));
 
 		if (this.sortMode === "threaded" && !trimmed) {
 			// Threaded mode without search: show tree structure
-			const roots = buildSessionTree(this.allSessions);
+			const roots = buildSessionTree(nameFiltered);
 			this.filteredSessions = flattenSessionTree(roots);
 		} else {
 			// Other modes or with search: flat list
-			const filtered = trimmed ? filterAndSortSessions(this.allSessions, query, this.sortMode) : this.allSessions;
+			const filtered = filterAndSortSessions(nameFiltered, query, this.sortMode, "all");
 			this.filteredSessions = filtered.map((session) => ({
 				session,
 				depth: 0,
@@ -362,18 +404,22 @@ class SessionList implements Component, Focusable {
 		lines.push(""); // Blank line after search
 
 		if (this.filteredSessions.length === 0) {
-			if (this.showCwd) {
+			let emptyMessage: string;
+			if (this.nameFilter === "named") {
+				const toggleKey = appKey(this.keybindings, "toggleSessionNamedFilter");
+				if (this.showCwd) {
+					emptyMessage = `  No named sessions found. Press ${toggleKey} to show all.`;
+				} else {
+					emptyMessage = `  No named sessions in current folder. Press ${toggleKey} to show all, or Tab to view all.`;
+				}
+			} else if (this.showCwd) {
 				// "All" scope - no sessions anywhere that match filter
-				lines.push(theme.fg("muted", truncateToWidth("  No sessions found", width, "…")));
+				emptyMessage = "  No sessions found";
 			} else {
 				// "Current folder" scope - hint to try "all"
-				lines.push(
-					theme.fg(
-						"muted",
-						truncateToWidth("  No sessions in current folder. Press Tab to view all.", width, "…"),
-					),
-				);
+				emptyMessage = "  No sessions in current folder. Press Tab to view all.";
 			}
+			lines.push(theme.fg("muted", truncateToWidth(emptyMessage, width, "…")));
 			return lines;
 		}
 
@@ -497,6 +543,11 @@ class SessionList implements Component, Focusable {
 
 		if (kb.matches(keyData, "toggleSessionSort")) {
 			this.onToggleSort?.();
+			return;
+		}
+
+		if (this.keybindings.matches(keyData, "toggleSessionNamedFilter")) {
+			this.onToggleNameFilter?.();
 			return;
 		}
 
@@ -635,8 +686,10 @@ export class SessionSelectorComponent extends Container implements Focusable {
 	private canRename = true;
 	private sessionList: SessionList;
 	private header: SessionSelectorHeader;
+	private keybindings: KeybindingsManager;
 	private scope: SessionScope = "current";
 	private sortMode: SortMode = "threaded";
+	private nameFilter: NameFilter = "all";
 	private currentSessions: SessionInfo[] | null = null;
 	private allSessions: SessionInfo[] | null = null;
 	private currentSessionsLoader: SessionsLoader;
@@ -690,22 +743,37 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		options?: {
 			renameSession?: (sessionPath: string, currentName: string | undefined) => Promise<void>;
 			showRenameHint?: boolean;
+			keybindings?: KeybindingsManager;
 		},
 		currentSessionFilePath?: string,
 	) {
 		super();
+		this.keybindings = options?.keybindings ?? KeybindingsManager.create();
 		this.currentSessionsLoader = currentSessionsLoader;
 		this.allSessionsLoader = allSessionsLoader;
 		this.onCancel = onCancel;
 		this.requestRender = requestRender;
-		this.header = new SessionSelectorHeader(this.scope, this.sortMode, this.requestRender);
+		this.header = new SessionSelectorHeader(
+			this.scope,
+			this.sortMode,
+			this.nameFilter,
+			this.keybindings,
+			this.requestRender,
+		);
 		const renameSession = options?.renameSession;
 		this.renameSession = renameSession;
 		this.canRename = !!renameSession;
 		this.header.setShowRenameHint(options?.showRenameHint ?? this.canRename);
 
 		// Create session list (starts empty, will be populated after load)
-		this.sessionList = new SessionList([], false, this.sortMode, currentSessionFilePath);
+		this.sessionList = new SessionList(
+			[],
+			false,
+			this.sortMode,
+			this.nameFilter,
+			this.keybindings,
+			currentSessionFilePath,
+		);
 
 		this.buildBaseLayout(this.sessionList);
 
@@ -729,6 +797,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		};
 		this.sessionList.onToggleScope = () => this.toggleScope();
 		this.sessionList.onToggleSort = () => this.toggleSortMode();
+		this.sessionList.onToggleNameFilter = () => this.toggleNameFilter();
 		this.sessionList.onRenameSession = (sessionPath) => {
 			if (!renameSession) return;
 			if (this.scope === "current" && this.currentLoading) return;
@@ -909,6 +978,13 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		this.sortMode = this.sortMode === "threaded" ? "recent" : this.sortMode === "recent" ? "relevance" : "threaded";
 		this.header.setSortMode(this.sortMode);
 		this.sessionList.setSortMode(this.sortMode);
+		this.requestRender();
+	}
+
+	private toggleNameFilter(): void {
+		this.nameFilter = this.nameFilter === "all" ? "named" : "all";
+		this.header.setNameFilter(this.nameFilter);
+		this.sessionList.setNameFilter(this.nameFilter);
 		this.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3502,6 +3502,7 @@ export class InteractiveMode {
 						mgr.appendSessionInfo(next);
 					},
 					showRenameHint: true,
+					keybindings: this.keybindings,
 				},
 
 				this.sessionManager.getSessionFile(),

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -1,4 +1,6 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { DEFAULT_EDITOR_KEYBINDINGS, EditorKeybindingsManager, setEditorKeybindings } from "@mariozechner/pi-tui";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.js";
 import type { SessionInfo } from "../src/core/session-manager.js";
 import { SessionSelectorComponent } from "../src/modes/interactive/components/session-selector.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -43,6 +45,13 @@ const CTRL_D = "\x04";
 const CTRL_BACKSPACE = "\x1b[127;5u";
 
 describe("session selector path/delete interactions", () => {
+	const keybindings = KeybindingsManager.inMemory();
+
+	beforeEach(() => {
+		// Ensure test isolation: editor keybindings are a global singleton
+		setEditorKeybindings(new EditorKeybindingsManager(DEFAULT_EDITOR_KEYBINDINGS));
+	});
+
 	beforeAll(() => {
 		// session selector uses the global theme instance
 		initTheme("dark");
@@ -57,6 +66,7 @@ describe("session selector path/delete interactions", () => {
 			() => {},
 			() => {},
 			() => {},
+			{ keybindings },
 		);
 		await flushPromises();
 
@@ -80,6 +90,7 @@ describe("session selector path/delete interactions", () => {
 			() => {},
 			() => {},
 			() => {},
+			{ keybindings },
 		);
 		await flushPromises();
 
@@ -103,6 +114,7 @@ describe("session selector path/delete interactions", () => {
 			() => {},
 			() => {},
 			() => {},
+			{ keybindings },
 		);
 		await flushPromises();
 
@@ -138,6 +150,7 @@ describe("session selector path/delete interactions", () => {
 			() => {},
 			() => {},
 			() => {},
+			{ keybindings },
 		);
 		await flushPromises();
 
@@ -169,6 +182,7 @@ describe("session selector path/delete interactions", () => {
 			() => {},
 			() => {},
 			() => {},
+			{ keybindings },
 		);
 		await flushPromises();
 

--- a/packages/coding-agent/test/session-selector-search.test.ts
+++ b/packages/coding-agent/test/session-selector-search.test.ts
@@ -124,4 +124,72 @@ describe("session selector search", () => {
 		const result = filterAndSortSessions(sessions, "re:(", "recent");
 		expect(result).toEqual([]);
 	});
+
+	describe("name filter", () => {
+		const sessions: SessionInfo[] = [
+			makeSession({
+				id: "named1",
+				name: "My Project",
+				modified: new Date("2026-01-03T00:00:00.000Z"),
+				allMessagesText: "blueberry",
+			}),
+			makeSession({
+				id: "named2",
+				name: "Another Named",
+				modified: new Date("2026-01-02T00:00:00.000Z"),
+				allMessagesText: "blueberry",
+			}),
+			makeSession({
+				id: "other1",
+				modified: new Date("2026-01-04T00:00:00.000Z"),
+				allMessagesText: "blueberry",
+			}),
+			makeSession({
+				id: "other2",
+				modified: new Date("2026-01-01T00:00:00.000Z"),
+				allMessagesText: "blueberry",
+			}),
+		];
+
+		it("returns all sessions when nameFilter is 'all'", () => {
+			const result = filterAndSortSessions(sessions, "", "recent", "all");
+			expect(result.map((session) => session.id)).toEqual(["named1", "named2", "other1", "other2"]);
+		});
+
+		it("returns only named sessions when nameFilter is 'named'", () => {
+			const result = filterAndSortSessions(sessions, "", "recent", "named");
+			expect(result.map((session) => session.id)).toEqual(["named1", "named2"]);
+		});
+
+		it("applies name filter before search query", () => {
+			const result = filterAndSortSessions(sessions, "blueberry", "recent", "named");
+			expect(result.map((session) => session.id)).toEqual(["named1", "named2"]);
+		});
+
+		it("excludes whitespace-only names from named filter", () => {
+			const sessionsWithWhitespace: SessionInfo[] = [
+				makeSession({
+					id: "whitespace",
+					name: "   ",
+					modified: new Date("2026-01-01T00:00:00.000Z"),
+					allMessagesText: "test",
+				}),
+				makeSession({
+					id: "empty",
+					name: "",
+					modified: new Date("2026-01-02T00:00:00.000Z"),
+					allMessagesText: "test",
+				}),
+				makeSession({
+					id: "named",
+					name: "Real Name",
+					modified: new Date("2026-01-03T00:00:00.000Z"),
+					allMessagesText: "test",
+				}),
+			];
+
+			const result = filterAndSortSessions(sessionsWithWhitespace, "", "recent", "named");
+			expect(result.map((session) => session.id)).toEqual(["named"]);
+		});
+	});
 });


### PR DESCRIPTION
Originating issue: [#862](https://github.com/badlogic/pi-mono/issues/862) , previous PR version: https://github.com/badlogic/pi-mono/pull/868

The `/resume` picker already supports search, scope toggling, and sort modes, but named sessions can get lost easily sometimes. This adds a `Ctrl+N` toggle to filter the list down to sessions named via `/name`, while keeping the existing search/sort behavior intact (name filtering applies even when the query is empty, including in the new threaded view).

Summary of changes:

-   add `NameFilter` (`all | named`) to `filterAndSortSessions()` and apply it before query parsing/matching
-   add `Ctrl+N` in the session selector to toggle `Name: All` ↔ `Name: Named`, and show current state in the header
-   improve empty-state messaging when the named filter is active (including the escape hatch key)
-   tests: add `name filter` coverage (incl. whitespace-only names excluded via `trim()`)
-   add configurable app keybinding `toggleSessionNamedFilter` (default: `ctrl+n`) via `~/.pi/agent/keybindings.json`
-   session selector now uses `KeybindingsManager` for the named-filter toggle and UI hints/empty-state messaging, so users can remap it (e.g. for Emacs/readline `ctrl+n` = down)

Files:

- `packages/coding-agent/CHANGELOG.md`
- `packages/coding-agent/docs/keybindings.md`
- `packages/coding-agent/src/cli/session-picker.ts`
- `packages/coding-agent/src/core/keybindings.ts`
- `packages/coding-agent/src/modes/interactive/components/session-selector-search.ts`
- `packages/coding-agent/src/modes/interactive/components/session-selector.ts`
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`
- `packages/coding-agent/test/session-selector-path-delete.test.ts`
- `packages/coding-agent/test/session-selector-search.test.ts`

Manual testing:

-   `/resume`: toggle keybinding toggles All/Named; header updates; hint shows `<toggle keybinding, e.g. ctrl+n>: named`
-   `/resume`: named filter works with empty search query and with an active query
-   `/resume`: empty state mentions the toggle keybinding when no named sessions are available in the current scope
-   `/resume`: named filter toggle works; header updates; hint shows the configured keybinding
-   `keybindings.json`: remapping `toggleSessionNamedFilter` works (e.g. free up `ctrl+n` for `selectDown`)
-   All behaves as expected across all sort modes (including the new threaded† one)

† In threaded mode, the named filter hides unnamed parents, so named children may appear as roots.

<p align="center">
<img width="360" alt="all" src="https://github.com/user-attachments/assets/5d7908d9-dba2-4067-85d3-735f84723ce7" />

<img width="360" alt="named" src="https://github.com/user-attachments/assets/ccf1f969-79b9-439f-b5b6-53731a777e90" />
</p>