### PR TITLE
feat(coding-agent): add SSH URL support for git packages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added SSH URL support for git packages. You can now use SSH URLs with `pi install` (e.g., `git@github.com:user/repo`, `ssh://git@github.com/user/repo`). SSH URLs respect your configured SSH keys and `~/.ssh/config` settings.
+
 ## [0.51.6] - 2026-02-04
 
 ### New Features

--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -60,12 +60,31 @@ npm:pkg
 ```
 git:github.com/user/repo@v1
 https://github.com/user/repo@v1
+git@github.com:user/repo@v1
+ssh://git@github.com/user/repo@v1
 ```
 
+- HTTPS and SSH URLs are both supported.
+- SSH URLs use your configured SSH keys automatically (respects `~/.ssh/config`).
 - Raw `https://` URLs work without the `git:` prefix.
 - Refs pin the package and skip `pi update`.
 - Cloned to `~/.pi/agent/git/<host>/<path>` (global) or `.pi/git/<host>/<path>` (project).
 - Runs `npm install` after clone or pull if `package.json` exists.
+
+**SSH examples:**
+```bash
+# Standard git@host:path format
+pi install git@github.com:user/repo
+
+# With git: prefix
+pi install git:git@github.com:user/repo
+
+# ssh:// protocol format
+pi install ssh://git@github.com/user/repo
+
+# With version ref
+pi install git@github.com:user/repo@v1.0.0
+```
 
 ### Local Paths
 

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -4,3 +4,75 @@ export function looksLikeGitUrl(source: string): boolean {
 	const normalized = source.replace(/^https?:\/\//, "");
 	return GIT_HOSTS.some((host) => normalized.startsWith(`${host}/`));
 }
+
+/**
+ * Check if a string looks like an SSH git URL.
+ * Matches patterns like:
+ * - git@github.com:user/repo
+ * - ssh://git@github.com/user/repo
+ */
+export function looksLikeSshGitUrl(source: string): boolean {
+	// ssh:// protocol
+	if (source.startsWith("ssh://")) {
+		return true;
+	}
+	// git@host:path pattern
+	if (/^[^@]+@[^:]+:.+/.test(source)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Parse SSH git URL into host and path components.
+ * Returns normalized format suitable for storage/comparison.
+ * Handles refs like: git@github.com:user/repo@v1.0.0
+ */
+export function parseSshGitUrl(source: string): { host: string; path: string; ref?: string } | null {
+	// ssh://git@github.com/user/repo or ssh://git@github.com:port/user/repo
+	if (source.startsWith("ssh://")) {
+		// Find last @ for ref
+		const lastAtIndex = source.lastIndexOf("@");
+		const firstAtIndex = source.indexOf("@");
+
+		let urlPart = source;
+		let ref: string | undefined;
+
+		// If there are multiple @, the last one might be a ref
+		if (lastAtIndex > firstAtIndex && lastAtIndex > source.indexOf("/")) {
+			urlPart = source.slice(0, lastAtIndex);
+			ref = source.slice(lastAtIndex + 1);
+		}
+
+		const match = urlPart.match(/^ssh:\/\/(?:[^@]+@)?([^/:]+)(?::\d+)?\/(.+)$/);
+		if (match) {
+			return { host: match[1]!, path: match[2]!.replace(/\.git$/, ""), ref };
+		}
+		return null;
+	}
+
+	// git@github.com:user/repo or git@github.com:user/repo@v1.0.0
+	// Need to find the @ after the : for the ref
+	const colonIndex = source.indexOf(":");
+	if (colonIndex === -1) return null;
+
+	const beforeColon = source.slice(0, colonIndex);
+	const afterColon = source.slice(colonIndex + 1);
+
+	// Check for ref (@ after the path starts)
+	const refAtIndex = afterColon.indexOf("@");
+	let path = afterColon;
+	let ref: string | undefined;
+
+	if (refAtIndex !== -1) {
+		path = afterColon.slice(0, refAtIndex);
+		ref = afterColon.slice(refAtIndex + 1);
+	}
+
+	const match = beforeColon.match(/^[^@]+@(.+)$/);
+	if (match) {
+		return { host: match[1]!, path: path.replace(/\.git$/, ""), ref };
+	}
+
+	return null;
+}

--- a/packages/coding-agent/test/git-ssh-url.test.ts
+++ b/packages/coding-agent/test/git-ssh-url.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeSshGitUrl, parseSshGitUrl } from "../src/utils/git.js";
+
+describe("SSH Git URL Detection", () => {
+	it("should detect ssh:// protocol URLs", () => {
+		expect(looksLikeSshGitUrl("ssh://git@github.com/user/repo")).toBe(true);
+		expect(looksLikeSshGitUrl("ssh://git@gitlab.com/user/repo")).toBe(true);
+	});
+
+	it("should detect git@host:path pattern", () => {
+		expect(looksLikeSshGitUrl("git@github.com:user/repo")).toBe(true);
+		expect(looksLikeSshGitUrl("git@gitlab.com:user/repo.git")).toBe(true);
+	});
+
+	it("should not detect HTTPS URLs", () => {
+		expect(looksLikeSshGitUrl("https://github.com/user/repo")).toBe(false);
+		expect(looksLikeSshGitUrl("http://github.com/user/repo")).toBe(false);
+	});
+
+	it("should not detect plain host/path", () => {
+		expect(looksLikeSshGitUrl("github.com/user/repo")).toBe(false);
+	});
+});
+
+describe("SSH Git URL Parsing", () => {
+	describe("ssh:// protocol", () => {
+		it("should parse basic ssh:// URL", () => {
+			const result = parseSshGitUrl("ssh://git@github.com/user/repo");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "user/repo",
+				ref: undefined,
+			});
+		});
+
+		it("should parse ssh:// URL with port", () => {
+			const result = parseSshGitUrl("ssh://git@github.com:22/user/repo");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "user/repo",
+				ref: undefined,
+			});
+		});
+
+		it("should parse ssh:// URL with .git suffix", () => {
+			const result = parseSshGitUrl("ssh://git@github.com/user/repo.git");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "user/repo",
+				ref: undefined,
+			});
+		});
+
+		it("should parse ssh:// URL with ref", () => {
+			const result = parseSshGitUrl("ssh://git@github.com/user/repo@v1.0.0");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "user/repo",
+				ref: "v1.0.0",
+			});
+		});
+
+		it("should parse ssh:// URL with ref and .git", () => {
+			const result = parseSshGitUrl("ssh://git@github.com/user/repo.git@main");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "user/repo",
+				ref: "main",
+			});
+		});
+	});
+
+	describe("git@host:path pattern", () => {
+		it("should parse basic git@host:path", () => {
+			const result = parseSshGitUrl("git@github.com:user/repo");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "user/repo",
+				ref: undefined,
+			});
+		});
+
+		it("should parse git@host:path with .git", () => {
+			const result = parseSshGitUrl("git@github.com:user/repo.git");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "user/repo",
+				ref: undefined,
+			});
+		});
+
+		it("should parse git@host:path with ref", () => {
+			const result = parseSshGitUrl("git@github.com:user/repo@v1.0.0");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "user/repo",
+				ref: "v1.0.0",
+			});
+		});
+
+		it("should parse git@host:path with ref and .git", () => {
+			const result = parseSshGitUrl("git@github.com:user/repo.git@main");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "user/repo",
+				ref: "main",
+			});
+		});
+
+		it("should parse with nested path", () => {
+			const result = parseSshGitUrl("git@github.com:org/team/project");
+			expect(result).toEqual({
+				host: "github.com",
+				path: "org/team/project",
+				ref: undefined,
+			});
+		});
+	});
+
+	describe("edge cases", () => {
+		it("should return null for invalid SSH URLs", () => {
+			expect(parseSshGitUrl("https://github.com/user/repo")).toBeNull();
+			expect(parseSshGitUrl("github.com/user/repo")).toBeNull();
+			expect(parseSshGitUrl("git@github.com")).toBeNull();
+		});
+
+		it("should handle different hosts", () => {
+			const gitlab = parseSshGitUrl("git@gitlab.com:user/repo");
+			expect(gitlab?.host).toBe("gitlab.com");
+
+			const bitbucket = parseSshGitUrl("git@bitbucket.org:user/repo");
+			expect(bitbucket?.host).toBe("bitbucket.org");
+
+			const custom = parseSshGitUrl("git@git.company.com:user/repo");
+			expect(custom?.host).toBe("git.company.com");
+		});
+	});
+});

--- a/packages/coding-agent/test/package-manager-ssh.test.ts
+++ b/packages/coding-agent/test/package-manager-ssh.test.ts
@@ -1,0 +1,186 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DefaultPackageManager } from "../src/core/package-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+
+describe("Package Manager SSH URL Support", () => {
+	let tempDir: string;
+	let agentDir: string;
+	let settingsManager: SettingsManager;
+	let packageManager: DefaultPackageManager;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pm-ssh-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		agentDir = join(tempDir, "agent");
+		mkdirSync(agentDir, { recursive: true });
+
+		settingsManager = SettingsManager.inMemory();
+		packageManager = new DefaultPackageManager({
+			cwd: tempDir,
+			agentDir,
+			settingsManager,
+		});
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	describe("parseSource with SSH URLs", () => {
+		it("should parse git@host:path format", () => {
+			const parsed = (packageManager as any).parseSource("git@github.com:user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(true);
+			expect(parsed.pinned).toBe(false);
+		});
+
+		it("should parse git@host:path with ref", () => {
+			const parsed = (packageManager as any).parseSource("git@github.com:user/repo@v1.0.0");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ref).toBe("v1.0.0");
+			expect(parsed.ssh).toBe(true);
+			expect(parsed.pinned).toBe(true);
+		});
+
+		it("should parse ssh:// protocol format", () => {
+			const parsed = (packageManager as any).parseSource("ssh://git@github.com/user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(true);
+		});
+
+		it("should parse ssh:// with port", () => {
+			const parsed = (packageManager as any).parseSource("ssh://git@github.com:22/user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(true);
+		});
+
+		it("should parse git: prefix with SSH URL", () => {
+			const parsed = (packageManager as any).parseSource("git:git@github.com:user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(true);
+		});
+
+		it("should parse .git suffix", () => {
+			const parsed = (packageManager as any).parseSource("git@github.com:user/repo.git");
+			expect(parsed.type).toBe("git");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(true);
+		});
+
+		it("should preserve original SSH URL in repo field", () => {
+			const parsed = (packageManager as any).parseSource("git@github.com:user/repo");
+			expect(parsed.repo).toBe("git@github.com:user/repo");
+		});
+
+		it("should preserve SSH URL without ref in repo field", () => {
+			const parsed = (packageManager as any).parseSource("git@github.com:user/repo@v1.0.0");
+			expect(parsed.repo).toBe("git@github.com:user/repo");
+			expect(parsed.ref).toBe("v1.0.0");
+		});
+	});
+
+	describe("getPackageIdentity with SSH URLs", () => {
+		it("should normalize SSH URL to same identity as HTTPS", () => {
+			const sshIdentity = (packageManager as any).getPackageIdentity("git@github.com:user/repo");
+			const httpsIdentity = (packageManager as any).getPackageIdentity("https://github.com/user/repo");
+			expect(sshIdentity).toBe(httpsIdentity);
+			expect(sshIdentity).toBe("git:github.com/user/repo");
+		});
+
+		it("should normalize ssh:// to same identity as git@", () => {
+			const sshProtocol = (packageManager as any).getPackageIdentity("ssh://git@github.com/user/repo");
+			const gitAt = (packageManager as any).getPackageIdentity("git@github.com:user/repo");
+			expect(sshProtocol).toBe(gitAt);
+		});
+
+		it("should ignore ref in identity", () => {
+			const withRef = (packageManager as any).getPackageIdentity("git@github.com:user/repo@v1.0.0");
+			const withoutRef = (packageManager as any).getPackageIdentity("git@github.com:user/repo");
+			expect(withRef).toBe(withoutRef);
+		});
+	});
+
+	describe("SSH URL install behavior", () => {
+		it("should emit start event for SSH URL install", async () => {
+			const events: any[] = [];
+			packageManager.setProgressCallback((event) => events.push(event));
+
+			try {
+				await packageManager.install("git@github.com:nonexistent/repo");
+			} catch {
+				// Expected to fail - repo doesn't exist or no SSH access
+			}
+
+			expect(events.some((e) => e.type === "start" && e.action === "install")).toBe(true);
+		});
+
+		it("should emit start event for ssh:// URL install", async () => {
+			const events: any[] = [];
+			packageManager.setProgressCallback((event) => events.push(event));
+
+			try {
+				await packageManager.install("ssh://git@github.com/nonexistent/repo");
+			} catch {
+				// Expected to fail
+			}
+
+			expect(events.some((e) => e.type === "start" && e.action === "install")).toBe(true);
+		});
+	});
+
+	describe("different git hosts", () => {
+		it("should parse GitLab SSH URL", () => {
+			const parsed = (packageManager as any).parseSource("git@gitlab.com:group/project");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("gitlab.com");
+			expect(parsed.path).toBe("group/project");
+			expect(parsed.ssh).toBe(true);
+		});
+
+		it("should parse Bitbucket SSH URL", () => {
+			const parsed = (packageManager as any).parseSource("git@bitbucket.org:team/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("bitbucket.org");
+			expect(parsed.path).toBe("team/repo");
+			expect(parsed.ssh).toBe(true);
+		});
+
+		it("should parse custom host SSH URL", () => {
+			const parsed = (packageManager as any).parseSource("git@git.company.com:internal/tools");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("git.company.com");
+			expect(parsed.path).toBe("internal/tools");
+			expect(parsed.ssh).toBe(true);
+		});
+	});
+
+	describe("nested paths", () => {
+		it("should handle nested group paths", () => {
+			const parsed = (packageManager as any).parseSource("git@gitlab.com:org/team/subteam/project");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("gitlab.com");
+			expect(parsed.path).toBe("org/team/subteam/project");
+			expect(parsed.ssh).toBe(true);
+		});
+
+		it("should handle nested paths with ref", () => {
+			const parsed = (packageManager as any).parseSource("git@gitlab.com:org/team/project@main");
+			expect(parsed.type).toBe("git");
+			expect(parsed.path).toBe("org/team/project");
+			expect(parsed.ref).toBe("main");
+		});
+	});
+});

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -248,6 +248,121 @@ Content`,
 		});
 	});
 
+	describe("HTTPS git URL parsing (old behavior)", () => {
+		it("should parse HTTPS GitHub URLs correctly", async () => {
+			const parsed = (packageManager as any).parseSource("https://github.com/user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(false);
+			expect(parsed.pinned).toBe(false);
+		});
+
+		it("should parse HTTPS URLs with git: prefix", async () => {
+			const parsed = (packageManager as any).parseSource("git:https://github.com/user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(false);
+		});
+
+		it("should parse HTTPS URLs with ref", async () => {
+			const parsed = (packageManager as any).parseSource("https://github.com/user/repo@v1.2.3");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ref).toBe("v1.2.3");
+			expect(parsed.pinned).toBe(true);
+			expect(parsed.ssh).toBe(false);
+		});
+
+		it("should parse HTTPS URLs without protocol", async () => {
+			const parsed = (packageManager as any).parseSource("github.com/user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(false);
+		});
+
+		it("should parse HTTPS URLs with .git suffix", async () => {
+			const parsed = (packageManager as any).parseSource("https://github.com/user/repo.git");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("github.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(false);
+		});
+
+		it("should parse GitLab HTTPS URLs", async () => {
+			const parsed = (packageManager as any).parseSource("https://gitlab.com/user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("gitlab.com");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(false);
+		});
+
+		it("should parse Bitbucket HTTPS URLs", async () => {
+			const parsed = (packageManager as any).parseSource("https://bitbucket.org/user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("bitbucket.org");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(false);
+		});
+
+		it("should parse Codeberg HTTPS URLs", async () => {
+			const parsed = (packageManager as any).parseSource("https://codeberg.org/user/repo");
+			expect(parsed.type).toBe("git");
+			expect(parsed.host).toBe("codeberg.org");
+			expect(parsed.path).toBe("user/repo");
+			expect(parsed.ssh).toBe(false);
+		});
+
+		it("should generate correct package identity for HTTPS URLs", async () => {
+			const identity1 = (packageManager as any).getPackageIdentity("https://github.com/user/repo");
+			const identity2 = (packageManager as any).getPackageIdentity("https://github.com/user/repo@v1.0.0");
+			const identity3 = (packageManager as any).getPackageIdentity("github.com/user/repo");
+			const identity4 = (packageManager as any).getPackageIdentity("https://github.com/user/repo.git");
+
+			// All should have the same identity (normalized)
+			expect(identity1).toBe("git:github.com/user/repo");
+			expect(identity2).toBe("git:github.com/user/repo");
+			expect(identity3).toBe("git:github.com/user/repo");
+			expect(identity4).toBe("git:github.com/user/repo");
+		});
+
+		it("should deduplicate HTTPS URLs with different formats", async () => {
+			const pkgDir = join(tempDir, "https-dedup-pkg");
+			mkdirSync(join(pkgDir, "extensions"), { recursive: true });
+			writeFileSync(join(pkgDir, "extensions", "test.ts"), "export default function() {}");
+
+			// Mock the package as if it were cloned from different URL formats
+			// In reality, these would all point to the same local dir after install
+			settingsManager.setPackages([
+				"https://github.com/user/repo",
+				"github.com/user/repo",
+				"https://github.com/user/repo.git",
+			]);
+
+			// Since these URLs don't actually exist and we can't clone them,
+			// we verify they produce the same identity
+			const id1 = (packageManager as any).getPackageIdentity("https://github.com/user/repo");
+			const id2 = (packageManager as any).getPackageIdentity("github.com/user/repo");
+			const id3 = (packageManager as any).getPackageIdentity("https://github.com/user/repo.git");
+
+			expect(id1).toBe(id2);
+			expect(id2).toBe(id3);
+		});
+
+		it("should handle HTTPS URLs with refs in resolve", async () => {
+			// This tests that the ref is properly extracted and stored
+			const parsed = (packageManager as any).parseSource("https://github.com/user/repo@main");
+			expect(parsed.ref).toBe("main");
+			expect(parsed.pinned).toBe(true);
+
+			const parsed2 = (packageManager as any).parseSource("https://github.com/user/repo@feature/branch");
+			expect(parsed2.ref).toBe("feature/branch");
+		});
+	});
+
 	describe("pattern filtering in top-level arrays", () => {
 		it("should exclude extensions with ! pattern", async () => {
 			const extDir = join(agentDir, "extensions");
@@ -708,6 +823,78 @@ Content`,
 			const result = await packageManager.resolve();
 			expect(result.extensions.some((r) => r.path.includes("pkg1"))).toBe(true);
 			expect(result.extensions.some((r) => r.path.includes("pkg2"))).toBe(true);
+		});
+
+		it("should dedupe SSH and HTTPS URLs for same repo", async () => {
+			// Same repository, different URL formats
+			const httpsUrl = "https://github.com/user/repo";
+			const sshUrl = "git@github.com:user/repo";
+
+			const httpsIdentity = (packageManager as any).getPackageIdentity(httpsUrl);
+			const sshIdentity = (packageManager as any).getPackageIdentity(sshUrl);
+
+			// Both should resolve to the same identity
+			expect(httpsIdentity).toBe("git:github.com/user/repo");
+			expect(sshIdentity).toBe("git:github.com/user/repo");
+			expect(httpsIdentity).toBe(sshIdentity);
+		});
+
+		it("should dedupe SSH and HTTPS with refs", async () => {
+			const httpsUrl = "https://github.com/user/repo@v1.0.0";
+			const sshUrl = "git@github.com:user/repo@v1.0.0";
+
+			const httpsIdentity = (packageManager as any).getPackageIdentity(httpsUrl);
+			const sshIdentity = (packageManager as any).getPackageIdentity(sshUrl);
+
+			// Identity should ignore ref (version)
+			expect(httpsIdentity).toBe("git:github.com/user/repo");
+			expect(sshIdentity).toBe("git:github.com/user/repo");
+			expect(httpsIdentity).toBe(sshIdentity);
+		});
+
+		it("should dedupe SSH URL with ssh:// protocol and git@ format", async () => {
+			const sshProtocol = "ssh://git@github.com/user/repo";
+			const gitAt = "git@github.com:user/repo";
+
+			const sshProtocolIdentity = (packageManager as any).getPackageIdentity(sshProtocol);
+			const gitAtIdentity = (packageManager as any).getPackageIdentity(gitAt);
+
+			// Both SSH formats should resolve to same identity
+			expect(sshProtocolIdentity).toBe("git:github.com/user/repo");
+			expect(gitAtIdentity).toBe("git:github.com/user/repo");
+			expect(sshProtocolIdentity).toBe(gitAtIdentity);
+		});
+
+		it("should dedupe all URL formats for same repo (HTTPS, SSH, git@)", async () => {
+			const urls = [
+				"https://github.com/user/repo",
+				"github.com/user/repo",
+				"https://github.com/user/repo.git",
+				"git@github.com:user/repo",
+				"git@github.com:user/repo.git",
+				"ssh://git@github.com/user/repo",
+				"git:https://github.com/user/repo",
+			];
+
+			const identities = urls.map((url) => (packageManager as any).getPackageIdentity(url));
+
+			// All should produce the same identity
+			const uniqueIdentities = [...new Set(identities)];
+			expect(uniqueIdentities.length).toBe(1);
+			expect(uniqueIdentities[0]).toBe("git:github.com/user/repo");
+		});
+
+		it("should keep different repos separate (HTTPS vs SSH)", async () => {
+			const repo1Https = "https://github.com/user/repo1";
+			const repo2Ssh = "git@github.com:user/repo2";
+
+			const id1 = (packageManager as any).getPackageIdentity(repo1Https);
+			const id2 = (packageManager as any).getPackageIdentity(repo2Ssh);
+
+			// Different repos should have different identities
+			expect(id1).toBe("git:github.com/user/repo1");
+			expect(id2).toBe("git:github.com/user/repo2");
+			expect(id1).not.toBe(id2);
 		});
 	});
 


### PR DESCRIPTION
- Add SSH URL detection and parsing in git.ts
- Support git@host:path and ssh:// URL formats
- Preserve SSH URLs instead of converting to HTTPS
- Fix deduplication to treat SSH/HTTPS of same repo as identical
- Add comprehensive test coverage (50 new tests)
- Update documentation with SSH examples