### PR TITLE
fix(coding-agent): filter out commands conflict with builtins

### DIFF
--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -170,6 +170,7 @@ export class ExtensionRunner {
 	private switchSessionHandler: SwitchSessionHandler = async () => ({ cancelled: false });
 	private shutdownHandler: ShutdownHandler = () => {};
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
+	private commandDiagnostics: ResourceDiagnostic[] = [];
 
 	constructor(
 		extensions: Extension[],
@@ -371,14 +372,29 @@ export class ExtensionRunner {
 		return undefined;
 	}
 
-	getRegisteredCommands(): RegisteredCommand[] {
+	getRegisteredCommands(reserved?: Set<string>): RegisteredCommand[] {
+		this.commandDiagnostics = [];
+
 		const commands: RegisteredCommand[] = [];
 		for (const ext of this.extensions) {
 			for (const command of ext.commands.values()) {
+				if (reserved?.has(command.name)) {
+					const message = `Extension command '${command.name}' from ${ext.path} conflicts with built-in commands. Skipping.`;
+					this.commandDiagnostics.push({ type: "warning", message, path: ext.path });
+					if (!this.hasUI()) {
+						console.warn(message);
+					}
+					continue;
+				}
+
 				commands.push(command);
 			}
 		}
 		return commands;
+	}
+
+	getCommandDiagnostics(): ResourceDiagnostic[] {
+		return this.commandDiagnostics;
 	}
 
 	getRegisteredCommandsWithPaths(): Array<{ command: RegisteredCommand; extensionPath: string }> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -347,13 +347,14 @@ export class InteractiveMode {
 		}));
 
 		// Convert extension commands to SlashCommand format
-		const extensionCommands: SlashCommand[] = (this.session.extensionRunner?.getRegisteredCommands() ?? []).map(
-			(cmd) => ({
-				name: cmd.name,
-				description: cmd.description ?? "(extension command)",
-				getArgumentCompletions: cmd.getArgumentCompletions,
-			}),
-		);
+		const builtinCommandNames = new Set(slashCommands.map((c) => c.name));
+		const extensionCommands: SlashCommand[] = (
+			this.session.extensionRunner?.getRegisteredCommands(builtinCommandNames) ?? []
+		).map((cmd) => ({
+			name: cmd.name,
+			description: cmd.description ?? "(extension command)",
+			getArgumentCompletions: cmd.getArgumentCompletions,
+		}));
 
 		// Build skill commands from session.skills (if enabled)
 		this.skillCommands.clear();
@@ -958,6 +959,9 @@ export class InteractiveMode {
 				extensionDiagnostics.push({ type: "error", message: error.error, path: error.path });
 			}
 		}
+
+		const commandDiagnostics = this.session.extensionRunner?.getCommandDiagnostics() ?? [];
+		extensionDiagnostics.push(...commandDiagnostics);
 
 		const shortcutDiagnostics = this.session.extensionRunner?.getShortcutDiagnostics() ?? [];
 		extensionDiagnostics.push(...shortcutDiagnostics);


### PR DESCRIPTION
`Pi` only detects conflicts between extensions' commands. If an extension tries to override a built-in command, it does not show a warning and adds the custom command to the auto-completion list.

This PR detects this kind of conflicts, shows warnings and removes the invalid commands from the auto-completion list.

`/tmp/share.ts`:
```typescript
import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";

export default function(pi: ExtensionAPI) {
    pi.registerCommand("share", {
        description: "Say hello",
        handler: async (args, ctx) => {
            ctx.ui.notify(`Hello ${args || "world"}!`, "info");
        },
    });
}
```

Before:
<img width="807" height="1039" alt="screenshot-2026-02-03_01-27-41" src="https://github.com/user-attachments/assets/b407f601-5d44-4117-aee6-09de32c69908" />


After:
<img width="924" height="1118" alt="screenshot-2026-02-03_01-28-26" src="https://github.com/user-attachments/assets/971ef798-a865-413d-9cab-f7c5dc92e56c" />
