### PR TITLE
fix(coding-agent/tui): restore Termux support (broken since v0.53.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@mariozechner/pi-coding-agent": "^0.30.2",
-		"get-east-asian-width": "^1.4.0",
-		"koffi": "^2.15.1"
+		"get-east-asian-width": "^1.4.0"
 	},
 	"overrides": {
 		"rimraf": "6.1.2",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -39,9 +39,11 @@
 		"@types/mime-types": "^2.1.4",
 		"chalk": "^5.5.0",
 		"get-east-asian-width": "^1.3.0",
-		"koffi": "^2.9.0",
 		"marked": "^15.0.12",
 		"mime-types": "^3.0.1"
+	},
+	"optionalDependencies": {
+		"koffi": "^2.9.0"
 	},
 	"devDependencies": {
 		"@xterm/headless": "^5.5.0",


### PR DESCRIPTION
pi-coding-agent installation on Termux is failing since #1495 , v0.53.0 , which introduced koffi as required dependency.

This makes koffi optional dependency and that fixes the installation issues on Termux