### PR TITLE
feat: adds the ability to use pnpm in `pi install`

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -647,9 +647,9 @@ export class InteractiveMode {
 	 * Get a short path relative to the package root for display.
 	 */
 	private getShortPath(fullPath: string, source: string): string {
-		// For npm packages, show path relative to node_modules/pkg/
+		// For npm/pnpm packages, show path relative to node_modules/pkg/
 		const npmMatch = fullPath.match(/node_modules\/(@?[^/]+(?:\/[^/]+)?)\/(.*)/);
-		if (npmMatch && source.startsWith("npm:")) {
+		if (npmMatch && (source.startsWith("npm:") || source.startsWith("pnpm:"))) {
 			return npmMatch[2];
 		}
 
@@ -697,7 +697,7 @@ export class InteractiveMode {
 	}
 
 	private isPackageSource(source: string): boolean {
-		return source.startsWith("npm:") || source.startsWith("git:");
+		return source.startsWith("npm:") || source.startsWith("pnpm:") || source.startsWith("git:");
 	}
 
 	private buildScopeGroups(


### PR DESCRIPTION
Currently `pi install` only supports npm as its package manager. Since the behavior of `pnpm add` and `npm i` is almost identical and many users prefer to use pnpm this PR extends `pi` to support pnpm as well. 

Additionally it lays the groundwork for being able to easily add more options i.e. yarn in the future)

With these changes it is now possible to run `pi install pnpm:@foo/bar` and `pi` will use `pnpm` instead.

I added a new manager field to `NpmSource`  ("npm" | "pnpm") that is accessed through the entire install/uninstall/path-resolution pipeline and replaces the hardcoded `"npm"` value. Each manager gets its own install root so packages don't collide, and the very few CLI differences are handled at the call sites (`pnpm add` vs `npm install`, `--dir` vs `--prefix`).

It is worth nothing that this change introduces a small question when it comes to installing packages locally. Should npm:foo and pnpm:foo be two different packages? I decided to solve this by creating a separate `pnpm` root and handling config detention: if a user already has npm:chalk installed and tries to install pnpm:chalk, the CLI will catch the overlap and prompt the user to either keep both, replace the existing one, or abort. This avoids silently duplicating packages.

The interactive mode display logic was also updated to recognize `pnpm:` sources for path shortening and package identification. 

Tests cover parsing, identity/path separation, and the conflict detection.