### PR TITLE
fix(google): subtract cached tokens from input to prevent double-counting

### DIFF
--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -204,11 +204,14 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 				}
 
 				if (chunk.usageMetadata) {
+					// promptTokenCount includes cachedContentTokenCount, so subtract to get fresh input
+					const promptTokens = chunk.usageMetadata.promptTokenCount || 0;
+					const cacheReadTokens = chunk.usageMetadata.cachedContentTokenCount || 0;
 					output.usage = {
-						input: chunk.usageMetadata.promptTokenCount || 0,
+						input: promptTokens - cacheReadTokens,
 						output:
 							(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
-						cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
+						cacheRead: cacheReadTokens,
 						cacheWrite: 0,
 						totalTokens: chunk.usageMetadata.totalTokenCount || 0,
 						cost: {


### PR DESCRIPTION
## Summary

- `google.ts` maps `promptTokenCount` directly to `usage.input`, but Google's `promptTokenCount` **includes** `cachedContentTokenCount` as a subset ([Google docs](https://ai.google.dev/gemini-api/docs/tokens#cached-tokens))
- `cacheRead` is also set to `cachedContentTokenCount`, so downstream consumers computing `input + cacheRead` double-count cached tokens
- This causes false context overflow detection in projects like OpenClaw (reported as [openclaw/openclaw#15265](https://github.com/openclaw/openclaw/issues/15265))

## Fix

Subtract `cachedContentTokenCount` from `promptTokenCount` when mapping to `input`, matching the existing correct implementation in `google-gemini-cli.ts` (line 660-664):

```typescript
// Before (google.ts)
input: chunk.usageMetadata.promptTokenCount || 0,

// After (consistent with google-gemini-cli.ts)
const promptTokens = chunk.usageMetadata.promptTokenCount || 0;
const cacheReadTokens = chunk.usageMetadata.cachedContentTokenCount || 0;
input: promptTokens - cacheReadTokens,
```

## Test plan

- [ ] Verify `input + cacheRead` no longer exceeds `totalTokens` when caching is active
- [ ] Confirm overflow detection in consumers no longer triggers false positives
- [ ] Existing tests pass (no test coverage for this code path currently)

Closes openclaw/openclaw#15265