### PR TITLE
fix(ai): use parametersJsonSchema for google tools

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -235,14 +235,14 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
  */
 export function convertTools(
 	tools: Tool[],
-): { functionDeclarations: { name: string; description?: string; parameters: Schema }[] }[] | undefined {
+): { functionDeclarations: { name: string; description?: string; parametersJsonSchema: Schema }[] }[] | undefined {
 	if (tools.length === 0) return undefined;
 	return [
 		{
 			functionDeclarations: tools.map((tool) => ({
 				name: tool.name,
 				description: tool.description,
-				parameters: tool.parameters as Schema,
+				parametersJsonSchema: tool.parameters as Schema,
 			})),
 		},
 	];


### PR DESCRIPTION
Google’s functionDeclarations requires JSON Schema in the parametersJsonSchema field, but we were
sending it in parameters, which lacks support for full JSON schemas.

This commit updates convertTools to use parametersJsonSchema instead of parameters for Google providers.

https://ai.google.dev/api/caching#FunctionDeclaration