### PR TITLE
feat(notify): add Kitty (OSC 99) and Windows Terminal support

### DIFF
--- a/packages/coding-agent/examples/extensions/notify.ts
+++ b/packages/coding-agent/examples/extensions/notify.ts
@@ -1,21 +1,51 @@
 /**
- * Desktop Notification Extension
+ * Pi Notify Extension
  *
- * Sends a native desktop notification when the agent finishes and is waiting for input.
- * Uses OSC 777 escape sequence - no external dependencies.
- *
- * Supported terminals: Ghostty, iTerm2, WezTerm, rxvt-unicode
- * Not supported: Kitty (uses OSC 99), Terminal.app, Windows Terminal, Alacritty
+ * Sends a native terminal notification when Pi agent is done and waiting for input.
+ * Supports multiple terminal protocols:
+ * - OSC 777: Ghostty, iTerm2, WezTerm, rxvt-unicode
+ * - OSC 99: Kitty
+ * - Windows toast: Windows Terminal (WSL)
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-/**
- * Send a desktop notification via OSC 777 escape sequence.
- */
-function notify(title: string, body: string): void {
-	// OSC 777 format: ESC ] 777 ; notify ; title ; body BEL
+function windowsToastScript(title: string, body: string): string {
+	const type = "Windows.UI.Notifications";
+	const mgr = `[${type}.ToastNotificationManager, ${type}, ContentType = WindowsRuntime]`;
+	const template = `[${type}.ToastTemplateType]::ToastText01`;
+	const toast = `[${type}.ToastNotification]::new($xml)`;
+	return [
+		`${mgr} > $null`,
+		`$xml = [${type}.ToastNotificationManager]::GetTemplateContent(${template})`,
+		`$xml.GetElementsByTagName('text')[0].AppendChild($xml.CreateTextNode('${body}')) > $null`,
+		`[${type}.ToastNotificationManager]::CreateToastNotifier('${title}').Show(${toast})`,
+	].join("; ");
+}
+
+function notifyOSC777(title: string, body: string): void {
 	process.stdout.write(`\x1b]777;notify;${title};${body}\x07`);
+}
+
+function notifyOSC99(title: string, body: string): void {
+	// Kitty OSC 99: i=notification id, d=0 means not done yet, p=body for second part
+	process.stdout.write(`\x1b]99;i=1:d=0;${title}\x1b\\`);
+	process.stdout.write(`\x1b]99;i=1:p=body;${body}\x1b\\`);
+}
+
+function notifyWindows(title: string, body: string): void {
+	const { execFile } = require("child_process");
+	execFile("powershell.exe", ["-NoProfile", "-Command", windowsToastScript(title, body)]);
+}
+
+function notify(title: string, body: string): void {
+	if (process.env.WT_SESSION) {
+		notifyWindows(title, body);
+	} else if (process.env.KITTY_WINDOW_ID) {
+		notifyOSC99(title, body);
+	} else {
+		notifyOSC777(title, body);
+	}
 }
 
 export default function (pi: ExtensionAPI) {


### PR DESCRIPTION
Adds support for two more terminal environments to the notify extension:

## Changes

- **Kitty terminal** (OSC 99): Detected via `KITTY_WINDOW_ID` environment variable
- **Windows Terminal** (WSL): Detected via `WT_SESSION` environment variable, uses PowerShell toast notifications

OSC 777 remains the default/fallback for Ghostty, iTerm2, WezTerm, and rxvt-unicode.

## Terminal Support Matrix

| Terminal | Support | Protocol |
|----------|---------|----------|
| Ghostty | ✓ | OSC 777 |
| iTerm2 | ✓ | OSC 777 |
| WezTerm | ✓ | OSC 777 |
| rxvt-unicode | ✓ | OSC 777 |
| Kitty | ✓ | OSC 99 |
| Windows Terminal | ✓ | PowerShell toast |

## Credits

Windows Terminal support contributed by @Soleone in [ferologics/pi-notify#1](https://github.com/ferologics/pi-notify/pull/1).