### PR TITLE
fix(openai-completions): handle non-standard finish_reason from compatible APIs

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -747,10 +747,11 @@ function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"]): Sto
 			return "toolUse";
 		case "content_filter":
 			return "error";
-		default: {
-			const _exhaustive: never = reason;
-			throw new Error(`Unhandled stop reason: ${_exhaustive}`);
-		}
+		default:
+			// Non-standard finish_reason values from OpenAI-compatible providers
+			// (e.g. z.ai returns "abort", "sensitive", "network_error").
+			// Treat them as errors instead of crashing.
+			return "error";
 	}
 }
 


### PR DESCRIPTION
## Problem

OpenAI-compatible providers can return non-standard `finish_reason` values that aren't part of the OpenAI spec. For example, [z.ai](https://z.ai) (Zhipu/GLM) returns:

- `"abort"` — server-side request termination
- `"sensitive"` — content safety filter
- `"network_error"` — inference failure

The strict exhaustive switch in `mapStopReason` throws `Unhandled stop reason: abort`, crashing the session instead of recovering gracefully.

## Fix

Change the `default` case from throwing to returning `"error"`, allowing consumers (like OpenClaw) to handle the error through normal retry/recovery paths.

This is a 4-line change: remove the `never` exhaustive check and return `"error"` for any unrecognized finish_reason.

## Context

- Affects anyone using the `openai-completions` provider with non-OpenAI backends (z.ai, Together, etc.)
- Related: #978 (similar issue with Anthropic's `"sensitive"` stop reason)
- The other providers (anthropic, google, openai-responses) keep their strict checks since they control their own finish_reason values
- Tested with z.ai GLM-5 — confirmed fix resolves the crash

## Diff

```diff
-		default: {
-			const _exhaustive: never = reason;
-			throw new Error(\`Unhandled stop reason: \${_exhaustive}\`);
-		}
+		default:
+			// Non-standard finish_reason values from OpenAI-compatible providers
+			// (e.g. z.ai returns "abort", "sensitive", "network_error").
+			// Treat them as errors instead of crashing.
+			return "error";
```