### PR TITLE
feat(tui, coding-agent): clickable file links in markdown and tool output

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -132,6 +132,30 @@ When a provider requests a retry delay longer than `maxDelayMs` (e.g., Google's 
 |---------|------|---------|-------------|
 | `markdown.codeBlockIndent` | string | `"  "` | Indentation for code blocks |
 
+### Editor Links
+
+Controls how file references in tool output and markdown are turned into clickable hyperlinks.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `editorLink.scheme` | string | `"file"` | URL scheme for file hyperlinks |
+
+Supported values for `editorLink.scheme`:
+
+- `"file"` — plain `file://` URL (default, opens in OS default app)
+- `"vscode"` — `vscode://file/<path>:<line>:<col>` (opens in VS Code at line/column)
+- `"cursor"` — same format for Cursor editor
+- `"windsurf"` — same format for Windsurf editor
+Example:
+
+```json
+{
+  "editorLink": {
+    "scheme": "vscode"
+  }
+}
+```
+
 ### Resources
 
 These settings define where to load extensions, skills, prompts, and themes from.

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -36,6 +36,10 @@ export interface ThinkingBudgetsSettings {
 	high?: number;
 }
 
+export interface EditorLinkSettings {
+	scheme?: "file" | "vscode" | "cursor" | "windsurf"; // default: "file"
+}
+
 export interface MarkdownSettings {
 	codeBlockIndent?: string; // default: "  "
 }
@@ -86,6 +90,7 @@ export interface Settings {
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
+	editorLink?: EditorLinkSettings;
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -747,5 +752,9 @@ export class SettingsManager {
 
 	getCodeBlockIndent(): string {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
+	}
+
+	getEditorLinkScheme(): "file" | "vscode" | "cursor" | "windsurf" {
+		return this.settings.editorLink?.scheme ?? "file";
 	}
 }

--- a/packages/tui/src/file-links.ts
+++ b/packages/tui/src/file-links.ts
@@ -1,0 +1,127 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export interface FileReference {
+	path: string;
+	line?: number;
+	column?: number;
+}
+
+export type EditorLinkScheme = "file" | "vscode" | "cursor" | "windsurf";
+
+export interface EditorFileUrlOptions {
+	cwd?: string;
+	scheme?: EditorLinkScheme;
+}
+
+const KNOWN_EXTENSIONLESS_FILE_NAMES = new Set(["Dockerfile", "Makefile", "LICENSE"]);
+
+export function lineMayContainFileReference(line: string): boolean {
+	return line.length > 0 && (line.includes("/") || line.includes("\\"));
+}
+
+export function parseFileReference(candidate: string): FileReference | undefined {
+	if (candidate.includes("://")) {
+		return undefined;
+	}
+
+	if (/\s/.test(candidate)) {
+		return undefined;
+	}
+
+	if (candidate.endsWith("/*")) {
+		return undefined;
+	}
+
+	let filePath = candidate;
+	let line: number | undefined;
+	let column: number | undefined;
+
+	const lineMatch = candidate.match(/:(\d+)(?:(?::(\d+))|(?:-\d+))?$/);
+	if (lineMatch) {
+		const parsedLine = Number.parseInt(lineMatch[1], 10);
+		const parsedColumn = lineMatch[2] ? Number.parseInt(lineMatch[2], 10) : undefined;
+		if (!Number.isNaN(parsedLine) && parsedLine > 0) {
+			line = parsedLine;
+			column =
+				parsedColumn !== undefined && !Number.isNaN(parsedColumn) && parsedColumn > 0 ? parsedColumn : undefined;
+			filePath = candidate.slice(0, -lineMatch[0].length);
+		}
+	}
+
+	if (!hasExplicitPath(filePath)) {
+		return undefined;
+	}
+
+	if (!isValidFileReferencePath(filePath)) {
+		return undefined;
+	}
+
+	return {
+		path: filePath,
+		line,
+		column,
+	};
+}
+
+export function buildEditorFileUrl(file: string | FileReference, options: EditorFileUrlOptions = {}): string {
+	const fileReference: FileReference = typeof file === "string" ? { path: file } : file;
+	const scheme = options.scheme ?? "file";
+
+	const cwd = options.cwd ?? process.cwd();
+	const expandedPath = fileReference.path.startsWith("~/")
+		? path.join(os.homedir(), fileReference.path.slice(2))
+		: fileReference.path;
+	const absolutePath = path.isAbsolute(expandedPath) ? expandedPath : path.resolve(cwd, expandedPath);
+
+	if (scheme === "vscode" || scheme === "cursor" || scheme === "windsurf") {
+		const line = fileReference.line ?? 1;
+		const column = fileReference.column ?? 1;
+		return `${scheme}://file${absolutePath}:${line}:${column}`;
+	}
+
+	return pathToFileURL(absolutePath).toString();
+}
+
+export function linkFileDisplayText(
+	displayText: string,
+	file: string | FileReference,
+	options: EditorFileUrlOptions = {},
+): string {
+	const href = buildEditorFileUrl(file, options);
+	return createTerminalHyperlink(displayText, href);
+}
+
+export function createTerminalHyperlink(text: string, href: string): string {
+	return `\x1b]8;;${href}\x07${text}\x1b]8;;\x07`;
+}
+
+function isValidFileReferencePath(filePath: string): boolean {
+	if (filePath.length === 0 || /\s/.test(filePath)) {
+		return false;
+	}
+
+	if (filePath.endsWith("/") || filePath.endsWith("\\")) {
+		return false;
+	}
+
+	const lastSegment = filePath.split(/[\\/]/).pop();
+	if (!lastSegment) {
+		return false;
+	}
+
+	return looksLikeFilePath(lastSegment);
+}
+
+function hasExplicitPath(filePath: string): boolean {
+	return filePath.includes("/") || filePath.includes("\\") || filePath.startsWith("~/");
+}
+
+function looksLikeFilePath(fileName: string): boolean {
+	if (/\.[A-Za-z0-9][A-Za-z0-9._-]*$/.test(fileName)) {
+		return true;
+	}
+
+	return KNOWN_EXTENSIONLESS_FILE_NAMES.has(fileName);
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -22,6 +22,15 @@ export { Text } from "./components/text.js";
 export { TruncatedText } from "./components/truncated-text.js";
 // Editor component interface (for custom editors)
 export type { EditorComponent } from "./editor-component.js";
+// File link detection/resolution utilities
+export {
+	buildEditorFileUrl,
+	createTerminalHyperlink,
+	type EditorFileUrlOptions,
+	type EditorLinkScheme,
+	type FileReference,
+	linkFileDisplayText,
+} from "./file-links.js";
 // Fuzzy matching
 export { type FuzzyMatch, fuzzyFilter, fuzzyMatch } from "./fuzzy.js";
 // Keybindings

--- a/packages/tui/test/file-links.test.ts
+++ b/packages/tui/test/file-links.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert";
+import * as os from "node:os";
+import { describe, it } from "node:test";
+import {
+	buildEditorFileUrl,
+	createTerminalHyperlink,
+	lineMayContainFileReference,
+	linkFileDisplayText,
+	parseFileReference,
+} from "../src/file-links.js";
+
+describe("file-links", () => {
+	describe("lineMayContainFileReference", () => {
+		it("should return true for lines with path separators", () => {
+			assert.ok(lineMayContainFileReference("src/main.ts"));
+			assert.ok(lineMayContainFileReference("src\\main.ts"));
+		});
+
+		it("should return false for plain text with only a dot", () => {
+			assert.ok(!lineMayContainFileReference("This is a sentence."));
+			assert.ok(!lineMayContainFileReference("Hello world."));
+		});
+
+		it("should return false for empty lines", () => {
+			assert.ok(!lineMayContainFileReference(""));
+		});
+	});
+
+	describe("parseFileReference", () => {
+		it("should parse path with line number", () => {
+			const ref = parseFileReference("src/main.ts:42");
+			assert.deepStrictEqual(ref, { path: "src/main.ts", line: 42, column: undefined });
+		});
+
+		it("should parse path with line and column", () => {
+			const ref = parseFileReference("src/main.ts:42:10");
+			assert.deepStrictEqual(ref, { path: "src/main.ts", line: 42, column: 10 });
+		});
+
+		it("should parse path with line range and use start line only", () => {
+			const ref = parseFileReference("src/main.ts:12-40");
+			assert.deepStrictEqual(ref, { path: "src/main.ts", line: 12, column: undefined });
+		});
+
+		it("should reject URLs", () => {
+			assert.strictEqual(parseFileReference("https://example.com"), undefined);
+		});
+
+		it("should reject paths with whitespace", () => {
+			assert.strictEqual(parseFileReference("src/ main.ts"), undefined);
+		});
+
+		it("should reject wildcard paths", () => {
+			assert.strictEqual(parseFileReference("src/*"), undefined);
+		});
+
+		it("should reject bare filenames without explicit path", () => {
+			assert.strictEqual(parseFileReference("main.ts"), undefined);
+		});
+
+		it("should accept home-relative paths", () => {
+			const ref = parseFileReference("~/config/settings.json");
+			assert.deepStrictEqual(ref, { path: "~/config/settings.json", line: undefined, column: undefined });
+		});
+	});
+
+	describe("buildEditorFileUrl", () => {
+		it("should build a file:// URL by default", () => {
+			const url = buildEditorFileUrl({ path: "/Users/test/src/main.ts" });
+			assert.ok(url.startsWith("file:///"));
+			assert.ok(url.includes("main.ts"));
+		});
+
+		it("should resolve relative paths with cwd", () => {
+			const url = buildEditorFileUrl("src/main.ts", { cwd: "/Users/test/project" });
+			assert.strictEqual(url, "file:///Users/test/project/src/main.ts");
+		});
+
+		it("should expand ~ to home directory", () => {
+			const url = buildEditorFileUrl("~/config.json");
+			assert.ok(url.startsWith("file://"));
+			assert.ok(url.includes("config.json"));
+			assert.ok(url.includes(os.homedir().replace(/\\/g, "/")));
+		});
+
+		it("should build a vscode:// URL with line and column", () => {
+			const url = buildEditorFileUrl(
+				{ path: "/Users/test/src/main.ts", line: 42, column: 10 },
+				{ scheme: "vscode" },
+			);
+			assert.strictEqual(url, "vscode://file/Users/test/src/main.ts:42:10");
+		});
+
+		it("should default line and column to 1 for vscode scheme", () => {
+			const url = buildEditorFileUrl({ path: "/Users/test/src/main.ts" }, { scheme: "vscode" });
+			assert.strictEqual(url, "vscode://file/Users/test/src/main.ts:1:1");
+		});
+
+		it("should build a cursor:// URL", () => {
+			const url = buildEditorFileUrl({ path: "/Users/test/src/main.ts", line: 10, column: 3 }, { scheme: "cursor" });
+			assert.strictEqual(url, "cursor://file/Users/test/src/main.ts:10:3");
+		});
+
+		it("should build a windsurf:// URL", () => {
+			const url = buildEditorFileUrl({ path: "/Users/test/src/main.ts", line: 7 }, { scheme: "windsurf" });
+			assert.strictEqual(url, "windsurf://file/Users/test/src/main.ts:7:1");
+		});
+	});
+
+	describe("linkFileDisplayText", () => {
+		it("should create a terminal hyperlink with file:// URL", () => {
+			const result = linkFileDisplayText("main.ts", { path: "/Users/test/main.ts" });
+			assert.ok(result.includes("\x1b]8;;file:///Users/test/main.ts\x07"));
+			assert.ok(result.includes("main.ts"));
+			assert.ok(result.endsWith("\x1b]8;;\x07"));
+		});
+
+		it("should create a terminal hyperlink with vscode scheme", () => {
+			const result = linkFileDisplayText("main.ts", { path: "/Users/test/main.ts", line: 10 }, { scheme: "vscode" });
+			assert.ok(result.includes("\x1b]8;;vscode://file/Users/test/main.ts:10:1\x07"));
+		});
+	});
+
+	describe("createTerminalHyperlink", () => {
+		it("should wrap text in OSC 8 sequences", () => {
+			const result = createTerminalHyperlink("click me", "https://example.com");
+			assert.strictEqual(result, "\x1b]8;;https://example.com\x07click me\x1b]8;;\x07");
+		});
+	});
+});


### PR DESCRIPTION
with this, it’s easy to inspect files by opening them in your editor via ctrl (or cmd) + click (as long as the clanker gives you clear paths, useful when you ask it to explore a specific part of a big codebase) 

for example, you can append to the prompt smth like “and provide the file paths”, then just open them in your favorite editor without having to open it first just to copy-paste paths and go to the file

i know that's a lot of changes, so open to discuss/modify if needed

## clanker description

Add clickable terminal hyperlinks (OSC 8) for file references in markdown content
and tool execution displays (read, write, edit).

- `packages/tui/src/file-links.ts`: new module for parsing file references (e.g. `src/main.ts:42:10`), building editor URLs, and emitting OSC 8 sequences
- Markdown renderer auto-links file paths in prose and codespans via `resolveFileLink` theme hook
- Tool execution component links file paths in read/write/edit tool headers
- Configurable `editorLink.scheme` setting: supports `file`, `vscode`, `cursor`, `windsurf`
- Tests for file reference parsing, URL building, and markdown integration