### PR TITLE
fix(coding-agent): fix relative path handling

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed local package paths being stored without `./` prefix, which could cause ambiguity with git repository names (e.g., `packages/foo` vs `user/repo`)
+
 ## [0.52.10] - 2026-02-12
 
 ### New Features

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -962,7 +962,14 @@ export class DefaultPackageManager implements PackageManager {
 		const baseDir = this.getBaseDirForScope(scope);
 		const resolved = this.resolvePath(parsed.path);
 		const rel = relative(baseDir, resolved);
-		return rel || ".";
+		if (!rel || rel === ".") {
+			return ".";
+		}
+		// Ensure relative paths start with "./" to avoid ambiguity with git URLs (e.g., "user/repo")
+		if (!rel.startsWith(".") && !rel.startsWith("/")) {
+			return `./${rel}`;
+		}
+		return rel;
 	}
 
 	private parseSource(source: string): ParsedSource {


### PR DESCRIPTION
The normalitaion from within ~/.pi/agent caused incorrect relative path handling, making the extension loading to default to remote location and fail to find the reference. This now adds more defensive checks and add preceding "./" to the path.

I'm aware of the OSS vacation and I wasn't even a part of the approved contributor list. I'm fine this getting closed immediately now, I'm just opening this for reference to clarify my intention of my original issue of #1426 (I could confirm the path duplication was fixed in the recent commit)