### PR TITLE
fix(ai): honor explicit thinking-off for openrouter openai-completions

### DIFF
--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -75,6 +75,75 @@ describe("openai-completions tool_choice", () => {
 		expect(params.tools?.length ?? 0).toBeGreaterThan(0);
 	});
 
+	it("sends OpenRouter reasoning effort none when reasoning is explicitly undefined", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = {
+			...baseModel,
+			api: "openai-completions",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+		} as const;
+		let payload: unknown;
+
+		await streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Hello",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test",
+				reasoning: undefined,
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? mockState.lastParams) as { reasoning?: { effort?: string } };
+		expect(params.reasoning).toEqual({ effort: "none" });
+	});
+
+	it("does not send OpenRouter reasoning effort none when reasoning is omitted", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = {
+			...baseModel,
+			api: "openai-completions",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+		} as const;
+		let payload: unknown;
+
+		await streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Hello",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? mockState.lastParams) as { reasoning?: { effort?: string } };
+		expect(params.reasoning).toBeUndefined();
+	});
+
 	it("omits strict when compat disables strict mode", async () => {
 		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
 		const model = {


### PR DESCRIPTION
## Why this is needed

In OpenClaw, `thinkingLevel: "off"` is passed down as an explicit `reasoning: undefined`.

For OpenRouter (`openai-completions`), that explicit "off" signal was not preserved, so models like **Kimi 2.5** could still run reasoning by default — leading to unexpected thinking output and tool-turn behavior/stops.

## What changed

- Detect explicit `reasoning: undefined` (vs omitted) via `Object.hasOwn` in the simple-stream path, scoped to OpenRouter only
- Send `{ reasoning: { effort: "none" } }` per [OpenRouter docs](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens)
- No public API change; `reasoningOff` is internal plumbing only

## Tests

- Explicit `reasoning: undefined` → sends `{ effort: "none" }`
- Omitted `reasoning` → does **not** send disable payload