### PR TITLE
fix: add strip-ansi as explicit dependency to prevent global installation issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8574,6 +8574,7 @@
 				"marked": "^15.0.12",
 				"minimatch": "^10.1.1",
 				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^6.0.1",
 				"yaml": "^2.8.2"
 			},
 			"bin": {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -54,6 +54,7 @@
 		"marked": "^15.0.12",
 		"minimatch": "^10.1.1",
 		"proper-lockfile": "^4.1.2",
+		"strip-ansi": "^6.0.1",
 		"yaml": "^2.8.2"
 	},
 	"overrides": {


### PR DESCRIPTION
The interactive mode components were importing stripAnsi from the strip-ansi package, but it wasn't listed as an explicit dependency in package.json. This caused issues during global installation when the transitive dependency wasn't properly resolved.