### PR TITLE
Fix OpenAI responses store flag

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -285,7 +285,7 @@ function buildRequestBody(
 
 	const body: RequestBody = {
 		model: model.id,
-		store: false,
+		store: true,
 		stream: true,
 		instructions: context.systemPrompt,
 		input: messages,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -191,7 +191,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		stream: true,
 		prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
 		prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
-		store: false,
+		store: true,
 	};
 
 	if (options?.maxTokens) {


### PR DESCRIPTION
## Summary
- set `store: true` in OpenAI responses request bodies

## Motivation
`store: false` prevents conversation history from being stored, which breaks workflows that rely on persisted context. This flips it to `true` in both OpenAI response providers.

Refs: https://github.com/openclaw/openclaw/issues/16829
