### PR TITLE
feat(ai): forward Anthropic advanced tool calling fields

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -197,6 +197,14 @@ export interface Tool<TParameters extends TSchema = TSchema> {
 	name: string;
 	description: string;
 	parameters: TParameters;
+	/** Anthropic Tool Use Examples: example inputs to guide the model */
+	input_examples?: any[];
+	/** Anthropic PTC: restrict which tools can call this tool */
+	allowed_callers?: string[];
+	/** Anthropic server-managed tool type (e.g. "tool_search") */
+	type?: string;
+	/** Anthropic Tool Search: defer loading this tool's schema */
+	defer_loading?: boolean;
 }
 
 export interface Context {


### PR DESCRIPTION
## Summary

Adds support for Anthropic's new advanced tool calling features by forwarding additional fields through `convertTools()` and handling new response content block types in the streaming parser.

### Tool Definition Fields (all optional, backwards-compatible)

| Field | Purpose | Anthropic Feature |
|-------|---------|-------------------|
| `input_examples` | Example inputs to guide model tool usage | [Tool Use Examples](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-use-examples) |
| `allowed_callers` | Restrict which tools can invoke this tool | [Programmatic Tool Calling](https://platform.claude.com/docs/en/agents-and-tools/tool-use/programmatic-tool-calling) |
| `defer_loading` | Defer tool schema loading for on-demand discovery | [Tool Search](https://www.anthropic.com/engineering/advanced-tool-use) |
| `type` | Server-managed tool type (e.g. `tool_search`) | Tool Search |

### Response Parser

Handles three new content block types by mapping them to existing pi-ai types:

- `server_tool_use` → `ToolCall` (Tool Search results)
- `code_execution_tool_use` → `ToolCall` with code in arguments (PTC sandbox)
- `code_execution_tool_result` → `TextContent` (PTC execution output)

### Impact

- **Zero breaking changes** — all new fields are optional
- **No behavior change** for existing callers that don't set the new fields
- Enables 30-50% token reduction via PTC and ~80% context savings via Tool Search for downstream consumers

### Testing

- TypeScript type check: clean (`tsgo --noEmit` passes)
- Existing test suite: all tests pass (vitest)
- Smoke tested in production via OpenClaw (patched dist, confirmed tool calling pipeline works)