### PR TITLE
feat(ai): add supportsStrictMode compat option for OpenAI completions

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -428,7 +428,7 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 	}
 
 	if (context.tools) {
-		params.tools = convertTools(context.tools);
+		params.tools = convertTools(context.tools, compat);
 	} else if (hasToolHistory(context.messages)) {
 		// Anthropic (via LiteLLM/proxy) requires tools param when conversation has tool_calls/tool_results
 		params.tools = [];
@@ -738,14 +738,18 @@ export function convertMessages(
 	return params;
 }
 
-function convertTools(tools: Tool[]): OpenAI.Chat.Completions.ChatCompletionTool[] {
+function convertTools(
+	tools: Tool[],
+	compat: Required<OpenAICompletionsCompat>,
+): OpenAI.Chat.Completions.ChatCompletionTool[] {
 	return tools.map((tool) => ({
 		type: "function",
 		function: {
 			name: tool.name,
 			description: tool.description,
 			parameters: tool.parameters as any, // TypeBox already generates JSON Schema
-			strict: false, // Disable strict mode to allow optional parameters without null unions
+			// Only include strict field if provider supports it (some reject unknown fields)
+			...(compat.supportsStrictMode !== false && { strict: false }),
 		},
 	}));
 }
@@ -812,6 +816,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		thinkingFormat: isZai ? "zai" : "openai",
 		openRouterRouting: {},
 		vercelGatewayRouting: {},
+		supportsStrictMode: true,
 	};
 }
 
@@ -837,5 +842,6 @@ function getCompat(model: Model<"openai-completions">): Required<OpenAICompletio
 		thinkingFormat: model.compat.thinkingFormat ?? detected.thinkingFormat,
 		openRouterRouting: model.compat.openRouterRouting ?? {},
 		vercelGatewayRouting: model.compat.vercelGatewayRouting ?? detected.vercelGatewayRouting,
+		supportsStrictMode: model.compat.supportsStrictMode ?? detected.supportsStrictMode,
 	};
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -235,6 +235,8 @@ export interface OpenAICompletionsCompat {
 	openRouterRouting?: OpenRouterRouting;
 	/** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */
 	vercelGatewayRouting?: VercelGatewayRouting;
+	/** Whether the provider supports the `strict` field in tool definitions. Set to false to omit the field entirely. Default: true. */
+	supportsStrictMode?: boolean;
 }
 
 /** Compatibility settings for OpenAI Responses APIs. */

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -32,6 +32,7 @@ const compat: Required<OpenAICompletionsCompat> = {
 	thinkingFormat: "openai",
 	openRouterRouting: {},
 	vercelGatewayRouting: {},
+	supportsStrictMode: true,
 };
 
 function buildToolResult(toolCallId: string, timestamp: number): ToolResultMessage {


### PR DESCRIPTION
## Summary

Some OpenAI-compatible endpoints reject requests that include the `strict` field in tool/function definitions, even when set to `false`. The endpoint's schema validation rejects any unknown fields entirely.

Example error from RouteLLM (`routellm.abacus.ai`):
```
HTTP 400: "Validation Error: \"strict\" - Extra inputs are not permitted"
```

## Changes

- Added `supportsStrictMode?: boolean` to `OpenAICompletionsCompat` in `types.ts`
- Updated `convertTools` in `openai-completions.ts` to conditionally omit the `strict` field when `supportsStrictMode: false`
- Updated test file to include the new compat option

## How it works

When `supportsStrictMode: false` is set in the model's compat config, the `strict` field is completely **omitted** from tool definitions (not just set to `false`):

```javascript
// Before (always included)
{ name, description, parameters, strict: false }

// After (omitted when supportsStrictMode: false)
{ name, description, parameters }
```

## Model Config Example

```json
{
  "id": "route-llm",
  "name": "RouteLLM",
  "compat": { "supportsStrictMode": false }
}
```

## Test Plan

- [x] Tested with RouteLLM endpoint that previously rejected the `strict` field
- [x] Existing functionality preserved (strict: false still sent by default)
- [x] Updated test file

Closes #1172

---
Generated with [Claude Code](https://claude.com/claude-code)