### PR TITLE
feat: support project-level keybindings.json

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -9,7 +9,7 @@ import {
 } from "@mariozechner/pi-tui";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { getAgentDir } from "../config.js";
+import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
 
 /**
  * Application-level actions (coding agent specific).
@@ -121,11 +121,16 @@ export class KeybindingsManager {
 	}
 
 	/**
-	 * Create from config file and set up editor keybindings.
+	 * Create from config files and set up editor keybindings.
+	 * Loads global (~/.pi/agent/keybindings.json) then merges project-level
+	 * (.pi/agent/keybindings.json in cwd) on top, so project settings win.
 	 */
 	static create(agentDir: string = getAgentDir()): KeybindingsManager {
-		const configPath = join(agentDir, "keybindings.json");
-		const config = KeybindingsManager.loadFromFile(configPath);
+		const globalPath = join(agentDir, "keybindings.json");
+		const globalConfig = KeybindingsManager.loadFromFile(globalPath);
+		const projectPath = join(process.cwd(), CONFIG_DIR_NAME, "agent", "keybindings.json");
+		const projectConfig = KeybindingsManager.loadFromFile(projectPath);
+		const config: KeybindingsConfig = { ...globalConfig, ...projectConfig };
 		const manager = new KeybindingsManager(config);
 
 		// Set up editor keybindings globally


### PR DESCRIPTION
## Summary

- Loads keybindings from both `~/.pi/agent/keybindings.json` (global) and `.pi/agent/keybindings.json` in cwd (project-level), merging project settings on top so project-level bindings take precedence
- Follows the same pattern already used by `SettingsManager` for `settings.json` (global + project merge)
- No behavior change when no project-level `keybindings.json` exists — `loadFromFile` returns `{}` for missing files, so the spread is a no-op

## Motivation

Settings already support project-level overrides via `.pi/settings.json`, but keybindings only read from the global `~/.pi/agent/keybindings.json`. This means teams can't share keybinding configs per-project (e.g., Emacs-style cursor navigation in a repo's `.pi/agent/keybindings.json`).

## Changes

**`packages/coding-agent/src/core/keybindings.ts`**
- Import `CONFIG_DIR_NAME` from config
- In `KeybindingsManager.create()`, load both global and project-level configs and merge with `{ ...globalConfig, ...projectConfig }`

## Test plan

- [ ] Verify that with no project-level `keybindings.json`, behavior is unchanged (global config still works)
- [ ] Create `.pi/agent/keybindings.json` in a project directory and verify project bindings override global ones
- [ ] Verify that global bindings not overridden by project config still apply