### PR TITLE
fix: preserve thoughtSignature on cross-model tool calls for Gemini 3

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -136,7 +136,13 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 						});
 					}
 				} else if (block.type === "toolCall") {
-					const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.thoughtSignature);
+					// Preserve any valid base64 thoughtSignature regardless of whether
+					// the message is from the same model. Google APIs require signatures
+					// on Gemini 3 function calls — they work cross-model as long as
+					// the format is valid base64.
+					const thoughtSignature = isValidThoughtSignature(block.thoughtSignature)
+						? block.thoughtSignature
+						: resolveThoughtSignature(isSameProviderAndModel, block.thoughtSignature);
 					// Gemini 3 requires thoughtSignature on all function calls when thinking mode is enabled.
 					// When replaying history from providers without thought signatures (e.g. Claude via Antigravity),
 					// convert unsigned function calls to text to avoid API validation errors.

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -63,10 +63,10 @@ export function transformMessages<TApi extends Api>(
 					const toolCall = block as ToolCall;
 					let normalizedToolCall: ToolCall = toolCall;
 
-					if (!isSameModel && toolCall.thoughtSignature) {
-						normalizedToolCall = { ...toolCall };
-						delete (normalizedToolCall as { thoughtSignature?: string }).thoughtSignature;
-					}
+					// Do NOT delete thoughtSignature here — Google APIs require valid
+					// signatures on function calls for Gemini 3 regardless of which
+					// model produced them. The downstream convertMessages() decides
+					// whether to keep or discard signatures per-provider.
 
 					if (!isSameModel && normalizeToolCallId) {
 						const normalizedId = normalizeToolCallId(toolCall.id, model, assistantMsg);


### PR DESCRIPTION
## Problem

When replaying conversation history across models (e.g. Claude via Antigravity → Gemini 3),
`transformMessages()` deletes `thoughtSignature` from tool calls when `!isSameModel`.
Then `convertMessages()` sees no signature on Gemini 3 function calls and converts them to
`[Historical context: a different model called tool...]` text instead of proper `functionCall`
parts.

This causes Gemini 3 to:
1. Lose proper function calling for historical tool calls
2. Learn and mimic the "[Historical context: ...]" pattern in its own output

## Fix

- **transform-messages.ts**: Stop deleting `thoughtSignature` when `!isSameModel`.
  Let downstream `convertMessages()` decide per-provider.
- **google-shared.ts**: For tool calls, preserve any valid base64 `thoughtSignature`
  regardless of model matching, falling back to `resolveThoughtSignature()` only if invalid.

## Context

Gemini 3 requires `thoughtSignature` on all function calls when thinking mode is enabled.
Valid base64 signatures work cross-model — they don't need to come from the same model.