### PR TITLE
fix(tui): allow slash command menu on first line with existing text

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Slash command menu now triggers on the first line even when other lines have content, allowing commands to be prepended to existing text ([#1227](https://github.com/badlogic/pi-mono/pull/1227) by [@aliou](https://github.com/aliou))
+
 ## [0.51.5] - 2026-02-04
 
 ## [0.51.4] - 2026-02-03

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1884,13 +1884,9 @@ export class Editor implements Component, Focusable {
 		this.setCursorCol(newCol);
 	}
 
-	// Slash menu only allowed when all other lines are empty (no mixed content)
+	// Slash menu only allowed on the first line of the editor
 	private isSlashMenuAllowed(): boolean {
-		for (let i = 0; i < this.state.lines.length; i++) {
-			if (i === this.state.cursorLine) continue;
-			if (this.state.lines[i].trim() !== "") return false;
-		}
-		return true;
+		return this.state.cursorLine === 0;
 	}
 
 	// Helper method to check if cursor is at start of message (for slash command detection)


### PR DESCRIPTION
Hello!

Noticed that when trying to prepend a custom command when the editor has multiple line, the slash command completion wouldn't trigger.

------

<details><summary>Summary by Opus:</summary>
<p>

Changes `isSlashMenuAllowed()` in `packages/tui/src/components/editor.ts` from checking that all non-cursor lines are empty to simply checking `cursorLine === 0`.

**Before:** Typing `/` at the beginning of line 0 would not trigger the slash command autocomplete menu if any other line had content. This prevented the workflow of writing text first, then prepending a slash command to use that text as the command's argument.

**After:** The slash command menu triggers on line 0 regardless of content on other lines. It still does not trigger on non-first lines, preserving the fix for #904 (slash menu appearing on arbitrary new lines in multi-line input).

**File:** `packages/tui/src/components/editor.ts`
- `isSlashMenuAllowed()`: changed from a loop checking all lines to `return this.state.cursorLine === 0`
- `isAtStartOfMessage()` and `isInSlashCommandContext()` are unchanged but inherit the new behavior

Commands that already accept arguments via `startsWith` (`/model`, `/compact`, `/name`, `/export`) work with trailing text. Commands that use exact match (`/settings`, `/new`, etc.) are unaffected since they don't accept arguments.

</p>
</details>