### PR TITLE
feat(coding-agent): extension to show spinner when agent is running

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `titlebar-spinner.ts` example extension that shows a braille spinner animation in the terminal title while the agent is working.
+
 ## [0.50.8] - 2026-02-01
 
 ### Added

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -56,6 +56,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `modal-editor.ts` | Custom vim-like modal editor via `ctx.ui.setEditorComponent()` |
 | `rainbow-editor.ts` | Animated rainbow text effect via custom editor |
 | `notify.ts` | Desktop notifications via OSC 777 when agent finishes (Ghostty, iTerm2, WezTerm) |
+| `titlebar-spinner.ts` | Braille spinner animation in terminal title while the agent is working |
 | `summarize.ts` | Summarize conversation with GPT-5.2 and show in transient UI |
 | `custom-footer.ts` | Custom footer with git branch and token stats via `ctx.ui.setFooter()` |
 | `custom-header.ts` | Custom header via `ctx.ui.setHeader()` |

--- a/packages/coding-agent/examples/extensions/titlebar-spinner.ts
+++ b/packages/coding-agent/examples/extensions/titlebar-spinner.ts
@@ -1,0 +1,58 @@
+/**
+ * Titlebar Spinner Extension
+ *
+ * Shows a braille spinner animation in the terminal title while the agent is working.
+ * Uses `ctx.ui.setTitle()` to update the terminal title via the extension API.
+ *
+ * Usage:
+ *   pi --extension examples/extensions/titlebar-spinner.ts
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import path from "node:path";
+
+const BRAILLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+function getBaseTitle(pi: ExtensionAPI): string {
+	const cwd = path.basename(process.cwd());
+	const session = pi.getSessionName();
+	return session ? `π - ${session} - ${cwd}` : `π - ${cwd}`;
+}
+
+export default function (pi: ExtensionAPI) {
+	let timer: ReturnType<typeof setInterval> | null = null;
+	let frameIndex = 0;
+
+	function stopAnimation(ctx: ExtensionContext) {
+		if (timer) {
+			clearInterval(timer);
+			timer = null;
+		}
+		frameIndex = 0;
+		ctx.ui.setTitle(getBaseTitle(pi));
+	}
+
+	function startAnimation(ctx: ExtensionContext) {
+		stopAnimation(ctx);
+		timer = setInterval(() => {
+			const frame = BRAILLE_FRAMES[frameIndex % BRAILLE_FRAMES.length];
+			const cwd = path.basename(process.cwd());
+			const session = pi.getSessionName();
+			const title = session ? `${frame} π - ${session} - ${cwd}` : `${frame} π - ${cwd}`;
+			ctx.ui.setTitle(title);
+			frameIndex++;
+		}, 80);
+	}
+
+	pi.on("agent_start", async (_event, ctx) => {
+		startAnimation(ctx);
+	});
+
+	pi.on("agent_end", async (_event, ctx) => {
+		stopAnimation(ctx);
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		stopAnimation(ctx);
+	});
+}


### PR DESCRIPTION
When the agent is running, this extension prefixes an animated braille spinner to the title to show busy state. Its cleared when the agent is done.

@badlogic if you'd like this in core, I can redo the changes