### PR TITLE
feat(ai): add GLM-5 model support for Z.AI provider

### DIFF
--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -12203,5 +12203,23 @@ export const MODELS = {
 			contextWindow: 200000,
 			maxTokens: 131072,
 		} satisfies Model<"openai-completions">,
+		"glm-5": {
+			id: "glm-5",
+			name: "GLM-5",
+			api: "openai-completions",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/api/coding/paas/v4",
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai"},
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 0.6,
+				output: 2.2,
+				cacheRead: 0.11,
+				cacheWrite: 0,
+			},
+			contextWindow: 200000,
+			maxTokens: 98304,
+		} satisfies Model<"openai-completions">,
 	},
 } as const;


### PR DESCRIPTION
## Summary
- Add GLM-5 model to the Z.AI provider catalog
- GLM-5 is Zhipu AI's latest model with 745B parameters (44B active MoE)
- Features 200K token context window and reasoning capabilities

## Details
GLM-5 is accessed via the Z.AI coding API endpoint:
- Model ID: `glm-5`
- Provider: `zai`
- API: OpenAI-compatible completions
- Base URL: `https://api.z.ai/api/coding/paas/v4`

## Model Specifications
- **Parameters**: 745B total (44B active MoE)
- **Context Window**: 200K tokens
- **Max Output**: 98,304 tokens
- **Capabilities**: Reasoning, text input
- **Thinking Format**: Z.AI native

## Test Plan
- [x] Tested locally with clawdbot using `zai/glm-5`
- [x] Verified API responds correctly to model ID `glm-5`
- [x] Model identifies as GLM-5 from Zhipu AI

🤖 Generated with [Claude Code](https://claude.ai/code)