### PR TITLE
fix(ai): don't cache false for Vertex ADC credentials during async import race

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -22,9 +22,15 @@ let cachedVertexAdcCredentialsExists: boolean | null = null;
 
 function hasVertexAdcCredentials(): boolean {
 	if (cachedVertexAdcCredentialsExists === null) {
-		// In browser or if node modules not loaded yet, return false
+		// If node modules haven't loaded yet (async import race at startup),
+		// return false WITHOUT caching so the next call retries once they're ready.
+		// Only cache false permanently in a browser environment where fs is never available.
 		if (!_existsSync || !_homedir || !_join) {
-			cachedVertexAdcCredentialsExists = false;
+			const isNode = typeof process !== "undefined" && (process.versions?.node || process.versions?.bun);
+			if (!isNode) {
+				// Definitively in a browser — safe to cache false permanently
+				cachedVertexAdcCredentialsExists = false;
+			}
 			return false;
 		}
 


### PR DESCRIPTION
## Problem

`hasVertexAdcCredentials()` loads `node:fs`, `node:os`, and `node:path` via dynamic `import()` to avoid breaking browser/Vite builds. These imports fire eagerly at module load but resolve **asynchronously**. If the function is called during gateway startup before those promises resolve, `_existsSync`, `_homedir`, and `_join` are still `null` — and the function caches `false` permanently.

This silently breaks Vertex AI auth for users who have valid credentials configured. Every subsequent call returns `false` regardless of environment, so `getEnvApiKey("google-vertex")` never returns `"<authenticated>"`. Calls fall back to the AI Studio endpoint (`generativelanguage.googleapis.com`) which has much stricter rate limits, causing unexpected **429 errors** even though Vertex credentials are correctly set up via `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION`.

## Fix

In Node.js/Bun environments, return `false` **without caching** when the async modules aren't loaded yet, so the next call retries. Only cache `false` permanently in browser environments where `fs` is genuinely never available.

## Before

```typescript
if (!_existsSync || !_homedir || !_join) {
    cachedVertexAdcCredentialsExists = false; // ← caches too early in Node.js
    return false;
}
```

## After

```typescript
if (!_existsSync || !_homedir || !_join) {
    const isNode = typeof process !== "undefined" && (process.versions?.node || process.versions?.bun);
    if (!isNode) {
        // Definitively in a browser — safe to cache false permanently
        cachedVertexAdcCredentialsExists = false;
    }
    return false; // Node.js: no cache, will retry on next call
}
```

## Impact

- No behaviour change for browser environments
- No behaviour change for users who call `hasVertexAdcCredentials()` after module init (the common case — it works fine already)
- Fixes silent Vertex AI fallback to AI Studio for users running long-lived gateway processes (e.g. systemd) where startup timing causes the race