### PR TITLE
tui: avoid scrollback clear; add followOutput + manual viewport scroll

### DIFF
--- a/packages/tui/test/tui-follow-output-keys.test.ts
+++ b/packages/tui/test/tui-follow-output-keys.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { type Component, TUI } from "../src/tui.js";
+import { VirtualTerminal } from "./virtual-terminal.js";
+
+class Lines implements Component {
+	constructor(public lines: string[]) {}
+	render(): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+describe("TUI followOutput key controls", () => {
+	it("Shift+PageUp disables followOutput and scrolls viewportTop up", async () => {
+		const terminal = new VirtualTerminal(20, 5);
+		const tui = new TUI(terminal);
+		tui.addChild(new Lines(Array.from({ length: 30 }, (_, i) => `L${i}`)));
+
+		tui.start();
+		await terminal.flush();
+
+		const beforeTop = tui.getViewportTop();
+		assert.ok(beforeTop > 0, `expected bottom viewportTop > 0, got ${beforeTop}`);
+		assert.strictEqual(tui.getFollowOutput(), true);
+
+		// Shift+PageUp (legacy escape sequence)
+		terminal.sendInput("\x1b[5$");
+		await terminal.flush();
+
+		assert.strictEqual(tui.getFollowOutput(), false);
+		assert.ok(tui.getViewportTop() < beforeTop, "expected viewportTop to move up");
+	});
+});

--- a/packages/tui/test/tui-follow-output.test.ts
+++ b/packages/tui/test/tui-follow-output.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { Terminal } from "../src/terminal.js";
+import { type Component, TUI } from "../src/tui.js";
+
+class RecordingTerminal implements Terminal {
+	public columns: number;
+	public rows: number;
+	public kittyProtocolActive = true;
+
+	constructor(columns = 40, rows = 10) {
+		this.columns = columns;
+		this.rows = rows;
+	}
+
+	start(_onInput: (data: string) => void, _onResize: () => void): void {}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(_data: string): void {}
+	moveBy(_lines: number): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(_title: string): void {}
+}
+
+class Lines implements Component {
+	constructor(public lines: string[]) {}
+	render(): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+const nextTick = async (): Promise<void> => new Promise((resolve) => process.nextTick(resolve));
+
+describe("TUI followOutput", () => {
+	it("followOutput=false preserves viewportTop across renders", async () => {
+		const terminal = new RecordingTerminal(20, 5);
+		const tui = new TUI(terminal);
+		const buffer = new Lines(Array.from({ length: 20 }, (_, i) => `L${i}`));
+		tui.addChild(buffer);
+
+		tui.start();
+		await nextTick();
+
+		// Simulate user scrolling up and disabling follow.
+		tui.setFollowOutput(false);
+		tui.setViewportTop(0);
+
+		buffer.lines.push("L20", "L21", "L22");
+		tui.requestRender();
+		await nextTick();
+
+		assert.strictEqual(tui.getFollowOutput(), false);
+		assert.strictEqual(tui.getViewportTop(), 0);
+	});
+});

--- a/packages/tui/test/tui-scrollback-clear.test.ts
+++ b/packages/tui/test/tui-scrollback-clear.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { Terminal } from "../src/terminal.js";
+import { type Component, TUI } from "../src/tui.js";
+
+class RecordingTerminal implements Terminal {
+	public writes: string[] = [];
+	public columns: number;
+	public rows: number;
+	public kittyProtocolActive = true;
+
+	constructor(columns = 40, rows = 10) {
+		this.columns = columns;
+		this.rows = rows;
+	}
+
+	start(_onInput: (data: string) => void, _onResize: () => void): void {}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(data: string): void {
+		this.writes.push(data);
+	}
+	moveBy(_lines: number): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(_title: string): void {}
+}
+
+class Lines implements Component {
+	constructor(public lines: string[]) {}
+	render(): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+const nextTick = async (): Promise<void> => new Promise((resolve) => process.nextTick(resolve));
+
+describe("TUI scrollback clearing", () => {
+	it("does not emit clear-scrollback (CSI 3 J) during routine full re-renders", async () => {
+		const terminal = new RecordingTerminal(20, 6);
+		const tui = new TUI(terminal);
+		tui.addChild(new Lines(["one", "two", "three", "four", "five", "six"]));
+
+		tui.start();
+		await nextTick();
+		terminal.writes.length = 0;
+
+		// Force widthChanged => fullRender(true)
+		terminal.columns = 25;
+		tui.requestRender();
+		await nextTick();
+
+		const out = terminal.writes.join("");
+		assert.ok(out.length > 0, "expected terminal output");
+		assert.ok(!out.includes("\x1b[3J"), "should not clear scrollback (\\x1b[3J) on routine re-renders");
+	});
+});


### PR DESCRIPTION
(Contributor process) This PR was opened before I noticed the approved-contributor gate. The full problem statement + env + minimal repro evidence are in #1231; I’ll re-open/resubmit after a maintainer replies `lgtm` there.

Minimal repro evidence bundle (scripts + output):
- https://gist.github.com/ElliotBadinger/9faab7cc53f1065c3db15c2492faa3a3

---

Fixes #1231

## Summary
- Avoid clearing terminal scrollback on routine full re-renders (drop CSI 3 J / `\x1b[3J`).
- Add `followOutput` + persistent `viewportTop` so manual scrolling doesn’t snap back to bottom during streaming.
- Add global Shift+PgUp/PgDn/Home/End viewport controls (avoids clashing with editor PageUp/PageDown).

## Tests
```bash
cd packages/tui && npm test
```
