### PR TITLE
fix(ai): send context-1m beta header when contextWindow > 200k

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -481,6 +481,9 @@ function createClient(
 	if (interleavedThinking) {
 		betaFeatures.push("interleaved-thinking-2025-05-14");
 	}
+	if (model.contextWindow > 200000) {
+		betaFeatures.push("context-1m-2025-08-07");
+	}
 
 	const oauthToken = isOAuthToken(apiKey);
 	if (oauthToken) {


### PR DESCRIPTION
## Problem

When users override `contextWindow` to `1000000` via `models.json` (as suggested in #1329), the Anthropic API still enforces the default 200k limit because the required `context-1m-2025-08-07` beta header is never sent.

This creates a dangerous mismatch: the system internally uses the configured 1M context window for compaction/pruning thresholds, but the API silently truncates at 200k. Sessions eventually hit context overflow errors that are difficult to diagnose.

## Fix

Add 3 lines to `createClient()` in `anthropic.ts`:

```typescript
if (model.contextWindow > 200000) {
    betaFeatures.push("context-1m-2025-08-07");
}
```

When the model's `contextWindow` exceeds 200k (i.e., the user has explicitly opted in via models.json), include the `context-1m-2025-08-07` beta header in API requests.

## What this does NOT do

- Does **not** change the default 200k `contextWindow` — respects the decision in #1329
- Does **not** affect users who haven't overridden `contextWindow`
- The header is harmless when included but actual context stays under 200k

## What this fixes

- Makes the `models.json` contextWindow override actually functional (as documented in #1329)
- Prevents the silent mismatch between internal context tracking and API enforcement

Refs: #1329