### PR TITLE
Rename package from @mariozechner/pi-agent to @mariozechner/pi-agent-core

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -167,7 +167,7 @@
 
 - **`UserMessageWithAttachments` and `Attachment` types removed**: Attachment handling is now the responsibility of the `convertToLlm` function.
 
-- **Agent loop moved from `@mariozechner/pi-ai`**: The `agentLoop`, `agentLoopContinue`, and related types have moved to this package. Import from `@mariozechner/pi-agent` instead.
+- **Agent loop moved from `@mariozechner/pi-ai`**: The `agentLoop`, `agentLoopContinue`, and related types have moved to this package. Import from `@mariozechner/pi-agent-core` instead.
 
 ### Added
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,17 +1,17 @@
-# @mariozechner/pi-agent
+# @mariozechner/pi-agent-core
 
 Stateful agent with tool execution and event streaming. Built on `@mariozechner/pi-ai`.
 
 ## Installation
 
 ```bash
-npm install @mariozechner/pi-agent
+npm install @mariozechner/pi-agent-core
 ```
 
 ## Quick Start
 
 ```typescript
-import { Agent } from "@mariozechner/pi-agent";
+import { Agent } from "@mariozechner/pi-agent-core";
 import { getModel } from "@mariozechner/pi-ai";
 
 const agent = new Agent({
@@ -293,7 +293,7 @@ Follow-up messages are checked only when there are no more tool calls and no ste
 Extend `AgentMessage` via declaration merging:
 
 ```typescript
-declare module "@mariozechner/pi-agent" {
+declare module "@mariozechner/pi-agent-core" {
   interface CustomAgentMessages {
     notification: { role: "notification"; text: string; timestamp: number };
   }
@@ -365,7 +365,7 @@ Thrown errors are caught by the agent and reported to the LLM as tool errors wit
 For browser apps that proxy through a backend:
 
 ```typescript
-import { Agent, streamProxy } from "@mariozechner/pi-agent";
+import { Agent, streamProxy } from "@mariozechner/pi-agent-core";
 
 const agent = new Agent({
   streamFn: (model, context, options) =>
@@ -382,7 +382,7 @@ const agent = new Agent({
 For direct control without the Agent class:
 
 ```typescript
-import { agentLoop, agentLoopContinue } from "@mariozechner/pi-agent";
+import { agentLoop, agentLoopContinue } from "@mariozechner/pi-agent-core";
 
 const context: AgentContext = {
   systemPrompt: "You are helpful.",


### PR DESCRIPTION
## Summary
This PR updates all references to the agent package to reflect a naming change from `@mariozechner/pi-agent` to `@mariozechner/pi-agent-core`.

## Changes
- Updated package name in CHANGELOG.md to reflect the new package name
- Updated all import statements in README.md examples from `@mariozechner/pi-agent` to `@mariozechner/pi-agent-core`
- Updated module declaration examples to use the new package name
- Updated documentation references for `Agent`, `streamProxy`, `agentLoop`, and `agentLoopContinue` imports

## Details
This is a documentation and metadata update to align with the actual package naming. All code examples and references now consistently use `@mariozechner/pi-agent-core` as the import source, ensuring users follow the correct package name when installing and importing from this library.
