### PR TITLE
fix(ai): track and price OpenAI web search tool calls

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1216,6 +1216,13 @@ async function generateModels() {
 		}
 	}
 
+	// Set web search per-call pricing for OpenAI Responses API models ($10/1000 calls = $0.01/call)
+	for (const model of allModels) {
+		if (model.provider === "openai" && model.api === "openai-responses") {
+			model.cost.webSearchPerCall = 0.01;
+		}
+	}
+
 	const azureOpenAiModels: Model<Api>[] = allModels
 		.filter((model) => model.provider === "openai" && model.api === "openai-responses")
 		.map((model) => ({
@@ -1279,6 +1286,9 @@ export const MODELS = {
 			output += `\t\t\t\toutput: ${model.cost.output},\n`;
 			output += `\t\t\t\tcacheRead: ${model.cost.cacheRead},\n`;
 			output += `\t\t\t\tcacheWrite: ${model.cost.cacheWrite},\n`;
+			if (model.cost.webSearchPerCall !== undefined) {
+				output += `\t\t\t\twebSearchPerCall: ${model.cost.webSearchPerCall},\n`;
+			}
 			output += `\t\t\t},\n`;
 			output += `\t\t\tcontextWindow: ${model.contextWindow},\n`;
 			output += `\t\t\tmaxTokens: ${model.maxTokens},\n`;

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -41,7 +41,9 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
 	usage.cost.output = (model.cost.output / 1000000) * usage.output;
 	usage.cost.cacheRead = (model.cost.cacheRead / 1000000) * usage.cacheRead;
 	usage.cost.cacheWrite = (model.cost.cacheWrite / 1000000) * usage.cacheWrite;
-	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
+	usage.cost.webSearch = (model.cost.webSearchPerCall ?? 0) * (usage.webSearchCalls ?? 0);
+	usage.cost.total =
+		usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite + (usage.cost.webSearch ?? 0);
 	return usage.cost;
 }
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -270,5 +270,6 @@ function applyServiceTierPricing(usage: Usage, serviceTier: ResponseCreateParams
 	usage.cost.output *= multiplier;
 	usage.cost.cacheRead *= multiplier;
 	usage.cost.cacheWrite *= multiplier;
-	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
+	usage.cost.total =
+		usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite + (usage.cost.webSearch ?? 0);
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -137,11 +137,13 @@ export interface Usage {
 	cacheRead: number;
 	cacheWrite: number;
 	totalTokens: number;
+	webSearchCalls?: number;
 	cost: {
 		input: number;
 		output: number;
 		cacheRead: number;
 		cacheWrite: number;
+		webSearch?: number;
 		total: number;
 	};
 }
@@ -282,6 +284,7 @@ export interface Model<TApi extends Api> {
 		output: number; // $/million tokens
 		cacheRead: number; // $/million tokens
 		cacheWrite: number; // $/million tokens
+		webSearchPerCall?: number; // $/call for web search tool
 	};
 	contextWindow: number;
 	maxTokens: number;


### PR DESCRIPTION
## Summary

- **Stream processing**: `processResponsesStream` silently dropped `web_search_call` output items and web search progress events (`in_progress`, `searching`, `completed`). Added handling so they are no longer silently ignored, and completed web search calls are counted.
- **Pricing**: Web search per-call costs ($10/1000 calls = $0.01/call) were never accounted for. Added `webSearchCalls` and `cost.webSearch` to the `Usage` type, `webSearchPerCall` to `Model.cost`, and updated `calculateCost` to include web search costs in the total.
- **Model generation**: The `generate-models` script now sets `webSearchPerCall: 0.01` on all OpenAI Responses API models and emits the field in generated model definitions.

All new fields are optional to avoid breaking existing providers and test fixtures.

## Changes

| File | What changed |
|---|---|
| `packages/ai/src/types.ts` | Added optional `webSearchCalls` to `Usage`, `webSearch` to `Usage.cost`, `webSearchPerCall` to `Model.cost` |
| `packages/ai/src/models.ts` | `calculateCost` now computes and includes web search cost |
| `packages/ai/src/providers/openai-responses-shared.ts` | `processResponsesStream` handles `web_search_call` output items (counts them) and web search progress events |
| `packages/ai/src/providers/openai-responses.ts` | `applyServiceTierPricing` includes `webSearch` cost in total |
| `packages/ai/scripts/generate-models.ts` | Sets `webSearchPerCall` on OpenAI models, emits field in codegen |

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit` passes for `packages/ai`)
- [ ] Trigger an OpenAI API call with `web_search_preview` tool enabled and verify `usage.webSearchCalls` is populated and `usage.cost.webSearch` / `usage.cost.total` reflect the per-call cost
- [ ] Verify non-web-search API calls still work normally (new fields are optional, default to 0)
- [ ] Run `npm run generate-models` and verify `webSearchPerCall` appears on OpenAI Responses models