### PR TITLE
feat(ai): expose response ID from Responses API stream

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -428,6 +428,9 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.completed") {
 			const response = event.response;
+			if (response?.id) {
+				output.responseId = response.id;
+			}
 			if (response?.usage) {
 				const cachedTokens = response.usage.input_tokens_details?.cached_tokens || 0;
 				output.usage = {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -177,6 +177,8 @@ export interface AssistantMessage {
 	stopReason: StopReason;
 	errorMessage?: string;
 	timestamp: number; // Unix timestamp in milliseconds
+	/** Provider response ID (Responses API). Enables `previous_response_id` conversation chaining. */
+	responseId?: string;
 }
 
 export interface ToolResultMessage<TDetails = any> {


### PR DESCRIPTION
## Summary

- Capture `response.id` from the `response.completed` SSE event in `processResponsesStream()` and store it on `AssistantMessage.responseId`
- Add optional `responseId?: string` field to the `AssistantMessage` interface
- Enables downstream consumers to implement `previous_response_id` conversation chaining (Responses API)

## Motivation

The OpenAI/xAI Responses API supports `previous_response_id` for server-side conversation state management. This allows clients to send only the new message instead of the full conversation history on each turn, significantly improving cache hit rates and reducing latency.

Currently, the response ID from `response.completed` events is silently discarded. This 5-line change captures it on the existing `AssistantMessage` output object, making it available to consumers without any behavioral change for existing code.

## Changes

**`packages/ai/src/providers/openai-responses-shared.ts`** (+3 lines)
- Extract `response.id` from the `response.completed` event and assign to `output.responseId`

**`packages/ai/src/types.ts`** (+2 lines)  
- Add `responseId?: string` to the `AssistantMessage` interface with JSDoc

## Test plan

- [x] Field is only populated for Responses API providers (OpenAI, xAI)
- [x] No behavioral change for Chat Completions API or other providers
- [x] Optional field — existing consumers are unaffected
- [ ] Verified with xAI Grok 4.1 in production (OpenClaw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)