### PR TITLE
fix(coding-agent): discover .pi/settings.json from subdirectories via upward traversal

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -5,7 +5,6 @@ import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import ignore from "ignore";
 import { minimatch } from "minimatch";
-import { CONFIG_DIR_NAME } from "../config.js";
 import { type GitSource, parseGitUrl } from "../utils/git.js";
 import type { PackageSource, SettingsManager } from "./settings-manager.js";
 
@@ -701,7 +700,7 @@ export class DefaultPackageManager implements PackageManager {
 		await this.resolvePackageSources(packageSources, accumulator, onMissing);
 
 		const globalBaseDir = this.agentDir;
-		const projectBaseDir = join(this.cwd, CONFIG_DIR_NAME);
+		const projectBaseDir = this.settingsManager.getProjectConfigDir();
 
 		for (const resourceType of RESOURCE_TYPES) {
 			const target = this.getTargetMap(accumulator, resourceType);
@@ -1238,7 +1237,7 @@ export class DefaultPackageManager implements PackageManager {
 			return this.getTemporaryDir("npm");
 		}
 		if (scope === "project") {
-			return join(this.cwd, CONFIG_DIR_NAME, "npm");
+			return join(this.settingsManager.getProjectConfigDir(), "npm");
 		}
 		return join(this.getGlobalNpmRoot(), "..");
 	}
@@ -1257,7 +1256,7 @@ export class DefaultPackageManager implements PackageManager {
 			return join(this.getTemporaryDir("npm"), "node_modules", source.name);
 		}
 		if (scope === "project") {
-			return join(this.cwd, CONFIG_DIR_NAME, "npm", "node_modules", source.name);
+			return join(this.settingsManager.getProjectConfigDir(), "npm", "node_modules", source.name);
 		}
 		return join(this.getGlobalNpmRoot(), source.name);
 	}
@@ -1267,7 +1266,7 @@ export class DefaultPackageManager implements PackageManager {
 			return this.getTemporaryDir(`git-${source.host}`, source.path);
 		}
 		if (scope === "project") {
-			return join(this.cwd, CONFIG_DIR_NAME, "git", source.host, source.path);
+			return join(this.settingsManager.getProjectConfigDir(), "git", source.host, source.path);
 		}
 		return join(this.agentDir, "git", source.host, source.path);
 	}
@@ -1277,7 +1276,7 @@ export class DefaultPackageManager implements PackageManager {
 			return undefined;
 		}
 		if (scope === "project") {
-			return join(this.cwd, CONFIG_DIR_NAME, "git");
+			return join(this.settingsManager.getProjectConfigDir(), "git");
 		}
 		return join(this.agentDir, "git");
 	}
@@ -1292,7 +1291,7 @@ export class DefaultPackageManager implements PackageManager {
 
 	private getBaseDirForScope(scope: SourceScope): string {
 		if (scope === "project") {
-			return join(this.cwd, CONFIG_DIR_NAME);
+			return this.settingsManager.getProjectConfigDir();
 		}
 		if (scope === "user") {
 			return this.agentDir;

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import chalk from "chalk";
-import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
+import { getAgentDir } from "../config.js";
 import { loadThemeFromPath, type Theme } from "../modes/interactive/theme/theme.js";
 import type { ResourceDiagnostic } from "./diagnostics.js";
 
@@ -597,7 +597,10 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const themes: Theme[] = [];
 		const diagnostics: ResourceDiagnostic[] = [];
 		if (includeDefaults) {
-			const defaultDirs = [join(this.agentDir, "themes"), join(this.cwd, CONFIG_DIR_NAME, "themes")];
+			const defaultDirs = [
+				join(this.agentDir, "themes"),
+				join(this.settingsManager.getProjectConfigDir(), "themes"),
+			];
 
 			for (const dir of defaultDirs) {
 				this.loadThemesFromDir(dir, themes, diagnostics);
@@ -743,7 +746,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	}
 
 	private discoverSystemPromptFile(): string | undefined {
-		const projectPath = join(this.cwd, CONFIG_DIR_NAME, "SYSTEM.md");
+		const projectPath = join(this.settingsManager.getProjectConfigDir(), "SYSTEM.md");
 		if (existsSync(projectPath)) {
 			return projectPath;
 		}
@@ -757,7 +760,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	}
 
 	private discoverAppendSystemPromptFile(): string | undefined {
-		const projectPath = join(this.cwd, CONFIG_DIR_NAME, "APPEND_SYSTEM.md");
+		const projectPath = join(this.settingsManager.getProjectConfigDir(), "APPEND_SYSTEM.md");
 		if (existsSync(projectPath)) {
 			return projectPath;
 		}
@@ -786,11 +789,12 @@ export class DefaultResourceLoader implements ResourceLoader {
 			join(this.agentDir, "themes"),
 			join(this.agentDir, "extensions"),
 		];
+		const projectConfigDir = this.settingsManager.getProjectConfigDir();
 		const projectRoots = [
-			join(this.cwd, CONFIG_DIR_NAME, "skills"),
-			join(this.cwd, CONFIG_DIR_NAME, "prompts"),
-			join(this.cwd, CONFIG_DIR_NAME, "themes"),
-			join(this.cwd, CONFIG_DIR_NAME, "extensions"),
+			join(projectConfigDir, "skills"),
+			join(projectConfigDir, "prompts"),
+			join(projectConfigDir, "themes"),
+			join(projectConfigDir, "extensions"),
 		];
 
 		for (const root of agentRoots) {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
 
 export interface CompactionSettings {
@@ -88,6 +88,34 @@ export interface Settings {
 	markdown?: MarkdownSettings;
 }
 
+/**
+ * Find the nearest .pi/settings.json by walking up the directory tree from cwd.
+ * Returns the path if found, or null if not found.
+ * Similar to how git searches for .git directories.
+ */
+function findProjectSettings(cwd: string): string | null {
+	let currentDir = resolve(cwd);
+	const root = resolve("/");
+
+	while (true) {
+		const settingsPath = join(currentDir, CONFIG_DIR_NAME, "settings.json");
+		if (existsSync(settingsPath)) {
+			return settingsPath;
+		}
+
+		// Stop at root
+		if (currentDir === root) break;
+
+		const parentDir = resolve(currentDir, "..");
+		// Additional safety check for root
+		if (parentDir === currentDir) break;
+
+		currentDir = parentDir;
+	}
+
+	return null;
+}
+
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
 function deepMergeSettings(base: Settings, overrides: Settings): Settings {
 	const result: Settings = { ...base };
@@ -122,6 +150,7 @@ function deepMergeSettings(base: Settings, overrides: Settings): Settings {
 export class SettingsManager {
 	private settingsPath: string | null;
 	private projectSettingsPath: string | null;
+	private cwd: string; // Track the working directory for creating new project settings
 	private globalSettings: Settings;
 	private inMemoryProjectSettings: Settings; // For in-memory mode
 	private settings: Settings;
@@ -133,12 +162,14 @@ export class SettingsManager {
 	private constructor(
 		settingsPath: string | null,
 		projectSettingsPath: string | null,
+		cwd: string,
 		initialSettings: Settings,
 		persist: boolean,
 		loadError: Error | null = null,
 	) {
 		this.settingsPath = settingsPath;
 		this.projectSettingsPath = projectSettingsPath;
+		this.cwd = cwd;
 		this.persist = persist;
 		this.globalSettings = initialSettings;
 		this.inMemoryProjectSettings = {};
@@ -150,7 +181,8 @@ export class SettingsManager {
 	/** Create a SettingsManager that loads from files */
 	static create(cwd: string = process.cwd(), agentDir: string = getAgentDir()): SettingsManager {
 		const settingsPath = join(agentDir, "settings.json");
-		const projectSettingsPath = join(cwd, CONFIG_DIR_NAME, "settings.json");
+		// Walk up the directory tree to find the nearest .pi/settings.json
+		const projectSettingsPath = findProjectSettings(cwd);
 
 		let globalSettings: Settings = {};
 		let loadError: Error | null = null;
@@ -163,12 +195,12 @@ export class SettingsManager {
 			console.error(`Fix the syntax error to enable settings persistence.`);
 		}
 
-		return new SettingsManager(settingsPath, projectSettingsPath, globalSettings, true, loadError);
+		return new SettingsManager(settingsPath, projectSettingsPath, cwd, globalSettings, true, loadError);
 	}
 
 	/** Create an in-memory SettingsManager (no file I/O) */
-	static inMemory(settings: Partial<Settings> = {}): SettingsManager {
-		return new SettingsManager(null, null, settings, false);
+	static inMemory(settings: Partial<Settings> = {}, cwd: string = process.cwd()): SettingsManager {
+		return new SettingsManager(null, null, cwd, settings, false);
 	}
 
 	private static loadFromFile(path: string): Settings {
@@ -238,6 +270,14 @@ export class SettingsManager {
 
 	getProjectSettings(): Settings {
 		return this.loadProjectSettings();
+	}
+
+	/** Return the .pi config directory where project settings were found, or cwd/.pi as fallback */
+	getProjectConfigDir(): string {
+		if (this.projectSettingsPath) {
+			return dirname(this.projectSettingsPath);
+		}
+		return join(this.cwd, CONFIG_DIR_NAME);
 	}
 
 	reload(): void {
@@ -341,15 +381,20 @@ export class SettingsManager {
 			return;
 		}
 
-		if (!this.projectSettingsPath) {
-			return;
-		}
+		// Determine the save path: use existing path if found during traversal,
+		// otherwise create in current directory
+		const savePath = this.projectSettingsPath ?? join(this.cwd, CONFIG_DIR_NAME, "settings.json");
+
 		try {
-			const dir = dirname(this.projectSettingsPath);
+			const dir = dirname(savePath);
 			if (!existsSync(dir)) {
 				mkdirSync(dir, { recursive: true });
 			}
-			writeFileSync(this.projectSettingsPath, JSON.stringify(settings, null, 2), "utf-8");
+			writeFileSync(savePath, JSON.stringify(settings, null, 2), "utf-8");
+			// Update the cached path if we just created it
+			if (!this.projectSettingsPath) {
+				this.projectSettingsPath = savePath;
+			}
 		} catch (error) {
 			console.error(`Warning: Could not save project settings file: ${error}`);
 		}

--- a/packages/coding-agent/test/git-update.test.ts
+++ b/packages/coding-agent/test/git-update.test.ts
@@ -67,7 +67,7 @@ describe("DefaultPackageManager git update", () => {
 
 		mkdirSync(agentDir, { recursive: true });
 
-		settingsManager = SettingsManager.inMemory();
+		settingsManager = SettingsManager.inMemory({}, tempDir);
 		packageManager = new DefaultPackageManager({
 			cwd: tempDir,
 			agentDir,

--- a/packages/coding-agent/test/package-manager-ssh.test.ts
+++ b/packages/coding-agent/test/package-manager-ssh.test.ts
@@ -17,7 +17,7 @@ describe("Package Manager SSH URL Support", () => {
 		agentDir = join(tempDir, "agent");
 		mkdirSync(agentDir, { recursive: true });
 
-		settingsManager = SettingsManager.inMemory();
+		settingsManager = SettingsManager.inMemory({}, tempDir);
 		packageManager = new DefaultPackageManager({
 			cwd: tempDir,
 			agentDir,

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -24,7 +24,7 @@ describe("DefaultPackageManager", () => {
 		agentDir = join(tempDir, "agent");
 		mkdirSync(agentDir, { recursive: true });
 
-		settingsManager = SettingsManager.inMemory();
+		settingsManager = SettingsManager.inMemory({}, tempDir);
 		packageManager = new DefaultPackageManager({
 			cwd: tempDir,
 			agentDir,


### PR DESCRIPTION
## Summary

When running `pi` from a subdirectory, `.pi/settings.json` in parent directories was not discovered, causing skills, extensions, prompts, and themes to not load. This adds upward directory traversal matching the existing `AGENTS.md` discovery pattern.

Related issue: #1366

## Problem

```bash
cd ~/myproject && pi -p "list skills"       # works
cd ~/myproject/docs && pi -p "list skills"  # nothing loads
```

`SettingsManager.create()` only checked `join(cwd, ".pi", "settings.json")` — no upward traversal. Additionally, `PackageManager` and `ResourceLoader` hardcoded `join(cwd, ".pi")` as the project config base, so even after finding settings via traversal, resource paths would resolve against the wrong directory.

## Changes

**`settings-manager.ts`**
- Added `findProjectSettings(cwd)` — walks up directory tree to find `.pi/settings.json`
- Updated `create()` to use it instead of hardcoded `join(cwd, ".pi", "settings.json")`
- Added `getProjectConfigDir()` — returns the actual `.pi` directory where settings were found (or `cwd/.pi` as fallback)
- Added optional `cwd` parameter to `inMemory()` for test compatibility

**`package-manager.ts`**
- Updated `resolve()`, `getBaseDirForScope()`, and install path methods to use `settingsManager.getProjectConfigDir()` instead of `join(this.cwd, ".pi")`

**`resource-loader.ts`**
- Updated theme defaults, `SYSTEM.md`/`APPEND_SYSTEM.md` discovery, and metadata path roots to use `settingsManager.getProjectConfigDir()`

**Tests** — Updated 3 test files to pass `cwd` to `SettingsManager.inMemory()` to match `PackageManager` cwd.

## Testing

- All 63 package-manager tests pass
- All 16 package-manager-ssh tests pass
- All 10 git-update tests pass
- Biome lint clean on all modified files

## Test plan

- [ ] Verify settings load from `.pi/settings.json` in cwd (regression)
- [ ] Verify settings load when running from a subdirectory (primary fix)
- [ ] Verify auto-discovered resources (`.pi/skills/`, `.pi/extensions/`) resolve from the found `.pi/` directory
- [ ] Verify relative paths in project settings resolve correctly from subdirectories
- [ ] Verify `saveProjectSettings` creates `.pi/settings.json` in cwd when none exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)