### PR TITLE
feat(coding-agent): include custom tools in system prompt

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1158,8 +1158,8 @@ Register tools the LLM can call via `pi.registerTool()`. Tools appear in the sys
 Note: Some models are idiots and include the @ prefix in tool path arguments. Built-in tools strip a leading @ before resolving paths. If your custom tool accepts a path, normalize a leading @ as well.
 
 - `description` — detailed description sent to the LLM via the API tool listing (can be multi-line).
-- `shortDescription` — optional short one-liner shown in the system prompt tool list. Falls back to the first line of `description` if omitted.
-- `systemGuidelines` — bullet points added to the system prompt guidelines section when the tool is active.
+- `shortDescription` — optional short one-liner for the system prompt tool list. If provided, the tool appears in the "Available tools" section. If omitted, the tool is not listed in the system prompt (but still callable via the API tool listing).
+- `systemGuidelines` — optional bullet points added to the system prompt guidelines section when the tool is active.
 
 ### Tool Definition
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -464,7 +464,7 @@ const { session } = await createAgentSession({
 });
 ```
 
-`description` is the detailed text sent to the LLM via the API tool listing. `shortDescription` provides the one-liner shown in the system prompt tool list (falls back to the first line of `description`). `systemGuidelines` adds bullet points to the system prompt guidelines section.
+`description` is the detailed text sent to the LLM via the API tool listing. `shortDescription` is an optional one-liner — if provided, the tool appears in the system prompt "Available tools" list; if omitted, the tool is not listed in the system prompt. `systemGuidelines` optionally adds bullet points to the system prompt guidelines section.
 
 Custom tools passed via `customTools` are combined with extension-registered tools. Extensions loaded by the ResourceLoader can also register tools via `pi.registerTool()`.
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1977,7 +1977,7 @@ export class AgentSession {
 			const { definition } = customTool;
 			systemPromptToolInfo.set(definition.name, {
 				name: definition.name,
-				shortDescription: definition.shortDescription ?? definition.description?.split("\n")[0],
+				shortDescription: definition.shortDescription,
 				systemGuidelines: definition.systemGuidelines,
 			});
 		}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -327,7 +327,7 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	label: string;
 	/** Description sent to the LLM via the API tool listing (can be detailed/long) */
 	description: string;
-	/** Short one-line description shown in the system prompt tool list. Undefined = falls back to first line of `description`. Empty string = hidden from the system prompt tool list. */
+	/** Short one-line description for the system prompt tool list. If provided, the tool appears in the "Available tools" section of the system prompt. If omitted, the tool is not listed in the system prompt (but still available to the LLM via the API tool listing). */
 	shortDescription?: string;
 	/** Additional guideline bullets appended to the system prompt guidelines section when tool is active */
 	systemGuidelines?: string[];

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -22,7 +22,7 @@ export const BUILTIN_TOOL_SHORT_DESCRIPTIONS: Record<BuiltinToolName, string> = 
 export interface SystemPromptToolInfo {
 	/** Tool name (used in the Available tools list) */
 	name: string;
-	/** Short one-line description for the system prompt tool list. Empty string = hidden from list. Undefined = resolve from full description at construction time. */
+	/** Short one-line description for the system prompt tool list. If provided, the tool is shown. If undefined, the tool is hidden. */
 	shortDescription?: string;
 	/** Additional guideline bullets appended to the system prompt guidelines section */
 	systemGuidelines?: string[];
@@ -126,10 +126,10 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const examplesPath = getExamplesPath();
 
 	// Build tools list based on provided tool info (short one-liners)
-	const visibleTools = tools.filter((tool) => tool.shortDescription !== "");
+	const visibleTools = tools.filter((tool) => tool.shortDescription != null);
 	const toolsList =
 		visibleTools.length > 0
-			? visibleTools.map((tool) => `- ${tool.name}: ${tool.shortDescription ?? tool.name}`).join("\n")
+			? visibleTools.map((tool) => `- ${tool.name}: ${tool.shortDescription}`).join("\n")
 			: "(none)";
 
 	// Build guidelines based on which tools are actually available

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -64,22 +64,9 @@ describe("buildSystemPrompt", () => {
 			expect(prompt).toContain("- my_tool: Manage a todo list");
 		});
 
-		test("falls back to tool name when shortDescription is undefined", () => {
+		test("hides tool from list when shortDescription is undefined (opt-in)", () => {
 			const prompt = buildSystemPrompt({
-				tools: [{ name: "my_tool" }],
-				contextFiles: [],
-				skills: [],
-			});
-
-			expect(prompt).toContain("- my_tool: my_tool");
-		});
-
-		test("hides tool from list when shortDescription is empty string", () => {
-			const prompt = buildSystemPrompt({
-				tools: [
-					{ name: "read", shortDescription: "Read file contents" },
-					{ name: "hidden_tool", shortDescription: "" },
-				],
+				tools: [{ name: "read", shortDescription: "Read file contents" }, { name: "hidden_tool" }],
 				contextFiles: [],
 				skills: [],
 			});
@@ -102,6 +89,22 @@ describe("buildSystemPrompt", () => {
 			});
 
 			expect(prompt).toContain("- Confirm with the user before removing items");
+		});
+
+		test("includes systemGuidelines even when tool is hidden from tool list", () => {
+			const prompt = buildSystemPrompt({
+				tools: [
+					{
+						name: "hidden_tool",
+						systemGuidelines: ["Always check permissions before modifying files"],
+					},
+				],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).not.toContain("hidden_tool");
+			expect(prompt).toContain("- Always check permissions before modifying files");
 		});
 
 		test("deduplicates guidelines", () => {


### PR DESCRIPTION
Custom tools registered via extensions or the SDK are available to the LLM through the API tool listing, but invisible in the system prompt. The "Available tools" and "Guidelines" sections only show built-ins. This means the LLM gets no high-level orientation about custom tools and extension authors can't inject behavioral guidelines.

### Changes

Add two optional fields to `ToolDefinition`:

- **`shortDescription`** — one-liner for the system prompt tool list (falls back to first line of `description`)
- **`systemGuidelines`** — bullet points appended to the system prompt guidelines section

Custom tools now appear in the system prompt alongside built-ins, with stable ordering: built-ins first (fixed order), then custom tools alphabetically. Guidelines are deduplicated via Set.

**Example:**
```typescript
pi.registerTool({
  name: "my_tool",
  description: "Manage a todo list. Supports listing, adding, and removing items.",
  shortDescription: "Manage a todo list",
  systemGuidelines: ["Confirm with the user before removing todo items"],
  // ...
});
```

Produces:
```
Available tools:
- read: Read file contents
- bash: Execute bash commands (ls, grep, find, etc.)
- my_tool: Manage a todo list

Guidelines:
- Use read to examine files before editing...
- Confirm with the user before removing todo items
```

### Files

- `extensions/types.ts` — add `shortDescription?`, `systemGuidelines?` to `ToolDefinition`
- `system-prompt.ts` — `SystemPromptToolInfo`, `resolveShortDescription()` fallback, `addGuideline()` dedup, export `DEFAULT_TOOL_ORDER`
- `agent-session.ts` — build `SystemPromptToolInfo` map from built-in + custom tools, stable ordering, pass `tools` to `buildSystemPrompt()`
- `docs/extensions.md` — document new fields with examples
- `docs/sdk.md` — document new fields for SDK usage

### Possible follow-up: **Per-tool system prompt sections**

This is out of scope for this PR but worth considering:
- a `systemPromptSection` field that emits a dedicated block per tool in the system prompt, similar to how skills get `<available_skills>` and context files get `## path` sections. 
- This would allow extensions to provide usage examples, workflow descriptions, or domain context beyond what fits in a guideline bullet. Could be placed before the skills listing: