### PR TITLE
fix: guard content.filter() with Array.isArray in agent-loop

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -149,7 +149,8 @@ async function runLoop(
 			}
 
 			// Check for tool calls
-			const toolCalls = message.content.filter((c) => c.type === "toolCall");
+			const contentArr = Array.isArray(message.content) ? message.content : [];
+			const toolCalls = contentArr.filter((c) => c.type === "toolCall");
 			hasMoreToolCalls = toolCalls.length > 0;
 
 			const toolResults: ToolResultMessage[] = [];
@@ -298,7 +299,8 @@ async function executeToolCalls(
 	stream: EventStream<AgentEvent, AgentMessage[]>,
 	getSteeringMessages?: AgentLoopConfig["getSteeringMessages"],
 ): Promise<{ toolResults: ToolResultMessage[]; steeringMessages?: AgentMessage[] }> {
-	const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
+	const contentArr = Array.isArray(assistantMessage.content) ? assistantMessage.content : [];
+	const toolCalls = contentArr.filter((c) => c.type === "toolCall");
 	const results: ToolResultMessage[] = [];
 	let steeringMessages: AgentMessage[] | undefined;
 


### PR DESCRIPTION
## Problem
`message.content.filter is not a function` crash in agent-loop when content is string/null/undefined.

## Root Cause
Lines 95 and 208 in agent-loop call `.content.filter()` assuming content is always an array. But runtime scenarios (session deserialization, provider errors, partial streaming) can produce non-array content.

## Fix
Add `Array.isArray` guard before both `.filter()` calls. Non-array content falls back to empty array.

## Testing
- Unable to run package tests locally in this environment because dependencies are not installed (`vitest: command not found`).
- Change is a minimal defensive guard and does not alter behavior for array content.