### PR TITLE
fix(ai): remove URL gate on extended prompt cache TTL

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -45,15 +45,15 @@ function resolveCacheRetention(cacheRetention?: CacheRetention): CacheRetention 
 	return "short";
 }
 
-function getCacheControl(
-	baseUrl: string,
-	cacheRetention?: CacheRetention,
-): { retention: CacheRetention; cacheControl?: { type: "ephemeral"; ttl?: "1h" } } {
+function getCacheControl(cacheRetention?: CacheRetention): {
+	retention: CacheRetention;
+	cacheControl?: { type: "ephemeral"; ttl?: "1h" };
+} {
 	const retention = resolveCacheRetention(cacheRetention);
 	if (retention === "none") {
 		return { retention };
 	}
-	const ttl = retention === "long" && baseUrl.includes("api.anthropic.com") ? "1h" : undefined;
+	const ttl = retention === "long" ? "1h" : undefined;
 	return {
 		retention,
 		cacheControl: { type: "ephemeral", ...(ttl && { ttl }) },
@@ -534,7 +534,7 @@ function buildParams(
 	isOAuthToken: boolean,
 	options?: AnthropicOptions,
 ): MessageCreateParamsStreaming {
-	const { cacheControl } = getCacheControl(model.baseUrl, options?.cacheRetention);
+	const { cacheControl } = getCacheControl(options?.cacheRetention);
 	const params: MessageCreateParamsStreaming = {
 		model: model.id,
 		messages: convertMessages(context.messages, model, isOAuthToken, cacheControl),

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -34,17 +34,13 @@ function resolveCacheRetention(cacheRetention?: CacheRetention): CacheRetention 
 }
 
 /**
- * Get prompt cache retention based on cacheRetention and base URL.
- * Only applies to direct OpenAI API calls (api.openai.com).
+ * Get prompt cache retention based on cacheRetention.
  */
-function getPromptCacheRetention(baseUrl: string, cacheRetention: CacheRetention): "24h" | undefined {
+function getPromptCacheRetention(cacheRetention: CacheRetention): "24h" | undefined {
 	if (cacheRetention !== "long") {
 		return undefined;
 	}
-	if (baseUrl.includes("api.openai.com")) {
-		return "24h";
-	}
-	return undefined;
+	return "24h";
 }
 
 // OpenAI Responses-specific options
@@ -205,7 +201,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		input: messages,
 		stream: true,
 		prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
-		prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
+		prompt_cache_retention: getPromptCacheRetention(cacheRetention),
 		store: false,
 	};
 

--- a/packages/ai/test/cache-retention.test.ts
+++ b/packages/ai/test/cache-retention.test.ts
@@ -70,7 +70,7 @@ describe("Cache Retention (PI_CACHE_RETENTION)", () => {
 			expect(capturedPayload.system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 		});
 
-		it("should not add ttl when baseUrl is not api.anthropic.com", async () => {
+		it("should add 1h ttl for proxy baseUrl when cacheRetention is long", async () => {
 			process.env.PI_CACHE_RETENTION = "long";
 
 			// Create a model with a different baseUrl (simulating a proxy)
@@ -82,12 +82,6 @@ describe("Cache Retention (PI_CACHE_RETENTION)", () => {
 
 			let capturedPayload: any = null;
 
-			// We can't actually make the request (no proxy), but we can verify the payload
-			// by using a mock or checking the logic directly
-			// For this test, we'll import the helper directly
-
-			// Since we can't easily test this without mocking, we'll skip the actual API call
-			// and just verify the helper logic works correctly
 			const { streamAnthropic } = await import("../src/providers/anthropic.js");
 
 			try {
@@ -106,11 +100,9 @@ describe("Cache Retention (PI_CACHE_RETENTION)", () => {
 				// Expected to fail
 			}
 
-			// The payload should have been captured before the error
-			if (capturedPayload) {
-				// System prompt should have cache_control WITHOUT ttl (proxy URL)
-				expect(capturedPayload.system[0].cache_control).toEqual({ type: "ephemeral" });
-			}
+			expect(capturedPayload).not.toBeNull();
+			expect(capturedPayload.system).toBeDefined();
+			expect(capturedPayload.system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 		});
 
 		it("should omit cache_control when cacheRetention is none", async () => {
@@ -240,7 +232,7 @@ describe("Cache Retention (PI_CACHE_RETENTION)", () => {
 			},
 		);
 
-		it("should not set prompt_cache_retention when baseUrl is not api.openai.com", async () => {
+		it("should set prompt_cache_retention for proxy baseUrl when cacheRetention is long", async () => {
 			process.env.PI_CACHE_RETENTION = "long";
 
 			// Create a model with a different baseUrl (simulating a proxy)
@@ -270,10 +262,8 @@ describe("Cache Retention (PI_CACHE_RETENTION)", () => {
 				// Expected to fail
 			}
 
-			// The payload should have been captured before the error
-			if (capturedPayload) {
-				expect(capturedPayload.prompt_cache_retention).toBeUndefined();
-			}
+			expect(capturedPayload).not.toBeNull();
+			expect(capturedPayload.prompt_cache_retention).toBe("24h");
 		});
 
 		it("should omit prompt_cache_key when cacheRetention is none", async () => {


### PR DESCRIPTION
Fixes #1377.

Going with the yolo approach per [the comment](https://github.com/badlogic/pi-mono/issues/1377#issuecomment-3865187723).

Removes the `baseUrl.includes("api.anthropic.com")` / `baseUrl.includes("api.openai.com")` checks from `getCacheControl()` and `getPromptCacheRetention()`. Gateway/proxy users who set `PI_CACHE_RETENTION=long` were getting silently downgraded to the default short TTL because their base URL didn't match.

Now if `cacheRetention` resolves to `"long"`, we just send the extended TTL. The `ttl` and `prompt_cache_retention` fields are optional in both APIs, so servers that don't support it will ignore it or fall back to shorter TTL. And the user is already explicitly opting in via the env var.

Same fix applied to both the anthropic and openai-responses providers. Tests updated accordingly.

Tested manually against a corporate gateway with `PI_CACHE_RETENTION=long`.