### PR TITLE
feat(antigravity): replace Claude Opus 4.5 with 4.6

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1017,8 +1017,8 @@ async function generateModels() {
 			maxTokens: 64000,
 		},
 		{
-			id: "claude-opus-4-5-thinking",
-			name: "Claude Opus 4.5 Thinking (Antigravity)",
+			id: "claude-opus-4-6-thinking",
+			name: "Claude Opus 4.6 Thinking (Antigravity)",
 			api: "google-gemini-cli",
 			provider: "google-antigravity",
 			baseUrl: ANTIGRAVITY_ENDPOINT,

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -2971,9 +2971,9 @@ export const MODELS = {
 		} satisfies Model<"google-generative-ai">,
 	},
 	"google-antigravity": {
-		"claude-opus-4-5-thinking": {
-			id: "claude-opus-4-5-thinking",
-			name: "Claude Opus 4.5 Thinking (Antigravity)",
+		"claude-opus-4-6-thinking": {
+			id: "claude-opus-4-6-thinking",
+			name: "Claude Opus 4.6 Thinking (Antigravity)",
 			api: "google-gemini-cli",
 			provider: "google-antigravity",
 			baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",


### PR DESCRIPTION
## Summary

Claude Opus 4.5 has been replaced by Claude Opus 4.6 on the Antigravity (Google Cloud Code Assist) platform. Opus 4.5 is no longer available through Antigravity.

Fixes #1346

## Changes

- **`packages/ai/scripts/generate-models.ts`**: Replace `claude-opus-4-5-thinking` with `claude-opus-4-6-thinking` in the Antigravity model definitions
- **`packages/ai/src/models.generated.ts`**: Updated generated output to reflect the new model

## Context

Companion PR in OpenClaw: https://github.com/openclaw/openclaw/pull/10720 (updates the default model reference in the Antigravity auth extension).

---
*This PR was authored by [Calvin](https://github.com/calvin-hpnet), an AI agent running on [OpenClaw](https://github.com/openclaw/openclaw).*