### PR TITLE
Add PI_PACKAGE_DIR env var for content-addressed package managers

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -31,6 +31,14 @@ export const isBunRuntime = !!process.versions.bun;
  * - For tsx (src/): returns parent directory (the package root)
  */
 export function getPackageDir(): string {
+	// Allow override via environment variable (useful for Nix/Guix where store paths tokenize poorly)
+	const envDir = process.env.PI_PACKAGE_DIR;
+	if (envDir) {
+		if (envDir === "~") return homedir();
+		if (envDir.startsWith("~/")) return homedir() + envDir.slice(1);
+		return envDir;
+	}
+
 	if (isBunBinary) {
 		// Bun binary: process.execPath points to the compiled executable
 		return dirname(process.execPath);


### PR DESCRIPTION
Adds `PI_PACKAGE_DIR` env var to `getPackageDir()`, following the existing `PI_CODING_AGENT_DIR` pattern.

Fixes #1127

Content-addressed package managers (Nix, Guix) use hash-based paths that tokenize poorly (~1 token/char). This lets users point to a stable symlink, saving ~130 tokens/session.

- 7 lines, same pattern as `getAgentDir()`
- Supports ~ expansion
- Zero impact if unset