### PR TITLE
feat(tui): add configurable `paddingX` setting for chat UI

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `paddingX` setting to control horizontal padding for the entire chat UI (0-8, default: 0)
+
 ## [0.53.0] - 2026-02-17
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -87,6 +87,7 @@ export interface Settings {
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
 	doubleEscapeAction?: "fork" | "tree" | "none"; // Action for double-escape with empty editor (default: "tree")
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
+	paddingX?: number; // Horizontal padding for the entire chat UI (default: 0)
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
@@ -859,6 +860,16 @@ export class SettingsManager {
 	setShowHardwareCursor(enabled: boolean): void {
 		this.globalSettings.showHardwareCursor = enabled;
 		this.markModified("showHardwareCursor");
+		this.save();
+	}
+
+	getPaddingX(): number {
+		return this.settings.paddingX ?? 0;
+	}
+
+	setPaddingX(padding: number): void {
+		this.globalSettings.paddingX = Math.max(0, Math.min(8, Math.floor(padding)));
+		this.markModified("paddingX");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -39,6 +39,7 @@ export interface SettingsConfig {
 	collapseChangelog: boolean;
 	doubleEscapeAction: "fork" | "tree" | "none";
 	showHardwareCursor: boolean;
+	paddingX: number;
 	editorPaddingX: number;
 	autocompleteMaxVisible: number;
 	quietStartup: boolean;
@@ -61,6 +62,7 @@ export interface SettingsCallbacks {
 	onCollapseChangelogChange: (collapsed: boolean) => void;
 	onDoubleEscapeActionChange: (action: "fork" | "tree" | "none") => void;
 	onShowHardwareCursorChange: (enabled: boolean) => void;
+	onPaddingXChange: (padding: number) => void;
 	onEditorPaddingXChange: (padding: number) => void;
 	onAutocompleteMaxVisibleChange: (maxVisible: number) => void;
 	onQuietStartupChange: (enabled: boolean) => void;
@@ -304,9 +306,19 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
-		// Editor padding toggle (insert after show-hardware-cursor)
+		// UI padding toggle (insert after show-hardware-cursor)
 		const hardwareCursorIndex = items.findIndex((item) => item.id === "show-hardware-cursor");
 		items.splice(hardwareCursorIndex + 1, 0, {
+			id: "padding",
+			label: "UI padding",
+			description: "Horizontal padding for the entire chat UI (0-8)",
+			currentValue: String(config.paddingX),
+			values: ["0", "1", "2", "3", "4", "5", "6", "7", "8"],
+		});
+
+		// Editor padding toggle (insert after padding)
+		const paddingIndex = items.findIndex((item) => item.id === "padding");
+		items.splice(paddingIndex + 1, 0, {
 			id: "editor-padding",
 			label: "Editor padding",
 			description: "Horizontal padding for input editor (0-3)",
@@ -381,6 +393,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "show-hardware-cursor":
 						callbacks.onShowHardwareCursorChange(newValue === "true");
+						break;
+					case "padding":
+						callbacks.onPaddingXChange(parseInt(newValue, 10));
 						break;
 					case "editor-padding":
 						callbacks.onEditorPaddingXChange(parseInt(newValue, 10));

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -259,6 +259,7 @@ export class InteractiveMode {
 		this.session = session;
 		this.version = VERSION;
 		this.ui = new TUI(new ProcessTerminal(), this.settingsManager.getShowHardwareCursor());
+		this.ui.setPaddingX(this.settingsManager.getPaddingX());
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
 		this.headerContainer = new Container();
 		this.chatContainer = new Container();
@@ -3043,6 +3044,7 @@ export class InteractiveMode {
 					collapseChangelog: this.settingsManager.getCollapseChangelog(),
 					doubleEscapeAction: this.settingsManager.getDoubleEscapeAction(),
 					showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
+					paddingX: this.settingsManager.getPaddingX(),
 					editorPaddingX: this.settingsManager.getEditorPaddingX(),
 					autocompleteMaxVisible: this.settingsManager.getAutocompleteMaxVisible(),
 					quietStartup: this.settingsManager.getQuietStartup(),
@@ -3124,6 +3126,10 @@ export class InteractiveMode {
 					onShowHardwareCursorChange: (enabled) => {
 						this.settingsManager.setShowHardwareCursor(enabled);
 						this.ui.setShowHardwareCursor(enabled);
+					},
+					onPaddingXChange: (padding) => {
+						this.settingsManager.setPaddingX(padding);
+						this.ui.setPaddingX(padding);
 					},
 					onEditorPaddingXChange: (padding) => {
 						this.settingsManager.setEditorPaddingX(padding);
@@ -3775,6 +3781,7 @@ export class InteractiveMode {
 				this.editor.setPaddingX?.(editorPaddingX);
 				this.editor.setAutocompleteMaxVisible?.(autocompleteMaxVisible);
 			}
+			this.ui.setPaddingX(this.settingsManager.getPaddingX());
 			this.ui.setShowHardwareCursor(this.settingsManager.getShowHardwareCursor());
 			this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
 			this.setupAutocomplete(this.fdPath);

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added configurable `paddingX` on `Container` and `TUI` for horizontal content inset
+
 ## [0.53.0] - 2026-02-17
 
 ## [0.52.12] - 2026-02-13

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -160,10 +160,20 @@ export interface OverlayHandle {
 }
 
 /**
- * Container - a component that contains other components
+ * Container - a component that contains other components.
+ * Supports optional left/right padding that insets all child content.
  */
 export class Container implements Component {
 	children: Component[] = [];
+	private paddingX: number;
+
+	constructor(paddingX?: number) {
+		this.paddingX = paddingX ?? 0;
+	}
+
+	setPaddingX(paddingX: number): void {
+		this.paddingX = paddingX;
+	}
 
 	addChild(component: Component): void {
 		this.children.push(component);
@@ -187,9 +197,18 @@ export class Container implements Component {
 	}
 
 	render(width: number): string[] {
+		const contentWidth = Math.max(1, width - this.paddingX * 2);
+		const pad = this.paddingX > 0 ? " ".repeat(this.paddingX) : "";
 		const lines: string[] = [];
 		for (const child of this.children) {
-			lines.push(...child.render(width));
+			const childLines = child.render(contentWidth);
+			if (this.paddingX > 0) {
+				for (const line of childLines) {
+					lines.push(pad + line);
+				}
+			} else {
+				lines.push(...childLines);
+			}
 		}
 		return lines;
 	}


### PR DESCRIPTION
Add horizontal (left/right) padding support to Container/TUI and expose it as a `paddingX` setting in settings.json (range 0-8, default 0). This allows for a document-like view with left/right padding.

The setting is available in the interactive settings UI and applied on construction and session reload.