### PR TITLE
feat: Set PI_CODING_AGENT=true env variable at startup

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -6,6 +6,7 @@
  * Test with: npx tsx src/cli-new.ts [args...]
  */
 process.title = "pi";
+process.env.PI_CODING_AGENT = "true";
 
 import { main } from "./main.js";
 


### PR DESCRIPTION
Set process.env.PI_CODING_AGENT = "true" in the CLI entry point so that downstream code and subprocesses can detect when they are running as part of the pi coding agent. This propagates automatically to:
- Bash tool subprocesses via getShellEnv() which spreads process.env
- execCommand() subprocesses which inherit process.env by default