### PR TITLE
fix(ai): allow max/xhigh thinking level selection for Opus 4.6 models

### DIFF
--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -50,7 +50,11 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
  * Currently only certain OpenAI Codex models support this.
  */
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
-	return model.id.includes("gpt-5.2") || model.id.includes("gpt-5.3");
+	return (
+		model.id.includes("gpt-5.2") ||
+		model.id.includes("gpt-5.3") ||
+		model.id.includes("opus-4-6")
+	);
 }
 
 /**


### PR DESCRIPTION
Opus 4.6 supports adaptive thinking with effort: max, but supportsXhigh() only checked for GPT-5.x models. This meant xhigh was clamped to high, making it impossible to send effort: max to the Anthropic API.