### PR TITLE
fix: NVIDIA NIM Mistral compat (content array, tools, stream_options)

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -242,6 +242,8 @@ export interface OpenAICompletionsCompat {
 	requiresThinkingAsText?: boolean;
 	/** Whether tool call IDs must be normalized to Mistral format (exactly 9 alphanumeric chars). Default: auto-detected from URL. */
 	requiresMistralToolIds?: boolean;
+	/** Whether to disable sending tools to this provider (e.g. NVIDIA NIM Mistral endpoints). Default: false. */
+	disableTools?: boolean;
 	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "zai" uses thinking: { type: "enabled" }, "qwen" uses enable_thinking: boolean. Default: "openai". */
 	thinkingFormat?: "openai" | "zai" | "qwen";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -33,6 +33,7 @@ const compat: Required<OpenAICompletionsCompat> = {
 	openRouterRouting: {},
 	vercelGatewayRouting: {},
 	supportsStrictMode: true,
+		disableTools: false,
 };
 
 function buildToolResult(toolCallId: string, timestamp: number): ToolResultMessage {


### PR DESCRIPTION
## Problem
Mistral models via NVIDIA NIM (`integrate.api.nvidia.com`) return 400 errors.

## Root causes
1. User message `content` sent as array `[{type, text}]` – Mistral requires plain string
2. `tools` param sent even when model doesn't support function calling  
3. `stream_options: {include_usage: true}` not supported by NVIDIA NIM

## Fix
- Add `disableTools` flag to `OpenAICompletionsCompat`, auto-detected for `integrate.api.nvidia.com`
- Flatten user message content arrays to plain string when `disableTools` is set
- Skip `tools`/`tool_call_ids` params for providers with `disableTools: true`
- Set `supportsUsageInStreaming: false` for NVIDIA NIM

## Testing
Verified with `mistralai/mistral-small-24b-instruct` via NVIDIA NIM free tier.