### PR TITLE
docs: clarify toolkit scope in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All PRs will be auto-closed until then. Approved contributors can submit PRs aft
 > **Looking for the pi coding agent?** See **[packages/coding-agent](packages/coding-agent)** for installation and usage.
 
 Tools for building AI agents and managing LLM deployments.
+Pi Mono provides reusable runtime/tooling packages; it is not a channel-integrated personal-assistant product by itself.
 
 ## Packages
 


### PR DESCRIPTION
## Summary
Clarify repository positioning in README:
- add an explicit sentence that pi-mono is a toolkit/package monorepo and not a channel-integrated personal-assistant product by itself.

## Why
This avoids scope confusion when users compare coding-agent toolkits against personal-assistant products.

## Scope
- README-only change
