### PR TITLE
feat(tui): stream @ file autocomplete with fd

### DIFF
--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -4,6 +4,7 @@
 export {
 	type AutocompleteItem,
 	type AutocompleteProvider,
+	type AutocompleteSuggestions,
 	CombinedAutocompleteProvider,
 	type SlashCommand,
 } from "./autocomplete.js";

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1748,6 +1748,7 @@ describe("Editor component", () => {
 					}
 					return null;
 				},
+				getSuggestionsAsync: async (_lines, _cursorLine, _cursorCol, _signal, _onUpdate) => null,
 				applyCompletion,
 			};
 
@@ -1783,6 +1784,7 @@ describe("Editor component", () => {
 				getForceFileSuggestions: AutocompleteProvider["getSuggestions"];
 			} = {
 				getSuggestions: () => null,
+				getSuggestionsAsync: async (_lines, _cursorLine, _cursorCol, _signal, _onUpdate) => null,
 				getForceFileSuggestions: (lines, _cursorLine, cursorCol) => {
 					const text = lines[0] || "";
 					const prefix = text.slice(0, cursorCol);
@@ -1824,6 +1826,7 @@ describe("Editor component", () => {
 				getForceFileSuggestions: AutocompleteProvider["getSuggestions"];
 			} = {
 				getSuggestions: () => null,
+				getSuggestionsAsync: async (_lines, _cursorLine, _cursorCol, _signal, _onUpdate) => null,
 				getForceFileSuggestions: (lines, _cursorLine, cursorCol) => {
 					const text = lines[0] || "";
 					const prefix = text.slice(0, cursorCol);
@@ -1892,6 +1895,7 @@ describe("Editor component", () => {
 					}
 					return null;
 				},
+				getSuggestionsAsync: async (_lines, _cursorLine, _cursorCol, _signal, _onUpdate) => null,
 				getForceFileSuggestions: (lines, _cursorLine, cursorCol) => {
 					const text = lines[0] || "";
 					const prefix = text.slice(0, cursorCol);
@@ -1949,6 +1953,7 @@ describe("Editor component", () => {
 					}
 					return null;
 				},
+				getSuggestionsAsync: async (_lines, _cursorLine, _cursorCol, _signal, _onUpdate) => null,
 				applyCompletion,
 			};
 


### PR DESCRIPTION
## Summary
Stream `fd` output for @ file autocomplete so the UI stays responsive and suggestions appear incrementally. Fixes #1278.

[pi-autocomplete-fix.mp4](https://github.com/user-attachments/assets/6d772489-ba8b-4606-a194-fb97c24d3e1f)

## Changes
- Async streaming `fd` integration for @ autocomplete.
- Optional `getSuggestionsAsync` API and final-result handling.
- Editor applies streaming updates with snapshot/abort guards and selection preservation.
- Exported `AutocompleteSuggestions` and updated editor test mocks.

## Prompt
```
Goal
Refactor pi-tui autocomplete for @ file references to be async/streaming with fd, keeping the UI
responsive and avoiding flicker. Keep code simple and idiomatic.

Requirements
- Convert fd search to async streaming (spawn + line-by-line stdout parsing).
- Autocomplete provider should expose:
    - getSuggestions(...) for fast sync results (non-@ cases).
    - getSuggestionsAsync(...) for slow streaming (@ file search).
- getSuggestionsAsync must be optional and return Promise<AutocompleteSuggestions | null> (avoid
breaking API).
- UI should remain responsive; streaming updates should not block typing.
- Avoid unnecessary API surface and over‑engineering.
- Preserve selection only if the user moved it; otherwise default to index 0.
- No hardcoded key checks; keep keybindings config‑driven.
- No any types.
- Must read files fully before modifying.

UX expectations
- @ results stream in; no blocking.
- If the @ prefix changes and sync returns empty, do not show stale results for the old prefix.
- Prefer correctness (“what you see is what you get”) over keeping stale suggestions visible.

Files to inspect/update
- packages/tui/src/autocomplete.ts
    - CombinedAutocompleteProvider
    - walkDirectoryWithFd
- packages/tui/src/components/editor.ts
- packages/tui/src/index.ts
- packages/tui/test/editor.test.ts (update provider mocks)

Implementation outline
1. autocomplete.ts
    - Replace spawnSync with streaming spawn.
    - walkDirectoryWithFd should stream stdout, parse lines, and call onEntry.
    - Add AutocompleteSuggestions type and use it for providers.
    - Add getSuggestionsAsync to the provider interface (optional in type, but implemented by CombinedAutocompleteProvider for @ file search).
    - For @ prefix, getSuggestions() should return null or empty and defer to async.
    - getSuggestionsAsync should stream updates and return final suggestions (or null).
2. editor.ts
    - Add async autocomplete handling:
            - Use AbortController.
            - Capture snapshot (text + cursor) and ignore async updates if stale.
    - Apply streaming updates directly and call tui.requestRender().
    - If streaming never emits, apply the final result (or cancel if empty).
    - Preserve selection only if user explicitly moved it.
3. index.ts
    - Export AutocompleteSuggestions.
4. tests
    - Update mocks to include getSuggestionsAsync returning null.

Testing
- Run npm run check after code changes.

Style
- Simple, readable TS.
- No dynamic imports.
- Minimal new helpers.
```