### PR TITLE
feat(rpc): add tree navigation, session mutation, and enriched RPC commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### Added
+
+- New RPC command `list_sessions` with `scope` (`"current"` or `"all"`) and optional `includeSearchText` for client-side session search
+- New RPC command `get_tree` returns lightweight session tree projection with per-node previews, optional full content, and resolved tool call info
+- New RPC command `navigate_tree` with branch summarization and abort support
+- New RPC command `set_label` for setting/clearing labels on tree entries
+- New RPC command `rename_session` for renaming any session by file path (not just the active session)
+- New RPC command `delete_session` for deleting sessions by file path with trash-first safety
+- Enriched `get_fork_messages` response with `timestamp`, `index`, and `totalUserMessages` per message
+
+### Fixed
+
+- Fixed `setWorkingMessage()` being silently dropped in RPC mode; extensions calling `ctx.ui.setWorkingMessage()` now emit a fire-and-forget `extension_ui_request` event to RPC clients, matching the behavior of `setStatus`, `notify`, and other fire-and-forget methods
+- Fixed RPC handler error attribution: errors now report the correct command type and request id instead of misattributing to `"parse"`
+- Fixed `get_tree` previews: whitespace normalized for single-line display, meaningful fallbacks for aborted/errored/empty assistant messages, `bashExecution` commands shown as `[bash]: <command>`
+- Fixed `get_tree` parent linkage: projected `parentId` now correctly references the structural parent after metadata node filtering
+- Fixed `list_sessions` with `scope: "current"` to follow the active session after `switch_session`
+- Fixed `navigate_tree` response: empty `editorText` preserved, `summaryEntry.summary` returned in full
+- Fixed `get_fork_messages` timestamp contract: throws on missing entry instead of emitting invalid empty string
+- Fixed unknown-command RPC responses to echo request `id` instead of returning `undefined`
+
 ## [0.52.12] - 2026-02-13
 
 ### Added

--- a/packages/coding-agent/docs/session.md
+++ b/packages/coding-agent/docs/session.md
@@ -16,6 +16,8 @@ Sessions can be removed by deleting their `.jsonl` files under `~/.pi/agent/sess
 
 Pi also supports deleting sessions interactively from `/resume` (select a session and press `Ctrl+D`, then confirm). When available, pi uses the `trash` CLI to avoid permanent deletion.
 
+**RPC clients**: Use the [`delete_session`](rpc.md#delete_session) command instead of removing files directly. It handles trash-first safety and prevents deleting the active session.
+
 ## Session Version
 
 Sessions have a version field in the header:

--- a/packages/coding-agent/src/core/format-tool-call.ts
+++ b/packages/coding-agent/src/core/format-tool-call.ts
@@ -1,0 +1,66 @@
+/** Format a tool call for display (`[read: ~/path:1-20]`, `[bash: cmd...]`). */
+
+import { homedir } from "node:os";
+
+const BASH_CMD_DISPLAY_LIMIT = 50;
+const DEFAULT_ARGS_DISPLAY_LIMIT = 40;
+
+/** Shorten absolute paths by replacing $HOME with ~ */
+export function shortenPath(path: string): string {
+	const home = homedir();
+	if (path.startsWith(home)) return `~${path.slice(home.length)}`;
+	return path;
+}
+
+/** Extract and shorten the path argument from tool args. */
+function pathArg(args: Record<string, unknown>, fallback = ""): string {
+	return shortenPath(String(args.path ?? fallback));
+}
+
+/** Format a tool call into a bracketed display string. */
+export function formatToolCall(name: string, args: Record<string, unknown>): string {
+	switch (name) {
+		case "read": {
+			const path = pathArg(args);
+			const offset = args.offset as number | undefined;
+			const limit = args.limit as number | undefined;
+			let display = path;
+			if (offset !== undefined || limit !== undefined) {
+				const start = offset ?? 1;
+				const end = limit !== undefined ? start + limit - 1 : "";
+				display += `:${start}${end ? `-${end}` : ""}`;
+			}
+			return `[read: ${display}]`;
+		}
+		case "write": {
+			return `[write: ${pathArg(args)}]`;
+		}
+		case "edit": {
+			return `[edit: ${pathArg(args)}]`;
+		}
+		case "bash": {
+			const rawCmd = String(args.command ?? "");
+			const normalized = rawCmd.replace(/[\n\t]/g, " ").trim();
+			const cmd = normalized.slice(0, BASH_CMD_DISPLAY_LIMIT);
+			return `[bash: ${cmd}${normalized.length > BASH_CMD_DISPLAY_LIMIT ? "..." : ""}]`;
+		}
+		case "grep": {
+			const pattern = String(args.pattern ?? "");
+			const path = pathArg(args, ".");
+			return `[grep: /${pattern}/ in ${path}]`;
+		}
+		case "find": {
+			const pattern = String(args.pattern ?? "");
+			const path = pathArg(args, ".");
+			return `[find: ${pattern} in ${path}]`;
+		}
+		case "ls": {
+			return `[ls: ${pathArg(args, ".")}]`;
+		}
+		default: {
+			const serialized = JSON.stringify(args);
+			const argsStr = serialized.slice(0, DEFAULT_ARGS_DISPLAY_LIMIT);
+			return `[${name}: ${argsStr}${serialized.length > DEFAULT_ARGS_DISPLAY_LIMIT ? "..." : ""}]`;
+		}
+	}
+}

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -14,7 +14,6 @@ export {
 export { type BashExecutorOptions, type BashResult, executeBash, executeBashWithOperations } from "./bash-executor.js";
 export type { CompactionResult } from "./compaction/index.js";
 export { createEventBus, type EventBus, type EventBusController } from "./event-bus.js";
-
 // Extensions system
 export {
 	type AgentEndEvent,
@@ -59,3 +58,5 @@ export {
 	type TurnStartEvent,
 	wrapToolsWithExtensions,
 } from "./extensions/index.js";
+export { formatToolCall, shortenPath } from "./format-tool-call.js";
+export { type DeleteSessionResult, deleteSessionFile } from "./session-file-ops.js";

--- a/packages/coding-agent/src/core/session-file-ops.ts
+++ b/packages/coding-agent/src/core/session-file-ops.ts
@@ -1,0 +1,84 @@
+/** Session file deletion with trash fallback. */
+
+import { spawn } from "node:child_process";
+import { unlink } from "node:fs/promises";
+
+const TRASH_ERROR_HINT_LIMIT = 200;
+
+/** Result of running the trash CLI. */
+interface TrashResult {
+	status: number | null;
+	stderr: string;
+	error?: string;
+}
+
+/** Result of a session file deletion attempt. */
+export interface DeleteSessionResult {
+	ok: boolean;
+	method: "trash" | "unlink";
+	error?: string;
+}
+
+/** Build a diagnostic hint from a failed trash attempt. */
+function getTrashErrorHint(trashResult: TrashResult): string | undefined {
+	const parts: string[] = [];
+	if (trashResult.error) {
+		parts.push(trashResult.error);
+	}
+	const stderr = trashResult.stderr?.trim();
+	if (stderr) {
+		parts.push(stderr.split("\n")[0] ?? stderr);
+	}
+	if (parts.length === 0) return undefined;
+	return `trash: ${parts.join(" · ").slice(0, TRASH_ERROR_HINT_LIMIT)}`;
+}
+
+/** Delete a session file, trying the `trash` CLI first, then falling back to unlink. */
+export async function deleteSessionFile(sessionPath: string): Promise<DeleteSessionResult> {
+	if (!sessionPath) throw new Error("sessionPath must be non-empty");
+
+	const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
+
+	// Try `trash` first (if installed)
+	const trashResult = await runTrash(trashArgs);
+
+	if (trashResult.status === 0) {
+		return { ok: true, method: "trash" };
+	}
+
+	// Fallback to permanent deletion
+	try {
+		await unlink(sessionPath);
+		return { ok: true, method: "unlink" };
+	} catch (err) {
+		// File already gone (trash may have worked, or file never existed) — treat as success
+		if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+			return { ok: true, method: "trash" };
+		}
+		const unlinkError = err instanceof Error ? err.message : String(err);
+		const trashErrorHint = getTrashErrorHint(trashResult);
+		const error = trashErrorHint ? `${unlinkError} (${trashErrorHint})` : unlinkError;
+		return { ok: false, method: "unlink", error };
+	}
+}
+
+/** Run `trash` as an async child process and collect its result. */
+function runTrash(args: string[]): Promise<TrashResult> {
+	return new Promise((resolve) => {
+		let stderr = "";
+		try {
+			const child = spawn("trash", args, { stdio: ["ignore", "ignore", "pipe"] });
+			child.stderr.on("data", (chunk: Buffer) => {
+				stderr += chunk.toString();
+			});
+			child.on("error", (err) => {
+				resolve({ status: null, stderr, error: err.message });
+			});
+			child.on("close", (code) => {
+				resolve({ status: code, stderr });
+			});
+		} catch (err) {
+			resolve({ status: null, stderr, error: err instanceof Error ? err.message : String(err) });
+		}
+	});
+}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -41,6 +41,7 @@ export interface MarkdownSettings {
 	codeBlockIndent?: string; // default: "  "
 }
 
+/** @deprecated Use `Transport` from `@mariozechner/pi-ai` directly. */
 export type TransportSetting = Transport;
 
 /**
@@ -63,7 +64,7 @@ export interface Settings {
 	defaultProvider?: string;
 	defaultModel?: string;
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
-	transport?: TransportSetting; // default: "sse"
+	transport?: Transport; // default: "sse"
 	steeringMode?: "all" | "one-at-a-time";
 	followUpMode?: "all" | "one-at-a-time";
 	theme?: string;
@@ -443,11 +444,11 @@ export class SettingsManager {
 		this.save();
 	}
 
-	getTransport(): TransportSetting {
+	getTransport(): Transport {
 		return this.settings.transport ?? "sse";
 	}
 
-	setTransport(transport: TransportSetting): void {
+	setTransport(transport: Transport): void {
 		this.globalSettings.transport = transport;
 		this.markModified("transport");
 		this.save();

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -6,4 +6,11 @@ export { InteractiveMode, type InteractiveModeOptions } from "./interactive/inte
 export { type PrintModeOptions, runPrintMode } from "./print-mode.js";
 export { type ModelInfo, RpcClient, type RpcClientOptions, type RpcEventListener } from "./rpc/rpc-client.js";
 export { runRpcMode } from "./rpc/rpc-mode.js";
-export type { RpcCommand, RpcResponse, RpcSessionState } from "./rpc/rpc-types.js";
+export type {
+	RpcCommand,
+	RpcForkMessage,
+	RpcResponse,
+	RpcSessionListItem,
+	RpcSessionState,
+	RpcTreeNode,
+} from "./rpc/rpc-types.js";

--- a/packages/coding-agent/src/modes/rpc/rpc-session-mutation.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-session-mutation.ts
@@ -1,0 +1,57 @@
+/**
+ * Session mutation operations for RPC commands.
+ *
+ * Handles rename_session and delete_session on arbitrary session paths.
+ * Functions throw on validation errors - the RPC handler catches and
+ * converts to error responses.
+ */
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { deleteSessionFile } from "../../core/session-file-ops.js";
+import { SessionManager } from "../../core/session-manager.js";
+
+/**
+ * Rename a session by path.
+ *
+ * Opens the session file, appends a session_info entry with the new name.
+ * Throws if path doesn't exist or name is empty.
+ */
+export function renameSessionByPath(sessionPath: string, name: string): void {
+	const trimmed = name.trim();
+	if (!trimmed) {
+		throw new Error("Session name cannot be empty");
+	}
+
+	const resolved = resolve(sessionPath);
+	if (!existsSync(resolved)) {
+		throw new Error(`Session file not found: ${sessionPath}`);
+	}
+
+	const mgr = SessionManager.open(resolved);
+	mgr.appendSessionInfo(trimmed);
+}
+
+/**
+ * Delete a session by path.
+ *
+ * Throws if path doesn't exist, path is the active session, or deletion fails.
+ */
+export async function deleteSessionByPath(sessionPath: string, activeSessionPath: string | undefined): Promise<void> {
+	const resolved = resolve(sessionPath);
+
+	if (!existsSync(resolved)) {
+		throw new Error(`Session file not found: ${sessionPath}`);
+	}
+
+	// Compare resolved paths to avoid false negatives from relative vs absolute
+	if (activeSessionPath && resolved === resolve(activeSessionPath)) {
+		throw new Error("Cannot delete the currently active session");
+	}
+
+	const result = await deleteSessionFile(resolved);
+
+	if (!result.ok) {
+		throw new Error(result.error || "Failed to delete session file");
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-tree-projection.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-tree-projection.ts
@@ -1,0 +1,265 @@
+/**
+ * Lightweight projection of SessionTreeNode to RpcTreeNode for RPC transport.
+ *
+ * Filters metadata entries (label, session_info, custom), resolves tool call info
+ * from assistant messages, and produces compact nodes with preview text.
+ */
+
+import type { AssistantMessage, ToolResultMessage } from "@mariozechner/pi-ai";
+import { formatToolCall } from "../../core/format-tool-call.js";
+import type { BashExecutionMessage } from "../../core/messages.js";
+import type { SessionTreeNode } from "../../core/session-manager.js";
+import type { RpcTreeNode, RpcTreeNodeBase } from "./rpc-types.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Base fields for a projected node before adding the role-specific `type`. */
+type ProjectedBase = Omit<RpcTreeNodeBase, "type">;
+
+/** Resolved tool call info, keyed by toolCallId */
+export interface ToolCallInfo {
+	name: string;
+	arguments: Record<string, unknown>;
+}
+
+/** A content block with a type discriminant; text blocks carry a `.text` string. */
+interface ContentBlock {
+	type: string;
+	text?: string;
+}
+
+/** Content shapes accepted by {@link extractText}. */
+type ExtractableContent = string | readonly ContentBlock[] | null | undefined;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Extract text from message content, optionally truncated.
+ * Handles string content and content block arrays (only "text" blocks -
+ * images, tool calls, and thinking blocks have no textual preview).
+ */
+export function extractText(content: ExtractableContent, maxLen?: number): string {
+	if (typeof content === "string") return maxLen !== undefined ? content.slice(0, maxLen) : content;
+	if (Array.isArray(content)) {
+		let result = "";
+		for (const c of content) {
+			if (c.type === "text" && c.text) {
+				result += c.text;
+				if (maxLen !== undefined && result.length >= maxLen) return result.slice(0, maxLen);
+			}
+		}
+		return result;
+	}
+	return "";
+}
+
+/** Normalize text for single-line preview display: replace newlines/tabs with spaces, trim. */
+function normalizePreview(text: string): string {
+	return text.replace(/[\n\t]/g, " ").trim();
+}
+
+/** Return `{ content }` when `include` is true, empty object otherwise. Reduces spread boilerplate. */
+function optionalContent(include: boolean, content: string): { content?: string } {
+	return include ? { content } : {};
+}
+
+/**
+ * Build a map from toolCallId to {name, arguments} by scanning tree nodes
+ * for assistant messages with toolCall content blocks.
+ */
+export function buildToolCallMap(roots: SessionTreeNode[]): Map<string, ToolCallInfo> {
+	const map = new Map<string, ToolCallInfo>();
+
+	function visit(node: SessionTreeNode): void {
+		const entry = node.entry;
+		if (entry.type === "message" && entry.message.role === "assistant") {
+			const { content } = entry.message as AssistantMessage;
+			for (const block of content) {
+				if (block.type === "toolCall") {
+					map.set(block.id, { name: block.name, arguments: block.arguments });
+				}
+			}
+		}
+		for (const child of node.children) visit(child);
+	}
+
+	for (const root of roots) visit(root);
+	return map;
+}
+
+/**
+ * Project a SessionTreeNode tree into RpcTreeNode tree.
+ *
+ * Filters out label, session_info, and custom entries (metadata only).
+ * Labels are already resolved onto target nodes via node.label.
+ */
+export function projectTree(
+	roots: SessionTreeNode[],
+	toolCallMap: Map<string, ToolCallInfo>,
+	includeContent: boolean,
+): RpcTreeNode[] {
+	return roots.flatMap((node) => projectNode(node, toolCallMap, includeContent, null));
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+function projectNode(
+	node: SessionTreeNode,
+	toolCallMap: Map<string, ToolCallInfo>,
+	includeContent: boolean,
+	projectedParentId: string | null,
+): RpcTreeNode[] {
+	const entry = node.entry;
+
+	// Filter out metadata entries — labels are resolved on target nodes,
+	// session_info is available via get_state
+	if (entry.type === "label" || entry.type === "session_info") {
+		// Still project children (they may be non-metadata)
+		return projectChildren(node.children, toolCallMap, includeContent, projectedParentId);
+	}
+
+	// Skip custom entries (extension-internal data, not rendered)
+	if (entry.type === "custom") {
+		return projectChildren(node.children, toolCallMap, includeContent, projectedParentId);
+	}
+
+	const children = projectChildren(node.children, toolCallMap, includeContent, entry.id);
+	const base = {
+		id: entry.id,
+		parentId: projectedParentId,
+		timestamp: entry.timestamp,
+		label: node.label,
+		children,
+	};
+
+	switch (entry.type) {
+		case "message": {
+			const { message } = entry;
+
+			if (message.role === "toolResult") {
+				return [projectToolResult(base, message, toolCallMap, includeContent)];
+			}
+
+			if (message.role === "bashExecution") {
+				const bash = message as BashExecutionMessage;
+				const command = normalizePreview(bash.command);
+				return [
+					{
+						...base,
+						type: "message",
+						role: "bashExecution",
+						preview: `[bash]: ${command}`,
+						...optionalContent(includeContent, bash.output),
+					},
+				];
+			}
+
+			if (message.role === "assistant") {
+				return [projectAssistant(base, message, includeContent)];
+			}
+
+			// user and other roles
+			const content = "content" in message ? (message.content as ExtractableContent) : undefined;
+			return [
+				{
+					...base,
+					type: "message",
+					// After toolResult/bashExecution/assistant are handled above, remaining
+					// roles are user, custom, branchSummary, compactionSummary.  TS can't
+					// narrow AgentMessage through declaration-merged custom roles, so cast.
+					role: message.role as Extract<RpcTreeNode, { type: "message" }>["role"],
+					preview: normalizePreview(extractText(content, 200)),
+					...optionalContent(includeContent, extractText(content)),
+				},
+			];
+		}
+
+		case "compaction": {
+			return [{ ...base, type: "compaction", tokensBefore: entry.tokensBefore }];
+		}
+
+		case "model_change": {
+			return [{ ...base, type: "model_change", provider: entry.provider, modelId: entry.modelId }];
+		}
+
+		case "thinking_level_change": {
+			return [{ ...base, type: "thinking_level_change", thinkingLevel: entry.thinkingLevel }];
+		}
+
+		case "branch_summary": {
+			return [{ ...base, type: "branch_summary", summary: entry.summary }];
+		}
+
+		case "custom_message": {
+			return [
+				{
+					...base,
+					type: "custom_message",
+					customType: entry.customType,
+					preview: normalizePreview(extractText(entry.content, 200)),
+					...optionalContent(includeContent, extractText(entry.content)),
+				},
+			];
+		}
+
+		default:
+			// Unknown entry type — skip but project children
+			return projectChildren(node.children, toolCallMap, includeContent, projectedParentId);
+	}
+}
+
+function projectChildren(
+	nodes: SessionTreeNode[],
+	toolCallMap: Map<string, ToolCallInfo>,
+	includeContent: boolean,
+	projectedParentId: string | null,
+): RpcTreeNode[] {
+	return nodes.flatMap((child) => projectNode(child, toolCallMap, includeContent, projectedParentId));
+}
+
+function projectAssistant(base: ProjectedBase, message: AssistantMessage, includeContent: boolean): RpcTreeNode {
+	const text = extractText(message.content, 200);
+	const preview = text
+		? normalizePreview(text)
+		: message.stopReason === "aborted"
+			? "(aborted)"
+			: message.errorMessage
+				? normalizePreview(message.errorMessage)
+				: "(no content)";
+
+	return {
+		...base,
+		type: "message",
+		role: "assistant",
+		preview,
+		...optionalContent(includeContent, extractText(message.content)),
+		stopReason: message.stopReason,
+		errorMessage: message.errorMessage,
+	};
+}
+
+function projectToolResult(
+	base: ProjectedBase,
+	message: ToolResultMessage,
+	toolCallMap: Map<string, ToolCallInfo>,
+	includeContent: boolean,
+): RpcTreeNode {
+	const toolCall = message.toolCallId ? toolCallMap.get(message.toolCallId) : undefined;
+	const formatted = toolCall ? formatToolCall(toolCall.name, toolCall.arguments) : undefined;
+
+	return {
+		...base,
+		type: "tool_result",
+		toolName: toolCall?.name ?? message.toolName,
+		toolArgs: toolCall?.arguments,
+		formattedToolCall: formatted,
+		preview: normalizePreview(formatted ?? `[${message.toolName ?? "tool"}]`),
+		...optionalContent(includeContent, extractText(message.content)),
+	};
+}

--- a/packages/coding-agent/test/format-tool-call.test.ts
+++ b/packages/coding-agent/test/format-tool-call.test.ts
@@ -1,0 +1,142 @@
+/** Unit tests for formatToolCall. */
+
+import { describe, expect, test } from "vitest";
+import { formatToolCall } from "../src/core/format-tool-call.js";
+
+describe("formatToolCall", () => {
+	// =========================================================================
+	// read
+	// =========================================================================
+
+	test("read with path only", () => {
+		expect(formatToolCall("read", { path: "/tmp/test.ts" })).toBe("[read: /tmp/test.ts]");
+	});
+
+	test("read with offset and limit", () => {
+		expect(formatToolCall("read", { path: "/tmp/test.ts", offset: 10, limit: 21 })).toBe(
+			"[read: /tmp/test.ts:10-30]",
+		);
+	});
+
+	test("read with offset only", () => {
+		expect(formatToolCall("read", { path: "/tmp/test.ts", offset: 10 })).toBe("[read: /tmp/test.ts:10]");
+	});
+
+	test("read with limit only defaults start to 1", () => {
+		expect(formatToolCall("read", { path: "/tmp/test.ts", limit: 20 })).toBe("[read: /tmp/test.ts:1-20]");
+	});
+
+	test("read shortens HOME prefix to ~", () => {
+		const home = (process.env.HOME || process.env.USERPROFILE)!;
+		expect(formatToolCall("read", { path: `${home}/subfolder/file.ts` })).toBe("[read: ~/subfolder/file.ts]");
+	});
+
+	// =========================================================================
+	// write
+	// =========================================================================
+
+	test("write with path", () => {
+		expect(formatToolCall("write", { path: "/tmp/out.ts" })).toBe("[write: /tmp/out.ts]");
+	});
+
+	// =========================================================================
+	// edit
+	// =========================================================================
+
+	test("edit with path", () => {
+		expect(formatToolCall("edit", { path: "/tmp/out.ts" })).toBe("[edit: /tmp/out.ts]");
+	});
+
+	// =========================================================================
+	// bash
+	// =========================================================================
+
+	test("bash with short command", () => {
+		expect(formatToolCall("bash", { command: "ls -la" })).toBe("[bash: ls -la]");
+	});
+
+	test("bash truncates long commands at 50 chars with ellipsis", () => {
+		const longCmd = "a".repeat(60);
+		const result = formatToolCall("bash", { command: longCmd });
+		expect(result).toBe(`[bash: ${"a".repeat(50)}...]`);
+	});
+
+	test("bash normalizes newlines and tabs to spaces", () => {
+		expect(formatToolCall("bash", { command: "echo hello\n\techo world" })).toBe("[bash: echo hello  echo world]");
+	});
+
+	test("bash ellipsis is based on normalized command length", () => {
+		// Raw length is 51 (>50 limit), but after normalizing tabs to spaces and
+		// trimming, the normalized string is only 45 chars — no truncation, no ellipsis.
+		const rawCmd = `${"x".repeat(45)}\t\t\t\t\t\t`;
+		expect(rawCmd.length).toBe(51);
+		const result = formatToolCall("bash", { command: rawCmd });
+		expect(result).toBe(`[bash: ${"x".repeat(45)}]`);
+	});
+
+	test("bash ellipsis appears when normalized command exceeds limit", () => {
+		const rawCmd = "x".repeat(55);
+		const result = formatToolCall("bash", { command: rawCmd });
+		expect(result).toContain("...");
+		expect(result).toBe(`[bash: ${"x".repeat(50)}...]`);
+	});
+
+	// =========================================================================
+	// grep
+	// =========================================================================
+
+	test("grep with pattern and path", () => {
+		expect(formatToolCall("grep", { pattern: "TODO", path: "/src" })).toBe("[grep: /TODO/ in /src]");
+	});
+
+	test("grep defaults path to .", () => {
+		expect(formatToolCall("grep", { pattern: "TODO" })).toBe("[grep: /TODO/ in .]");
+	});
+
+	// =========================================================================
+	// find
+	// =========================================================================
+
+	test("find with pattern and path", () => {
+		expect(formatToolCall("find", { pattern: "*.ts", path: "/src" })).toBe("[find: *.ts in /src]");
+	});
+
+	test("find defaults path to .", () => {
+		expect(formatToolCall("find", { pattern: "*.ts" })).toBe("[find: *.ts in .]");
+	});
+
+	// =========================================================================
+	// ls
+	// =========================================================================
+
+	test("ls with path", () => {
+		expect(formatToolCall("ls", { path: "/tmp" })).toBe("[ls: /tmp]");
+	});
+
+	test("ls defaults path to .", () => {
+		expect(formatToolCall("ls", {})).toBe("[ls: .]");
+	});
+
+	// =========================================================================
+	// unknown tool (default case)
+	// =========================================================================
+
+	test("unknown tool shows name and JSON args", () => {
+		expect(formatToolCall("mytool", { key: "val" })).toBe('[mytool: {"key":"val"}]');
+	});
+
+	test("unknown tool truncates long JSON at 40 chars with ellipsis", () => {
+		const args = { longKey: "x".repeat(50) };
+		const fullJson = JSON.stringify(args);
+		expect(fullJson.length).toBeGreaterThan(40);
+		const result = formatToolCall("mytool", args);
+		expect(result).toBe(`[mytool: ${fullJson.slice(0, 40)}...]`);
+	});
+
+	test("unknown tool does not add ellipsis for short JSON", () => {
+		const args = { a: 1 };
+		const result = formatToolCall("mytool", args);
+		expect(result).toBe('[mytool: {"a":1}]');
+		expect(result).not.toContain("...");
+	});
+});

--- a/packages/coding-agent/test/rpc-list-sessions-scope.test.ts
+++ b/packages/coding-agent/test/rpc-list-sessions-scope.test.ts
@@ -1,0 +1,154 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { assistantMsg, createTestSession, type TestSessionContext, userMsg } from "./utilities.js";
+
+interface SessionScopeFixture {
+	workspaceRoot: string;
+	projectA: string;
+	projectB: string;
+	sessionDirA: string;
+	sessionDirB: string;
+	sessionFileA: string;
+	sessionFileB: string;
+	ctx: TestSessionContext;
+}
+
+function createPersistedSession(
+	cwd: string,
+	sessionDir: string,
+	prefix: string,
+): { manager: SessionManager; file: string } {
+	mkdirSync(cwd, { recursive: true });
+	mkdirSync(sessionDir, { recursive: true });
+
+	const manager = SessionManager.create(cwd, sessionDir);
+	manager.appendMessage(userMsg(`${prefix} user`));
+	manager.appendMessage(assistantMsg(`${prefix} assistant`));
+
+	const file = manager.getSessionFile();
+	if (!file) {
+		throw new Error("Expected persisted session file path");
+	}
+
+	return { manager, file };
+}
+
+function createFixture(): SessionScopeFixture {
+	const workspaceRoot = join(tmpdir(), `pi-rpc-current-scope-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	const projectA = join(workspaceRoot, "project-a");
+	const projectB = join(workspaceRoot, "project-b");
+	const sessionDirA = join(workspaceRoot, "sessions-a");
+	const sessionDirB = join(workspaceRoot, "sessions-b");
+
+	const { manager: sessionManagerA, file: sessionFileA } = createPersistedSession(projectA, sessionDirA, "A");
+	const { file: sessionFileB } = createPersistedSession(projectB, sessionDirB, "B");
+	const ctx = createTestSession({ sessionManager: sessionManagerA, cwd: projectA });
+
+	return {
+		workspaceRoot,
+		projectA,
+		projectB,
+		sessionDirA,
+		sessionDirB,
+		sessionFileA,
+		sessionFileB,
+		ctx,
+	};
+}
+
+/** Resolve current scope from an AgentSession, matching the rpc-mode.ts inline logic. */
+function resolveFromSession(session: AgentSession): { cwd: string; sessionDir: string | undefined } {
+	const headerCwd = session.sessionManager.getHeader()?.cwd;
+	const sessionFile = session.sessionFile;
+	if (headerCwd && sessionFile) {
+		return { cwd: headerCwd, sessionDir: dirname(sessionFile) };
+	}
+	return { cwd: session.sessionManager.getCwd(), sessionDir: session.sessionManager.getSessionDir() };
+}
+
+describe("RPC list_sessions current scope semantics", () => {
+	let fixture: SessionScopeFixture;
+
+	beforeEach(() => {
+		fixture = createFixture();
+	});
+
+	afterEach(() => {
+		fixture.ctx.cleanup();
+		if (existsSync(fixture.workspaceRoot)) {
+			rmSync(fixture.workspaceRoot, { recursive: true });
+		}
+	});
+
+	test("scope: current follows switched session context in RPC resolver", async () => {
+		const session = fixture.ctx.session;
+
+		const listCurrent = async (): Promise<string[]> => {
+			const currentScope = resolveFromSession(session);
+			const sessions = await SessionManager.list(currentScope.cwd, currentScope.sessionDir);
+			return sessions.map((s) => s.path);
+		};
+
+		const startupCwd = session.sessionManager.getCwd();
+		const startupSessionDir = session.sessionManager.getSessionDir();
+
+		const beforeSwitchScope = resolveFromSession(session);
+		expect(beforeSwitchScope.cwd).toBe(fixture.projectA);
+		expect(beforeSwitchScope.sessionDir).toBe(fixture.sessionDirA);
+
+		const beforeSwitch = await listCurrent();
+		expect(beforeSwitch).toContain(fixture.sessionFileA);
+		expect(beforeSwitch).not.toContain(fixture.sessionFileB);
+
+		const switched = await session.switchSession(fixture.sessionFileB);
+		expect(switched).toBe(true);
+		expect(session.sessionManager.getSessionFile()).toBe(fixture.sessionFileB);
+		expect(session.sessionManager.getHeader()?.cwd).toBe(fixture.projectB);
+
+		// Core SessionManager context remains startup-bound after switch_session.
+		// The RPC resolver compensates by reading from the active session header.
+		expect(session.sessionManager.getCwd()).toBe(startupCwd);
+		expect(session.sessionManager.getSessionDir()).toBe(startupSessionDir);
+
+		const afterSwitchScope = resolveFromSession(session);
+		expect(afterSwitchScope.cwd).toBe(fixture.projectB);
+		expect(afterSwitchScope.sessionDir).toBe(fixture.sessionDirB);
+
+		const afterSwitch = await listCurrent();
+		expect(afterSwitch).toContain(fixture.sessionFileB);
+		expect(afterSwitch).not.toContain(fixture.sessionFileA);
+	});
+
+	test("falls back to SessionManager context when session file is unavailable", () => {
+		const fallbackSessionManager = SessionManager.inMemory("/fallback-cwd");
+		const fallbackCtx = createTestSession({ sessionManager: fallbackSessionManager, cwd: "/fallback-cwd" });
+
+		const resolvedScope = resolveFromSession(fallbackCtx.session);
+		expect(resolvedScope.cwd).toBe(fallbackSessionManager.getCwd());
+		expect(resolvedScope.sessionDir).toBe(fallbackSessionManager.getSessionDir());
+
+		fallbackCtx.cleanup();
+	});
+
+	test("falls back to SessionManager context when header cwd is unavailable", () => {
+		const fallbackSessionManager = SessionManager.create(fixture.projectA, fixture.sessionDirA);
+		// Simulate missing header cwd: sessionFile present but headerCwd undefined
+		const sessionFile = "/tmp/example/session.jsonl";
+		const headerCwd: string | undefined = undefined;
+		let resolvedScope: { cwd: string; sessionDir: string | undefined };
+		if (headerCwd && sessionFile) {
+			resolvedScope = { cwd: headerCwd, sessionDir: dirname(sessionFile) };
+		} else {
+			resolvedScope = {
+				cwd: fallbackSessionManager.getCwd(),
+				sessionDir: fallbackSessionManager.getSessionDir(),
+			};
+		}
+		expect(resolvedScope.cwd).toBe(fallbackSessionManager.getCwd());
+		expect(resolvedScope.sessionDir).toBe(fallbackSessionManager.getSessionDir());
+	});
+});

--- a/packages/coding-agent/test/rpc-navigate-tree.test.ts
+++ b/packages/coding-agent/test/rpc-navigate-tree.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for AgentSession.navigateTree().
+ *
+ * Tests basic navigation without summarization (no API key needed).
+ * Uses createTestSession with in-memory SessionManager.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { assistantMsg, createTestSession, type TestSessionContext, userMsg } from "./utilities.js";
+
+/** Sync agent state with session manager so navigateTree sees the full tree. */
+function syncAgentState(ctx: TestSessionContext): void {
+	const context = ctx.sessionManager.buildSessionContext();
+	ctx.session.agent.replaceMessages(context.messages);
+}
+
+describe("navigate_tree", () => {
+	let ctx: TestSessionContext;
+
+	beforeEach(() => {
+		ctx = createTestSession({ inMemory: true });
+	});
+
+	afterEach(() => {
+		ctx.cleanup();
+	});
+
+	test("navigating to user message returns editorText and changes leaf", async () => {
+		const { session, sessionManager } = ctx;
+
+		// Build: u1 -> a1 -> u2 -> a2
+		sessionManager.appendMessage(userMsg("First message"));
+		sessionManager.appendMessage(assistantMsg("Response 1"));
+		const u2Id = sessionManager.appendMessage(userMsg("Second message"));
+		sessionManager.appendMessage(assistantMsg("Response 2"));
+		syncAgentState(ctx);
+
+		const leafBefore = sessionManager.getLeafId();
+		const result = await session.navigateTree(u2Id, { summarize: false });
+
+		expect(result.cancelled).toBe(false);
+		expect(result.editorText).toBe("Second message");
+		// Leaf moved to parent of user message (a1)
+		expect(sessionManager.getLeafId()).not.toBe(leafBefore);
+	});
+
+	test("navigating to root user message sets leaf to null", async () => {
+		const { session, sessionManager } = ctx;
+
+		const u1Id = sessionManager.appendMessage(userMsg("Root message"));
+		sessionManager.appendMessage(assistantMsg("Response"));
+		syncAgentState(ctx);
+
+		const result = await session.navigateTree(u1Id, { summarize: false });
+
+		expect(result.cancelled).toBe(false);
+		expect(result.editorText).toBe("Root message");
+		expect(sessionManager.getLeafId()).toBeNull();
+	});
+
+	test("navigating to assistant message returns no editorText", async () => {
+		const { session, sessionManager } = ctx;
+
+		sessionManager.appendMessage(userMsg("Hello"));
+		const a1Id = sessionManager.appendMessage(assistantMsg("Hi back"));
+		sessionManager.appendMessage(userMsg("Follow up"));
+		syncAgentState(ctx);
+
+		const result = await session.navigateTree(a1Id, { summarize: false });
+
+		expect(result.cancelled).toBe(false);
+		expect(result.editorText).toBeUndefined();
+		expect(sessionManager.getLeafId()).toBe(a1Id);
+	});
+
+	test("navigating to current leaf is a no-op", async () => {
+		const { session, sessionManager } = ctx;
+
+		sessionManager.appendMessage(userMsg("Hello"));
+		const a1Id = sessionManager.appendMessage(assistantMsg("Response"));
+		syncAgentState(ctx);
+
+		expect(sessionManager.getLeafId()).toBe(a1Id);
+		const result = await session.navigateTree(a1Id, { summarize: false });
+
+		expect(result.cancelled).toBe(false);
+		expect(sessionManager.getLeafId()).toBe(a1Id);
+	});
+
+	test("navigating to non-existent entry throws", async () => {
+		const { session } = ctx;
+		await expect(session.navigateTree("nonexistent", { summarize: false })).rejects.toThrow(
+			"Entry nonexistent not found",
+		);
+	});
+});

--- a/packages/coding-agent/test/rpc-session-mutation.test.ts
+++ b/packages/coding-agent/test/rpc-session-mutation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for rename_session and delete_session RPC commands.
+ *
+ * Tests:
+ * 1. Core operations (SessionManager + deleteSessionFile)
+ * 2. RPC handler validation (empty name, non-existent path, active session)
+ *
+ * Uses temp files for filesystem operations — no API key needed.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { deleteSessionFile } from "../src/core/session-file-ops.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { deleteSessionByPath, renameSessionByPath } from "../src/modes/rpc/rpc-session-mutation.js";
+import { assistantMsg, userMsg } from "./utilities.js";
+
+describe("session mutation", () => {
+	let testDir: string;
+
+	beforeEach(() => {
+		testDir = join(tmpdir(), `rpc-session-mutation-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(testDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	/** Create a persisted session file in testDir and return its path. */
+	function createPersistedSession(name?: string): string {
+		const sm = SessionManager.create(testDir, testDir);
+		const sessionPath = sm.getSessionFile()!;
+		sm.appendMessage(userMsg("test message"));
+		sm.appendMessage(assistantMsg("test reply"));
+		if (name) {
+			sm.appendSessionInfo(name);
+		}
+		return sessionPath;
+	}
+
+	describe("rename_session (core)", () => {
+		test("renames an existing session file", () => {
+			const sessionPath = createPersistedSession();
+			expect(SessionManager.open(sessionPath).getSessionName()).toBeUndefined();
+
+			const mgr = SessionManager.open(sessionPath);
+			mgr.appendSessionInfo("new-name");
+
+			expect(SessionManager.open(sessionPath).getSessionName()).toBe("new-name");
+		});
+
+		test("overwrites an existing name", () => {
+			const sessionPath = createPersistedSession("old-name");
+			expect(SessionManager.open(sessionPath).getSessionName()).toBe("old-name");
+
+			const mgr = SessionManager.open(sessionPath);
+			mgr.appendSessionInfo("renamed");
+
+			expect(SessionManager.open(sessionPath).getSessionName()).toBe("renamed");
+		});
+
+		test("appendSessionInfo with whitespace-only name results in no name", () => {
+			const sessionPath = createPersistedSession();
+			const mgr = SessionManager.open(sessionPath);
+			mgr.appendSessionInfo("  ");
+
+			expect(SessionManager.open(sessionPath).getSessionName()).toBeUndefined();
+		});
+	});
+
+	describe("delete_session (core)", () => {
+		test("deletes an existing session file", async () => {
+			const sessionPath = createPersistedSession("doomed");
+			expect(existsSync(sessionPath)).toBe(true);
+
+			const result = await deleteSessionFile(sessionPath);
+
+			expect(result.ok).toBe(true);
+			expect(existsSync(sessionPath)).toBe(false);
+		});
+
+		test("reports ok for already-absent file", async () => {
+			const fakePath = join(testDir, "already-gone.jsonl");
+
+			const result = await deleteSessionFile(fakePath);
+
+			expect(result.ok).toBe(true);
+		});
+	});
+
+	describe("renameSessionByPath (RPC handler logic)", () => {
+		test("renames session successfully", () => {
+			const sessionPath = createPersistedSession();
+
+			renameSessionByPath(sessionPath, "my-session");
+
+			expect(SessionManager.open(sessionPath).getSessionName()).toBe("my-session");
+		});
+
+		test("throws on empty name after trimming", () => {
+			const sessionPath = createPersistedSession();
+
+			expect(() => renameSessionByPath(sessionPath, "   ")).toThrow(/empty/i);
+		});
+
+		test("throws on non-existent session path", () => {
+			const fakePath = join(testDir, "nonexistent.jsonl");
+
+			expect(() => renameSessionByPath(fakePath, "test")).toThrow(/not found/i);
+		});
+	});
+
+	describe("deleteSessionByPath (RPC handler logic)", () => {
+		test("deletes session successfully", async () => {
+			const sessionPath = createPersistedSession("doomed");
+
+			await deleteSessionByPath(sessionPath, undefined);
+
+			expect(existsSync(sessionPath)).toBe(false);
+		});
+
+		test("throws when deleting the active session", async () => {
+			const sessionPath = createPersistedSession("active");
+
+			await expect(deleteSessionByPath(sessionPath, sessionPath)).rejects.toThrow(/active|current/i);
+			expect(existsSync(sessionPath)).toBe(true);
+		});
+
+		test("throws on non-existent session path", async () => {
+			const fakePath = join(testDir, "nonexistent.jsonl");
+
+			await expect(deleteSessionByPath(fakePath, undefined)).rejects.toThrow(/not found/i);
+		});
+	});
+});

--- a/packages/coding-agent/test/rpc-set-label.test.ts
+++ b/packages/coding-agent/test/rpc-set-label.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for set_label RPC command.
+ *
+ * Tests label set/clear and error on non-existent entries.
+ * Uses SessionManager.inMemory() — no API key needed.
+ */
+
+import { describe, expect, test } from "vitest";
+import { SessionManager } from "../src/core/session-manager.js";
+import { userMsg } from "./utilities.js";
+
+describe("set_label (via SessionManager)", () => {
+	test("set a label on an entry", () => {
+		const sm = SessionManager.inMemory();
+		const id = sm.appendMessage(userMsg("Hello"));
+
+		sm.appendLabelChange(id, "checkpoint");
+
+		expect(sm.getLabel(id)).toBe("checkpoint");
+	});
+
+	test("clear a label by passing undefined", () => {
+		const sm = SessionManager.inMemory();
+		const id = sm.appendMessage(userMsg("Hello"));
+
+		sm.appendLabelChange(id, "checkpoint");
+		expect(sm.getLabel(id)).toBe("checkpoint");
+
+		sm.appendLabelChange(id, undefined);
+		expect(sm.getLabel(id)).toBeUndefined();
+	});
+
+	test("clear a label by passing empty string", () => {
+		const sm = SessionManager.inMemory();
+		const id = sm.appendMessage(userMsg("Hello"));
+
+		sm.appendLabelChange(id, "checkpoint");
+		expect(sm.getLabel(id)).toBe("checkpoint");
+
+		sm.appendLabelChange(id, "");
+		expect(sm.getLabel(id)).toBeUndefined();
+	});
+
+	test("throws on non-existent entry", () => {
+		const sm = SessionManager.inMemory();
+		expect(() => sm.appendLabelChange("nonexistent", "test")).toThrow("Entry nonexistent not found");
+	});
+});

--- a/packages/coding-agent/test/rpc-tree-projection.test.ts
+++ b/packages/coding-agent/test/rpc-tree-projection.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Unit tests for the RPC tree projection.
+ *
+ * Tests the pure function logic that maps SessionTreeNode → RpcTreeNode.
+ * Uses SessionManager.inMemory() to build realistic tree structures
+ * without file I/O or API keys.
+ */
+
+import { describe, expect, test } from "vitest";
+import { SessionManager } from "../src/core/session-manager.js";
+import { buildToolCallMap, extractText, projectTree } from "../src/modes/rpc/rpc-tree-projection.js";
+import type { RpcTreeNode } from "../src/modes/rpc/rpc-types.js";
+import {
+	abortedAssistantMsg,
+	assistantMsg,
+	assistantToolCallMsg,
+	bashExecMsg,
+	errorAssistantMsg,
+	toolResultMsg,
+	userMsg,
+} from "./utilities.js";
+
+// ============================================================================
+// Typed narrowing helpers for RpcTreeNode discriminated union
+// ============================================================================
+
+type RpcMessageNode = Extract<RpcTreeNode, { type: "message" }>;
+type RpcToolResultNode = Extract<RpcTreeNode, { type: "tool_result" }>;
+
+/** Narrow an RpcTreeNode to a message node, failing the test if the type is wrong. */
+function asMessageNode(node: RpcTreeNode): RpcMessageNode {
+	expect(node.type).toBe("message");
+	return node as RpcMessageNode;
+}
+
+/** Narrow an RpcTreeNode to a tool_result node, failing the test if the type is wrong. */
+function asToolResultNode(node: RpcTreeNode): RpcToolResultNode {
+	expect(node.type).toBe("tool_result");
+	return node as RpcToolResultNode;
+}
+
+describe("RPC tree projection", () => {
+	test("user message produces type 'message' with role and preview", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Hello world from user"));
+
+		const tree = sm.getTree();
+		const toolCallMap = buildToolCallMap(tree);
+		const projected = projectTree(tree, toolCallMap, false);
+
+		expect(projected).toHaveLength(1);
+		const node = asMessageNode(projected[0]);
+		expect(node.role).toBe("user");
+		expect(node.preview).toBe("Hello world from user");
+	});
+
+	test("assistant message includes stopReason", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Hi"));
+		sm.appendMessage(assistantMsg("Hello back"));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		expect(projected).toHaveLength(1);
+		const assistantNode = asMessageNode(projected[0].children[0]);
+		expect(assistantNode.role).toBe("assistant");
+		expect(assistantNode.stopReason).toBe("stop");
+		expect(assistantNode.preview).toBe("Hello back");
+	});
+
+	test("tool result resolves toolName, toolArgs, formattedToolCall from toolCallMap", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Read a file"));
+		sm.appendMessage(assistantToolCallMsg("tc-1", "read", { path: "/tmp/test.ts" }));
+		sm.appendMessage(toolResultMsg("tc-1"));
+
+		const tree = sm.getTree();
+		const toolCallMap = buildToolCallMap(tree);
+		const projected = projectTree(tree, toolCallMap, false);
+
+		// user -> assistant -> toolResult
+		const tr = asToolResultNode(projected[0].children[0].children[0]);
+		expect(tr.toolName).toBe("read");
+		expect(tr.toolArgs).toEqual({ path: "/tmp/test.ts" });
+		expect(tr.formattedToolCall).toContain("[read:");
+		expect(tr.preview).toContain("[read:");
+	});
+
+	test("tool result with missing toolCall falls back to message toolName", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Do something"));
+		// Tool result without a matching assistant toolCall
+		sm.appendMessage(toolResultMsg("nonexistent-tc", "myTool"));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		// Falls back to the toolName from the tool result message itself
+		const tr = asToolResultNode(projected[0].children[0]);
+		expect(tr.toolName).toBe("myTool");
+		// No toolArgs or formattedToolCall without the matching assistant toolCall
+		expect(tr.toolArgs).toBeUndefined();
+		expect(tr.formattedToolCall).toBeUndefined();
+		expect(tr.preview).toBe("[myTool]");
+	});
+
+	test("includeContent toggle — preview always present, content conditional", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Some user content here"));
+
+		const tree = sm.getTree();
+		const toolCallMap = buildToolCallMap(tree);
+
+		// Without content
+		const withoutContent = asMessageNode(projectTree(tree, toolCallMap, false)[0]);
+		expect(withoutContent.preview).toBe("Some user content here");
+		expect(withoutContent.content).toBeUndefined();
+
+		// With content
+		const withContent = asMessageNode(projectTree(tree, toolCallMap, true)[0]);
+		expect(withContent.preview).toBe("Some user content here");
+		expect(withContent.content).toBe("Some user content here");
+	});
+
+	test("label entries filtered from output, label resolved on target node", () => {
+		const sm = SessionManager.inMemory();
+		const userId = sm.appendMessage(userMsg("First message"));
+		sm.appendMessage(assistantMsg("Response"));
+		sm.appendLabelChange(userId, "checkpoint-1");
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		// label entry should not appear as a tree node
+		const allTypes = collectAllTypes(projected);
+		expect(allTypes).not.toContain("label");
+
+		// The user message node should have the label
+		expect(projected[0].label).toBe("checkpoint-1");
+	});
+
+	test("parent links stay consistent when filtered metadata nodes are removed", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Root user"));
+		const assistantId = sm.appendMessage(assistantMsg("Root assistant"));
+		sm.appendLabelChange(assistantId, "checkpoint");
+		sm.appendMessage(userMsg("User under filtered label node"));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+		const violations = collectParentLinkViolations(projected);
+
+		// Regression guard: parentId must align with structural parent after metadata filtering
+		expect(violations).toEqual([]);
+	});
+
+	test("preview normalizes whitespace (newlines, tabs, leading/trailing spaces)", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Hello\n\tworld\n  with   spaces  "));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		const node = asMessageNode(projected[0]);
+		// Newlines/tabs replaced with spaces, then trimmed (matches TUI normalize behavior)
+		// Multiple consecutive spaces are preserved — only \n and \t are replaced
+		expect(node.preview).toBe("Hello  world   with   spaces");
+	});
+
+	test("content is NOT normalized when includeContent is true", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Hello\n\tworld"));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), true);
+
+		const node = asMessageNode(projected[0]);
+		// Content preserves raw text
+		expect(node.content).toBe("Hello\n\tworld");
+		// Preview normalizes: \n→space, \t→space (consecutive spaces preserved)
+		expect(node.preview).toBe("Hello  world");
+	});
+
+	test("aborted assistant message has meaningful preview fallback", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Hi"));
+		sm.appendMessage(abortedAssistantMsg());
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		const assistantNode = asMessageNode(projected[0].children[0]);
+		expect(assistantNode.role).toBe("assistant");
+		expect(assistantNode.stopReason).toBe("aborted");
+		// Should show a meaningful fallback, not empty string
+		expect(assistantNode.preview).toBe("(aborted)");
+	});
+
+	test("error assistant message shows error in preview", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Hi"));
+		sm.appendMessage(errorAssistantMsg("Connection timeout after 30s"));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		const assistantNode = asMessageNode(projected[0].children[0]);
+		expect(assistantNode.role).toBe("assistant");
+		expect(assistantNode.errorMessage).toBe("Connection timeout after 30s");
+		// Preview should show the error message
+		expect(assistantNode.preview).toBe("Connection timeout after 30s");
+	});
+
+	test("assistant message with no text and no special state shows fallback", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Hi"));
+		sm.appendMessage(assistantToolCallMsg("tc-1", "read", { path: "/tmp/f.ts" }));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		const assistantNode = asMessageNode(projected[0].children[0]);
+		expect(assistantNode.role).toBe("assistant");
+		// Tool-call-only assistant: no text but not an error — show fallback
+		expect(assistantNode.preview).toBe("(no content)");
+	});
+
+	test("bashExecution message shows command in preview", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Run a command"));
+		sm.appendMessage(bashExecMsg("ls -la /tmp"));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		const bashNode = asMessageNode(projected[0].children[0]);
+		expect(bashNode.role).toBe("bashExecution");
+		expect(bashNode.preview).toBe("[bash]: ls -la /tmp");
+	});
+
+	test("bashExecution preview normalizes multiline commands", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("Run"));
+		sm.appendMessage(bashExecMsg("echo hello\n\techo world"));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		const bashNode = asMessageNode(projected[0].children[0]);
+		// Newlines/tabs replaced with spaces (consecutive spaces preserved)
+		expect(bashNode.preview).toBe("[bash]: echo hello  echo world");
+	});
+
+	test("tree structure preserved — children and depth", () => {
+		const sm = SessionManager.inMemory();
+		sm.appendMessage(userMsg("User 1"));
+		const a1Id = sm.appendMessage(assistantMsg("Asst 1"));
+		sm.appendMessage(userMsg("User 2"));
+		sm.appendMessage(assistantMsg("Asst 2"));
+
+		// Branch from a1
+		sm.branch(a1Id);
+		sm.appendMessage(userMsg("User 3 (branch)"));
+
+		const tree = sm.getTree();
+		const projected = projectTree(tree, buildToolCallMap(tree), false);
+
+		// Root: user1
+		expect(projected).toHaveLength(1);
+		expect(asMessageNode(projected[0]).preview).toBe("User 1");
+
+		// user1 -> asst1, which has 2 children (user2 and user3-branch)
+		const asst1 = projected[0].children[0];
+		expect(asst1.children).toHaveLength(2);
+	});
+});
+
+describe("extractText", () => {
+	test("returns full string when maxLen is undefined", () => {
+		expect(extractText("hello world")).toBe("hello world");
+	});
+
+	test("truncates string to maxLen", () => {
+		expect(extractText("hello world", 5)).toBe("hello");
+	});
+
+	test("returns empty string when maxLen is 0", () => {
+		// Regression: maxLen=0 is falsy — must not fall through to "no limit"
+		expect(extractText("hello world", 0)).toBe("");
+	});
+
+	test("extracts text from content block array", () => {
+		const content = [
+			{ type: "text", text: "hello " },
+			{ type: "text", text: "world" },
+		];
+		expect(extractText(content)).toBe("hello world");
+	});
+
+	test("truncates content block array to maxLen", () => {
+		const content = [
+			{ type: "text", text: "hello " },
+			{ type: "text", text: "world" },
+		];
+		expect(extractText(content, 8)).toBe("hello wo");
+	});
+
+	test("returns empty string for content block array when maxLen is 0", () => {
+		const content = [{ type: "text", text: "hello" }];
+		// Regression: maxLen=0 is falsy — must not accumulate text
+		expect(extractText(content, 0)).toBe("");
+	});
+
+	test("skips non-text content blocks", () => {
+		const content = [
+			{ type: "image", source: "data:..." },
+			{ type: "text", text: "hello" },
+			{ type: "toolCall", id: "tc-1", name: "read" },
+		];
+		expect(extractText(content)).toBe("hello");
+	});
+
+	test("returns empty string for non-string non-array content", () => {
+		// Cast to test defensive behavior against unexpected runtime values
+		expect(extractText(42 as never)).toBe("");
+		expect(extractText(null)).toBe("");
+		expect(extractText(undefined)).toBe("");
+	});
+});
+
+interface ParentLinkViolation {
+	nodeId: string;
+	structuralParentId: string | null;
+	parentId: string | null;
+	reason: "root_parent_not_null" | "parent_mismatch" | "missing_parent";
+}
+
+/** Collect parent/child linkage violations from a projected RPC tree. */
+function collectParentLinkViolations(nodes: RpcTreeNode[]): ParentLinkViolation[] {
+	const allIds = collectAllIds(nodes);
+	const violations: ParentLinkViolation[] = [];
+
+	const walk = (currentNodes: RpcTreeNode[], structuralParentId: string | null) => {
+		for (const node of currentNodes) {
+			if (structuralParentId === null && node.parentId !== null) {
+				violations.push({
+					nodeId: node.id,
+					structuralParentId,
+					parentId: node.parentId,
+					reason: "root_parent_not_null",
+				});
+			} else if (structuralParentId !== null && node.parentId !== structuralParentId) {
+				violations.push({
+					nodeId: node.id,
+					structuralParentId,
+					parentId: node.parentId,
+					reason: "parent_mismatch",
+				});
+			}
+
+			if (node.parentId !== null && !allIds.has(node.parentId)) {
+				violations.push({
+					nodeId: node.id,
+					structuralParentId,
+					parentId: node.parentId,
+					reason: "missing_parent",
+				});
+			}
+
+			walk(node.children, node.id);
+		}
+	};
+
+	walk(nodes, null);
+	return violations;
+}
+
+/** Recursively collect all node IDs from a tree */
+function collectAllIds(nodes: RpcTreeNode[]): Set<string> {
+	const ids = new Set<string>();
+	for (const node of nodes) {
+		ids.add(node.id);
+		for (const childId of collectAllIds(node.children)) {
+			ids.add(childId);
+		}
+	}
+	return ids;
+}
+
+/** Recursively collect all type values from a tree */
+function collectAllTypes(nodes: RpcTreeNode[]): string[] {
+	const types: string[] = [];
+	for (const node of nodes) {
+		types.push(node.type);
+		types.push(...collectAllTypes(node.children));
+	}
+	return types;
+}

--- a/packages/coding-agent/test/session-file-ops.test.ts
+++ b/packages/coding-agent/test/session-file-ops.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for session-file-ops.ts.
+ *
+ * Tests deleteSessionFile() — the shared utility for session deletion
+ * with trash→unlink fallback logic. Uses temp files for isolation.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { deleteSessionFile } from "../src/core/session-file-ops.js";
+
+function createTempFile(dir: string, name = "test-session.jsonl"): string {
+	const filePath = join(dir, name);
+	writeFileSync(filePath, '{"type":"test"}\n', "utf-8");
+	return filePath;
+}
+
+describe("deleteSessionFile", () => {
+	let testDir: string;
+
+	beforeEach(() => {
+		testDir = join(tmpdir(), `pi-session-ops-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(testDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	test("deletes an existing file and reports method", async () => {
+		const filePath = createTempFile(testDir);
+
+		expect(existsSync(filePath)).toBe(true);
+		const result = await deleteSessionFile(filePath);
+
+		expect(result.ok).toBe(true);
+		expect(result.method).toMatch(/^(trash|unlink)$/);
+		expect(existsSync(filePath)).toBe(false);
+	});
+
+	test("reports success for non-existent file (idempotent)", async () => {
+		const filePath = join(testDir, "does-not-exist.jsonl");
+
+		expect(existsSync(filePath)).toBe(false);
+		const result = await deleteSessionFile(filePath);
+
+		// trash may exit 0 or non-zero for missing files depending on implementation,
+		// but the function should always report ok: true when file doesn't exist
+		expect(result.ok).toBe(true);
+	});
+});


### PR DESCRIPTION
Add get_tree, navigate_tree, set_label, list_sessions, rename_session, and delete_session RPC commands with full tree projection, fork message enrichment, and setWorkingMessage event forwarding.

Extract formatToolCall and deleteSessionFile into shared core utilities. Refactor interactive components to use shared utilities. Add comprehensive test coverage and RPC protocol documentation.