### PR TITLE
fix(ai): add Sonnet 4.6 to supportsAdaptiveThinking

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -411,11 +411,17 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 };
 
 /**
- * Check if a model supports adaptive thinking (Opus 4.6+)
+ * Check if a model supports adaptive thinking (Opus 4.6+ and Sonnet 4.6+)
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
-	// Opus 4.6 model IDs (with or without date suffix)
-	return modelId.includes("opus-4-6") || modelId.includes("opus-4.6");
+	// Opus 4.6 and Sonnet 4.6 model IDs (with or without date suffix)
+	// Ref: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#supported-models
+	return (
+		modelId.includes("opus-4-6") ||
+		modelId.includes("opus-4.6") ||
+		modelId.includes("sonnet-4-6") ||
+		modelId.includes("sonnet-4.6")
+	);
 }
 
 /**


### PR DESCRIPTION
## Problem

Claude Sonnet 4.6 supports adaptive thinking per Anthropic's official docs, but `supportsAdaptiveThinking()` only checks for Opus 4.6 model IDs. This causes Sonnet 4.6 to fall through to the legacy budget-based thinking path instead of using adaptive thinking with effort levels.

## Fix

Add `sonnet-4-6` and `sonnet-4.6` to the `supportsAdaptiveThinking()` check, matching the same pattern already used for Opus 4.6.

## Reference

- Anthropic adaptive thinking docs: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#supported-models
  > Adaptive thinking is supported on the following models:
  > - Claude Opus 4.6 (`claude-opus-4-6`)
  > - Claude Sonnet 4.6 (`claude-sonnet-4-6`)