### PR TITLE
Add 'z-ai' provider to API key configurations

### DIFF
--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -77,6 +77,7 @@ Store credentials in `~/.pi/agent/auth.json`:
   "openai": { "type": "api_key", "key": "sk-..." },
   "google": { "type": "api_key", "key": "..." },
   "opencode": { "type": "api_key", "key": "..." }
+  "z-ai" { "type": "api_key", "key": "..." }
 }
 ```
 


### PR DESCRIPTION
I used perplexity for z.ai pi-coding-agent
it really struggled. 

turned out z-ai is the correct provider name
and it should be defined in the auth.json or through the ZAI_API_KEY

Will update the /login command next to support z.ai