### PR TITLE
fix: extract error details from response.failed streaming events

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -453,7 +453,9 @@ export async function processResponsesStream<TApi extends Api>(
 		} else if (event.type === "error") {
 			throw new Error(`Error Code ${event.code}: ${event.message}` || "Unknown error");
 		} else if (event.type === "response.failed") {
-			throw new Error("Unknown error");
+			const error = event.response?.error;
+			const message = error ? `${error.code}: ${error.message}` : "Unknown error";
+			throw new Error(message);
 		}
 	}
 }


### PR DESCRIPTION
## Problem

The `response.failed` handler in `processResponsesStream` throws a bare `"Unknown error"` without extracting any details from the event:

```typescript
} else if (event.type === "response.failed") {
    throw new Error("Unknown error");
}
```

The `ResponseFailedEvent` carries a `response` object with an `error` field (`ResponseError`) that contains `code` and `message` — for example `rate_limit_exceeded`, `server_error`, `invalid_prompt`, etc. This information is discarded.

Consumers (like OpenClaw) that match error messages to classify failures (rate limit → retry, auth → fail, etc.) can never trigger their retry logic because all they see is `"Unknown error"`.

## Reproduction

Use Azure OpenAI with a low TPM (tokens-per-minute) deployment limit (e.g. 50K). Send several rapid streaming requests via the Responses API. When the rate limit is hit, Azure returns a `response.failed` SSE event with:

```json
{
  "type": "response.failed",
  "response": {
    "status": "failed",
    "error": {
      "code": "rate_limit_exceeded",
      "message": "Requests to the ... Operation have exceeded token rate limit ..."
    }
  }
}
```

The current code discards this and throws `"Unknown error"`.

## Fix

Extract `error.code` and `error.message` from the failed response, matching the pattern already used by the `error` event handler on the line above:

```typescript
} else if (event.type === "response.failed") {
    const error = event.response?.error;
    const message = error ? `${error.code}: ${error.message}` : "Unknown error";
    throw new Error(message);
}
```

Falls back to `"Unknown error"` only if the error object is missing.