### PR TITLE
Enhance /copy with numbered code blocks, richer autocomplete, and label visibility

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Enhanced `/copy` to target numbered code blocks with autocomplete suggestions, labels, and immediate submit on selection.
+
 ## [0.51.4] - 2026-02-03
 
 ### New Features

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -21,7 +21,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session to HTML file" },
 	{ name: "share", description: "Share session as a secret GitHub gist" },
-	{ name: "copy", description: "Copy last agent message to clipboard" },
+	{ name: "copy", description: "Copy last agent message or a code block to clipboard" },
 	{ name: "name", description: "Set session display name" },
 	{ name: "session", description: "Show session info and stats" },
 	{ name: "changelog", description: "Show changelog entries" },

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -12,6 +12,8 @@ export class CustomEditor extends Editor {
 	public onEscape?: () => void;
 	public onCtrlD?: () => void;
 	public onPasteImage?: () => void;
+	/** Handler for autocomplete visibility changes. */
+	public onAutocompleteStateChange?: (visible: boolean) => void;
 	/** Handler for extension-registered shortcuts. Returns true if handled. */
 	public onExtensionShortcut?: (data: string) => boolean;
 
@@ -28,53 +30,63 @@ export class CustomEditor extends Editor {
 	}
 
 	handleInput(data: string): void {
-		// Check extension-registered shortcuts first
-		if (this.onExtensionShortcut?.(data)) {
-			return;
-		}
+		const wasAutocomplete = this.isShowingAutocomplete();
+		try {
+			// Check extension-registered shortcuts first
+			if (this.onExtensionShortcut?.(data)) {
+				return;
+			}
 
-		// Check for paste image keybinding
-		if (this.keybindings.matches(data, "pasteImage")) {
-			this.onPasteImage?.();
-			return;
-		}
+			// Check for paste image keybinding
+			if (this.keybindings.matches(data, "pasteImage")) {
+				this.onPasteImage?.();
+				return;
+			}
 
-		// Check app keybindings first
+			// Check app keybindings first
 
-		// Escape/interrupt - only if autocomplete is NOT active
-		if (this.keybindings.matches(data, "interrupt")) {
-			if (!this.isShowingAutocomplete()) {
-				// Use dynamic onEscape if set, otherwise registered handler
-				const handler = this.onEscape ?? this.actionHandlers.get("interrupt");
-				if (handler) {
+			// Escape/interrupt - only if autocomplete is NOT active
+			if (this.keybindings.matches(data, "interrupt")) {
+				if (!this.isShowingAutocomplete()) {
+					// Use dynamic onEscape if set, otherwise registered handler
+					const handler = this.onEscape ?? this.actionHandlers.get("interrupt");
+					if (handler) {
+						handler();
+						return;
+					}
+				}
+				// Let parent handle escape for autocomplete cancellation
+				super.handleInput(data);
+				return;
+			}
+
+			// Exit (Ctrl+D) - only when editor is empty
+			if (this.keybindings.matches(data, "exit")) {
+				if (this.getText().length === 0) {
+					const handler = this.onCtrlD ?? this.actionHandlers.get("exit");
+					if (handler) handler();
+					return;
+				}
+				// Fall through to editor handling for delete-char-forward when not empty
+			}
+
+			// Check all other app actions
+			for (const [action, handler] of this.actionHandlers) {
+				if (action !== "interrupt" && action !== "exit" && this.keybindings.matches(data, action)) {
 					handler();
 					return;
 				}
 			}
-			// Let parent handle escape for autocomplete cancellation
+
+			// Pass to parent for editor handling
 			super.handleInput(data);
-			return;
-		}
-
-		// Exit (Ctrl+D) - only when editor is empty
-		if (this.keybindings.matches(data, "exit")) {
-			if (this.getText().length === 0) {
-				const handler = this.onCtrlD ?? this.actionHandlers.get("exit");
-				if (handler) handler();
-				return;
-			}
-			// Fall through to editor handling for delete-char-forward when not empty
-		}
-
-		// Check all other app actions
-		for (const [action, handler] of this.actionHandlers) {
-			if (action !== "interrupt" && action !== "exit" && this.keybindings.matches(data, action)) {
-				handler();
-				return;
+		} finally {
+			const isAutocomplete = this.isShowingAutocomplete();
+			if (wasAutocomplete !== isAutocomplete) {
+				this.onAutocompleteStateChange?.(isAutocomplete);
+			} else if (isAutocomplete) {
+				this.onAutocompleteStateChange?.(true);
 			}
 		}
-
-		// Pass to parent for editor handling
-		super.handleInput(data);
 	}
 }

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Markdown code block metadata and labels for identifying blocks in rendered output.
+- Added `submitOnSelect` to `AutocompleteItem` for immediate submit after selecting a completion.
+
 ## [0.51.4] - 2026-02-03
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -149,6 +149,7 @@ export interface AutocompleteItem {
 	value: string;
 	label: string;
 	description?: string;
+	submitOnSelect?: boolean;
 }
 
 export interface SlashCommand {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -549,6 +549,12 @@ export class Editor implements Component, Focusable {
 					this.state.cursorLine = result.cursorLine;
 					this.setCursorCol(result.cursorCol);
 
+					if (selected.submitOnSelect && !this.disableSubmit) {
+						this.cancelAutocomplete();
+						this.submitValue();
+						return;
+					}
+
 					if (this.autocompletePrefix.startsWith("/")) {
 						this.cancelAutocomplete();
 						// Fall through to submit

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -8,6 +8,7 @@ export interface SelectItem {
 	value: string;
 	label: string;
 	description?: string;
+	submitOnSelect?: boolean;
 }
 
 export interface SelectListTheme {

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -14,7 +14,16 @@ export { Editor, type EditorOptions, type EditorTheme } from "./components/edito
 export { Image, type ImageOptions, type ImageTheme } from "./components/image.js";
 export { Input } from "./components/input.js";
 export { Loader } from "./components/loader.js";
-export { type DefaultTextStyle, Markdown, type MarkdownTheme } from "./components/markdown.js";
+export {
+	CODE_BLOCK_MARKER_REGEX,
+	type CodeBlockInfo,
+	type CodeBlockLabelInfo,
+	type DefaultTextStyle,
+	extractCodeBlockId,
+	Markdown,
+	type MarkdownOptions,
+	type MarkdownTheme,
+} from "./components/markdown.js";
 export { type SelectItem, SelectList, type SelectListTheme } from "./components/select-list.js";
 export { type SettingItem, SettingsList, type SettingsListTheme } from "./components/settings-list.js";
 export { Spacer } from "./components/spacer.js";


### PR DESCRIPTION
## Summary
- add Markdown code block metadata and per-block labels so rendered output can identify and reference specific code blocks, including label offsets for multi-segment messages
- extend /copy to target numbered code blocks with richer autocomplete entries (previews + language hints) and label visibility tied to the /copy autocomplete context, so users can reliably pick the right block from the last assistant response
- add submit-on-select support for autocomplete items so selecting a /copy entry immediately executes the command without extra confirmation, while keeping existing editor behavior intact
