### PR TITLE
feat(coding-agent): add resume as configurable keybinding action

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `resume` as a configurable keybinding action, allowing users to bind a key to open the session resume selector (like `newSession`, `tree`, and `fork`)
+
 ## [0.51.5] - 2026-02-04
 
 ### Changed

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -32,7 +32,8 @@ export type AppAction =
 	| "pasteImage"
 	| "newSession"
 	| "tree"
-	| "fork";
+	| "fork"
+	| "resume";
 
 /**
  * All configurable actions.
@@ -68,6 +69,7 @@ export const DEFAULT_APP_KEYBINDINGS: Record<AppAction, KeyId | KeyId[]> = {
 	newSession: [],
 	tree: [],
 	fork: [],
+	resume: [],
 };
 
 /**
@@ -98,6 +100,7 @@ const APP_ACTIONS: AppAction[] = [
 	"newSession",
 	"tree",
 	"fork",
+	"resume",
 ];
 
 function isAppAction(action: string): action is AppAction {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1779,6 +1779,7 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("newSession", () => this.handleClearCommand());
 		this.defaultEditor.onAction("tree", () => this.showTreeSelector());
 		this.defaultEditor.onAction("fork", () => this.showUserMessageSelector());
+		this.defaultEditor.onAction("resume", () => this.showSessionSelector());
 
 		this.defaultEditor.onChange = (text: string) => {
 			const wasBashMode = this.isBashMode;


### PR DESCRIPTION
Add `resume` as a configurable app-level keybinding action, allowing users to bind a key to open the session resume selector directly.

This follows the same pattern as the existing `newSession`, `tree`, and `fork` actions:
- Added to `AppAction` type union
- Default binding is `[]` (unbound), configurable via `keybindings.json`
- Editor action handler calls `showSessionSelector()`

Previously, the session resume selector was only accessible via the `/resume` slash command.