### PR TITLE
Fix buildBaseOptions not passing cacheRetention option

### DIFF
--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -10,6 +10,7 @@ export function buildBaseOptions(model: Model<Api>, options?: SimpleStreamOption
 		headers: options?.headers,
 		onPayload: options?.onPayload,
 		maxRetryDelayMs: options?.maxRetryDelayMs,
+		cacheRetention: options?.cacheRetention,
 	};
 }
 


### PR DESCRIPTION
## Summary
- Fix `buildBaseOptions` function in `simple-options.ts` to pass through the `cacheRetention` option
- Add tests to verify `cacheRetention` is correctly passed via simple stream functions (`streamSimpleAnthropic`, `streamSimpleOpenAIResponses`)

Fixes #1154

## Test plan
- [x] `npm run check` passes
- [x] `./test.sh` passes
- [x] New tests verify the fix detects the regression when reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)