### PR TITLE
fix(tui): exact matches rank above prefix matches in fuzzy filter

### DIFF
--- a/packages/tui/src/fuzzy.ts
+++ b/packages/tui/src/fuzzy.ts
@@ -60,6 +60,9 @@ export function fuzzyMatch(query: string, text: string): FuzzyMatch {
 			return { matches: false, score: 0 };
 		}
 
+		// Penalize excess length so exact matches rank above prefix matches
+		score += (textLower.length - normalizedQuery.length) * 0.5;
+
 		return { matches: true, score };
 	};
 

--- a/packages/tui/test/fuzzy.test.ts
+++ b/packages/tui/test/fuzzy.test.ts
@@ -58,6 +58,18 @@ describe("fuzzyMatch", () => {
 		const result = fuzzyMatch("codex52", "gpt-5.2-codex");
 		assert.strictEqual(result.matches, true);
 	});
+
+	it("exact match scores better than prefix match", () => {
+		const exact = fuzzyMatch("gs", "gs");
+		const prefix = fuzzyMatch("gs", "gsh");
+
+		assert.strictEqual(exact.matches, true);
+		assert.strictEqual(prefix.matches, true);
+		assert.ok(
+			exact.score < prefix.score,
+			`exact (${exact.score}) should score lower (better) than prefix (${prefix.score})`,
+		);
+	});
 });
 
 describe("fuzzyFilter", () => {
@@ -81,6 +93,13 @@ describe("fuzzyFilter", () => {
 
 		// "app" should be first (exact consecutive match at start)
 		assert.strictEqual(result[0], "app");
+	});
+
+	it("exact match ranks above prefix match", () => {
+		const items = ["gsh", "gs", "gsp", "gsa"];
+		const result = fuzzyFilter(items, "gs", (x: string) => x);
+
+		assert.strictEqual(result[0], "gs", `expected "gs" first, got "${result[0]}"`);
 	});
 
 	it("works with custom getText function", () => {


### PR DESCRIPTION
### Problem

When using slash commands `fuzzyMatch` scored "gs" (git status)→"gs" and "gs"→"gshow" (git show) identically because there was no penalty for excess characters in the target string. This caused slash command autocomplete to pick longer prefix matches over exact ones (e.g. `/gsh` selected instead of `/gs` when typing `/gs` + `Enter`).

### Fix

Add a small length penalty (0.5 per excess character) so shorter/exact matches rank first.

#### Before

- Type `/gs` and `Enter`
- Executes `/gshow`

#### After

- Type `/gs` and `Enter`
- Executes `/gs`

### Testing

Unit tests, and tested in local build of pi-coding-agent.