### PR TITLE
Ignore Python venv directories in the skill loader

### DIFF
--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -116,6 +116,10 @@ function loadSkillsFromDirInternal(dir: string, source: string, includeRootFiles
 			if (entry.name === "node_modules") {
 				continue;
 			}
+            // Also skip Python virtual environments and caches
+            if (entry.name === "venv" || entry.name === ".venv" || entry.name === "__pycache__" || entry.name === "site-packages") {
+                continue;
+            }
 
 			const fullPath = join(dir, entry.name);
 


### PR DESCRIPTION
Fixes file descriptor leak where loadSkillsFromDir recursively scanned into Python virtual environments, opening 36k+ file descriptors in some cases.

The patch adds venv, .venv, __pycache__, and site-packages to the skip list alongside node_modules.

Closes https://github.com/badlogic/pi-mono/issues/1294