### PR TITLE
feat(ai): support adaptive thinking for claude opus 4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,9 +63,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.71.2",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
-			"integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
 			"license": "MIT",
 			"dependencies": {
 				"json-schema-to-ts": "^3.1.1"
@@ -8470,7 +8470,7 @@
 			"version": "0.52.0",
 			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/sdk": "0.71.2",
+				"@anthropic-ai/sdk": "0.73.0",
 				"@aws-sdk/client-bedrock-runtime": "^3.966.0",
 				"@google/genai": "1.34.0",
 				"@mistralai/mistralai": "1.10.0",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -22,7 +22,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@anthropic-ai/sdk": "0.71.2",
+		"@anthropic-ai/sdk": "0.73.0",
 		"@aws-sdk/client-bedrock-runtime": "^3.966.0",
 		"@google/genai": "1.34.0",
 		"@mistralai/mistralai": "1.10.0",

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -43,3 +43,32 @@ export function adjustMaxTokensForThinking(
 
 	return { maxTokens, thinkingBudget };
 }
+
+export function supportsAdaptiveThinking(modelId: string, baseUrl?: string): boolean {
+	const normalizedBaseUrl = baseUrl?.trim().toLowerCase();
+	if (!normalizedBaseUrl) {
+		return false;
+	}
+	if (!normalizedBaseUrl.includes("api.anthropic.com")) {
+		return false;
+	}
+
+	const id = modelId.toLowerCase();
+	return id.includes("opus-4-6") || id.includes("opus-4.6");
+}
+
+export type EffortLevel = "low" | "medium" | "high" | "max";
+
+export function mapThinkingLevelToEffort(level: ThinkingLevel): EffortLevel {
+	switch (level) {
+		case "minimal":
+		case "low":
+			return "low";
+		case "medium":
+			return "medium";
+		case "high":
+			return "high";
+		case "xhigh":
+			return "max";
+	}
+}


### PR DESCRIPTION
This PR adds support for Claude Opus 4.6's adaptive thinking API, replacing the deprecated `budget_tokens` approach.

Opus 4.6 introduced a new way to handle extended thinking. Instead of specifying a fixed token budget upfront, you tell the model `thinking: { type: 'adaptive' }` and it decides when and how much to think based on task complexity. The `output_config.effort` parameter influences this decision.

The old `budget_tokens` approach still works but Anthropic has deprecated it for Opus 4.6. The SDK now warns when you use it.

This PR makes pi automatically use adaptive thinking for Opus 4.6 on the direct Anthropic API while keeping `budget_tokens` for older models and other endpoints (Bedrock, proxies) that don't support adaptive yet.

Detection is conservative. We only use adaptive when:
- baseUrl contains `api.anthropic.com`
- model ID contains `opus-4-6` or `opus-4.6`

Everything else falls back to the existing budget-based approach.

For direct `streamAnthropic` callers, two new options provide explicit control:
- `thinkingMode: 'enabled' | 'adaptive' | 'disabled'` - override auto-detection
- `effort: 'low' | 'medium' | 'high' | 'max'` - set effort level directly