### PR TITLE
feat(anthropic): support output_config.format for structured output

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -630,6 +630,13 @@ function buildParams(
 		}
 	}
 
+	if (options?.outputFormat) {
+		params.output_config = {
+			...(params.output_config || {}),
+			format: options.outputFormat,
+		};
+	}
+
 	if (options?.metadata) {
 		const userId = options.metadata.user_id;
 		if (typeof userId === "string") {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -100,6 +100,9 @@ export interface StreamOptions {
 	 * For example, Anthropic uses `user_id` for abuse tracking and rate limiting.
 	 */
 	metadata?: Record<string, unknown>;
+
+	/** Output format for structured responses. Anthropic maps this to output_config.format. */
+	outputFormat?: { type: string; schema?: Record<string, unknown> };
 }
 
 export type ProviderStreamOptions = StreamOptions & Record<string, unknown>;


### PR DESCRIPTION
## Summary

- Adds `outputFormat` field to `StreamOptions` in `types.ts` — accepts `{ type: string; schema?: Record<string, unknown> }`
- Wires it through the Anthropic provider's `buildParams` in `anthropic.ts`, merging with any existing `output_config` (e.g. `effort` for adaptive thinking)
- Enables callers to request structured JSON output via Anthropic's `output_config.format` API

## Usage

```typescript
const stream = streamAnthropic(model, context, {
    outputFormat: {
        type: "json_schema",
        schema: { /* JSON schema */ }
    }
});
```

Produces the Anthropic API payload:
```json
{
    "output_config": {
        "format": {
            "type": "json_schema",
            "schema": { ... }
        }
    }
}
```

## Test plan

- [ ] Verify `outputFormat` alone sets `output_config.format` correctly
- [ ] Verify `outputFormat` + `effort` merges both into `output_config`
- [ ] Verify omitting `outputFormat` leaves `output_config` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)