### PR TITLE
feat(mom): support HTTPS_PROXY for Slack Socket Mode WebSocket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6330,7 +6330,6 @@
 			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
 			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@lit/reactive-element": "^2.1.0",
 				"lit-element": "^4.2.0",
@@ -7687,7 +7686,6 @@
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
 			"integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -7716,8 +7714,7 @@
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
 			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -7835,7 +7832,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7932,7 +7928,6 @@
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -8021,7 +8016,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -8136,7 +8130,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -8600,7 +8593,8 @@
 				"@slack/web-api": "^7.0.0",
 				"chalk": "^5.6.2",
 				"croner": "^9.1.0",
-				"diff": "^8.0.2"
+				"diff": "^8.0.2",
+				"https-proxy-agent": "^7.0.6"
 			},
 			"bin": {
 				"mom": "dist/main.js"

--- a/packages/mom/CHANGELOG.md
+++ b/packages/mom/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support HTTPS_PROXY/HTTP_PROXY for Slack Socket Mode WebSocket connection
+
 ## [0.52.9] - 2026-02-08
 
 ## [0.52.8] - 2026-02-07

--- a/packages/mom/package.json
+++ b/packages/mom/package.json
@@ -28,7 +28,8 @@
 		"@slack/web-api": "^7.0.0",
 		"chalk": "^5.6.2",
 		"croner": "^9.1.0",
-		"diff": "^8.0.2"
+		"diff": "^8.0.2",
+		"https-proxy-agent": "^7.0.6"
 	},
 	"devDependencies": {
 		"@types/diff": "^7.0.2",

--- a/packages/mom/src/slack.ts
+++ b/packages/mom/src/slack.ts
@@ -1,5 +1,6 @@
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "fs";
 import { basename, join } from "path";
 import * as log from "./log.js";
@@ -142,7 +143,12 @@ export class SlackBot {
 		this.handler = handler;
 		this.workingDir = config.workingDir;
 		this.store = config.store;
-		this.socketClient = new SocketModeClient({ appToken: config.appToken });
+		const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+		const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
+		this.socketClient = new SocketModeClient({
+			appToken: config.appToken,
+			clientOptions: agent ? { agent } : {},
+		});
 		this.webClient = new WebClient(config.botToken);
 	}
 


### PR DESCRIPTION
## Summary

When running mom behind an egress proxy (e.g. Squid), the Slack Socket Mode WebSocket connection fails because it does not use the proxy. HTTP/HTTPS API calls can be routed via `HTTPS_PROXY` and a preload script, but the WebSocket connection (wss://) bypasses that.

## Solution

`@slack/socket-mode`'s `SocketModeClient` already supports passing an `agent` via `clientOptions`—it forwards this to the underlying `ws` library for the WebSocket connection. This change:

1. Adds `https-proxy-agent` as a dependency
2. When `HTTPS_PROXY` or `HTTP_PROXY` is set, creates an `HttpsProxyAgent` and passes it to `SocketModeClient` via `clientOptions: { agent }`

## Benefits

- Enables mom to run in air-gapped or proxy-only environments (e.g. Docker behind Squid)
- No monkey-patching or `NODE_OPTIONS=--require` needed for WebSocket
- Backward compatible: when no proxy env var is set, behavior is unchanged

Note: Issues are disabled on this repo; would have opened an issue first per maintainer preference.

Made with [Cursor](https://cursor.com)