### PR TITLE
Add onToolCallParse hook to StreamOptions for extension-based JSON fixing

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -87,6 +87,20 @@ export interface StreamOptions {
 	 * Default: 60000 (60 seconds). Set to 0 to disable the cap.
 	 */
 	maxRetryDelayMs?: number;
+
+	/**
+	 * Optional hook called when parsing tool call JSON arguments.
+	 * Allows extensions to intercept and fix malformed JSON before it's used.
+	 *
+	 * If the hook is provided and returns successfully, the provider uses the returned args.
+	 * If the hook throws or returns invalid data, the provider falls back to default parsing.
+	 *
+	 * @param rawArgs - The raw JSON string from the model
+	 * @param toolName - The name of the tool being called
+	 * @returns Parsed arguments object
+	 * @throws Error if parsing fails (will be caught by provider)
+	 */
+	onToolCallParse?: (rawArgs: string, toolName: string) => Promise<unknown>;
 }
 
 export type ProviderStreamOptions = StreamOptions & Record<string, unknown>;


### PR DESCRIPTION
Add onToolCallParse hook to StreamOptions for extension-based JSON fixing

 This commit adds a minimal hook mechanism that extensions can use to intercept and fix malformed JSON tool call arguments.

 Changes:
 - Add onToolCallParse hook to StreamOptions interface
 - Add onToolCallParse to OpenAIResponsesStreamOptions
 - Use hook in openai-completions provider with fallback to parseStreamingJson
 - Use hook in openai-responses-shared provider with fallback to parseStreamingJson
 - Make finishCurrentBlock async to support async hook

 The hook allows extensions to:
 1. Intercept raw JSON before parsing
 2. Fix malformed JSON using their own logic
 3. Return parsed arguments for the provider to use

 Usage in extension:
```ts
   const streamFn = (model, context, options) => {
     return streamSimpleOpenAICompletions(model, context, {
       ...options,
       onToolCallParse: async (rawArgs, toolName) => {
         // Attempt to parse and fix
         try {
           return JSON.parse(rawArgs);
         } catch {
           return await autofixJson(rawArgs);
         }
       }
     });
   };
```
 This is a minimal change that enables extension-based autofix without hardcoding autofix logic into the core.