### PR TITLE
Propagate autocomplete to custom editors

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -359,6 +359,9 @@ export class InteractiveMode {
 			fdPath,
 		);
 		this.defaultEditor.setAutocompleteProvider(this.autocompleteProvider);
+		if (this.editor !== this.defaultEditor) {
+			this.editor.setAutocompleteProvider?.(this.autocompleteProvider);
+		}
 	}
 
 	async init(): Promise<void> {


### PR DESCRIPTION
`setupAutocomplete` only sets the provider on `defaultEditor`. When an extension customizes the editor via `setEditorComponent` during `session_start`, the custom editor is created before `setupAutocomplete` runs, so it never receives the autocomplete provider. This breaks forced file suggestions, slash commands, and all other completions.

Root cause: Commit b170341b moved `setupAutocomplete` into `initExtensions`, but placed it after `bindExtensions()` which fires `session_start`.

Set the provider on the active editor too when it differs from the default, covering initial load, reload, and settings changes.