### PR TITLE
fix: fallback to token estimation when provider returns no usage data

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1603,7 +1603,13 @@ export class AgentSession {
 		// Skip if this was an error (non-overflow errors don't have usage data)
 		if (assistantMessage.stopReason === "error") return;
 
-		const contextTokens = calculateContextTokens(assistantMessage.usage);
+		let contextTokens = calculateContextTokens(assistantMessage.usage);
+		// Fallback: if provider didn't return usage data (e.g. z.ai),
+		// estimate context tokens from message content using chars/4 heuristic
+		if (contextTokens === 0 && this.agent.state.messages.length > 0) {
+			const estimated = estimateContextTokens(this.agent.state.messages);
+			contextTokens = estimated.tokens;
+		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
 			await this._runAutoCompaction("threshold", false);
 		}


### PR DESCRIPTION
## Problem

Some providers (e.g. z.ai/GLM-5, GLM-4.7) don't always return usage data in streaming responses. When `calculateContextTokens` returns 0 (no usage), the threshold-based auto-compaction check in `_checkCompaction` evaluates `shouldCompact(0, contextWindow, settings)` which is always `false` — so compaction never triggers.

Related: https://github.com/openclaw/openclaw/issues/15153

## Fix

When `calculateContextTokens(assistantMessage.usage)` returns 0, fall back to `estimateContextTokens(this.agent.state.messages)` which estimates token count from actual message content using the existing chars/4 heuristic.

This function is already imported and used elsewhere in the codebase (e.g. the `contextTokens` getter). The fallback is conservative — it overestimates tokens, which means compaction triggers slightly earlier rather than later.

## Testing

Verified on a live OpenClaw 2026.2.9 instance with `zai/glm-5` (200K context window):

1. **Without fix**: `_checkCompaction` runs but `contextTokens=0` when Z.ai omits usage → `shouldCompact(0, 200000, settings)` → `false` → compaction never fires
2. **With fix**: Estimation fallback produces accurate token count → threshold check works correctly
3. **Forced threshold test**: Temporarily lowered threshold, confirmed auto-compaction fires and completes successfully with Z.ai/GLM-5

## Scope

- **1 file changed**, 7 insertions, 1 deletion
- Only affects the zero-usage fallback path — providers that return usage data are unaffected
- No new dependencies