### PR TITLE
fix(subagent): use getAgentDir for user agents path

### DIFF
--- a/packages/coding-agent/examples/extensions/subagent/agents.ts
+++ b/packages/coding-agent/examples/extensions/subagent/agents.ts
@@ -3,9 +3,8 @@
  */
 
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
-import { parseFrontmatter } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, parseFrontmatter } from "@mariozechner/pi-coding-agent";
 
 export type AgentScope = "user" | "project" | "both";
 
@@ -96,7 +95,7 @@ function findNearestProjectAgentsDir(cwd: string): string | null {
 }
 
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
-	const userDir = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDir = path.join(getAgentDir(), "agents");
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
 
 	const userAgents = scope === "project" ? [] : loadAgentsFromDir(userDir, "user");


### PR DESCRIPTION
## Summary
- replace hardcoded `~/.pi/agent/agents` lookup in the subagent example
- use `getAgentDir()/agents` instead

## Why
The hardcoded path ignores custom agent dirs (for example via `PI_CODING_AGENT_DIR`) and XDG-based setups. Using `getAgentDir()` matches the rest of pi's path resolution logic.

## Testing
- Not run (example extension path resolution change only)
