### PR TITLE
fix(mom): add missing getImageAutoResize and getBlockImages to MomSettingsManager

### DIFF
--- a/packages/mom/src/context.ts
+++ b/packages/mom/src/context.ts
@@ -157,12 +157,18 @@ export interface MomRetrySettings {
 	baseDelayMs: number;
 }
 
+export interface MomImageSettings {
+	autoResize?: boolean;
+	blockImages?: boolean;
+}
+
 export interface MomSettings {
 	defaultProvider?: string;
 	defaultModel?: string;
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high";
 	compaction?: Partial<MomCompactionSettings>;
 	retry?: Partial<MomRetrySettings>;
+	images?: MomImageSettings;
 }
 
 const DEFAULT_COMPACTION: MomCompactionSettings = {
@@ -293,5 +299,13 @@ export class MomSettingsManager {
 
 	getHookTimeout(): number {
 		return 30000;
+	}
+
+	getImageAutoResize(): boolean {
+		return this.settings.images?.autoResize ?? true;
+	}
+
+	getBlockImages(): boolean {
+		return this.settings.images?.blockImages ?? false;
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1444

`AgentSession` calls `settingsManager.getImageAutoResize()` but `MomSettingsManager` was missing this method, causing:

```
TypeError: this.settingsManager.getImageAutoResize is not a function
```

## Changes

- Added `MomImageSettings` interface
- Added `images` field to `MomSettings` interface  
- Added `getImageAutoResize()` method (defaults to `true`)
- Added `getBlockImages()` method (defaults to `false`)

## Testing

Tested locally with pi-mom 0.52.9 — patching context.js with these methods resolves the error and allows message processing to complete successfully.