### PR TITLE
docs: add auth.json keys to table and reference to envMap

### DIFF
--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -70,7 +70,7 @@ pi
 | MiniMax | `MINIMAX_API_KEY` | `minimax` |
 | MiniMax (China) | `MINIMAX_CN_API_KEY` | `minimax-cn` |
 
-Reference for environment variables and `auth.json` keys: [`const envMap` in `packages/ai/src/env-api-keys.ts`](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/env-api-keys.ts).
+Reference for environment variables and `auth.json` keys: [`const envMap`](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/env-api-keys.ts) in [`packages/ai/src/env-api-keys.ts`](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/env-api-keys.ts).
 
 #### Auth File
 


### PR DESCRIPTION
As discussed in https://github.com/badlogic/pi-mono/issues/1093#issuecomment-3824388094

## Summary
- document environment variables and `auth.json` keys in one table
- add `Azure OpenAI Responses` to match current provider env mapping
- reference `const envMap` implementation in `packages/ai/src/env-api-keys.ts`

## Why
- better discovery of `auth.json` provider keys
- keep docs aligned with implementation