### PR TITLE
feat: add rememberLastModel setting to prevent persisting model switches

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -118,6 +118,7 @@ When a provider requests a retry delay longer than `maxDelayMs` (e.g., Google's 
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
+| `rememberLastModel` | boolean | `true` | Persist last-used model as default across sessions |
 | `enabledModels` | string[] | - | Model patterns for Ctrl+P cycling (same format as `--models` CLI flag) |
 
 ```json
@@ -192,6 +193,7 @@ See [packages.md](packages.md) for package management details.
     "enabled": true,
     "maxRetries": 3
   },
+  "rememberLastModel": false,
   "enabledModels": ["claude-*", "gpt-4o"],
   "packages": ["pi-skills"]
 }

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1163,7 +1163,9 @@ export class AgentSession {
 		const previousModel = this.model;
 		this.agent.setModel(model);
 		this.sessionManager.appendModelChange(model.provider, model.id);
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		if (this.settingsManager.getRememberLastModel()) {
+			this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		}
 
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(this.thinkingLevel);
@@ -1221,7 +1223,9 @@ export class AgentSession {
 		// Apply model
 		this.agent.setModel(next.model);
 		this.sessionManager.appendModelChange(next.model.provider, next.model.id);
-		this.settingsManager.setDefaultModelAndProvider(next.model.provider, next.model.id);
+		if (this.settingsManager.getRememberLastModel()) {
+			this.settingsManager.setDefaultModelAndProvider(next.model.provider, next.model.id);
+		}
 
 		// Apply thinking level (setThinkingLevel clamps to model capabilities)
 		this.setThinkingLevel(next.thinkingLevel);
@@ -1250,7 +1254,9 @@ export class AgentSession {
 
 		this.agent.setModel(nextModel);
 		this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
-		this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+		if (this.settingsManager.getRememberLastModel()) {
+			this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+		}
 
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(this.thinkingLevel);

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -79,6 +79,7 @@ export interface Settings {
 	enableSkillCommands?: boolean; // default: true - register skills as /skill:name commands
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
+	rememberLastModel?: boolean; // default: true - persist last-used model as default across sessions
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
 	doubleEscapeAction?: "fork" | "tree" | "none"; // Action for double-escape with empty editor (default: "tree")
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
@@ -383,6 +384,10 @@ export class SettingsManager {
 		this.globalSettings.defaultModel = modelId;
 		this.markModified("defaultModel");
 		this.save();
+	}
+
+	getRememberLastModel(): boolean {
+		return this.settings.rememberLastModel !== false;
 	}
 
 	setDefaultModelAndProvider(provider: string, modelId: string): void {

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -318,8 +318,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private handleSelect(model: Model<any>): void {
-		// Save as new default
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		// Save as new default (if enabled)
+		if (this.settingsManager.getRememberLastModel()) {
+			this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		}
 		this.onSelectCallback(model);
 	}
 


### PR DESCRIPTION
## Summary

Add a new `rememberLastModel` setting (default: `true`) that controls whether switching models via `/model` or Ctrl+P persists the choice to `settings.json`. When set to `false`, the configured default model is always used when starting a new session.

This is useful for users who want to temporarily try different models during a session without changing their preferred default.

## Usage

```json
{
  "rememberLastModel": false
}
```

## Changes

- **`settings-manager.ts`**: Add `rememberLastModel` to `Settings` interface and `getRememberLastModel()` getter
- **`agent-session.ts`**: Guard all 3 `setDefaultModelAndProvider()` call sites (set model, cycle scoped, cycle available)
- **`model-selector.ts`**: Guard the model selector's `handleSelect()` call site
- **`settings.md`**: Document the new setting in the reference table and example
- **`settings-manager.test.ts`**: Add tests for default behavior, opt-out behavior, and getter