### PR TITLE
feat(agent): stamp thinkingLevel on AssistantMessage

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -271,6 +271,8 @@ async function streamAssistantResponse(
 			case "done":
 			case "error": {
 				const finalMessage = await response.result();
+				// Stamp the thinking level that was active for this request
+				finalMessage.thinkingLevel = config.reasoning ?? "off";
 				if (addedPartial) {
 					context.messages[context.messages.length - 1] = finalMessage;
 				} else {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -177,6 +177,8 @@ export interface AssistantMessage {
 	stopReason: StopReason;
 	errorMessage?: string;
 	timestamp: number; // Unix timestamp in milliseconds
+	/** The thinking level that was active when this message was generated. */
+	thinkingLevel?: ThinkingLevel | "off";
 }
 
 export interface ToolResultMessage<TDetails = any> {


### PR DESCRIPTION
## Summary

Add an optional `thinkingLevel` field to `AssistantMessage` that records which thinking level was active when the message was generated.

## Changes

- **`packages/ai/src/types.ts`**: Add optional `thinkingLevel?: ThinkingLevel | "off"` to `AssistantMessage`
- **`packages/agent/src/agent-loop.ts`**: Stamp `thinkingLevel` from `config.reasoning` (or `"off"`) on every final assistant message in `streamAssistantResponse`

## Motivation

Session logs currently record `thinking_level_change` entries separately, but individual assistant messages don't carry which thinking level was used. This makes it hard for consumers (e.g., cost tracking extensions) to correlate API costs with thinking levels — they'd need to reconstruct state by walking entries in order.

With this change, each assistant message in the session JSONL includes the thinking level directly, enabling straightforward grouping like "cost by thinking level".