### PR TITLE
fix(ai): match Gemini 3.1+ model IDs in thinking level detection

### DIFF
--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -794,7 +794,7 @@ export const streamSimpleGoogleGeminiCli: StreamFunction<"google-gemini-cli", Si
 	}
 
 	const effort = clampReasoning(options.reasoning)!;
-	if (model.id.includes("3-pro") || model.id.includes("3-flash")) {
+	if (/3(\.\d+)?-pro/.test(model.id) || /3(\.\d+)?-flash/.test(model.id)) {
 		return streamGoogleGeminiCli(model, context, {
 			...base,
 			thinking: {
@@ -917,7 +917,7 @@ export function buildRequest(
 type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh">;
 
 function getGeminiCliThinkingLevel(effort: ClampedThinkingLevel, modelId: string): GoogleThinkingLevel {
-	if (modelId.includes("3-pro")) {
+	if (/3(\.\d+)?-pro/.test(modelId)) {
 		switch (effort) {
 			case "minimal":
 			case "low":

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -416,11 +416,11 @@ function buildParams(
 type ClampedThinkingLevel = Exclude<PiThinkingLevel, "xhigh">;
 
 function isGemini3ProModel(model: Model<"google-generative-ai">): boolean {
-	return model.id.includes("3-pro");
+	return /3(\.\d+)?-pro/.test(model.id);
 }
 
 function isGemini3FlashModel(model: Model<"google-generative-ai">): boolean {
-	return model.id.includes("3-flash");
+	return /3(\.\d+)?-flash/.test(model.id);
 }
 
 function getGemini3ThinkingLevel(

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -386,11 +386,11 @@ function buildParams(
 type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh">;
 
 function isGemini3ProModel(model: Model<"google-generative-ai">): boolean {
-	return model.id.includes("3-pro");
+	return /3(\.\d+)?-pro/.test(model.id);
 }
 
 function isGemini3FlashModel(model: Model<"google-generative-ai">): boolean {
-	return model.id.includes("3-flash");
+	return /3(\.\d+)?-flash/.test(model.id);
 }
 
 function getGemini3ThinkingLevel(


### PR DESCRIPTION
## Summary

`isGemini3ProModel` / `isGemini3FlashModel` use `model.id.includes("3-pro")` which does not match Gemini 3.1 model IDs like `gemini-3.1-pro-preview` or `gemini-3.1-pro-high` (the ID contains `3.1-pro`, not `3-pro`).

This causes 3.1 models to fall through to the legacy budget-based thinking path where `getGoogleBudget` returns `-1` for unrecognized models, resulting in `INVALID_ARGUMENT` from the Google API ("Budget 0 is invalid. This model only works in thinking mode.").

## Fix

Use regex `/3(\.\d+)?-pro/` and `/3(\.\d+)?-flash/` instead of `includes("3-pro")` / `includes("3-flash")` to match both `gemini-3-pro-*` and `gemini-3.1-pro-*` (and future `3.2`, etc.).

Applied to all three Google providers:
- `google.ts`
- `google-vertex.ts`
- `google-gemini-cli.ts`

Existing tests for `gemini-3-pro-*` / `gemini-3-flash-*` models remain unaffected.