### PR TITLE
Prefer default provider for ambiguous exact model IDs

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -627,7 +627,9 @@ export async function main(args: string[]) {
 	let scopedModels: ScopedModel[] = [];
 	const modelPatterns = parsed.models ?? settingsManager.getEnabledModels();
 	if (modelPatterns && modelPatterns.length > 0) {
-		scopedModels = await resolveModelScope(modelPatterns, modelRegistry);
+		scopedModels = await resolveModelScope(modelPatterns, modelRegistry, {
+			preferredProvider: settingsManager.getDefaultProvider(),
+		});
 	}
 
 	// Create session manager based on CLI flags

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3255,7 +3255,9 @@ export class InteractiveMode {
 			const patterns = this.settingsManager.getEnabledModels();
 			if (patterns !== undefined && patterns.length > 0) {
 				hasFilter = true;
-				const scopedModels = await resolveModelScope(patterns, this.session.modelRegistry);
+				const scopedModels = await resolveModelScope(patterns, this.session.modelRegistry, {
+					preferredProvider: this.settingsManager.getDefaultProvider(),
+				});
 				for (const sm of scopedModels) {
 					enabledModelIds.add(`${sm.model.provider}/${sm.model.id}`);
 				}


### PR DESCRIPTION
## Summary
- prefer the configured default provider when resolving ambiguous unqualified exact model IDs (for example `gpt-5.3-codex` present under multiple providers)
- thread that provider preference through `resolveModelScope` and startup/settings-based scope resolution
- keep explicit `provider/model` patterns unchanged

## Why
When `enabledModels` contains an unqualified ID that exists under multiple providers, Pi currently takes the first provider match. This can select an unintended provider at startup.

## Testing
- `cd packages/coding-agent && npm test -- model-resolver.test.ts`
- added unit tests for ambiguous exact-ID tie-breaking in `parseModelPattern` and `resolveModelScope`
