### PR TITLE
fix: disable developer role for DeepInfra (returns 422)

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -778,6 +778,9 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		provider === "opencode" ||
 		baseUrl.includes("opencode.ai");
 
+	// DeepInfra does not support the "developer" role (returns 422)
+	const isDeepInfra = provider === "deepinfra" || baseUrl.includes("api.deepinfra.com");
+
 	const useMaxTokens = provider === "mistral" || baseUrl.includes("mistral.ai") || baseUrl.includes("chutes.ai");
 
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
@@ -786,7 +789,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 
 	return {
 		supportsStore: !isNonStandard,
-		supportsDeveloperRole: !isNonStandard,
+		supportsDeveloperRole: !isNonStandard && !isDeepInfra,
 		supportsReasoningEffort: !isGrok && !isZai,
 		supportsUsageInStreaming: true,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",


### PR DESCRIPTION
## Summary

- DeepInfra's OpenAI-compatible API rejects the `"developer"` role in system messages with a `422 Unprocessable Entity` (no body)
- The developer role is used when `model.reasoning=true` and `compat.supportsDeveloperRole=true`
- DeepInfra hosts reasoning models (e.g. `Qwen/Qwen3-Max-Thinking`, `deepseek-ai/DeepSeek-R1`), so users who configure these models hit the 422 on every request

## Fix

Detect DeepInfra by provider name (`"deepinfra"`) or base URL (`api.deepinfra.com`) and set `supportsDeveloperRole: false`, falling back to the standard `"system"` role.

## Reproduction

```bash
curl -X POST https://api.deepinfra.com/v1/openai/chat/completions \
  -H "Authorization: Bearer $DEEPINFRA_API_KEY" \
  -d '{"model":"Qwen/Qwen3-Max-Thinking","messages":[{"role":"developer","content":"You are helpful."},{"role":"user","content":"hi"}],"stream":true}'
# → 422: Input should be 'system', 'user', 'assistant', or 'tool'
```

## Workaround (for users until this is released)

Add `"compat": {"supportsDeveloperRole": false}` to each DeepInfra reasoning model in `openclaw.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)