### PR TITLE
fix(anthropic): handle redacted_thinking blocks from adaptive thinking

### DIFF
--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -51,6 +51,13 @@ export function transformMessages<TApi extends Api>(
 					};
 				}
 
+				if (block.type === "redacted_thinking") {
+					// Opaque encrypted block — preserve for same-model replay, drop otherwise
+					// (cannot be decoded or adapted for a different model/provider)
+					if (isSameModel) return block;
+					return [];
+				}
+
 				if (block.type === "text") {
 					if (isSameModel) return block;
 					return {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -130,6 +130,13 @@ export interface ThinkingContent {
 	thinkingSignature?: string; // e.g., for OpenAI responses, the reasoning item ID
 }
 
+export interface RedactedThinkingContent {
+	type: "redacted_thinking";
+	/** Opaque encrypted thinking content from Anthropic's adaptive thinking API (Opus 4.6+).
+	 *  Must be sent back to the API completely unchanged in subsequent requests. */
+	data: string;
+}
+
 export interface ImageContent {
 	type: "image";
 	data: string; // base64 encoded image data
@@ -169,7 +176,7 @@ export interface UserMessage {
 
 export interface AssistantMessage {
 	role: "assistant";
-	content: (TextContent | ThinkingContent | ToolCall)[];
+	content: (TextContent | ThinkingContent | RedactedThinkingContent | ToolCall)[];
 	api: Api;
 	provider: Provider;
 	model: string;


### PR DESCRIPTION
## Problem

Anthropic's adaptive thinking API (Opus 4.6+ with any effort level) can return `redacted_thinking` content blocks — opaque encrypted blocks that must be sent back to the API **completely unchanged** in subsequent requests.

Two missing cases in `anthropic.ts` caused these blocks to be **silently dropped**, permanently corrupting session history. On the next request, the Anthropic API returns:

```
thinking or redacted_thinking blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.
```

This is filed upstream at openclaw/openclaw#19450, where the maintainer confirmed the root cause and asked for a PR.

## Root cause

1. **`content_block_start` handler** — no case for `type === "redacted_thinking"`, so the block was never added to `output.content`
2. **`convertMessages` serialization loop** — no case for `block.type === "redacted_thinking"`, so even if stored it would have been dropped when replaying history
3. **`transform-messages.ts`** — no case for `redacted_thinking` in the cross-model transform (needed for correctness when the same model is replayed vs. cross-model)

## Changes

- **`types.ts`**: Add `RedactedThinkingContent` type (`{ type: "redacted_thinking"; data: string }`); add to `AssistantMessage.content` union
- **`anthropic.ts`**: 
  - Handle `redacted_thinking` in `content_block_start` event (data is fully present at block start — no delta events follow for this block type)
  - Serialize it back to the API unchanged in `convertMessages` using `RedactedThinkingBlockParam` (already in the SDK's `ContentBlockParam` union)
- **`transform-messages.ts`**: Preserve `redacted_thinking` blocks for same-model replay; drop for cross-model (opaque data is model-specific and cannot be adapted)

## Testing

Manually verified against a session history that previously triggered the error. The Anthropic SDK (`@anthropic-ai/sdk`) already exports `RedactedThinkingBlock` and `RedactedThinkingBlockParam` types, so no SDK changes are needed.