### PR TITLE
fix: remove broken path references and improve type safety

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -49,7 +49,7 @@ function hasVertexAdcCredentials(): boolean {
  */
 export function getEnvApiKey(provider: KnownProvider): string | undefined;
 export function getEnvApiKey(provider: string): string | undefined;
-export function getEnvApiKey(provider: any): string | undefined {
+export function getEnvApiKey(provider: string): string | undefined {
 	// Fall back to environment variables
 	if (provider === "github-copilot") {
 		return process.env.COPILOT_GITHUB_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,9 +20,7 @@
 			"@mariozechner/pi-tui": ["./packages/tui/src/index.ts"],
 			"@mariozechner/pi-tui/*": ["./packages/tui/src/*"],
 			"@mariozechner/pi-web-ui": ["./packages/web-ui/src/index.ts"],
-			"@mariozechner/pi-web-ui/*": ["./packages/web-ui/src/*"],
-			"@mariozechner/pi-agent-old": ["./packages/agent-old/src/index.ts"],
-			"@mariozechner/pi-agent-old/*": ["./packages/agent-old/src/*"]
+			"@mariozechner/pi-web-ui/*": ["./packages/web-ui/src/*"]
 		}
 	},
 	"include": ["packages/*/src/**/*", "packages/*/test/**/*", "packages/coding-agent/examples/**/*"],


### PR DESCRIPTION
This PR improves the TypeScript configuration and type safety by cleaning up stale references and removing unnecessary 'any' type usage.

## Changes

### tsconfig.json
- Removed non-existent `@mariozechner/pi-agent-old` path references (pointing to removed `agent-old` package)
- These stale path references could cause confusion and potential TypeScript resolution errors

### packages/ai/src/env-api-keys.ts
- Replaced `any` type with `string` in `getEnvApiKey` function implementation signature
- The function already has proper overload signatures, so the implementation signature should match the last overload
- This improves type safety without changing any runtime behavior

## Benefits
- Cleaner TypeScript configuration
- Better type safety with no functional changes
- Removes potential confusion from non-existent package references

## Testing
All changes are type-safe and don't affect runtime behavior. The existing test suite covers the functionality.