### PR TITLE
fix(subagent): list available agents in unknown-agent error

### DIFF
--- a/packages/coding-agent/examples/extensions/subagent/index.ts
+++ b/packages/coding-agent/examples/extensions/subagent/index.ts
@@ -231,13 +231,14 @@ async function runSingleAgent(
 	const agent = agents.find((a) => a.name === agentName);
 
 	if (!agent) {
+		const available = agents.map((a) => `"${a.name}"`).join(", ") || "none";
 		return {
 			agent: agentName,
 			agentSource: "unknown",
 			task,
 			exitCode: 1,
 			messages: [],
-			stderr: `Unknown agent: ${agentName}`,
+			stderr: `Unknown agent: "${agentName}". Available agents: ${available}.`,
 			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
 			step,
 		};


### PR DESCRIPTION
The invalid-params error paths already listed available agents, but the unknown-agent path in `runSingleAgent` just returned `Unknown agent: claude` with no hint what exists.

Now: `Unknown agent: "claude". Available agents: "worker".`

Model would guess names like `claude`, `default`, or skill names like `brave-search`. Now it self-corrects on the next call.

Tested with Opus 4.6: without fix, model gave up on subagent and ran the tool calls itself instead. With fix, 1 wasted call.

---

2-line change in `packages/coding-agent/examples/extensions/subagent/index.ts`.