### PR TITLE
feat(ai): add Z.AI GLM-5 model

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Z.AI GLM-5 model
+
 ## [0.52.9] - 2026-02-08
 
 ### Changed

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -12203,5 +12203,23 @@ export const MODELS = {
 			contextWindow: 200000,
 			maxTokens: 131072,
 		} satisfies Model<"openai-completions">,
+		"glm-5": {
+			id: "glm-5",
+			name: "GLM-5",
+			api: "openai-completions",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/api/coding/paas/v4",
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai"},
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 1,
+				output: 3.2,
+				cacheRead: 0.2,
+				cacheWrite: 0,
+			},
+			contextWindow: 204800,
+			maxTokens: 131072,
+		} satisfies Model<"openai-completions">,
 	},
 } as const;

--- a/packages/ai/test/cross-provider-handoff.test.ts
+++ b/packages/ai/test/cross-provider-handoff.test.ts
@@ -84,6 +84,8 @@ const PROVIDER_MODEL_PAIRS: ProviderModelPair[] = [
 	{ provider: "xai", model: "grok-code-fast-1", label: "xai-grok-code-fast-1" },
 	// Cerebras
 	{ provider: "cerebras", model: "zai-glm-4.7", label: "cerebras-zai-glm-4.7" },
+	// Z.AI
+	{ provider: "zai", model: "glm-5", label: "zai-glm-5" },
 	// Groq
 	{ provider: "groq", model: "openai/gpt-oss-120b", label: "groq-gpt-oss-120b" },
 	// Hugging Face

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -27,7 +27,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	xai: "grok-4-fast-non-reasoning",
 	groq: "openai/gpt-oss-120b",
 	cerebras: "zai-glm-4.6",
-	zai: "glm-4.6",
+	zai: "glm-5",
 	mistral: "devstral-medium-latest",
 	minimax: "MiniMax-M2.1",
 	"minimax-cn": "MiniMax-M2.1",


### PR DESCRIPTION
## Summary
- Added Z.AI GLM-5 model to models.generated.ts with pricing ($1/3.20 per 1M tokens, $0.20 cache read), 204800 context window, 131072 max output
- Updated zai default model from glm-4.6 to glm-5 in model-resolver.ts
- Added test case for zai glm-5 in cross-provider-handoff.test.ts
- Added changelog entry

Based on https://github.com/anomalyco/models.dev/blob/dev/providers/zai/models/glm-5.toml