### PR TITLE
feat(coding-agent): re-export AgentEvent type from pi-agent-core

### DIFF
--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -1,4 +1,5 @@
-// Core session management
+// Core types from pi-agent-core
+export type { AgentEvent } from "@mariozechner/pi-agent-core";
 
 // Config paths
 export { getAgentDir, VERSION } from "./config.js";


### PR DESCRIPTION
## Summary

Adds `export type { AgentEvent } from "@mariozechner/pi-agent-core";` to `packages/coding-agent/src/index.ts`.

## Problem

`AgentEvent` from `@mariozechner/pi-agent-core` is not re-exported from `@mariozechner/pi-coding-agent`, forcing downstream consumers (e.g. pi-packages/extensions) to add a separate dependency on `@mariozechner/pi-agent-core` just for this type. The only current workaround is patching `dist/index.d.ts` directly, which is overwritten on every `npm update`.

## Change

One line added to `packages/coding-agent/src/index.ts`:

```ts
export type { AgentEvent } from "@mariozechner/pi-agent-core";
```

This is consistent with how other core types (`AgentSession`, `AgentSessionEvent`, etc.) are already re-exported.