### PR TITLE
fix: filter Bedrock reasoningContent when model.reasoning is disabled

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -159,7 +159,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				} else if (item.contentBlockStart) {
 					handleContentBlockStart(item.contentBlockStart, blocks, output, stream);
 				} else if (item.contentBlockDelta) {
-					handleContentBlockDelta(item.contentBlockDelta, blocks, output, stream);
+					handleContentBlockDelta(item.contentBlockDelta, blocks, output, stream, model);
 				} else if (item.contentBlockStop) {
 					handleContentBlockStop(item.contentBlockStop, blocks, output, stream);
 				} else if (item.messageStop) {
@@ -276,6 +276,7 @@ function handleContentBlockDelta(
 	blocks: Block[],
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
+	model: Model,
 ): void {
 	const contentBlockIndex = event.contentBlockIndex!;
 	const delta = event.delta;
@@ -300,6 +301,7 @@ function handleContentBlockDelta(
 		block.arguments = parseStreamingJson(block.partialJson);
 		stream.push({ type: "toolcall_delta", contentIndex: index, delta: delta.toolUse.input || "", partial: output });
 	} else if (delta?.reasoningContent) {
+		if (!model.reasoning) return;
 		let thinkingBlock = block;
 		let thinkingIndex = index;
 


### PR DESCRIPTION
## Summary

When using non-Anthropic reasoning models on Bedrock (e.g. MoonshotAI Kimi K2.5) with `reasoning: false` in the model config, the model may still return `reasoningContent` deltas in the ConverseStream response. These are currently emitted as `thinking_start`/`thinking_delta`/`thinking_end` events, causing reasoning output to be displayed to the user even though reasoning is disabled.

This PR filters out `reasoningContent` blocks when `model.reasoning` is falsy by:

1. Passing the `model` object to `handleContentBlockDelta`
2. Returning early from the `reasoningContent` handler when `model.reasoning` is disabled

## Changes

- `packages/ai/src/providers/amazon-bedrock.ts`: 3-line change
  - Added `model` parameter to `handleContentBlockDelta` call site and function signature
  - Added early return guard `if (!model.reasoning) return;` before processing `reasoningContent` deltas

## Reproduction

1. Configure a Bedrock provider with Kimi K2.5 (`moonshotai.kimi-k2.5`) and `reasoning: false`
2. Send a message via the model
3. **Before fix:** Reasoning/thinking blocks are displayed to the user
4. **After fix:** Reasoning blocks are silently filtered; only the actual response content is shown

## Testing

Tested with Kimi K2.5 on Amazon Bedrock (eu-north-1) via OpenClaw Telegram integration. With the fix applied, reasoning output is no longer shown when `reasoning: false`.