### PR TITLE
feat(coding-agent): queue post-turn inputs

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -923,6 +923,18 @@ pi.registerCommand("stats", {
 });
 ```
 
+Optional: mark the command as queueable so users can queue it with Alt+Enter (default: false):
+
+```typescript
+pi.registerCommand("stats", {
+  description: "Show session statistics",
+  queueable: true,
+  handler: async (args, ctx) => {
+    ctx.ui.notify(`Queued stats: ${args}`, "info");
+  }
+});
+```
+
 Optional: add argument auto-completion for `/command ...`:
 
 ```typescript

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -836,6 +836,8 @@ export interface RegisteredCommand {
 	name: string;
 	description?: string;
 	getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null;
+	/** Whether the command can be queued for after the current turn (ALT+ENTER). */
+	queueable?: boolean;
 	handler: (args: string, ctx: ExtensionCommandContext) => Promise<void>;
 }
 

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -13,14 +13,15 @@ export interface SlashCommandInfo {
 export interface BuiltinSlashCommand {
 	name: string;
 	description: string;
+	queueable?: boolean;
 }
 
 export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
-	{ name: "export", description: "Export session to HTML file" },
-	{ name: "share", description: "Share session as a secret GitHub gist" },
+	{ name: "export", description: "Export session to HTML file", queueable: true },
+	{ name: "share", description: "Share session as a secret GitHub gist", queueable: true },
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{ name: "name", description: "Set session display name" },
 	{ name: "session", description: "Show session info and stats" },
@@ -31,7 +32,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "login", description: "Login with OAuth provider" },
 	{ name: "logout", description: "Logout from OAuth provider" },
 	{ name: "new", description: "Start a new session" },
-	{ name: "compact", description: "Manually compact the session context" },
+	{ name: "compact", description: "Manually compact the session context", queueable: true },
 	{ name: "resume", description: "Resume a different session" },
-	{ name: "reload", description: "Reload extensions, skills, prompts, and themes" },
+	{ name: "reload", description: "Reload extensions, skills, prompts, and themes", queueable: true },
 ];

--- a/packages/coding-agent/src/modes/interactive/post-turn-queue.ts
+++ b/packages/coding-agent/src/modes/interactive/post-turn-queue.ts
@@ -1,0 +1,131 @@
+export type QueuedCommandSource = "builtin" | "extension";
+
+export type PostTurnQueueItem = {
+	text: string;
+	mode: "steer" | "followUp";
+	kind: "message" | "command";
+	commandSource?: QueuedCommandSource;
+	commandName?: string;
+	commandArgs?: string;
+};
+
+export type PostTurnQueueOptions = {
+	isStreaming: () => boolean;
+	isCompacting: () => boolean;
+	prompt: (text: string) => Promise<void>;
+	queueUserInput: (text: string, mode: "steer" | "followUp") => Promise<void>;
+	executeQueuedCommand: (item: PostTurnQueueItem) => Promise<void>;
+	clearSessionQueue: () => void;
+	onQueueUpdated: () => void;
+	onError: (message: string) => void;
+};
+
+export class PostTurnQueue {
+	private items: PostTurnQueueItem[] = [];
+	private isFlushing = false;
+
+	constructor(private options: PostTurnQueueOptions) {}
+
+	getItems(): readonly PostTurnQueueItem[] {
+		return this.items;
+	}
+
+	reset(options?: { notify?: boolean }): PostTurnQueueItem[] {
+		const items = [...this.items];
+		this.items = [];
+		this.isFlushing = false;
+		if (options?.notify ?? true) {
+			this.options.onQueueUpdated();
+		}
+		return items;
+	}
+
+	enqueue(item: PostTurnQueueItem): void {
+		this.items.push(item);
+		this.options.onQueueUpdated();
+	}
+
+	async flush(options?: { willRetry?: boolean }): Promise<void> {
+		if (this.items.length === 0) {
+			return;
+		}
+		if (this.isFlushing) {
+			return;
+		}
+		if (this.options.isStreaming() || this.options.isCompacting()) {
+			return;
+		}
+
+		this.isFlushing = true;
+		const snapshot = [...this.items];
+
+		const restoreQueue = (error: unknown) => {
+			this.options.clearSessionQueue();
+			const extras = this.items.filter((item) => !snapshot.includes(item));
+			this.items = [...snapshot, ...extras];
+			this.options.onQueueUpdated();
+			const message = error instanceof Error ? error.message : String(error);
+			this.options.onError(`Failed to process queued item${snapshot.length > 1 ? "s" : ""}: ${message}`);
+		};
+
+		try {
+			if (options?.willRetry) {
+				const hasCommand = this.items.some((item) => item.kind === "command");
+				if (hasCommand) {
+					return;
+				}
+
+				const queuedItems = [...this.items];
+				this.items = [];
+				this.options.onQueueUpdated();
+				for (const item of queuedItems) {
+					if (item.kind === "command") continue;
+					await this.options.queueUserInput(item.text, item.mode);
+				}
+				this.options.onQueueUpdated();
+				return;
+			}
+
+			while (this.items.length > 0) {
+				const item = this.items[0];
+				if (!item) return;
+
+				if (item.kind === "command") {
+					this.items.shift();
+					this.options.onQueueUpdated();
+					await this.options.executeQueuedCommand(item);
+					if (this.options.isStreaming() || this.options.isCompacting()) {
+						return;
+					}
+					continue;
+				}
+
+				const nextCommandIndex = this.items.findIndex((entry, index) => index > 0 && entry.kind === "command");
+				const blockEnd = nextCommandIndex === -1 ? this.items.length : nextCommandIndex;
+				const messageBlock = this.items.splice(0, blockEnd);
+				this.options.onQueueUpdated();
+
+				const [firstMessage, ...restMessages] = messageBlock;
+				if (!firstMessage) return;
+
+				const promptPromise = this.options.prompt(firstMessage.text).catch((error) => {
+					restoreQueue(error);
+				});
+
+				if (restMessages.length > 0) {
+					for (const message of restMessages) {
+						await this.options.queueUserInput(message.text, message.mode);
+					}
+					this.options.onQueueUpdated();
+				}
+
+				void promptPromise;
+				return;
+			}
+		} catch (error) {
+			restoreQueue(error);
+		} finally {
+			this.isFlushing = false;
+		}
+	}
+}


### PR DESCRIPTION
Per issue https://github.com/badlogic/pi-mono/issues/1282 (see issue for demo). This is a large diff... I welcome thoughts for any cleaner implementation 🙏 .

Summary:
- Allow Alt+Enter follow-ups to queue compatible slash commands during streaming/compaction.
- Add ordered post-turn queue for messages + commands; flush after agent_end/compaction end without overlap.
- Mark built-in queueable commands and add `queueable?: boolean` for extension commands.
- Preserve input hooks/template expansion for queued messages; keep /model immediate (exact-match or selector).

## Tests
- npm run check
- ./test.sh
- Manual testing locally