### PR TITLE
fix(tui): use fuzzyFilter for @ file search instead of fd regex + substring scoring

### DIFF
--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -237,6 +237,23 @@ describe("CombinedAutocompleteProvider", () => {
 			assert.ok(!values?.includes("@src/utils/helpers.ts"));
 		});
 
+		test("fuzzy matches non-consecutive characters (e.g. imts -> interactive-mode.ts)", () => {
+			setupFolder(baseDir, {
+				files: {
+					"src/interactive-mode.ts": "export {};",
+					"src/utils.ts": "export {};",
+					"src/index.ts": "export {};",
+				},
+			});
+
+			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
+			const line = "@imts";
+			const result = provider.getSuggestions([line], 0, line.length);
+
+			const values = result?.items.map((item) => item.value);
+			assert.ok(values?.includes("@src/interactive-mode.ts"));
+		});
+
 		test("scopes fuzzy search to relative directories and searches recursively", () => {
 			setupFolder(outsideDir, {
 				files: {


### PR DESCRIPTION
## Problem

The `@` file finder passes user queries to `fd` as regex patterns, then scores results with basic substring matching (`scoreEntry`). Non-consecutive character queries like `imts` never match `interactive-mode.ts`.

`fuzzyFilter` from `fuzzy.ts` already does proper fzf-style character-by-character matching — but only for slash commands, not file search.

## Changes

In `CombinedAutocompleteProvider.getFuzzyFileSuggestions`:
- Call `walkDirectoryWithFd` without a query filter (list up to 5000 files)
- Use `fuzzyFilter` for client-side matching and ranking
- Remove `scoreEntry` (replaced by `fuzzyFilter`)

Added test: `imts` -> `interactive-mode.ts`

## Bonus ask

Would you consider adding an extension hook like `pi.registerAutocompleteProvider()` so users can customize file search without forking?