### PR TITLE
fix(coding-agent): extensions setting respects package.json pi.extensions manifest

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Fixed git package parsing fallback for unknown hosts so enterprise git sources like `git:github.tools.sap/org/repo` are treated as git packages instead of local paths
+- Fixed extensions setting not loading directories with `package.json` containing `pi.extensions` manifest (e.g., `"extensions": ["~/my-extensions"]` now correctly reads the manifest)
 
 ## [0.52.2] - 2026-02-05
 

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -402,6 +402,13 @@ function collectAutoExtensionEntries(dir: string): string[] {
 	const entries: string[] = [];
 	if (!existsSync(dir)) return entries;
 
+	// First check if this directory itself has explicit extension entries (package.json or index)
+	const rootEntries = resolveExtensionEntries(dir);
+	if (rootEntries) {
+		return rootEntries;
+	}
+
+	// Otherwise, discover extensions from directory contents
 	const ig = ignore();
 	addIgnoreRules(ig, dir, dir);
 


### PR DESCRIPTION
Directories with `package.json` containing `pi.extensions` are now correctly loaded when specified in the extensions setting.