### PR TITLE
feat: add git branch-based session directories

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -40,6 +40,11 @@ export interface MarkdownSettings {
 	codeBlockIndent?: string; // default: "  "
 }
 
+export interface BranchSessionsSettings {
+	enabled?: boolean; // default: false - when true, uses git branch for session directory
+	basePath?: string; // default: ~/.pi/agent/branch-sessions - base path for branch sessions
+}
+
 /**
  * Package source for npm/git packages.
  * - String form: load all resources from the package
@@ -86,6 +91,7 @@ export interface Settings {
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
+	branchSessions?: BranchSessionsSettings; // Git branch-based session directories
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -747,5 +753,31 @@ export class SettingsManager {
 
 	getCodeBlockIndent(): string {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
+	}
+
+	getBranchSessionsEnabled(): boolean {
+		return this.settings.branchSessions?.enabled ?? false;
+	}
+
+	setBranchSessionsEnabled(enabled: boolean): void {
+		if (!this.globalSettings.branchSessions) {
+			this.globalSettings.branchSessions = {};
+		}
+		this.globalSettings.branchSessions.enabled = enabled;
+		this.markModified("branchSessions", "enabled");
+		this.save();
+	}
+
+	getBranchSessionsBasePath(): string | undefined {
+		return this.settings.branchSessions?.basePath;
+	}
+
+	setBranchSessionsBasePath(basePath: string | undefined): void {
+		if (!this.globalSettings.branchSessions) {
+			this.globalSettings.branchSessions = {};
+		}
+		this.globalSettings.branchSessions.basePath = basePath;
+		this.markModified("branchSessions", "basePath");
+		this.save();
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -993,6 +993,16 @@ export class InteractiveMode {
 				this.chatContainer.addChild(new Spacer(1));
 			}
 		}
+
+		// Show branch session info if enabled (path only, branch mismatch shown in footer)
+		if (showListing && this.settingsManager.getBranchSessionsEnabled()) {
+			const sessionDir = this.session.sessionManager?.getSessionDir();
+			if (sessionDir) {
+				const branchInfo = `${theme.fg("dim", "[Branch sessions]")} ${theme.fg("dim", sessionDir)}`;
+				this.chatContainer.addChild(new Text(branchInfo, 0, 0));
+				this.chatContainer.addChild(new Spacer(1));
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Organizes pi sessions by git branch for seamless context switching between branches.

## New Settings

```json
{
  "branchSessions": {
    "enabled": true,
    "basePath": "~/.pi/agent"  // optional, this is the default
  }
}
```

## Behavior

When enabled:
- Sessions are stored in `<basePath>/sessions/--<encoded-cwd>--/--<branch>--/`
- `--continue` resumes the most recent session for the current branch
- `--resume` shows sessions only for the current branch
- `[Branch sessions]` info shown at startup (unless `quietStartup` is set)

## Example

Session structure with branch sessions enabled:
```
~/.pi/agent/sessions/
├── --Users-hjanuschka-pi-mono--/           # without branch sessions (default)
│   └── 2026-02-08T...jsonl
└── --Users-hjanuschka-pi-mono--/           # with branch sessions
    ├── --main--/
    │   └── 2026-02-08T...jsonl
    ├── --feature-auth--/
    │   └── 2026-02-08T...jsonl
    └── --bugfix-login--/
        └── 2026-02-08T...jsonl
```

## Notes

- CLI `--session-dir` flag takes precedence over branch sessions when both are specified
- Uses same path encoding pattern (`--name--`) as default session directories for consistency
- When switching git branches, start a new pi session to get the branch-specific context