### PR TITLE
refactor(agent): use Array.some() for tool call detection

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -149,8 +149,7 @@ async function runLoop(
 			}
 
 			// Check for tool calls
-			const toolCalls = message.content.filter((c) => c.type === "toolCall");
-			hasMoreToolCalls = toolCalls.length > 0;
+			hasMoreToolCalls = message.content.some(c => c.type === "toolCall");
 
 			const toolResults: ToolResultMessage[] = [];
 			if (hasMoreToolCalls) {


### PR DESCRIPTION
Replace filter().length check with .some() to short-circuit on first tool call match instead of iterating all content items.