### PR TITLE
fix: respect --tools filter for extension-registered tools

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2021,8 +2021,14 @@ export class AgentSession {
 		const baseActiveToolNames = options.activeToolNames ?? defaultActiveToolNames;
 		const activeToolNameSet = new Set<string>(baseActiveToolNames);
 		if (options.includeAllExtensionTools) {
+			// When tools were explicitly specified (e.g. --tools read,bash), only
+			// include extension tools that appear in that list. When no explicit
+			// list was given (using defaults), include all extension tools.
+			const hasExplicitToolList = options.activeToolNames !== undefined;
 			for (const tool of wrappedExtensionTools as AgentTool[]) {
-				activeToolNameSet.add(tool.name);
+				if (!hasExplicitToolList || activeToolNameSet.has(tool.name)) {
+					activeToolNameSet.add(tool.name);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

When `--tools` is explicitly specified (e.g. `--tools read,bash`), extension tools registered via `registerTool()` in extensions are unconditionally added to the active tool set, bypassing the user's filter.

This means an extension like `subagent` is available even when pi is spawned with a restricted tool list. Verified by running:

```
echo "List all your available tools by name" | pi --mode json -p --no-session --tools read,grep
```

Output includes `subagent` despite not being in the `--tools` list.

## Root cause

In `_buildRuntime()`, `includeAllExtensionTools: true` unconditionally adds all extension tools to `activeToolNameSet`:

```typescript
if (options.includeAllExtensionTools) {
    for (const tool of wrappedExtensionTools as AgentTool[]) {
        activeToolNameSet.add(tool.name);
    }
}
```

## Fix

When `activeToolNames` is explicitly provided (from `--tools`), only include extension tools whose names already appear in that list. When no explicit list is given (using defaults), all extension tools remain active — preserving current behavior.

```typescript
const hasExplicitToolList = options.activeToolNames !== undefined;
for (const tool of wrappedExtensionTools as AgentTool[]) {
    if (!hasExplicitToolList || activeToolNameSet.has(tool.name)) {
        activeToolNameSet.add(tool.name);
    }
}
```

## Note

The `--tools` arg parser currently only accepts built-in `ToolName` values and warns on unknown names, so extension tool names can't be explicitly opted into via `--tools` yet. A follow-up could expand the parser to accept extension tool names, but this fix addresses the immediate issue of tools leaking past the filter.