### PR TITLE
fix(coding-agent): preserve editor content during tree navigation summarization

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed `cacheRetention` option not being passed through in `buildBaseOptions` ([#1154](https://github.com/badlogic/pi-mono/issues/1154))
 - Fixed OAuth login/refresh not using HTTP proxy settings (`HTTP_PROXY`, `HTTPS_PROXY` env vars) ([#1132](https://github.com/badlogic/pi-mono/issues/1132))
 - Fixed `pi update <source>` installing packages locally when the source is only registered globally ([#1163](https://github.com/badlogic/pi-mono/pull/1163) by [@aliou](https://github.com/aliou))
+- Fixed tree navigation with summarization overwriting editor content typed during the summarization wait ([#1169](https://github.com/badlogic/pi-mono/pull/1169) by [@aliou](https://github.com/aliou))
 
 ## [0.50.9] - 2026-02-01
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1051,7 +1051,7 @@ export class InteractiveMode {
 
 					this.chatContainer.clear();
 					this.renderInitialMessages();
-					if (result.editorText) {
+					if (result.editorText && !this.editor.getText().trim()) {
 						this.editor.setText(result.editorText);
 					}
 					this.showStatus("Navigated to selected point");
@@ -3443,7 +3443,7 @@ export class InteractiveMode {
 						// Update UI
 						this.chatContainer.clear();
 						this.renderInitialMessages();
-						if (result.editorText) {
+						if (result.editorText && !this.editor.getText().trim()) {
 							this.editor.setText(result.editorText);
 						}
 						this.showStatus("Navigated to selected point");


### PR DESCRIPTION
Hello!

When going back up the three and summarising, when the summarisation finished it would overwrite the editor content and lose the content written. This PRs prevents this from happening if there's any content already in the editor. 

Session: https://buildwithpi.ai/session/#34a02f305dfcc5be90d74fd1ddb2eae5

------

<details><summary>Summary by Opus:</summary>
<p>

When using `/tree` (or double-escape) to navigate back to a previous message and choosing to summarize, the editor is editable while summarization runs. Any text typed during that wait is overwritten when summarization completes, because the code unconditionally calls `editor.setText(result.editorText)` with the rewound user message.

### Changes

**`packages/coding-agent/src/modes/interactive/interactive-mode.ts`**

Two `editor.setText(result.editorText)` calls after `session.navigateTree()` now check `!this.editor.getText().trim()` before setting:

1. **Line ~3447** - `/tree` selector handler (the main user-facing flow)
2. **Line ~1055** - Extension-driven `navigateTree` handler (same async pattern, same bug)

If the editor is empty, the rewound user message is populated as before. If the user has typed something during the summarization wait, their text is preserved.

No changes to the session layer (`agent-session.ts`) - `navigateTree()` still correctly returns `editorText`; the fix is purely in the UI layer's conditional application of that value.

</p>
</details>