### PR TITLE
fix(agent): replace `any` cast with `AssistantMessage` type for error handling when access `errorMessage`

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -7,6 +7,7 @@ import {
 	getModel,
 	type ImageContent,
 	type Message,
+	type AssistantMessage,
 	type Model,
 	streamSimple,
 	type TextContent,
@@ -486,8 +487,8 @@ export class Agent {
 					}
 
 					case "turn_end":
-						if (event.message.role === "assistant" && (event.message as any).errorMessage) {
-							this._state.error = (event.message as any).errorMessage;
+						if (event.message.role === "assistant" && (event.message as AssistantMessage).errorMessage) {
+							this._state.error = (event.message as AssistantMessage).errorMessage;
 						}
 						break;
 


### PR DESCRIPTION
   Use proper type assertion instead of `any` when accessing `errorMessage`
   on assistant messages in turn_end event handling.