### PR TITLE
fix(tui): prevent Input component from exceeding terminal width with tab characters

### DIFF
--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -256,8 +256,8 @@ export class Input implements Component, Focusable {
 	}
 
 	private handlePaste(pastedText: string): void {
-		// Clean the pasted text - remove newlines and carriage returns
-		const cleanText = pastedText.replace(/\r\n/g, "").replace(/\r/g, "").replace(/\n/g, "");
+		// Clean the pasted text - remove newlines, carriage returns, and convert tabs to spaces
+		const cleanText = pastedText.replace(/\r\n/g, "").replace(/\r/g, "").replace(/\n/g, "").replace(/\t/g, " ");
 
 		// Insert at cursor position
 		this.value = this.value.slice(0, this.cursor) + cleanText + this.value.slice(this.cursor);
@@ -277,30 +277,34 @@ export class Input implements Component, Focusable {
 			return [prompt];
 		}
 
+		// Normalize value for display: convert tabs to spaces to prevent width overflow
+		// Tab characters have length 1 but render as 8 spaces in terminals
+		const displayValue = this.value.replace(/\t/g, " ");
+
 		let visibleText = "";
 		let cursorDisplay = this.cursor;
 
-		if (this.value.length < availableWidth) {
+		if (displayValue.length < availableWidth) {
 			// Everything fits (leave room for cursor at end)
-			visibleText = this.value;
+			visibleText = displayValue;
 		} else {
 			// Need horizontal scrolling
 			// Reserve one character for cursor if it's at the end
-			const scrollWidth = this.cursor === this.value.length ? availableWidth - 1 : availableWidth;
+			const scrollWidth = this.cursor === displayValue.length ? availableWidth - 1 : availableWidth;
 			const halfWidth = Math.floor(scrollWidth / 2);
 
 			if (this.cursor < halfWidth) {
 				// Cursor near start
-				visibleText = this.value.slice(0, scrollWidth);
+				visibleText = displayValue.slice(0, scrollWidth);
 				cursorDisplay = this.cursor;
-			} else if (this.cursor > this.value.length - halfWidth) {
+			} else if (this.cursor > displayValue.length - halfWidth) {
 				// Cursor near end
-				visibleText = this.value.slice(this.value.length - scrollWidth);
-				cursorDisplay = scrollWidth - (this.value.length - this.cursor);
+				visibleText = displayValue.slice(displayValue.length - scrollWidth);
+				cursorDisplay = scrollWidth - (displayValue.length - this.cursor);
 			} else {
 				// Cursor in middle
 				const start = this.cursor - halfWidth;
-				visibleText = this.value.slice(start, start + scrollWidth);
+				visibleText = displayValue.slice(start, start + scrollWidth);
 				cursorDisplay = halfWidth;
 			}
 		}

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { Input } from "../src/components/input.js";
+import { visibleWidth } from "../src/utils.js";
 
 describe("Input component", () => {
 	it("submits value including backslash on Enter", () => {
@@ -31,5 +32,43 @@ describe("Input component", () => {
 		input.handleInput("x");
 
 		assert.strictEqual(input.getValue(), "\\x");
+	});
+
+	it("converts tabs to spaces in pasted text", () => {
+		const input = new Input();
+
+		// Simulate bracketed paste with tabs
+		input.handleInput("\x1b[200~hello\t\tworld\x1b[201~");
+
+		// Tabs should be converted to spaces
+		assert.strictEqual(input.getValue(), "hello  world");
+	});
+
+	it("render does not exceed width even with tabs in value", () => {
+		const input = new Input();
+		const width = 80;
+
+		// Directly set value with tabs (simulating edge case where tabs get in)
+		input.setValue("a\t\t\t\t\t\t\t\t\t\tb");
+
+		const lines = input.render(width);
+
+		// Each rendered line must not exceed width
+		for (const line of lines) {
+			const lineWidth = visibleWidth(line);
+			assert.ok(lineWidth <= width, `Rendered line width ${lineWidth} exceeds terminal width ${width}`);
+		}
+	});
+
+	it("render converts tabs to spaces for display", () => {
+		const input = new Input();
+
+		// Directly set value with a tab
+		input.setValue("hello\tworld");
+
+		const lines = input.render(80);
+
+		// The rendered output should have space instead of tab
+		assert.ok(!lines[0]?.includes("\t"), "Rendered line should not contain tab character");
 	});
 });


### PR DESCRIPTION
## Problem

When pasting text containing tab characters into the `Input` component, the TUI crashes with:

```
Error: Rendered line 1099 exceeds terminal width (711 > 239).

This is likely caused by a custom TUI component not truncating its output.
Use visibleWidth() to measure and truncateToWidth() to truncate lines.
```

### Root Cause

Tab characters (`\t`) have a string length of 1 but render as 8 spaces in terminals. The `Input` component was using `value.length` for scroll calculations, not accounting for the actual display width of tabs.

## Solution

1. **`handlePaste()`**: Convert tabs to spaces when pasting text (along with existing newline removal)
2. **`render()`**: Convert tabs to spaces for display calculation (defensive measure for edge cases)

## Changes

- `packages/tui/src/components/input.ts`: Fix tab character handling
- `packages/tui/test/input.test.ts`: Add tests for tab character scenarios

## Testing

All existing tests pass, plus new tests:
- `converts tabs to spaces in pasted text`
- `render does not exceed width even with tabs in value`  
- `render converts tabs to spaces for display`