### PR TITLE
fix(compaction): remove hardcoded reasoning: "high" from generateSummary

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -557,7 +557,7 @@ export async function generateSummary(
 	const response = await completeSimple(
 		model,
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		{ maxTokens, signal, apiKey, reasoning: "high" },
+		{ maxTokens, signal, apiKey },
 	);
 
 	if (response.stopReason === "error") {


### PR DESCRIPTION
## Problem

`generateSummary()` in `packages/coding-agent/src/core/compaction/compaction.ts` passes `reasoning: "high"` unconditionally to `completeSimple()`, bypassing the compat system entirely. This causes API rejections from any provider that does not support `reasoning_effort` — e.g. vLLM/NIM, Ollama, and other local OpenAI-compatible servers.

The failure is especially painful because it puts the session into an unrecoverable loop:
1. Context grows → compaction triggers
2. Compaction calls `generateSummary` with `reasoning: "high"`
3. Provider rejects the request
4. The "context overflow" handler retries compaction → back to step 2

### Error seen on NVIDIA NIM
```
400 Value error, 'reasoning_effort' is only supported for GPT-OSS reasoning models.
Current reasoning parser: 'not set'.
```

## Fix

Remove `reasoning: "high"` from the `completeSimple` options. Compaction is a background utility task; there is no benefit to forcing high reasoning effort for it. The `reasoning` option is optional and should only be passed when the caller explicitly requires it.

```diff
- { maxTokens, signal, apiKey, reasoning: "high" },
+ { maxTokens, signal, apiKey },
```

## Testing

Verified on NVIDIA NIM 1.15.5 / vLLM 0.10.2 with `nvidia/llama-3.3-nemotron-super-49b-v1.5` on a DGX Spark (GB10, ARM64). Compaction now completes successfully for any model that does not advertise `reasoning_effort` support.