### PR TITLE
feat(coding-agent): display name of selected model in modelSelectors

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -268,6 +268,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			}
 		} else if (this.filteredModels.length === 0) {
 			this.listContainer.addChild(new Text(theme.fg("muted", "  No matching models"), 0, 0));
+		} else {
+			const selected = this.filteredModels[this.selectedIndex];
+			this.listContainer.addChild(new Spacer(1));
+			this.listContainer.addChild(new Text(theme.fg("muted", `  Model Name: ${selected.model.name}`), 0, 0));
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
@@ -215,6 +215,12 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 				new Text(theme.fg("muted", `  (${this.selectedIndex + 1}/${this.filteredItems.length})`), 0, 0),
 			);
 		}
+
+		if (this.filteredItems.length > 0) {
+			const selected = this.filteredItems[this.selectedIndex];
+			this.listContainer.addChild(new Spacer(1));
+			this.listContainer.addChild(new Text(theme.fg("muted", `  Model Name: ${selected.model.name}`), 0, 0));
+		}
 	}
 
 	handleInput(data: string): void {


### PR DESCRIPTION
Amazon Bedrock requires users to specify the ARN of the inference profile in the model id field to use it (typically for tracking costs). It's difficult for users to distinguish different models from just their model id.

This PR adds a line under the model selectors to display the name of the selected model to improve the UX.

After:
`/scoped-models`
<img width="1372" height="417" alt="screenshot-2026-02-05_16-45-39" src="https://github.com/user-attachments/assets/f0e13290-7a24-4ad5-82bb-2f5b1f8ddfc3" />
`/models`
<img width="1294" height="379" alt="screenshot-2026-02-05_16-44-45" src="https://github.com/user-attachments/assets/e38ae1f7-b30a-4de2-b832-ed2a5da2da99" />
