### PR TITLE
fix(coding-agent): fix clipboard image tests crashing CI

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed OAuth login/refresh not using HTTP proxy settings (`HTTP_PROXY`, `HTTPS_PROXY` env vars) ([#1132](https://github.com/badlogic/pi-mono/issues/1132))
 - Fixed `pi update <source>` installing packages locally when the source is only registered globally ([#1163](https://github.com/badlogic/pi-mono/pull/1163) by [@aliou](https://github.com/aliou))
 - Fixed tree navigation with summarization overwriting editor content typed during the summarization wait ([#1169](https://github.com/badlogic/pi-mono/pull/1169) by [@aliou](https://github.com/aliou))
+- Fixed clipboard image tests crashing CI by extracting native module loading into a mockable ESM wrapper ([#1170](https://github.com/badlogic/pi-mono/pull/1170) by [@aliou](https://github.com/aliou))
 
 ## [0.50.9] - 2026-02-01
 

--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -1,21 +1,6 @@
 import { spawnSync } from "child_process";
-import { createRequire } from "module";
-
+import { clipboard as Clipboard } from "./clipboard-native.js";
 import { loadPhoton } from "./photon.js";
-
-type ClipboardModule = {
-	hasImage: () => boolean;
-	getImageBinary: () => Promise<Array<number>>;
-};
-
-const require = createRequire(import.meta.url);
-let Clipboard: ClipboardModule | null = null;
-
-try {
-	Clipboard = require("@mariozechner/clipboard") as ClipboardModule;
-} catch {
-	Clipboard = null;
-}
 
 export type ClipboardImage = {
 	bytes: Uint8Array;

--- a/packages/coding-agent/src/utils/clipboard-native.ts
+++ b/packages/coding-agent/src/utils/clipboard-native.ts
@@ -1,0 +1,17 @@
+import { createRequire } from "module";
+
+export type ClipboardModule = {
+	hasImage: () => boolean;
+	getImageBinary: () => Promise<Array<number>>;
+};
+
+const require = createRequire(import.meta.url);
+let clipboard: ClipboardModule | null = null;
+
+try {
+	clipboard = require("@mariozechner/clipboard") as ClipboardModule;
+} catch {
+	clipboard = null;
+}
+
+export { clipboard };

--- a/packages/coding-agent/test/clipboard-image.test.ts
+++ b/packages/coding-agent/test/clipboard-image.test.ts
@@ -17,9 +17,9 @@ vi.mock("child_process", () => {
 	};
 });
 
-vi.mock("@mariozechner/clipboard", () => {
+vi.mock("../src/utils/clipboard-native.js", () => {
 	return {
-		default: mocks.clipboard,
+		clipboard: mocks.clipboard,
 	};
 });
 


### PR DESCRIPTION
Wasn't sure if it was related to the musl update from earlier so had Opus take a look. 

Session: https://buildwithpi.ai/session/#d858e1def8333a37068089da0c821fbf

------

<details><summary>Summary by Opus:</summary>
<p>

## Problem

The `clipboard-image.test.ts` tests crash the CI runner with a Rust panic (`DisplayParsingError(DisplayNotSet)`) since `@mariozechner/clipboard` was updated to 0.3.2 (`47308d3f`).

Root cause: `vi.mock("@mariozechner/clipboard")` does not intercept `createRequire` calls (documented vitest limitation -- mocks only work with ESM `import`). The real native Rust module is loaded instead, which panics when no X11 display is available in CI.

## Fix

Extract the native module loading into a separate ESM wrapper module that `vi.mock` can intercept.

### Files changed

- **`packages/coding-agent/src/utils/clipboard-native.ts`** (new): Wrapper that loads `@mariozechner/clipboard` via `createRequire` with try/catch fallback, and re-exports it as a named ESM export.
- **`packages/coding-agent/src/utils/clipboard-image.ts`**: Imports `Clipboard` from `./clipboard-native.js` instead of loading it directly via `createRequire`. No behavioral change.
- **`packages/coding-agent/test/clipboard-image.test.ts`**: Mocks `../src/utils/clipboard-native.js` (ESM, interceptable) instead of `@mariozechner/clipboard` (CJS, not interceptable). Uses named export `{ clipboard: mocks.clipboard }` instead of default export.

</p>
</details>