### PR TITLE
feat: add terminal input hook for extensions

### DIFF
--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -119,6 +119,7 @@ export type {
 	SetLabelHandler,
 	SetModelHandler,
 	SetThinkingLevelHandler,
+	TerminalInputHandler,
 	// Events - Tool
 	ToolCallEvent,
 	ToolCallEventResult,

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -129,6 +129,7 @@ const noOpUIContext: ExtensionUIContext = {
 	confirm: async () => false,
 	input: async () => undefined,
 	notify: () => {},
+	onTerminalInput: () => () => {},
 	setStatus: () => {},
 	setWorkingMessage: () => {},
 	setWidget: () => {},

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -96,6 +96,9 @@ export interface ExtensionWidgetOptions {
 	placement?: WidgetPlacement;
 }
 
+/** Raw terminal input listener for extensions. */
+export type TerminalInputHandler = (data: string) => { consume?: boolean; data?: string } | undefined;
+
 /**
  * UI context for extensions to request interactive UI.
  * Each mode (interactive, RPC, print) provides its own implementation.
@@ -112,6 +115,9 @@ export interface ExtensionUIContext {
 
 	/** Show a notification to the user. */
 	notify(message: string, type?: "info" | "warning" | "error"): void;
+
+	/** Listen to raw terminal input (interactive mode only). Returns an unsubscribe function. */
+	onTerminalInput(handler: TerminalInputHandler): () => void;
 
 	/** Set status text in the footer/status bar. Pass undefined to clear. */
 	setStatus(key: string, text: string | undefined): void;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -100,6 +100,7 @@ export type {
 	SlashCommandInfo,
 	SlashCommandLocation,
 	SlashCommandSource,
+	TerminalInputHandler,
 	ToolCallEvent,
 	ToolDefinition,
 	ToolInfo,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1344,6 +1344,7 @@ export class InteractiveMode {
 			confirm: (title, message, opts) => this.showExtensionConfirm(title, message, opts),
 			input: (title, placeholder, opts) => this.showExtensionInput(title, placeholder, opts),
 			notify: (message, type) => this.showExtensionNotify(message, type),
+			onTerminalInput: (handler) => this.ui.addInputListener(handler),
 			setStatus: (key, text) => this.setExtensionStatus(key, text),
 			setWorkingMessage: (message) => {
 				if (this.loadingAnimation) {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -144,6 +144,11 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			} as RpcExtensionUIRequest);
 		},
 
+		onTerminalInput(): () => void {
+			// Raw terminal input not supported in RPC mode
+			return () => {};
+		},
+
 		setStatus(key: string, text: string | undefined): void {
 			// Fire and forget - no response needed
 			output({


### PR DESCRIPTION
**What**

  Adds a minimal onTerminalInput hook to the extension UI context so extensions can observe (and optionally consume/replace) raw terminal input sequences before they reach the editor.

**Why**

  Some extensions need to query terminal capabilities via OSC/CSI and parse the replies (e.g. background color, cursor position, terminal features). Without a hook, these features either require core changes or are not possible (or just plain buggy, exposed to race conditions etc)

Reading process.stdin directly from an extension isn’t viable because the TUI already owns stdin (raw mode + StdinBuffer), and extensions would race it, see unparsed chunks, and can’t safely consume sequences so they don’t reach the editor. This keeps the core changes fairly minor and enables clean extension implementations.

  **Usage Example (using the new onTerminalInput hook)**

```
  pi.on("session_start", (_event, ctx) => {
    if (!ctx.hasUI) return;
    const off = ctx.ui.onTerminalInput((data) => {
      if (data.includes("\x1b]11;")) {
        off();            // one-shot
        return { consume: true };
      }
    });
  });
```

 The example just registers a basic one‑shot listener that consumes an OSC 11 response so it doesn’t reach the editor.

  **Tests Run**

  - npm run check
  - ./test.sh

I've also tested this with a more complex extension to generate an auto theme with dynamic colors based on querying the users terminal using OSC 11 escape sequences. 