### PR TITLE
feat(ai): add gemini-3.1-pro-preview to google-gemini-cli provider

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1012,6 +1012,18 @@ async function generateModels() {
 			contextWindow: 1048576,
 			maxTokens: 65535,
 		},
+		{
+			id: "gemini-3.1-pro-preview",
+			name: "Gemini 3.1 Pro Preview (Cloud Code Assist)",
+			api: "google-gemini-cli",
+			provider: "google-gemini-cli",
+			baseUrl: CLOUD_CODE_ASSIST_ENDPOINT,
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1048576,
+			maxTokens: 65535,
+		},
 	];
 	allModels.push(...cloudCodeAssistModels);
 

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -3498,6 +3498,23 @@ export const MODELS = {
 			contextWindow: 1048576,
 			maxTokens: 65535,
 		} satisfies Model<"google-gemini-cli">,
+		"gemini-3.1-pro-preview": {
+			id: "gemini-3.1-pro-preview",
+			name: "Gemini 3.1 Pro Preview (Cloud Code Assist)",
+			api: "google-gemini-cli",
+			provider: "google-gemini-cli",
+			baseUrl: "https://cloudcode-pa.googleapis.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 1048576,
+			maxTokens: 65535,
+		} satisfies Model<"google-gemini-cli">,
 	},
 	"google-vertex": {
 		"gemini-1.5-flash": {


### PR DESCRIPTION
Add `gemini-3.1-pro-preview` to the Cloud Code Assist (`google-gemini-cli`) provider for parity with the `google` and `google-vertex` providers that already include this model.

Tested and confirmed working via the Cloud Code Assist API endpoint (`cloudcode-pa.googleapis.com`).