### PR TITLE
Add /exit alias for /quit

### DIFF
--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -35,4 +35,5 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload extensions, skills, prompts, and themes" },
 	{ name: "quit", description: "Quit pi" },
+	{ name: "exit", description: "Quit pi (alias for /quit)" },
 ];

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1950,7 +1950,7 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/quit") {
+			if (text === "/quit" || text === "/exit") {
 				this.editor.setText("");
 				await this.shutdown();
 				return;


### PR DESCRIPTION
### Summary
Claude Code (and similar CLIs like Codex) accept both `exit` and `quit` as ways to leave the app. In pi-mono interactive mode it only supports `/quit`, and `/exit` is neither suggested nor handled.

This PR adds `/exit` as a first-class alias of `/quit` so users coming from Claude Code/Codex have consistent muscle memory.

### Changes
- Add `exit` to the built-in slash command list so it appears in `/` autocomplete.
- Handle `/exit` the same as `/quit` (graceful shutdown path).

### Notes
- No behavior changes beyond adding the alias; autocomplete ordering and matching behavior remains unchanged.
- `/exit` triggers the same graceful cleanup as `/quit` (extension shutdown hooks, terminal cleanup, etc.).