### PR TITLE
fix(openai-completions): handle undefined baseUrl in detectCompat

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -776,7 +776,7 @@ function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"]): Sto
  */
 function detectCompat(model: Model<"openai-completions">): Required<OpenAICompletionsCompat> {
 	const provider = model.provider;
-	const baseUrl = model.baseUrl;
+	const baseUrl = model.baseUrl ?? "";
 
 	const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
 


### PR DESCRIPTION
## Problem

When using custom model providers that configure `baseUrl` at the provider level (e.g., local LLM servers like MLX), the resolved model object may not have `baseUrl` set. This causes `detectCompat()` to throw:

```
Cannot read properties of undefined (reading 'includes')
```

## Solution

Add a nullish coalescing fallback on line 779:

```typescript
const baseUrl = model.baseUrl ?? "";
```

This allows the function to proceed with provider-based detection when `baseUrl` is undefined, rather than throwing.

## Testing

Tested with local MLX models configured as custom providers in Clawdbot. Before fix: error on sub-agent spawn. After fix: requests proceed normally.

## Impact

- **Fixes:** Custom provider configurations where baseUrl is only set at provider level
- **No breaking changes:** Existing behavior unchanged when baseUrl is defined