### PR TITLE
feat: add claude-opus-4-6-thinking model for google-antigravity provider

### DIFF
--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -2988,6 +2988,23 @@ export const MODELS = {
 			contextWindow: 200000,
 			maxTokens: 64000,
 		} satisfies Model<"google-gemini-cli">,
+		"claude-opus-4-6-thinking": {
+			id: "claude-opus-4-6-thinking",
+			name: "Claude Opus 4.6 Thinking (Antigravity)",
+			api: "google-gemini-cli",
+			provider: "google-antigravity",
+			baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 5,
+				output: 25,
+				cacheRead: 0.5,
+				cacheWrite: 6.25,
+			},
+			contextWindow: 200000,
+			maxTokens: 64000,
+		} satisfies Model<"google-gemini-cli">,
 		"claude-sonnet-4-5": {
 			id: "claude-sonnet-4-5",
 			name: "Claude Sonnet 4.5 (Antigravity)",


### PR DESCRIPTION
Adds the Claude Opus 4.6 Thinking model definition to the `google-antigravity` provider in `models.generated.ts`.

## What

Adds `claude-opus-4-6-thinking` entry matching the existing `claude-opus-4-5-thinking` structure — same API, base URL, costs, context window, and max tokens.

## Why

The OpenClaw `google-antigravity-auth` extension already references `claude-opus-4-6-thinking` as its `DEFAULT_MODEL`, but the model definition is missing from the registry. This causes "Unknown model" errors at runtime.

This is the only change needed — the OpenClaw side already has the correct default set.