### PR TITLE
fix(coding-agent): surface auth.json parse errors at startup

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -13,7 +13,7 @@ import { selectConfig } from "./cli/config-selector.js";
 import { processFileArguments } from "./cli/file-processor.js";
 import { listModels } from "./cli/list-models.js";
 import { selectSession } from "./cli/session-picker.js";
-import { APP_NAME, getAgentDir, getModelsPath, VERSION } from "./config.js";
+import { APP_NAME, getAgentDir, getAuthPath, getModelsPath, VERSION } from "./config.js";
 import { AuthStorage } from "./core/auth-storage.js";
 import { DEFAULT_THINKING_LEVEL } from "./core/defaults.js";
 import { exportFromFile } from "./core/export-html/index.js";
@@ -62,6 +62,14 @@ function reportSettingsErrors(settingsManager: SettingsManager, context: string)
 		if (error.stack) {
 			console.error(chalk.dim(error.stack));
 		}
+	}
+}
+
+function reportAuthErrors(authStorage: AuthStorage, context: string): void {
+	const errors = authStorage.drainErrors();
+	for (const error of errors) {
+		console.error(chalk.yellow(`Warning (${context}, auth): ${error.message}`));
+		console.error(chalk.yellow(`Fix ${getAuthPath()} to restore OAuth/API key credentials.`));
 	}
 }
 
@@ -555,6 +563,7 @@ export async function main(args: string[]) {
 	const settingsManager = SettingsManager.create(cwd, agentDir);
 	reportSettingsErrors(settingsManager, "startup");
 	const authStorage = AuthStorage.create();
+	reportAuthErrors(authStorage, "startup");
 	const modelRegistry = new ModelRegistry(authStorage, getModelsPath());
 
 	const resourceLoader = new DefaultResourceLoader({


### PR DESCRIPTION
## Summary

When `~/.pi/agent/auth.json` is malformed, `AuthStorage` fails to load credentials silently from a user perspective. This can make `/login` appear empty and model/provider availability look inconsistent.

This PR adds a startup warning that clearly reports auth parse/load errors and points users to the auth file path.

## Changes

- Add `reportAuthErrors(authStorage, context)` in `packages/coding-agent/src/main.ts`
- Call it during startup immediately after `AuthStorage.create()`
- Print:
  - the auth error message
  - a direct hint to fix `auth.json` to restore OAuth/API key credentials

## Why

This makes broken auth config immediately visible and avoids confusing behavior where providers/models seem to disappear or reset even though settings files still exist.

## Validation

- `npm run check` passes
