### PR TITLE
feat(ai): pass through metadata in StreamOptions for Anthropic API

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -602,6 +602,10 @@ function buildParams(
 		}
 	}
 
+	if (options?.metadata) {
+		params.metadata = options.metadata;
+	}
+
 	return params;
 }
 

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -11,6 +11,7 @@ export function buildBaseOptions(model: Model<Api>, options?: SimpleStreamOption
 		headers: options?.headers,
 		onPayload: options?.onPayload,
 		maxRetryDelayMs: options?.maxRetryDelayMs,
+		metadata: options?.metadata,
 	};
 }
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -87,6 +87,13 @@ export interface StreamOptions {
 	 * Default: 60000 (60 seconds). Set to 0 to disable the cap.
 	 */
 	maxRetryDelayMs?: number;
+	/**
+	 * Optional metadata to include in API requests.
+	 * For Anthropic, this maps directly to the `metadata` field
+	 * (e.g. `{ user_id: "..." }` for tracking/caching).
+	 * Ignored by providers that don't support it.
+	 */
+	metadata?: Record<string, string>;
 }
 
 export type ProviderStreamOptions = StreamOptions & Record<string, unknown>;


### PR DESCRIPTION
## Summary

Add support for passing `metadata` through to the Anthropic API via `StreamOptions`.

## Motivation

Anthropic's Messages API supports a [`metadata` field](https://docs.anthropic.com/en/api/messages) that enables features like:
- `user_id` for abuse tracking and per-user rate limiting
- Prompt caching optimization via third-party API proxies that key on `metadata.user_id`

Currently there's no way to pass `metadata` through pi-ai — callers have to patch the built params or use `onPayload` as a workaround.

## Changes

- **`types.ts`**: Add optional `metadata` to `StreamOptions` with JSDoc
- **`simple-options.ts`**: Forward `metadata` in `buildBaseOptions`
- **`anthropic.ts`**: Include `metadata` in `buildParams` output

This follows the same pattern as existing pass-through fields like `headers` and `sessionId`. Non-Anthropic providers simply ignore it.

## Diff summary

3 files changed, 12 insertions(+)