### PR TITLE
feat(openai-completions): configurable strict mode for xAI/Grok tool schemas

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -237,6 +237,9 @@ export interface OpenAICompletionsCompat {
 	vercelGatewayRouting?: VercelGatewayRouting;
 	/** Whether the provider supports the `strict` field in tool definitions. Default: true. */
 	supportsStrictMode?: boolean;
+	/** Whether to default tool schemas to strict mode. When true, schemas are normalized
+	 *  (additionalProperties: false added, all properties required). Default: false. */
+	defaultStrict?: boolean;
 }
 
 /** Compatibility settings for OpenAI Responses APIs. */

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -33,6 +33,7 @@ const compat: Required<OpenAICompletionsCompat> = {
 	openRouterRouting: {},
 	vercelGatewayRouting: {},
 	supportsStrictMode: true,
+	defaultStrict: false,
 };
 
 function buildToolResult(toolCallId: string, timestamp: number): ToolResultMessage {


### PR DESCRIPTION
## Problem

xAI Grok models support [structured outputs with tools](https://docs.x.ai/docs/guides/structured-outputs#structured-outputs-with-tools), but require `strict: true` and `additionalProperties: false` at every object level in tool schemas. Without this, Grok often returns malformed or incomplete tool call arguments.

## Solution

Add a `defaultStrict` compat flag to the OpenAI completions provider that, when enabled, automatically normalizes tool schemas for strict mode:

### Changes

- **`types.ts`**: Added `defaultStrict?: boolean` to `OpenAICompletionsCompat` interface.
- **`openai-completions.ts`**:
  - Added `normalizeSchemaForStrict()` — deep-walks JSON Schema objects and adds `additionalProperties: false` at every object level. Preserves existing `required` arrays (does not force all properties to be required, which differs from OpenAI's strict mode — xAI does not require this).
  - Updated `convertTools()` to apply normalization and set `strict: true` when `defaultStrict` is enabled.
  - Updated `detectCompat()` to set `defaultStrict: true` when `isGrok` is detected.
  - Updated `getCompat()` to merge the new field from model overrides.
- **Test file**: Added `defaultStrict: false` to existing test compat object to match the updated interface.

### Key design decisions

- **Only `additionalProperties: false` is added** — unlike OpenAI's strict mode, xAI's strict mode does not require all properties in the `required` array. Making all fields required caused Grok to fill every optional field with `null`, which broke validation.
- **Opt-in via compat detection** — only activates for xAI (provider `"xai"` or baseUrl containing `api.x.ai`). All other providers are unaffected (`defaultStrict: false` by default).
- **Overridable** — users can set `defaultStrict` in their model compat config to override the auto-detected value.

## Testing

- All existing tests pass
- Manually tested with xAI Grok 4 — tool calls return correctly structured arguments with all required fields populated

## Related

Companion PR in [openclaw/openclaw](https://github.com/openclaw/openclaw/pull/12642) adds fully typed tool schemas, which this strict mode feature normalizes.