### PR TITLE
fix(coding-agent): remove URL padding in login dialog

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -84,7 +84,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	showAuth(url: string, instructions?: string): void {
 		this.contentContainer.clear();
 		this.contentContainer.addChild(new Spacer(1));
-		this.contentContainer.addChild(new Text(theme.fg("accent", url), 1, 0));
+		this.contentContainer.addChild(new Text(theme.fg("accent", url), 0, 0));
 
 		const clickHint = process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open";
 		const hyperlink = `\x1b]8;;${url}\x07${clickHint}\x1b]8;;\x07`;


### PR DESCRIPTION
The login URL rendered by /login has left/right padding which reduces the available width. This causes the URL to wrap, breaking copy-paste. Cmd+click is offered as an alternative but often doesn't work for me when ssh'd in and/or with tmux.

Sets `paddingX` to 0 for the URL text so it renders at full width.