### PR TITLE
Add VACATION.md for machine-readable vacation status

### DIFF
--- a/VACATION.md
+++ b/VACATION.md
@@ -1,0 +1,21 @@
+# 🏖️ OSS Vacation
+
+Issue tracker and PRs reopen February 23, 2026.
+
+All PRs will be auto-closed until then. Approved contributors can submit PRs after vacation without reapproval. For support, join Discord.
+
+```vacajson
+{
+  "vacations": [
+    {
+      "start": "2026-02-10",
+      "end": "2026-02-23",
+      "title": "OSS Vacation",
+      "message": "Issue tracker and PRs reopen February 23, 2026. All PRs will be auto-closed until then.",
+      "links": {
+        "discord": "https://discord.com/invite/3cU7Bz4UPx"
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
Adds a `VACATION.md` with a `vacajson` schedule block so tools, bots, and CI can programmatically check if the project is on vacation.

## What this enables

- **Status page:** [vacation.januschka.com/badlogic/pi-mono](https://vacation.januschka.com/badlogic/pi-mono)
- **JSON API:** `curl -H "Accept: application/json" https://vacation.januschka.com/badlogic/pi-mono`
- **README badge:** `[![Vacation](https://vacation.januschka.com/badlogic/pi-mono/badge.svg)](https://vacation.januschka.com/badlogic/pi-mono)`

The file uses a ```vacajson``` fence (not ```json```) so it won't clash with any regular JSON examples in the markdown. GitHub renders it as a plain code block.

The human-readable part of the file mirrors the existing vacation notice in the README.

Built with [on-vacation](https://github.com/hjanuschka/on-vacation).