### PR TITLE
fix(coding-agent): correct Termux package name for fd

### DIFF
--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -192,7 +192,7 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
 
 // Termux package names for tools
 const TERMUX_PACKAGES: Record<string, string> = {
-	fd: "fd-find",
+	fd: "fd",
 	rg: "ripgrep",
 };
 


### PR DESCRIPTION
The fd package is named 'fd' in Termux, not 'fd-find'.

fixes termux package name 

Fix and PR done with 'pi' inside Termux.