### PR TITLE
feat(extensions): apply configured sandbox patterns on internal tool …

### DIFF
--- a/packages/coding-agent/examples/extensions/sandbox/package-lock.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package-lock.json
@@ -1,92 +1,156 @@
 {
-	"name": "pi-extension-sandbox",
-	"version": "1.0.0",
-	"lockfileVersion": 3,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "pi-extension-sandbox",
-			"version": "1.0.0",
-			"dependencies": {
-				"@anthropic-ai/sandbox-runtime": "^0.0.26"
-			}
-		},
-		"node_modules/@anthropic-ai/sandbox-runtime": {
-			"version": "0.0.26",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.26.tgz",
-			"integrity": "sha512-DYV5LSsVMnzq0lbfaYMSpxZPUMAx4+hy343dRss+pVCLIfF62qOhxpYfZ5TmOk1GTDQm5f9wPprMNSStmnsV4w==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@pondwader/socks5-server": "^1.0.10",
-				"@types/lodash-es": "^4.17.12",
-				"commander": "^12.1.0",
-				"lodash-es": "^4.17.21",
-				"shell-quote": "^1.8.3",
-				"zod": "^3.24.1"
-			},
-			"bin": {
-				"srt": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@pondwader/socks5-server": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/@pondwader/socks5-server/-/socks5-server-1.0.10.tgz",
-			"integrity": "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/lodash-es": {
-			"version": "4.17.12",
-			"resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-			"integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/lodash": "*"
-			}
-		},
-		"node_modules/commander": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/lodash-es": {
-			"version": "4.17.22",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-			"integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
-			"license": "MIT"
-		},
-		"node_modules/shell-quote": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		}
-	}
+    "name": "pi-extension-sandbox",
+    "version": "1.1.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "pi-extension-sandbox",
+            "version": "1.1.0",
+            "dependencies": {
+                "@anthropic-ai/sandbox-runtime": "^0.0.37",
+                "minimatch": "^10.1.1"
+            }
+        },
+        "node_modules/@anthropic-ai/sandbox-runtime": {
+            "version": "0.0.37",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.37.tgz",
+            "integrity": "sha512-KKzHoe4blXQpTEtbFLKP76PHsUerqlG5UNN+MQvXf0SVZDtawP9hHc9HiMgzvUXST2OMYl2Sk27k18d6684eoQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@pondwader/socks5-server": "^1.0.10",
+                "@types/lodash-es": "^4.17.12",
+                "commander": "^12.1.0",
+                "lodash-es": "^4.17.23",
+                "shell-quote": "^1.8.3",
+                "zod": "^3.24.1"
+            },
+            "bin": {
+                "srt": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+            "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@pondwader/socks5-server": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/@pondwader/socks5-server/-/socks5-server-1.0.10.tgz",
+            "integrity": "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/lodash": {
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/lodash-es": {
+            "version": "4.17.12",
+            "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+            "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/lodash": "*"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
+            "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
+            "license": "MIT",
+            "dependencies": {
+                "jackspeak": "^4.2.3"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+            "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/commander": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+            "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^9.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/lodash-es": {
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "license": "MIT"
+        },
+        "node_modules/minimatch": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
+            "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        }
+    }
 }

--- a/packages/coding-agent/examples/extensions/sandbox/package.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package.json
@@ -1,19 +1,22 @@
 {
-	"name": "pi-extension-sandbox",
-	"private": true,
-	"version": "1.0.0",
-	"type": "module",
-	"scripts": {
-		"clean": "echo 'nothing to clean'",
-		"build": "echo 'nothing to build'",
-		"check": "echo 'nothing to check'"
-	},
-	"pi": {
-		"extensions": [
-			"./index.ts"
-		]
-	},
-	"dependencies": {
-		"@anthropic-ai/sandbox-runtime": "^0.0.26"
-	}
+    "name": "pi-extension-sandbox",
+    "private": true,
+    "version": "1.1.0",
+    "type": "module",
+    "scripts": {
+        "clean": "echo 'nothing to clean'",
+        "build": "echo 'nothing to build'",
+        "check": "echo 'nothing to check'",
+        "test": "npx vitest run test_paths.test.ts",
+        "test:watch": "npx vitest watch test_paths.test.ts"
+    },
+    "pi": {
+        "extensions": [
+            "./index.ts"
+        ]
+    },
+    "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "^0.0.37",
+        "minimatch": "^10.1.1"
+    }
 }

--- a/packages/coding-agent/examples/extensions/sandbox/test_paths.test.ts
+++ b/packages/coding-agent/examples/extensions/sandbox/test_paths.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Test file for isReadAllowed and isWriteAllowed functions
+ *
+ * This test file verifies that the filesystem access control functions
+ * behave according to the DEFAULT_CONFIG and platform-specific rules:
+ *
+ * - isReadAllowed: DENY-ONLY pattern (allow by default, deny specific paths)
+ * - isWriteAllowed: ALLOW-ONLY pattern (deny by default, allow specific paths)
+ *
+ * Platform differences:
+ * - macOS: Supports glob patterns (*, **, ?, [abc]) for path matching
+ * - Linux: Only supports literal path matching or prefix matching (no globs)
+ */
+
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG, expandPath, isReadAllowed, isWriteAllowed, matchesAnyPattern, resolvePath } from "./index.js";
+
+// Use actual process.platform
+const platform = process.platform;
+
+describe("path access control functions", () => {
+	const cwd = process.cwd();
+	const config = DEFAULT_CONFIG;
+
+	describe("expandPath", () => {
+		it("should expand ~ to home directory", () => {
+			const result = expandPath("~");
+			expect(result).toBe(homedir());
+		});
+
+		it("should expand ~/path to home directory", () => {
+			const result = expandPath("~/Documents/file.txt");
+			expect(result).toBe(join(homedir(), "Documents/file.txt"));
+		});
+
+		it("should not modify paths that don't start with ~", () => {
+			const result = expandPath("/absolute/path");
+			expect(result).toBe("/absolute/path");
+		});
+	});
+
+	describe("resolvePath", () => {
+		it("should resolve absolute paths as-is", () => {
+			const result = resolvePath("/absolute/path", cwd);
+			expect(result).toBe("/absolute/path");
+		});
+
+		it("should resolve relative paths against cwd", () => {
+			const result = resolvePath("relative/file.txt", cwd);
+			expect(result).toBe(resolve(cwd, "relative/file.txt"));
+		});
+
+		it("should expand ~ before resolving", () => {
+			const result = resolvePath("~/test.txt", cwd);
+			expect(result).toBe(resolve(join(homedir(), "test.txt")));
+		});
+	});
+
+	describe("matchesAnyPattern", () => {
+		it("should match exact paths on Linux", () => {
+			if (platform !== "darwin") {
+				const result = matchesAnyPattern("/tmp/test.txt", ["/tmp"], cwd, "linux");
+				expect(result.matched).toBe(true);
+			}
+		});
+
+		it("should match glob patterns on macOS", () => {
+			if (platform === "darwin") {
+				const result = matchesAnyPattern("test.env.production", ["*.env.*"], cwd, "darwin");
+				expect(result.matched).toBe(true);
+			}
+		});
+
+		it("should return the matched pattern", () => {
+			const patterns = ["~/.ssh", "~/.aws"];
+			const result = matchesAnyPattern("~/.ssh/id_rsa", patterns, cwd, platform);
+			if (result.matched) {
+				expect(result.pattern).toBe("~/.ssh");
+			}
+		});
+	});
+
+	describe("isReadAllowed", () => {
+		it("should allow read access by default (empty denyRead)", () => {
+			const testConfig = { ...config, filesystem: { ...config.filesystem, denyRead: [] } };
+			const result = isReadAllowed("/any/path", cwd, testConfig, platform);
+			expect(result.allowed).toBe(true);
+		});
+
+		const readTestCases = [
+			// Should be allowed (not in denyRead)
+			{ path: ".", expected: true, description: "Current directory" },
+			{ path: "./index.ts", expected: true, description: "File in current directory" },
+			{ path: "package.json", expected: true, description: "package.json file" },
+			{ path: "/tmp/test.txt", expected: true, description: "File in /tmp" },
+			{ path: "node_modules", expected: true, description: "node_modules directory" },
+
+			// Should be denied (in denyRead: ~/.ssh, ~/.aws, ~/.gnupg)
+			{ path: "~/.ssh", expected: false, description: "SSH directory (denied)" },
+			{ path: "~/.ssh/id_rsa", expected: false, description: "SSH key file (denied)" },
+			{ path: join(homedir(), ".ssh/id_rsa"), expected: false, description: "SSH key file absolute (denied)" },
+			{ path: "~/.aws", expected: false, description: "AWS directory (denied)" },
+			{ path: "~/.aws/credentials", expected: false, description: "AWS credentials file (denied)" },
+			{ path: "~/.gnupg", expected: false, description: "GPG directory (denied)" },
+			{ path: "~/.gnupg/secring.gpg", expected: false, description: "GPG key file (denied)" },
+		];
+
+		readTestCases.forEach((testCase) => {
+			it(`should ${testCase.expected ? "allow" : "deny"} read: ${testCase.description}`, () => {
+				const result = isReadAllowed(testCase.path, cwd, config, platform);
+				expect(result.allowed).toBe(testCase.expected);
+
+				if (!testCase.expected) {
+					expect(result.reason).toBeDefined();
+				}
+			});
+		});
+	});
+
+	describe("isWriteAllowed", () => {
+		it("should deny write access by default (empty allowWrite)", () => {
+			const testConfig = { ...config, filesystem: { ...config.filesystem, allowWrite: [] } };
+			const result = isWriteAllowed("/any/path", cwd, testConfig, platform);
+			expect(result.allowed).toBe(false);
+			expect(result.reason).toContain("allowWrite is empty");
+		});
+
+		const writeTestCases = [
+			// Should be allowed (in allowWrite: ".", "/tmp")
+			{ path: ".", expected: true, description: "Current directory (allowed)" },
+			{ path: "./test.txt", expected: true, description: "File in current directory (allowed)" },
+			{ path: "new-file.js", expected: true, description: "New file in current directory (allowed)" },
+			{ path: "/tmp", expected: true, description: "/tmp directory (allowed)" },
+			{ path: "/tmp/test.txt", expected: true, description: "File in /tmp (allowed)" },
+
+			// Should be denied (not in allowWrite)
+			{ path: "/etc", expected: false, description: "/etc directory (not allowed)" },
+			{ path: "/etc/passwd", expected: false, description: "/etc/passwd file (not allowed)" },
+			{ path: "/usr/local", expected: false, description: "/usr/local directory (not allowed)" },
+			{ path: "../sibling-dir", expected: false, description: "Parent sibling directory (not allowed)" },
+			{ path: "~/.config", expected: false, description: "Home config directory (not allowed)" },
+
+			// Should be denied (in denyWrite within allowed paths)
+			{ path: ".env", expected: false, description: ".env file (denied within allowed path)" },
+			{
+				path: ".env.production",
+				expected: platform !== "darwin",
+				description: ".env.* file (denied on macOS, allowed on Linux - no glob support)",
+			},
+			{
+				path: "key.pem",
+				expected: platform !== "darwin",
+				description: "*.pem file (denied on macOS, allowed on Linux - no glob support)",
+			},
+			{
+				path: "private.key",
+				expected: platform !== "darwin",
+				description: "*.key file (denied on macOS, allowed on Linux - no glob support)",
+			},
+
+			// Edge cases
+			{
+				path: "/home/user/test.txt",
+				expected: false,
+				description: "Absolute path outside allowed directories (denied)",
+			},
+			{ path: "../test.txt", expected: false, description: "Relative parent path (denied)" },
+			{ path: "subdir/test.txt", expected: true, description: "Subdirectory within allowed path (allowed)" },
+		];
+
+		writeTestCases.forEach((testCase) => {
+			it(`should ${testCase.expected ? "allow" : "deny"} write: ${testCase.description}`, () => {
+				const result = isWriteAllowed(testCase.path, cwd, config, platform);
+				expect(result.allowed).toBe(testCase.expected);
+
+				if (!testCase.expected) {
+					expect(result.reason).toBeDefined();
+				}
+			});
+		});
+	});
+
+	describe("platform-specific behavior", () => {
+		it("should handle glob patterns differently on macOS vs Linux", () => {
+			const testPath = ".env.production";
+			const patterns = [".env.*"];
+
+			const macOSResult = matchesAnyPattern(testPath, patterns, cwd, "darwin");
+			const linuxResult = matchesAnyPattern(testPath, patterns, cwd, "linux");
+
+			// macOS should match glob patterns
+			expect(macOSResult.matched).toBe(true);
+
+			// Linux should not match glob patterns (literal matching only)
+			expect(linuxResult.matched).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
Apply the same rules used by sandbox-runtime also for the calls into built-in tools.

Additionally mention how to enable unix sockets in the example config comment.