### PR TITLE
feat: add setToolsExpanded and getToolsExpanded to ExtensionsUIContext

### DIFF
--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -146,6 +146,8 @@ const noOpUIContext: ExtensionUIContext = {
 	getAllThemes: () => [],
 	getTheme: () => undefined,
 	setTheme: (_theme: string | Theme) => ({ success: false, error: "UI not available" }),
+	getToolsExpanded: () => false,
+	setToolsExpanded: () => {},
 };
 
 export class ExtensionRunner {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -218,6 +218,12 @@ export interface ExtensionUIContext {
 
 	/** Set the current theme by name or Theme object. */
 	setTheme(theme: string | Theme): { success: boolean; error?: string };
+
+	/** Get current tool output expansion state. */
+	getToolsExpanded(): boolean;
+
+	/** Set tool output expansion state. */
+	setToolsExpanded(expanded: boolean): void;
 }
 
 // ============================================================================

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1396,6 +1396,8 @@ export class InteractiveMode {
 				}
 				return result;
 			},
+			getToolsExpanded: () => this.toolOutputExpanded,
+			setToolsExpanded: (expanded) => this.setToolsExpanded(expanded),
 		};
 	}
 
@@ -2658,10 +2660,14 @@ export class InteractiveMode {
 	}
 
 	private toggleToolOutputExpansion(): void {
-		this.toolOutputExpanded = !this.toolOutputExpanded;
+		this.setToolsExpanded(!this.toolOutputExpanded);
+	}
+
+	private setToolsExpanded(expanded: boolean): void {
+		this.toolOutputExpanded = expanded;
 		for (const child of this.chatContainer.children) {
 			if (isExpandable(child)) {
-				child.setExpanded(this.toolOutputExpanded);
+				child.setExpanded(expanded);
 			}
 		}
 		this.ui.requestRender();

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -252,6 +252,15 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			// Theme switching not supported in RPC mode
 			return { success: false, error: "Theme switching not supported in RPC mode" };
 		},
+
+		getToolsExpanded() {
+			// Tool expansion not supported in RPC mode - no TUI
+			return false;
+		},
+
+		setToolsExpanded(_expanded: boolean) {
+			// Tool expansion not supported in RPC mode - no TUI
+		},
 	});
 
 	// Set up extensions with RPC-based UI context


### PR DESCRIPTION
as described in https://github.com/badlogic/pi-mono/issues/1192#event-22472539910

It required to change one of the original toggle method into a set method and then call the set method from the original toggle.

> **Note** this code was implemented with help of pi-agent itself but reviewed and validated manually by me

Added the following methods to the ExtensionUI interface

```typescript
// In ExtensionUIContext or ExtensionContext
interface ExtensionUIContext {
  // ... existing methods ...
  
  /** Get current tool output expansion state */
  getToolsExpanded(): boolean;
  
  /** Set tool output expansion state */
  setToolsExpanded(expanded: boolean): void;
}
```

example of an extension to "confirm" write/edit tool calls  (for people like me who wants to check the code their agents try to write)

```typescript
import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";

 const extension: ExtensionFactory = (pi) => {
   pi.on("tool_call", async (event, ctx) => {
     if (event.toolName === "write" || event.toolName === "edit") {
       const wasExpanded = ctx.ui.getToolsExpanded();
       ctx.ui.setToolsExpanded(true);

       const confirmed = await ctx.ui.confirm(
         "[TEST] Review changes",
         `Allow ${event.toolName} to ${event.input.path}?`
       );

       // Restore original expansion state
       ctx.ui.setToolsExpanded(wasExpanded);

       if (!confirmed) {
         return { block: true, reason: "User declined" };
       }
     }
   });
 };

 export default extension;
```