### PR TITLE
feat(coding-agent): add ctx.dispatchToolCall for extension commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## [Unreleased]
 
+### New Features
+
+- **User-initiated tool dispatch**: Extensions can now dispatch tools directly from command and shortcut handlers via `ctx.dispatchToolCall(toolName, args)`. The tool executes through pi's normal pipeline (events, UI, session history) without triggering an LLM turn. Useful for overlays and UI-driven workflows where the arguments are already known. See [docs/extensions.md#ctxdispatchtoolcalltoolname-args](docs/extensions.md#ctxdispatchtoolcalltoolname-args).
+
 ### Added
 
 - API keys in `auth.json` now support shell command resolution (`!command`) and environment variable lookup, matching the behavior in `models.json`
 - Added `minimal-mode.ts` example extension demonstrating how to override built-in tool rendering for a minimal display mode
+- Added `ctx.dispatchToolCall(toolName, args)` to `ExtensionCommandContext` for dispatching tool calls directly from commands and shortcuts
+- Shortcut handlers now receive `ExtensionCommandContext` (previously `ExtensionContext`), giving them access to session control methods including `dispatchToolCall`
 
 ### Fixed
 

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -28,6 +28,7 @@ import { execCommand } from "../exec.js";
 import type {
 	Extension,
 	ExtensionAPI,
+	ExtensionCommandContext,
 	ExtensionFactory,
 	ExtensionRuntime,
 	LoadExtensionsResult,
@@ -162,7 +163,7 @@ function createExtensionAPI(
 			shortcut: KeyId,
 			options: {
 				description?: string;
-				handler: (ctx: import("./types.js").ExtensionContext) => Promise<void> | void;
+				handler: (ctx: ExtensionCommandContext) => Promise<void> | void;
 			},
 		): void {
 			extension.shortcuts.set(shortcut, { shortcut, extensionPath: extension.path, ...options });

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -303,6 +303,9 @@ export interface ExtensionCommandContext extends ExtensionContext {
 
 	/** Switch to a different session file. */
 	switchSession(sessionPath: string): Promise<{ cancelled: boolean }>;
+
+	/** Dispatch an active tool directly, without an LLM turn. */
+	dispatchToolCall(toolName: string, args: Record<string, unknown>): Promise<ToolResultMessage>;
 }
 
 // ============================================================================
@@ -903,7 +906,7 @@ export interface ExtensionAPI {
 		shortcut: KeyId,
 		options: {
 			description?: string;
-			handler: (ctx: ExtensionContext) => Promise<void> | void;
+			handler: (ctx: ExtensionCommandContext) => Promise<void> | void;
 		},
 	): void;
 
@@ -1129,7 +1132,7 @@ export interface ExtensionFlag {
 export interface ExtensionShortcut {
 	shortcut: KeyId;
 	description?: string;
-	handler: (ctx: ExtensionContext) => Promise<void> | void;
+	handler: (ctx: ExtensionCommandContext) => Promise<void> | void;
 	extensionPath: string;
 }
 
@@ -1231,6 +1234,7 @@ export interface ExtensionCommandContextActions {
 		options?: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string },
 	) => Promise<{ cancelled: boolean }>;
 	switchSession: (sessionPath: string) => Promise<{ cancelled: boolean }>;
+	dispatchToolCall: (toolName: string, args: Record<string, unknown>) => Promise<ToolResultMessage>;
 }
 
 /**

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -39,6 +39,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	await session.bindExtensions({
 		commandContextActions: {
 			waitForIdle: () => session.agent.waitForIdle(),
+			dispatchToolCall: (toolName, args) => session.dispatchToolCall(toolName, args),
 			newSession: async (options) => {
 				const success = await session.newSession({ parentSession: options?.parentSession });
 				if (success && options?.setup) {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -268,6 +268,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 		uiContext: createExtensionUIContext(),
 		commandContextActions: {
 			waitForIdle: () => session.agent.waitForIdle(),
+			dispatchToolCall: (toolName, args) => session.dispatchToolCall(toolName, args),
 			newSession: async (options) => {
 				// Delegate to AgentSession (handles setup + agent state sync)
 				const success = await session.newSession(options);

--- a/packages/coding-agent/test/agent-session-tool-dispatch.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-dispatch.test.ts
@@ -1,0 +1,56 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, ToolCall, ToolResultMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import type { SessionMessageEntry } from "../src/core/session-manager.js";
+import { createTestSession } from "./utilities.js";
+
+const isAssistantMessage = (m: AgentMessage): m is AssistantMessage => (m as { role?: string }).role === "assistant";
+const isToolResultMessage = (m: AgentMessage): m is ToolResultMessage => (m as { role?: string }).role === "toolResult";
+
+describe("AgentSession.dispatchToolCall", () => {
+	it("persists an assistant toolCall message and a toolResult message", async () => {
+		const ctx = createTestSession({ inMemory: true });
+		try {
+			const filePath = path.join(ctx.tempDir, "hello.txt");
+			fs.writeFileSync(filePath, "hello", "utf-8");
+
+			const result = await ctx.session.dispatchToolCall("read", { path: filePath });
+
+			expect(result.role).toBe("toolResult");
+			expect(result.toolName).toBe("read");
+			const text = result.content.find((c) => c.type === "text")?.text;
+			expect(text).toContain("hello");
+
+			const messages = ctx.session.state.messages;
+			let toolCallMsg: AssistantMessage | undefined;
+			let toolResultMsg: ToolResultMessage | undefined;
+
+			for (let i = messages.length - 1; i >= 0; i--) {
+				const message = messages[i];
+				if (!toolResultMsg && isToolResultMessage(message)) toolResultMsg = message;
+				if (!toolCallMsg && isAssistantMessage(message)) toolCallMsg = message;
+				if (toolCallMsg && toolResultMsg) break;
+			}
+
+			expect(toolCallMsg).toBeDefined();
+			expect(toolResultMsg).toBeDefined();
+
+			const toolCalls = (toolCallMsg?.content ?? []).filter((c): c is ToolCall => c.type === "toolCall");
+			expect(toolCalls.some((c) => c.name === "read")).toBe(true);
+			expect(toolResultMsg?.toolName).toBe("read");
+
+			const entries = ctx.sessionManager.getEntries();
+			const lastTwo = entries.slice(-2);
+			expect(lastTwo.map((e) => e.type)).toEqual(["message", "message"]);
+
+			const first = lastTwo[0] as SessionMessageEntry;
+			const second = lastTwo[1] as SessionMessageEntry;
+			expect(first.message.role).toBe("assistant");
+			expect(second.message.role).toBe("toolResult");
+		} finally {
+			ctx.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
This PR adds `ctx.dispatchToolCall(toolName, args)` so extensions can dispatch tools directly.

Currently, tools only get called directly when the agent decides to call them.

But slash commands, keyboard shortcuts, dialogs, etc that run in response to user actions can't directly emit a tool call.

Before this PR you had two options, both less than ideal. Implement the functionality directly and pi has no idea it happened or use `pi.sendUserMessage("please call the read tool...")`. Either way, no clean tool call in history.

`ctx.dispatchToolCall(toolName, args)` is the bridge. Call it from your handler, it executes through pi's normal pipeline and everything shows up in history.

Before:

```ts
pi.registerCommand("run-scout", {
  handler: async (args, ctx) => {
    pi.sendUserMessage(`Run the scout agent with task: "${args}"`);
  },
});
```

After:

```ts
pi.registerCommand("run-scout", {
  handler: async (args, ctx) => {
    await ctx.dispatchToolCall("subagent", { agent: "scout", task: args });
  },
});
```

The tool executes normally, fires `tool_execution_*` events, shows up in the UI, and session history captures a proper `toolCall`/`toolResult` pair.