### PR TITLE
fix(ai): resolve actual model name from API response

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -428,6 +428,11 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.completed") {
 			const response = event.response;
+			// Update the model name if the API resolved to a different model
+			// (e.g. OpenRouter's openrouter/auto returns the actual model used)
+			if (response?.model && response.model !== model.id) {
+				output.model = response.model;
+			}
 			if (response?.usage) {
 				const cachedTokens = response.usage.input_tokens_details?.cached_tokens || 0;
 				output.usage = {


### PR DESCRIPTION
## Summary

- When using model routing services (e.g. OpenRouter's `openrouter/auto`), the API response includes the actual model that served the request in the `response.model` field
- Currently `processResponsesStream` ignores this field, so `AssistantMessage.model` always reports the *requested* model name (e.g. `openrouter/auto`) instead of the *resolved* model (e.g. `anthropic/claude-3.5-haiku`)
- This one-line fix captures the resolved model from the `response.completed` event, only updating when it differs from the requested model

## Details

The change is in `packages/ai/src/providers/openai-responses-shared.ts`, inside the `response.completed` event handler of `processResponsesStream`. The `response.model` field is already present in the OpenAI SDK's `ResponseCompletedEvent` type, so no type changes are needed.

This benefits any OpenAI-compatible provider that may return a different model than requested — OpenRouter being the primary use case. Downstream consumers (like usage footers or cost displays) can then show the actual model that generated the response.

## Test plan

- [ ] Verify TypeScript compilation passes (`tsc --noEmit` in `packages/ai`)
- [ ] Test with OpenRouter `openrouter/auto` model and confirm `AssistantMessage.model` reflects the resolved model
- [ ] Test with standard OpenAI models (e.g. `gpt-4o`) and confirm `AssistantMessage.model` remains unchanged when the response model matches the request
- [ ] Verify no regression in Azure OpenAI Responses or Codex Responses paths (they share `processResponsesStream`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)