### PR TITLE
fix(tui): handle emojis in input cursor

### DIFF
--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -307,9 +307,12 @@ export class Input implements Component, Focusable {
 
 		// Build line with fake cursor
 		// Insert cursor character at cursor position
+		const graphemes = [...segmenter.segment(visibleText.slice(cursorDisplay))];
+		const cursorGrapheme = graphemes[0];
+
 		const beforeCursor = visibleText.slice(0, cursorDisplay);
-		const atCursor = visibleText[cursorDisplay] || " "; // Character at cursor, or space if at end
-		const afterCursor = visibleText.slice(cursorDisplay + 1);
+		const atCursor = cursorGrapheme?.segment ?? " "; // Character at cursor, or space if at end
+		const afterCursor = visibleText.slice(cursorDisplay + atCursor.length);
 
 		// Hardware cursor marker (zero-width, emitted before fake cursor for IME positioning)
 		const marker = this.focused ? CURSOR_MARKER : "";


### PR DESCRIPTION
The fake cursor of `tui`'s `input` component does not handle emojis properly.

This PR fixes it with the `segmenter`.

(test it with `./pi-test.sh config`)
Before:
<img width="454" height="276" alt="screenshot-2026-02-02_17-33-32" src="https://github.com/user-attachments/assets/64b33550-dbaf-4fc8-b654-0dade5b7f411" />

After:
<img width="420" height="262" alt="screenshot-2026-02-02_17-40-46" src="https://github.com/user-attachments/assets/3bd2a9d6-d9af-4609-b4fe-39c1cebd67ff" />
