### PR TITLE
fix(ai): convert unsigned thinking blocks to plain text

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -125,11 +125,20 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 					// Otherwise convert to plain text (no tags to avoid model mimicking them)
 					if (isSameProviderAndModel) {
 						const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.thinkingSignature);
-						parts.push({
-							thought: true,
-							text: sanitizeSurrogates(block.thinking),
-							...(thoughtSignature && { thoughtSignature }),
-						});
+						if (thoughtSignature) {
+							parts.push({
+								thought: true,
+								text: sanitizeSurrogates(block.thinking),
+								thoughtSignature,
+							});
+						} else {
+							// No valid signature — convert to plain text to avoid
+							// "thinking.signature: Field required" rejection from downstream APIs
+							// (e.g. Anthropic via Cloud Code Assist / Antigravity)
+							parts.push({
+								text: sanitizeSurrogates(block.thinking),
+							});
+						}
 					} else {
 						parts.push({
 							text: sanitizeSurrogates(block.thinking),


### PR DESCRIPTION
## Summary

- When replaying thinking blocks from the same provider/model but without a valid `thoughtSignature`, `convertMessages` sends the block with `thought: true` but no signature
- When routed through Google Cloud Code Assist (Antigravity) to Anthropic, this causes rejection: `thinking.signature: Field required`
- Fix: if `resolveThoughtSignature` returns `undefined`, convert the thinking block to plain text — matching the existing cross-provider fallback path

## Root cause

In `convertMessages()` (`google-shared.ts`), when `isSameProviderAndModel` is `true`, thinking blocks are always emitted with `thought: true`. However, `resolveThoughtSignature` may return `undefined` (invalid base64, missing signature, etc.), and the spread `...(thoughtSignature && { thoughtSignature })` simply omits the field. The Google API then translates this to Anthropic format, which requires `signature` on all thinking blocks.

## Test plan

- [x] Verified fix resolves `thinking.signature: Field required` errors when using `google-antigravity/claude-*-thinking` models
- [ ] Existing behavior for Gemini models with valid signatures unchanged
- [ ] Cross-provider thinking blocks still converted to plain text as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)