### PR TITLE
examples(coding-agent): bump sandbox runtime

### DIFF
--- a/packages/coding-agent/examples/extensions/sandbox/package-lock.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package-lock.json
@@ -8,19 +8,19 @@
 			"name": "pi-extension-sandbox",
 			"version": "1.0.0",
 			"dependencies": {
-				"@anthropic-ai/sandbox-runtime": "^0.0.26"
+				"@anthropic-ai/sandbox-runtime": "^0.0.37"
 			}
 		},
 		"node_modules/@anthropic-ai/sandbox-runtime": {
-			"version": "0.0.26",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.26.tgz",
-			"integrity": "sha512-DYV5LSsVMnzq0lbfaYMSpxZPUMAx4+hy343dRss+pVCLIfF62qOhxpYfZ5TmOk1GTDQm5f9wPprMNSStmnsV4w==",
+			"version": "0.0.37",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.37.tgz",
+			"integrity": "sha512-KKzHoe4blXQpTEtbFLKP76PHsUerqlG5UNN+MQvXf0SVZDtawP9hHc9HiMgzvUXST2OMYl2Sk27k18d6684eoQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@pondwader/socks5-server": "^1.0.10",
 				"@types/lodash-es": "^4.17.12",
 				"commander": "^12.1.0",
-				"lodash-es": "^4.17.21",
+				"lodash-es": "^4.17.23",
 				"shell-quote": "^1.8.3",
 				"zod": "^3.24.1"
 			},
@@ -62,9 +62,9 @@
 			}
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.22",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-			"integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
 			"license": "MIT"
 		},
 		"node_modules/shell-quote": {

--- a/packages/coding-agent/examples/extensions/sandbox/package.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package.json
@@ -14,6 +14,6 @@
 		]
 	},
 	"dependencies": {
-		"@anthropic-ai/sandbox-runtime": "^0.0.26"
+		"@anthropic-ai/sandbox-runtime": "^0.0.37"
 	}
 }


### PR DESCRIPTION
Bumps sandbox example extension to `@anthropic-ai/sandbox-runtime@^0.0.37` and updates config merging to preserve all `SandboxRuntimeConfig` fields.

Newer versions add optional fields (e.g., `network.mitmProxy` and `enableWeakerNetworkIsolation`). The extension currently allows only a subset of fields, so other options were dropped.
