### PR TITLE
added supportsDeveloperRole

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6330,7 +6330,6 @@
 			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
 			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@lit/reactive-element": "^2.1.0",
 				"lit-element": "^4.2.0",
@@ -7687,7 +7686,6 @@
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
 			"integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -7716,8 +7714,7 @@
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
 			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -7835,7 +7832,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7932,7 +7928,6 @@
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -8021,7 +8016,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -8136,7 +8130,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenAI Responses: allow forcing systemPrompt to use `role: "system"` via `compat.supportsDeveloperRole=false`. Fixes Ollama ignoring `developer` role
+
 ## [0.52.8] - 2026-02-07
 
 ### Added

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -18,6 +18,7 @@ import type {
 	Context,
 	ImageContent,
 	Model,
+	OpenAIResponsesCompat,
 	StopReason,
 	TextContent,
 	ThinkingContent,
@@ -98,7 +99,10 @@ export function convertResponsesMessages<TApi extends Api>(
 
 	const includeSystemPrompt = options?.includeSystemPrompt ?? true;
 	if (includeSystemPrompt && context.systemPrompt) {
-		const role = model.reasoning ? "developer" : "system";
+		const compat = (model as any).compat as OpenAIResponsesCompat | undefined;
+		const supportsDeveloperRole = compat?.supportsDeveloperRole;
+		const role = model.reasoning && supportsDeveloperRole !== false ? "developer" : "system";
+
 		messages.push({
 			role,
 			content: sanitizeSurrogates(context.systemPrompt),

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -241,7 +241,8 @@ export interface OpenAICompletionsCompat {
 
 /** Compatibility settings for OpenAI Responses APIs. */
 export interface OpenAIResponsesCompat {
-	// Reserved for future use
+	/** Whether the provider supports the `developer` role. Default: matches `reasoning`. */
+	supportsDeveloperRole?: boolean;
 }
 
 /**

--- a/packages/ai/test/openai-responses-systemprompt-role.test.ts
+++ b/packages/ai/test/openai-responses-systemprompt-role.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { convertResponsesMessages } from "../src/providers/openai-responses-shared.js";
+import type { Model } from "../src/types.js";
+
+describe("openai-responses systemPrompt role", () => {
+	const baseModel: Model<"openai-responses"> = {
+		id: "test",
+		name: "test",
+		api: "openai-responses",
+		provider: "test",
+		baseUrl: "http://localhost:11434/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	};
+
+	it("defaults to developer when reasoning=true", () => {
+		const input = convertResponsesMessages(baseModel, { systemPrompt: "SP", messages: [] }, new Set());
+		expect(input[0]).toMatchObject({ role: "developer" });
+	});
+
+	it("uses system when compat.supportsDeveloperRole=false", () => {
+		const input = convertResponsesMessages(
+			{ ...baseModel, compat: { supportsDeveloperRole: false } as any },
+			{ systemPrompt: "SP", messages: [] },
+			new Set(),
+		);
+		expect(input[0]).toMatchObject({ role: "system" });
+	});
+});


### PR DESCRIPTION
for `openai-completions` and `reponses`, the ai package is tying `system` and `developer` to the `reasoning`:

with reasoning on, ai sends the system prompt as developer
with reasoning off, ai send the system prompt as system

ollama supports the openai reasoning feature, but it throws away developer prompts. unsure about other inference engines, but adding the option couldnt hurt though.

if supportsDeveloperRole is not set, it defaults to the existing functionality, linking developer/system to reasoning 