### PR TITLE
fix(coding-agent): exit early for help/version/export/list-models (fixes #1277)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed HTML export losing indentation in ANSI-rendered tool output (e.g. JSON code blocks in custom tool results) ([#1269](https://github.com/badlogic/pi-mono/pull/1269) by [@aliou](https://github.com/aliou))
 - Fixed images being silently dropped when `prompt()` is called with both `images` and `streamingBehavior` during streaming. `steer()`, `followUp()`, and the corresponding RPC commands now accept optional images. ([#1271](https://github.com/badlogic/pi-mono/pull/1271) by [@aliou](https://github.com/aliou))
+- CLI `--help`, `--version`, `--list-models`, and `--export` now exit even if extensions keep the event loop alive ([#1285](https://github.com/badlogic/pi-mono/pull/1285) by [@ferologics](https://github.com/ferologics))
 
 ## [0.51.6] - 2026-02-04
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -580,18 +580,18 @@ export async function main(args: string[]) {
 
 	if (parsed.version) {
 		console.log(VERSION);
-		return;
+		process.exit(0);
 	}
 
 	if (parsed.help) {
 		printHelp();
-		return;
+		process.exit(0);
 	}
 
 	if (parsed.listModels !== undefined) {
 		const searchPattern = typeof parsed.listModels === "string" ? parsed.listModels : undefined;
 		await listModels(modelRegistry, searchPattern);
-		return;
+		process.exit(0);
 	}
 
 	// Read piped stdin content (if any) - skip for RPC mode which uses stdin for JSON-RPC
@@ -606,16 +606,17 @@ export async function main(args: string[]) {
 	}
 
 	if (parsed.export) {
+		let result: string;
 		try {
 			const outputPath = parsed.messages.length > 0 ? parsed.messages[0] : undefined;
-			const result = await exportFromFile(parsed.export, outputPath);
-			console.log(`Exported to: ${result}`);
-			return;
+			result = await exportFromFile(parsed.export, outputPath);
 		} catch (error: unknown) {
 			const message = error instanceof Error ? error.message : "Failed to export session";
 			console.error(chalk.red(`Error: ${message}`));
 			process.exit(1);
 		}
+		console.log(`Exported to: ${result}`);
+		process.exit(0);
 	}
 
 	if (parsed.mode === "rpc" && parsed.fileArgs.length > 0) {


### PR DESCRIPTION
## Problem

CLI flags `--help`, `--version`, `--list-models`, and `--export` could hang when extensions kept the Node.js event loop alive (e.g., timers or file watchers).

## Solution

Exit the process explicitly after these early-exit paths so the CLI terminates regardless of event loop state.

## Changes

- `packages/coding-agent/src/main.ts`: call `process.exit(0)` for `--help`, `--version`, `--list-models`, and `--export`
- `packages/coding-agent/CHANGELOG.md`: add entry under Unreleased > Fixed

## Testing

- `npm run check`

Fixes #1277