### PR TITLE
feat(coding-agent): add ExtensionAPI.getCommands()

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ExtensionAPI.getCommands()` to let extensions list available slash commands (extensions, prompt templates, skills) for invocation via `prompt`
+
 ## [0.51.2] - 2026-02-03
 
 ### New Features

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -942,6 +942,31 @@ pi.registerCommand("deploy", {
 });
 ```
 
+### pi.getCommands()
+
+Get the slash commands available for invocation via `prompt` in the current session. Includes extension commands, prompt templates, and skill commands.
+The list matches the RPC `get_commands` ordering: extensions first, then templates, then skills.
+
+```typescript
+const commands = pi.getCommands();
+const bySource = commands.filter((command) => command.source === "extension");
+```
+
+Each entry has this shape:
+
+```typescript
+{
+  name: string; // Command name without the leading slash
+  description?: string;
+  source: "extension" | "template" | "skill";
+  location?: "user" | "project" | "path"; // For templates and skills
+  path?: string; // Files backing templates, skills, and extensions
+}
+```
+
+Built-in interactive commands (like `/model` and `/settings`) are not included here. They are handled only in interactive
+mode and would not execute if sent via `prompt`.
+
 ### pi.registerMessageRenderer(customType, renderer)
 
 Register a custom TUI renderer for messages with your `customType`. See [Custom UI](#custom-ui).

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -2,6 +2,7 @@
  * Extension system for lifecycle events and custom tools.
  */
 
+export type { SlashCommandInfo, SlashCommandLocation, SlashCommandSource } from "../slash-commands.js";
 export {
 	createExtensionRuntime,
 	discoverAndLoadExtensions,
@@ -68,6 +69,7 @@ export type {
 	FindToolResultEvent,
 	GetActiveToolsHandler,
 	GetAllToolsHandler,
+	GetCommandsHandler,
 	GetThinkingLevelHandler,
 	GrepToolCallEvent,
 	GrepToolResultEvent,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -119,6 +119,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		getActiveTools: notInitialized,
 		getAllTools: notInitialized,
 		setActiveTools: notInitialized,
+		getCommands: notInitialized,
 		setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
 		getThinkingLevel: notInitialized,
 		setThinkingLevel: notInitialized,
@@ -226,6 +227,10 @@ function createExtensionAPI(
 
 		setActiveTools(toolNames: string[]): void {
 			runtime.setActiveTools(toolNames);
+		},
+
+		getCommands() {
+			return runtime.getCommands();
 		},
 
 		setModel(model) {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -200,6 +200,7 @@ export class ExtensionRunner {
 		this.runtime.getActiveTools = actions.getActiveTools;
 		this.runtime.getAllTools = actions.getAllTools;
 		this.runtime.setActiveTools = actions.setActiveTools;
+		this.runtime.getCommands = actions.getCommands;
 		this.runtime.setModel = actions.setModel;
 		this.runtime.getThinkingLevel = actions.getThinkingLevel;
 		this.runtime.setThinkingLevel = actions.setThinkingLevel;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -53,6 +53,7 @@ import type {
 	SessionEntry,
 	SessionManager,
 } from "../session-manager.js";
+import type { SlashCommandInfo } from "../slash-commands.js";
 import type { BashOperations } from "../tools/bash.js";
 import type { EditToolDetails } from "../tools/edit.js";
 import type {
@@ -973,6 +974,9 @@ export interface ExtensionAPI {
 	/** Set the active tools by name. */
 	setActiveTools(toolNames: string[]): void;
 
+	/** Get available slash commands in the current session. */
+	getCommands(): SlashCommandInfo[];
+
 	// =========================================================================
 	// Model and Thinking Level
 	// =========================================================================
@@ -1154,6 +1158,8 @@ export type ToolInfo = Pick<ToolDefinition, "name" | "description">;
 
 export type GetAllToolsHandler = () => ToolInfo[];
 
+export type GetCommandsHandler = () => SlashCommandInfo[];
+
 export type SetActiveToolsHandler = (toolNames: string[]) => void;
 
 export type SetModelHandler = (model: Model<any>) => Promise<boolean>;
@@ -1188,6 +1194,7 @@ export interface ExtensionActions {
 	getActiveTools: GetActiveToolsHandler;
 	getAllTools: GetAllToolsHandler;
 	setActiveTools: SetActiveToolsHandler;
+	getCommands: GetCommandsHandler;
 	setModel: SetModelHandler;
 	getThinkingLevel: GetThinkingLevelHandler;
 	setThinkingLevel: SetThinkingLevelHandler;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -88,6 +88,9 @@ export type {
 	ExtensionCommandContext,
 	ExtensionContext,
 	ExtensionFactory,
+	SlashCommandInfo,
+	SlashCommandLocation,
+	SlashCommandSource,
 	ToolDefinition,
 } from "./extensions/index.js";
 export type { PromptTemplate } from "./prompt-templates.js";

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -1,0 +1,37 @@
+export type SlashCommandSource = "extension" | "template" | "skill";
+
+export type SlashCommandLocation = "user" | "project" | "path";
+
+export interface SlashCommandInfo {
+	name: string;
+	description?: string;
+	source: SlashCommandSource;
+	location?: SlashCommandLocation;
+	path?: string;
+}
+
+export interface BuiltinSlashCommand {
+	name: string;
+	description: string;
+}
+
+export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
+	{ name: "settings", description: "Open settings menu" },
+	{ name: "model", description: "Select model (opens selector UI)" },
+	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
+	{ name: "export", description: "Export session to HTML file" },
+	{ name: "share", description: "Share session as a secret GitHub gist" },
+	{ name: "copy", description: "Copy last agent message to clipboard" },
+	{ name: "name", description: "Set session display name" },
+	{ name: "session", description: "Show session info and stats" },
+	{ name: "changelog", description: "Show changelog entries" },
+	{ name: "hotkeys", description: "Show all keyboard shortcuts" },
+	{ name: "fork", description: "Create a new fork from a previous message" },
+	{ name: "tree", description: "Navigate session tree (switch branches)" },
+	{ name: "login", description: "Login with OAuth provider" },
+	{ name: "logout", description: "Logout from OAuth provider" },
+	{ name: "new", description: "Start a new session" },
+	{ name: "compact", description: "Manually compact the session context" },
+	{ name: "resume", description: "Resume a different session" },
+	{ name: "reload", description: "Reload extensions, skills, prompts, and themes" },
+];


### PR DESCRIPTION
Originating issue: https://github.com/badlogic/pi-mono/issues/1208

Extensions can register slash commands via `pi.registerCommand()`, but there was no supported way for an extension (or a headless client) to discover which `/...` commands are available in the current session.

This adds `pi.getCommands()` to the ExtensionAPI, aligned with the RPC `get_commands` contract: it lists prompt-invokable commands from extensions, prompt templates, and skills (in that order), and excludes interactive-only built-ins like `/model` and `/settings`.

Changes:
- add `ExtensionAPI.getCommands()` (AgentSession → runner/runtime → extension API)
- return command metadata aligned with RPC (`source`, optional `location`, optional `path`)
- centralize built-in interactive command names/descriptions in `core/slash-commands.ts` and reuse them for:
  - interactive autocomplete (single source of truth)
  - reserved-name filtering (extension commands that collide with built-ins are skipped)
- export `SlashCommandInfo` / `SlashCommandSource` / `SlashCommandLocation` via `core/extensions` and `core/sdk`
- docs + changelog entry

Files:
- `packages/coding-agent/CHANGELOG.md`
- `packages/coding-agent/docs/extensions.md`
- `packages/coding-agent/src/core/agent-session.ts`
- `packages/coding-agent/src/core/extensions/index.ts`
- `packages/coding-agent/src/core/extensions/loader.ts`
- `packages/coding-agent/src/core/extensions/runner.ts`
- `packages/coding-agent/src/core/extensions/types.ts`
- `packages/coding-agent/src/core/sdk.ts`
- `packages/coding-agent/src/core/slash-commands.ts` (new)
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`

Manual testing:
- verified interactive `/model` behavior:
  - `/model <partial>` + Tab shows completions
  - `/model` + Enter opens selector
  - typing `/model ` immediately suggests models
- verified `pi.getCommands()` end-to-end via a real extension at `~/.pi/agent/extensions/commands.ts` (ugly screenshot below):
  - works after `/reload`
  - ordering is `extensions → templates → skills`
  - built-in interactive commands are excluded
- verified built-in name collision handling:
  - registering an extension command named `model` is rejected with an explicit warning and skipped

<p align="center">
<img width="450" alt="commands-extension-using-getCommands" src="https://github.com/user-attachments/assets/545ccfa1-1f5d-43d5-a4e3-19c2bfbb5873" />
</p>

**Question**: Would you like this PR to add a test verifying that `getCommands()` returns the right ordering and metadata?  Setting up an extension, template, and skill in a test session is a bit involved, so lmk if there's a pattern you prefer for that kind of setup, or if you'd rather add tests in a follow-up.