### PR TITLE
fix(coding-agent): cap reserveTokens to 30% of context window

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed premature compaction when falling back from large-context models (e.g., 1M tokens) to smaller-context models (e.g., 200k tokens). The `reserveTokens` setting is now capped at 30% of the context window to ensure at least 70% remains usable regardless of fallback model size.
+
 ## [0.53.0] - 2026-02-17
 
 ### Breaking Changes


### PR DESCRIPTION
## Problem

When falling back from large-context models (e.g., 1M tokens) to smaller-context models (e.g., 200k tokens), the static `reserveTokens` value could consume an excessive portion of the fallback model's context, causing premature compaction.

**Example scenario:**
- Primary model: Gemini 1M context, `reserveTokens = 120000` (12%)
- Fallback model: MiniMax 200k context
- Same `reserveTokens` value (120000) = 60% of fallback context
- Compaction triggers at 80k tokens instead of expected threshold

## Root Cause

The `shouldCompact()` function uses `reserveTokens` directly without considering context window size:
```typescript
return contextTokens > contextWindow - settings.reserveTokens;
```

When context window shrinks (fallback), a large `reserveTokens` value leaves little usable space.

## Solution

Cap `reserveTokens` to 30% of the context window:

```typescript
const MAX_RESERVE_SHARE = 0.30;
const effectiveReserve = Math.min(settings.reserveTokens, Math.floor(contextWindow * MAX_RESERVE_SHARE));
return contextTokens > contextWindow - effectiveReserve;
```

This ensures at least 70% of any context window remains usable regardless of fallback model size.

## Testing

Added tests for:
- Cap applied when reserveTokens exceeds 30%
- No cap when reserveTokens is below 30%
- Real-world fallback scenario (1M → 200k context)

All 24 tests pass.