### PR TITLE
fix: default store to true for OpenAI Responses API providers

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -49,6 +49,11 @@ export interface OpenAICodexResponsesOptions extends StreamOptions {
 	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 	reasoningSummary?: "auto" | "concise" | "detailed" | "off" | "on" | null;
 	textVerbosity?: "low" | "medium" | "high";
+	/**
+	 * Whether to persist responses server-side for multi-turn conversation chaining.
+	 * Default: `true`.
+	 */
+	store?: boolean;
 }
 
 type CodexResponseStatus = "completed" | "incomplete" | "failed" | "cancelled" | "queued" | "in_progress";
@@ -285,7 +290,7 @@ function buildRequestBody(
 
 	const body: RequestBody = {
 		model: model.id,
-		store: false,
+		store: options?.store ?? true,
 		stream: true,
 		instructions: context.systemPrompt,
 		input: messages,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -53,6 +53,13 @@ export interface OpenAIResponsesOptions extends StreamOptions {
 	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
 	reasoningSummary?: "auto" | "detailed" | "concise" | null;
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
+	/**
+	 * Whether to persist responses server-side for multi-turn conversation chaining
+	 * via `previous_response_id`. When `false`, reasoning items (`rs_*` IDs) are not
+	 * persisted and subsequent turns referencing them will fail with HTTP 404.
+	 * Default: `true`.
+	 */
+	store?: boolean;
 }
 
 /**
@@ -191,7 +198,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		stream: true,
 		prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
 		prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
-		store: false,
+		store: options?.store ?? true,
 	};
 
 	if (options?.maxTokens) {


### PR DESCRIPTION
## Summary

- Default `store` to `true` (was hardcoded `false`) in both `openai-responses` and `openai-codex-responses` providers
- Add `store` as a configurable option on both provider option interfaces so callers can override

## Problem

When `store: false`, OpenAI does not persist reasoning items (`rs_*` IDs) server-side. Since pi-ai chains `previous_response_id` across turns, subsequent requests reference these unpersisted items and fail with:

```
HTTP 404: Item with id 'rs_...' not found. Items are not persisted
when store is set to false.
```

This breaks **all** multi-turn conversations using `openai/*` and `openai-codex/*` models. It reproduces on fresh sessions after the very first multi-turn exchange — not a stale state issue.

## Fix

- `openai-responses.ts`: `store: false` → `store: options?.store ?? true`
- `openai-codex-responses.ts`: `store: false` → `store: options?.store ?? true`
- No change to `azure-openai-responses` (Azure does not support `store`)

Callers who need `store: false` can still pass it explicitly.

## Bonus

`store: true` also enables [OpenAI prompt caching](https://platform.openai.com/docs/guides/conversation-state) for multi-turn conversations, giving 50% cheaper cached input tokens.

## References

- [OpenAI docs: Conversation State](https://platform.openai.com/docs/guides/conversation-state)
- [Vercel AI SDK #7543](https://github.com/vercel/ai/issues/7543) — same issue
- [OpenAI Agents Python #2020](https://github.com/openai/openai-agents-python/issues/2020) — same issue
- [openclaw/openclaw#16803](https://github.com/openclaw/openclaw/issues/16803) — downstream bug report

## Test Plan

- [ ] Send 2+ messages to an agent using an `openai/*` model — verify no 404 errors on second turn
- [ ] Verify `previous_response_id` chaining works across turns
- [ ] Verify callers can still pass `store: false` explicitly to opt out

---
Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>