### PR TITLE
chore(coding-agent): remove premature redundant setupAutocomplete

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -373,7 +373,6 @@ export class InteractiveMode {
 
 		// Setup autocomplete with fd tool for file path completion
 		this.fdPath = await ensureTool("fd");
-		this.setupAutocomplete(this.fdPath);
 
 		// Add header container as first child
 		this.ui.addChild(this.headerContainer);


### PR DESCRIPTION
The `initExtensions` method sets up autocomplete after binding the UI context. Therefore, calling `setupAutocomplete` in `init` before invoking `initExtensions` is redundant. 

Additionally, it is premature because the extensions' runner lacks a UI context at that stage and logs messages to the console.

before:
<img width="1171" height="1356" alt="screenshot-2026-02-06_20-05-04" src="https://github.com/user-attachments/assets/a551ceda-1f3b-4a08-8687-0715016a304a" />


after:
<img width="1147" height="1377" alt="screenshot-2026-02-06_20-06-09" src="https://github.com/user-attachments/assets/51b389d2-a6b3-4f9d-8e8f-432930320f23" />

