### PR TITLE
Clarify skill path resolution in skills prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Clarified skill prompt guidance so relative paths are resolved from the skill directory. ([#1136](https://github.com/badlogic/pi-mono/issues/1136))
+
 ## [0.50.9] - 2026-02-01
 
 ### Added

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -263,6 +263,7 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
 	const lines = [
 		"\n\nThe following skills provide specialized instructions for specific tasks.",
 		"Use the read tool to load a skill's file when the task matches its description.",
+		"Relative paths inside a skill file are resolved from the skill directory (parent of SKILL.md).",
 		"",
 		"<available_skills>",
 	];

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -241,6 +241,7 @@ describe("skills", () => {
 
 			expect(introText).toContain("The following skills provide specialized instructions");
 			expect(introText).toContain("Use the read tool to load a skill's file");
+			expect(introText).toContain("Relative paths inside a skill file are resolved from the skill directory");
 		});
 
 		it("should escape XML special characters", () => {


### PR DESCRIPTION
## Summary
- clarify that relative paths inside SKILL.md resolve from the skill directory
- keep skills prompt intro aligned with Agent Skills guidance
- update skills prompt test and changelog

## Testing
- npm run check

Fixes #1136