### PR TITLE
feat(coding-agent): add context setting for external tool compatibility

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - API keys in `auth.json` now support shell command resolution (`!command`) and environment variable lookup, matching the behavior in `models.json`
+- **Context directories setting**: New `context` setting allows specifying extra directories to search for AGENTS.md/CLAUDE.md files. Enables compatibility with other tools like Claude Code. See [docs/settings.md](docs/settings.md).
+- **Subagent extension**: Now respects `context` setting for agent discovery, enabling agents defined in `~/.claude/agents/` to be used when `context: ["~/.claude"]` is configured.
 
 ## [0.51.6] - 2026-02-04
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -134,7 +134,7 @@ When a provider requests a retry delay longer than `maxDelayMs` (e.g., Google's 
 
 ### Resources
 
-These settings define where to load extensions, skills, prompts, and themes from.
+These settings define where to load extensions, skills, prompts, themes, and context files from.
 
 Paths in `~/.pi/agent/settings.json` resolve relative to `~/.pi/agent`. Paths in `.pi/settings.json` resolve relative to `.pi`. Absolute paths and `~` are supported.
 
@@ -145,9 +145,26 @@ Paths in `~/.pi/agent/settings.json` resolve relative to `~/.pi/agent`. Paths in
 | `skills` | string[] | `[]` | Local skill file paths or directories |
 | `prompts` | string[] | `[]` | Local prompt template paths or directories |
 | `themes` | string[] | `[]` | Local theme file paths or directories |
+| `context` | string[] | `[]` | Extra directories to search for AGENTS.md/CLAUDE.md files |
 | `enableSkillCommands` | boolean | `true` | Register skills as `/skill:name` commands |
 
 Arrays support glob patterns and exclusions. Use `!pattern` to exclude. Use `+path` to force-include an exact path and `-path` to force-exclude an exact path.
+
+#### context
+
+The `context` setting adds extra directories to search for context files (AGENTS.md/CLAUDE.md). This enables compatibility with other tools like Claude Code:
+
+```json
+{
+  "context": ["~/.claude"]
+}
+```
+
+With this setting, pi will load:
+- `~/.claude/CLAUDE.md` (global context from Claude Code)
+- `.claude/CLAUDE.md` in ancestor directories (project context)
+
+This also enables the subagent extension to discover agents from `~/.claude/agents/`.
 
 #### packages
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -76,6 +76,7 @@ export interface Settings {
 	skills?: string[]; // Array of local skill file paths or directories
 	prompts?: string[]; // Array of local prompt template paths or directories
 	themes?: string[]; // Array of local theme file paths or directories
+	context?: string[]; // Array of directories to search for AGENTS.md/CLAUDE.md files
 	enableSkillCommands?: boolean; // default: true - register skills as /skill:name commands
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
@@ -621,6 +622,23 @@ export class SettingsManager {
 	setProjectThemePaths(paths: string[]): void {
 		const projectSettings = this.loadProjectSettings();
 		projectSettings.themes = paths;
+		this.saveProjectSettings(projectSettings);
+		this.settings = deepMergeSettings(this.globalSettings, projectSettings);
+	}
+
+	getContextPaths(): string[] {
+		return [...(this.settings.context ?? [])];
+	}
+
+	setContextPaths(paths: string[]): void {
+		this.globalSettings.context = paths;
+		this.markModified("context");
+		this.save();
+	}
+
+	setProjectContextPaths(paths: string[]): void {
+		const projectSettings = this.loadProjectSettings();
+		projectSettings.context = paths;
 		this.saveProjectSettings(projectSettings);
 		this.settings = deepMergeSettings(this.globalSettings, projectSettings);
 	}

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -224,4 +224,36 @@ describe("SettingsManager", () => {
 			expect(savedSettings.theme).toBe("light");
 		});
 	});
+
+	describe("context", () => {
+		it("should load context paths from settings", () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ context: ["~/.claude", "/custom/dir"] }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getContextPaths()).toEqual(["~/.claude", "/custom/dir"]);
+		});
+
+		it("should return empty array when context is not set", () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getContextPaths()).toEqual([]);
+		});
+
+		it("should preserve context when saving unrelated settings", () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ context: ["~/.claude"] }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setTheme("light");
+
+			const savedSettings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(savedSettings.context).toEqual(["~/.claude"]);
+			expect(savedSettings.theme).toBe("light");
+		});
+	});
 });


### PR DESCRIPTION
For context, I tried to go down a path to making an extension to achieve this but found it wasn't possible without edits in coding-agent itself. Happy to rework/change

Adds a 'context' setting that specifies extra directories to search for AGENTS.md/CLAUDE.md files. This enables using pi alongside other tools (like Claude Code) without migrating configuration files.

Example usage in settings.json:
```
  { "context": ["~/.claude"] }
```

This will load:
- `~/.claude/CLAUDE.md` as global context
- `.claude/CLAUDE.md` in project directories
- Agents from `~/.claude/agents/` (via subagent extension)

The implementation is generic - any directory pattern works, not just Claude Code paths. Users can point to any directory structure that contains AGENTS.md files.