### PR TITLE
Respect expand state for custom messages

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2333,9 +2333,9 @@ export class InteractiveMode {
 			case "custom": {
 				if (message.display) {
 					const renderer = this.session.extensionRunner?.getMessageRenderer(message.customType);
-					this.chatContainer.addChild(
-						new CustomMessageComponent(message, renderer, this.getMarkdownThemeWithSettings()),
-					);
+					const component = new CustomMessageComponent(message, renderer, this.getMarkdownThemeWithSettings());
+					component.setExpanded(this.toolOutputExpanded);
+					this.chatContainer.addChild(component);
 				}
 				break;
 			}


### PR DESCRIPTION
Custom messages didn’t inherit the current Ctrl+O expand state on first render. This sets the CustomMessageComponent expanded state when created so it matches other expandable components.

Fixes #1257.