### PR TITLE
Fix(coding-agent): restore custom theme hot reload

### DIFF
--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -610,6 +610,33 @@ function loadTheme(name: string, mode?: ColorMode): Theme {
 	return createTheme(themeJson, mode);
 }
 
+function reloadThemeFromSource(name: string): Theme {
+	const registeredTheme = registeredThemes.get(name);
+	if (registeredTheme?.sourcePath) {
+		const reloaded = loadThemeFromPath(registeredTheme.sourcePath);
+		registeredThemes.set(name, reloaded);
+		return reloaded;
+	}
+	return loadTheme(name);
+}
+
+function isBuiltinTheme(name: string): boolean {
+	return name in getBuiltinThemes();
+}
+
+function resolveThemeSourcePath(name: string): string | undefined {
+	const registeredTheme = registeredThemes.get(name);
+	if (registeredTheme?.sourcePath) {
+		return registeredTheme.sourcePath;
+	}
+	if (isBuiltinTheme(name)) {
+		return undefined;
+	}
+	const customThemesDir = getCustomThemesDir();
+	const themePath = path.join(customThemesDir, `${name}.json`);
+	return fs.existsSync(themePath) ? themePath : undefined;
+}
+
 export function getThemeByName(name: string): Theme | undefined {
 	try {
 		return loadTheme(name);
@@ -732,47 +759,52 @@ function startThemeWatcher(): void {
 	}
 
 	// Only watch if it's a custom theme (not built-in)
-	if (!currentThemeName || currentThemeName === "dark" || currentThemeName === "light") {
+	if (!currentThemeName || isBuiltinTheme(currentThemeName)) {
 		return;
 	}
 
-	const customThemesDir = getCustomThemesDir();
-	const themeFile = path.join(customThemesDir, `${currentThemeName}.json`);
-
+	const themeFile = resolveThemeSourcePath(currentThemeName);
 	// Only watch if the file exists
-	if (!fs.existsSync(themeFile)) {
+	if (!themeFile) {
 		return;
 	}
+
+	const reloadTheme = () => {
+		try {
+			if (!currentThemeName) {
+				return;
+			}
+			setGlobalTheme(reloadThemeFromSource(currentThemeName));
+			if (onThemeChangeCallback) {
+				onThemeChangeCallback();
+			}
+		} catch (_error) {
+			// Ignore errors (file might be in invalid state while being edited)
+		}
+	};
 
 	try {
 		themeWatcher = fs.watch(themeFile, (eventType) => {
 			if (eventType === "change") {
 				// Debounce rapid changes
-				setTimeout(() => {
-					try {
-						// Reload the theme
-						setGlobalTheme(loadTheme(currentThemeName!));
-						// Notify callback (to invalidate UI)
-						if (onThemeChangeCallback) {
-							onThemeChangeCallback();
-						}
-					} catch (_error) {
-						// Ignore errors (file might be in invalid state while being edited)
-					}
-				}, 100);
+				setTimeout(reloadTheme, 100);
 			} else if (eventType === "rename") {
-				// File was deleted or renamed - fall back to default theme
 				setTimeout(() => {
-					if (!fs.existsSync(themeFile)) {
-						currentThemeName = "dark";
-						setGlobalTheme(loadTheme("dark"));
-						if (themeWatcher) {
-							themeWatcher.close();
-							themeWatcher = undefined;
-						}
-						if (onThemeChangeCallback) {
-							onThemeChangeCallback();
-						}
+					if (fs.existsSync(themeFile)) {
+						// File may have been atomically replaced
+						startThemeWatcher();
+						reloadTheme();
+						return;
+					}
+					// File was deleted - fall back to default theme
+					currentThemeName = "dark";
+					setGlobalTheme(loadTheme("dark"));
+					if (themeWatcher) {
+						themeWatcher.close();
+						themeWatcher = undefined;
+					}
+					if (onThemeChangeCallback) {
+						onThemeChangeCallback();
 					}
 				}, 100);
 			}

--- a/packages/coding-agent/test/theme-hot-reload.test.ts
+++ b/packages/coding-agent/test/theme-hot-reload.test.ts
@@ -1,0 +1,213 @@
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	loadThemeFromPath,
+	onThemeChange,
+	setRegisteredThemes,
+	setTheme,
+	stopThemeWatcher,
+	theme,
+} from "../src/modes/interactive/theme/theme.js";
+
+const TEST_THEME_NAME = "test-theme";
+const TEST_THEME_ACCENT = "#111111";
+const TEST_THEME_UPDATED_ACCENT = "#22aa22";
+
+function writeThemeFile(path: string, name: string, accent: string): void {
+	const darkPath = join(process.cwd(), "src/modes/interactive/theme/dark.json");
+	const dark = JSON.parse(readFileSync(darkPath, "utf-8"));
+	dark.name = name;
+	dark.colors.accent = accent;
+	writeFileSync(path, JSON.stringify(dark, null, 2));
+}
+
+function writeThemeFileAtomically(path: string, name: string, accent: string): void {
+	const tmpPath = `${path}.tmp`;
+	writeThemeFile(tmpPath, name, accent);
+	renameSync(tmpPath, path);
+}
+
+function createThemeChangeTracker(): {
+	getCount: () => number;
+	waitForNext: (timeoutMs?: number) => Promise<void>;
+	expectNoChangeFor: (durationMs: number) => Promise<void>;
+	dispose: () => void;
+} {
+	let changes = 0;
+	let nextTarget = 1;
+	const waiters: Array<{
+		target: number;
+		resolve: () => void;
+		reject: (error: Error) => void;
+		timer: ReturnType<typeof setTimeout>;
+	}> = [];
+
+	onThemeChange(() => {
+		changes++;
+		for (let i = waiters.length - 1; i >= 0; i--) {
+			const waiter = waiters[i];
+			if (changes >= waiter.target) {
+				clearTimeout(waiter.timer);
+				waiters.splice(i, 1);
+				waiter.resolve();
+			}
+		}
+	});
+
+	const waitForTarget = (target: number, timeoutMs: number): Promise<void> => {
+		if (changes >= target) {
+			return Promise.resolve();
+		}
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				reject(new Error(`Timed out waiting for ${target} theme change(s), got ${changes}`));
+			}, timeoutMs);
+			waiters.push({ target, resolve, reject, timer });
+		});
+	};
+
+	return {
+		getCount: () => changes,
+		waitForNext: (timeoutMs: number = 2_000) => {
+			nextTarget = Math.max(nextTarget, changes + 1);
+			const target = nextTarget;
+			nextTarget++;
+			return waitForTarget(target, timeoutMs);
+		},
+		expectNoChangeFor: async (durationMs: number) => {
+			const before = changes;
+			await new Promise((resolve) => setTimeout(resolve, durationMs));
+			expect(changes).toBe(before);
+		},
+		dispose: () => {
+			for (const waiter of waiters) {
+				clearTimeout(waiter.timer);
+			}
+			waiters.length = 0;
+			onThemeChange(() => undefined);
+		},
+	};
+}
+
+describe("theme hot reload", () => {
+	const tempDirs: string[] = [];
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	let themesDir = "";
+	let themePath = "";
+	let tracker: ReturnType<typeof createThemeChangeTracker>;
+	let initialAccentOutput = "";
+
+	beforeEach(() => {
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-agent-dir-"));
+		themesDir = join(agentDir, "themes");
+		mkdirSync(themesDir, { recursive: true });
+		tempDirs.push(agentDir);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		stopThemeWatcher();
+		setRegisteredThemes([]);
+		onThemeChange(() => undefined);
+
+		themePath = registerTheme(TEST_THEME_NAME, TEST_THEME_ACCENT);
+		setTheme(TEST_THEME_NAME, true);
+		tracker = createThemeChangeTracker();
+		initialAccentOutput = theme.fg("accent", "X");
+	});
+
+	afterEach(() => {
+		tracker.dispose();
+		stopThemeWatcher();
+		setRegisteredThemes([]);
+		onThemeChange(() => undefined);
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+		process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+	});
+
+	function registerTheme(name: string, accent: string): string {
+		const filePath = join(themesDir, `${name}.json`);
+		writeThemeFile(filePath, name, accent);
+		setRegisteredThemes([loadThemeFromPath(filePath)]);
+		return filePath;
+	}
+
+	it("reloads active file-backed registered theme when file changes", async () => {
+		const changed = tracker.waitForNext();
+		writeThemeFile(themePath, TEST_THEME_NAME, TEST_THEME_UPDATED_ACCENT);
+		await changed;
+		expect(theme.fg("accent", "X")).not.toBe(initialAccentOutput);
+	});
+
+	it("watches the active theme source path, not only agentDir/themes", async () => {
+		const externalThemeDir = mkdtempSync(join(tmpdir(), "pi-theme-source-"));
+		tempDirs.push(externalThemeDir);
+		const externalThemePath = join(externalThemeDir, `${TEST_THEME_NAME}.json`);
+		writeThemeFile(externalThemePath, TEST_THEME_NAME, TEST_THEME_ACCENT);
+		setRegisteredThemes([loadThemeFromPath(externalThemePath)]);
+
+		tracker.dispose();
+		setTheme(TEST_THEME_NAME, true);
+		tracker = createThemeChangeTracker();
+
+		const decoyPath = join(themesDir, `${TEST_THEME_NAME}.json`);
+		writeThemeFile(decoyPath, TEST_THEME_NAME, "#999999");
+		await tracker.expectNoChangeFor(400);
+
+		const changed = tracker.waitForNext();
+		writeThemeFile(externalThemePath, TEST_THEME_NAME, TEST_THEME_UPDATED_ACCENT);
+		await changed;
+		expect(tracker.getCount()).toBeGreaterThan(0);
+	});
+
+	it("reattaches watcher and reloads after atomic-save rename events", async () => {
+		const changed = tracker.waitForNext();
+		writeThemeFileAtomically(themePath, TEST_THEME_NAME, TEST_THEME_UPDATED_ACCENT);
+		await changed;
+		expect(tracker.getCount()).toBeGreaterThan(0);
+		expect(theme.fg("accent", "X")).not.toBe(initialAccentOutput);
+	});
+
+	it("ignores invalid intermediate file content and recovers on next valid save", async () => {
+		writeFileSync(themePath, "{ invalid json");
+		await tracker.expectNoChangeFor(400);
+		expect(theme.fg("accent", "X")).toBe(initialAccentOutput);
+
+		const changed = tracker.waitForNext();
+		writeThemeFile(themePath, TEST_THEME_NAME, TEST_THEME_UPDATED_ACCENT);
+		await changed;
+		expect(theme.fg("accent", "X")).not.toBe(initialAccentOutput);
+	});
+
+	it("falls back when active theme file is deleted", async () => {
+		const changed = tracker.waitForNext();
+		rmSync(themePath, { force: true });
+		await changed;
+		expect(theme.fg("accent", "X")).not.toBe(initialAccentOutput);
+		expect(tracker.getCount()).toBeGreaterThan(0);
+	});
+
+	it("switches watched file when switching active theme", async () => {
+		const themePathA = join(themesDir, "theme-a.json");
+		const themePathB = join(themesDir, "theme-b.json");
+		writeThemeFile(themePathA, "theme-a", "#101010");
+		writeThemeFile(themePathB, "theme-b", "#202020");
+		setRegisteredThemes([loadThemeFromPath(themePathA), loadThemeFromPath(themePathB)]);
+
+		const switchTracker = createThemeChangeTracker();
+		setTheme("theme-a", true);
+		setTheme("theme-b", true);
+		const before = theme.fg("accent", "X");
+
+		writeThemeFile(themePathA, "theme-a", "#303030");
+		await switchTracker.expectNoChangeFor(400);
+		expect(theme.fg("accent", "X")).toBe(before);
+
+		const changed = switchTracker.waitForNext();
+		writeThemeFile(themePathB, "theme-b", "#404040");
+		await changed;
+		expect(theme.fg("accent", "X")).not.toBe(before);
+		switchTracker.dispose();
+	});
+});


### PR DESCRIPTION
## Problem

Custom theme hot reload was effectively broken because theme reload reused in-memory registered theme objects instead  of re-reading file-backed themes from disk.                                                                              
As a result, file edits did not change the active runtime theme even when a watcher event was fired.

## Changes / Resolution

- Added explicit reload path for file-backed registered themes that re-reads the theme JSON from `sourcePath`
- Updated hot-reload flow to refresh runtime theme state from disk-loaded theme data (should this go through the `ResourceLoader`?)
- Updated watcher path resolution to follow the active theme source path (with legacy fallback*)
- Improved rename handling for atomic-save behavior by reattaching watcher and reloading when file still exists
- Replaced hardcoded built-in theme name checks with dynamic built-in detection

## Tests

Added: `packages/coding-agent/test/theme-hot-reload.test.ts`

Covers:
1. File-backed registered theme changes are applied after source file edits
1. Watcher follows active source path (not only `agentDir/themes`).

&ast; There are some assumptions of themes being in the agent dir, though generally themes could be in multiple different directories. I **kept** the agent dir theme assumption as a fallback when reloading dirs.

---

🤖 Changes are ai assisted

I am aware that this PR will be auto-closed.