### PR TITLE
feat(agent): add inject delivery mode for silent context injection

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -170,6 +170,16 @@ async function runLoop(
 				}
 			}
 
+			// Drain injected context messages every turn (silent, no turn trigger, no tool skip).
+			// Placed after tool results (if any) and before turn_end so the LLM sees them on its next call.
+			const injected = (await config.getInjectedMessages?.()) || [];
+			for (const msg of injected) {
+				stream.push({ type: "message_start", message: msg });
+				stream.push({ type: "message_end", message: msg });
+				currentContext.messages.push(msg);
+				newMessages.push(msg);
+			}
+
 			stream.push({ type: "turn_end", message, toolResults });
 
 			// Get steering messages after turn completes

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -95,6 +95,20 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * Use this for follow-up messages that should wait until the agent finishes.
 	 */
 	getFollowUpMessages?: () => Promise<AgentMessage[]>;
+
+	/**
+	 * Returns messages to silently inject into context after tool execution.
+	 *
+	 * Called after all tool calls in a turn complete, before the turn_end event.
+	 * Messages are appended to context so the LLM sees them on its next call.
+	 *
+	 * Unlike steering: does not skip remaining tool calls.
+	 * Unlike follow-up: does not trigger new turns when the agent would stop.
+	 *
+	 * Use this for system nudges, state notifications, and context injection
+	 * that should be visible to the LLM without affecting the agent lifecycle.
+	 */
+	getInjectedMessages?: () => Promise<AgentMessage[]>;
 }
 
 /**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -941,11 +941,11 @@ export class AgentSession {
 	 *
 	 * @param message Custom message with customType, content, display, details
 	 * @param options.triggerTurn If true and not streaming, triggers a new LLM turn
-	 * @param options.deliverAs Delivery mode: "steer", "followUp", or "nextTurn"
+	 * @param options.deliverAs Delivery mode: "steer", "followUp", "nextTurn", or "inject"
 	 */
 	async sendCustomMessage<T = unknown>(
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details">,
-		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" | "inject" },
 	): Promise<void> {
 		const appMessage = {
 			role: "custom" as const,
@@ -957,6 +957,8 @@ export class AgentSession {
 		} satisfies CustomMessage<T>;
 		if (options?.deliverAs === "nextTurn") {
 			this._pendingNextTurnMessages.push(appMessage);
+		} else if (options?.deliverAs === "inject") {
+			this.agent.inject(appMessage);
 		} else if (this.isStreaming) {
 			if (options?.deliverAs === "followUp") {
 				this.agent.followUp(appMessage);

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -934,7 +934,7 @@ export interface ExtensionAPI {
 	/** Send a custom message to the session. */
 	sendMessage<T = unknown>(
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details">,
-		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" | "inject" },
 	): void;
 
 	/**
@@ -1137,7 +1137,7 @@ type HandlerFn = (...args: unknown[]) => Promise<unknown>;
 
 export type SendMessageHandler = <T = unknown>(
 	message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details">,
-	options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+	options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" | "inject" },
 ) => void;
 
 export type SendUserMessageHandler = (


### PR DESCRIPTION
Add a new 'inject' delivery mode for extension sendMessage() that appends messages to context after tool execution without side effects.

Unlike 'steer': does not skip remaining tool calls.
Unlike 'followUp': does not trigger new turns when the agent would stop.
Unlike 'nextTurn': messages are visible during the current agent run.

This matches how Claude Code injects TODO state reminders - silently appended after tool results so the LLM sees them on its next call.

Intended use-case of this is to use it for agent reminders of concurrent tasks/maintenance of a todo list (Single-run task decomposition). 

**Unresolved issue**: Should injected messages be guaranteed to be delivered? (Eg, if there are no more turns, but there was a message injected, we call the LLM once more),

**Alternative**: Allow steering messages to be just inserted, without dropping subsequent tools