### PR TITLE
fix: correct openai-codex contextWindow from 272K to 400K

### DIFF
--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -5025,7 +5025,7 @@ export const MODELS = {
 				cacheRead: 0.125,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
 		"gpt-5.1-codex-max": {
@@ -5042,7 +5042,7 @@ export const MODELS = {
 				cacheRead: 0.125,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
 		"gpt-5.1-codex-mini": {
@@ -5059,7 +5059,7 @@ export const MODELS = {
 				cacheRead: 0.025,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
 		"gpt-5.2": {
@@ -5076,7 +5076,7 @@ export const MODELS = {
 				cacheRead: 0.175,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
 		"gpt-5.2-codex": {
@@ -5093,7 +5093,7 @@ export const MODELS = {
 				cacheRead: 0.175,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
 		"gpt-5.3-codex": {
@@ -5110,7 +5110,7 @@ export const MODELS = {
 				cacheRead: 0.175,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
 	},


### PR DESCRIPTION
All 6 openai-codex models (`gpt-5.1`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`) have `contextWindow` set to `272000` in `models.generated.ts`.

Per OpenAI's official platform docs, all of these models have a **400,000** token context window.

**References:**
- https://platform.openai.com/docs/models/gpt-5.1 — 400,000 context window
- https://platform.openai.com/docs/models/gpt-5.1-codex — 400,000 context window
- https://platform.openai.com/docs/models/gpt-5.1-codex-mini — 400,000 context window  
- https://platform.openai.com/docs/models/gpt-5.2 — 400,000 context window
- https://platform.openai.com/docs/models/gpt-5.2-codex — 400,000 context window
- https://platform.openai.com/docs/models/gpt-5.3-codex — 400,000 context window