### PR TITLE
feat(agent-service): add runtime service and user best-practices guide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1922,6 +1922,10 @@
 			"resolved": "packages/agent",
 			"link": true
 		},
+		"node_modules/@mariozechner/pi-agent-service": {
+			"resolved": "packages/agent-service",
+			"link": true
+		},
 		"node_modules/@mariozechner/pi-ai": {
 			"resolved": "packages/ai",
 			"link": true
@@ -8550,6 +8554,40 @@
 			"engines": {
 				"node": ">=20.0.0"
 			}
+		},
+		"packages/agent-service": {
+			"name": "@mariozechner/pi-agent-service",
+			"version": "0.54.2",
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-coding-agent": "^0.54.2",
+				"@mariozechner/pi-tui": "^0.54.2"
+			},
+			"devDependencies": {
+				"@types/node": "^24.3.0",
+				"typescript": "^5.7.3",
+				"vitest": "^3.2.4"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"packages/agent-service/node_modules/@types/node": {
+			"version": "24.10.13",
+			"resolved": "https://registry.npmmirror.com/@types/node/-/node-24.10.13.tgz",
+			"integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
+		},
+		"packages/agent-service/node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"packages/agent/node_modules/@types/node": {
 			"version": "24.10.13",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	],
 	"scripts": {
 		"clean": "npm run clean --workspaces",
-		"build": "cd packages/tui && npm run build && cd ../ai && npm run build && cd ../agent && npm run build && cd ../coding-agent && npm run build && cd ../mom && npm run build && cd ../web-ui && npm run build && cd ../pods && npm run build",
+		"build": "cd packages/tui && npm run build && cd ../ai && npm run build && cd ../agent && npm run build && cd ../coding-agent && npm run build && cd ../mom && npm run build && cd ../web-ui && npm run build && cd ../pods && npm run build && cd ../agent-service && npm run build",
 		"dev": "concurrently --names \"ai,agent,coding-agent,mom,web-ui,tui\" --prefix-colors \"cyan,yellow,red,white,green,magenta\" \"cd packages/ai && npm run dev\" \"cd packages/agent && npm run dev\" \"cd packages/coding-agent && npm run dev\" \"cd packages/mom && npm run dev\" \"cd packages/web-ui && npm run dev\" \"cd packages/tui && npm run dev\"",
 		"dev:tsc": "concurrently --names \"ai,web-ui\" --prefix-colors \"cyan,green\" \"cd packages/ai && npm run dev:tsc\" \"cd packages/web-ui && npm run dev:tsc\"",
 		"check": "biome check --write --error-on-warnings . && tsgo --noEmit && cd packages/web-ui && npm run check",

--- a/packages/agent-service/README.md
+++ b/packages/agent-service/README.md
@@ -1,0 +1,23 @@
+# @mariozechner/pi-agent-service
+
+HTTP + SSE host service for `@mariozechner/pi-coding-agent` sessions.
+
+## User Documentation
+
+- Best Practices: [docs/BEST_PRACTICES.md](./docs/BEST_PRACTICES.md)
+- Optional Enhancements Evaluation: [docs/optional-evaluation.md](./docs/optional-evaluation.md)
+
+## Quick Start
+
+```ts
+import { createAgentService } from "@mariozechner/pi-agent-service";
+
+const service = createAgentService({
+  apiKey: process.env.AGENT_SERVICE_API_KEY!,
+  defaultCwd: process.cwd(),
+});
+
+await service.listen(8080, "127.0.0.1");
+```
+
+Use `X-API-Key` header for all `/v1` routes.

--- a/packages/agent-service/docs/BEST_PRACTICES.md
+++ b/packages/agent-service/docs/BEST_PRACTICES.md
@@ -1,0 +1,232 @@
+# Agent Service User Best Practices
+
+This guide describes practical operating patterns for `@mariozechner/pi-agent-service`.
+It focuses on production behavior of the current implementation in this repository.
+
+## 1. Use the Service in the Intended Architecture
+
+### 1.1 Prefer SDK-first host integration
+- Run the service in Node/TypeScript and use `createAgentService()` from this package.
+- Keep non-Node integration behind HTTP + SSE clients, not custom protocols.
+
+### 1.2 Keep one owner per session
+- Treat each `sessionId` as a single conversation owner.
+- Avoid concurrent `prompt` calls for one session. The service enforces this with `SESSION_BUSY`.
+
+### 1.3 Isolate environments by `cwd`
+- Set `cwd` intentionally when creating sessions.
+- Use separate session directories or working directories per tenant/project/workspace.
+
+## 2. Secure the Service Boundary First
+
+### 2.1 Always enforce API key auth at the edge
+- Every endpoint requires `X-API-Key`.
+- Do not expose this service publicly without a reverse proxy and TLS.
+
+### 2.2 Never hardcode keys in client code
+- Inject API keys via environment/config management.
+- Rotate regularly and invalidate leaked keys immediately.
+
+### 2.3 Add network-layer protections
+- Put the service behind an API gateway/reverse proxy.
+- Add request limits and connection limits at the edge.
+- Restrict source networks where possible.
+
+## 3. Session Lifecycle Best Practices
+
+### 3.1 Create sessions explicitly
+- Use `POST /v1/sessions` with explicit creation options (`cwd`, `agentDir`, `sessionDir`, `sessionPath`, `continueRecent`, model hints).
+- Persist returned `sessionId` in your app state.
+
+### 3.2 Treat JSONL sessions as source of truth
+- Session persistence is managed by built-in `SessionManager` JSONL files.
+- If you build indexing/search later, mirror JSONL; do not replace JSONL as authority.
+
+### 3.3 Use the right operation for context control
+- `fork`: branch from a historical entry while preserving lineage.
+- `tree/navigate`: move inside the existing session tree.
+- `switch`: load a different session file.
+- `newSession`: start clean with optional parent linkage.
+
+## 4. Prompt Orchestration: Prompt vs Steer vs Follow-up
+
+### 4.1 Use `prompt` only when idle
+- `POST /prompt` starts a new run.
+- If a run is active and you submit another prompt, you get `SESSION_BUSY`.
+
+### 4.2 Use `steer` for immediate correction
+- `POST /steer` is for urgent redirection while a run is active.
+- Use when the current trajectory is wrong and needs interruption.
+
+### 4.3 Use `follow-up` for queued continuation
+- `POST /follow-up` queues additional intent without forceful interruption.
+- Use for additive instructions that can wait until current work settles.
+
+### 4.4 Use `abort` for hard stop
+- `POST /abort` is idempotent in runtime behavior.
+- Abort before model switches or session switches to keep behavior deterministic.
+
+## 5. Streaming and SSE Consumption
+
+### 5.1 Use a dedicated SSE consumer
+- Subscribe via `GET /v1/sessions/{sessionId}/events/stream`.
+- Process `session_event` and `heartbeat` separately.
+
+### 5.2 Assume network interruptions
+- Heartbeats are emitted periodically; use them for liveness.
+- On disconnect, reconnect and query current state/messages before resuming UI assumptions.
+
+### 5.3 Order by `seq`
+- SSE envelopes include monotonic `seq` per runtime.
+- Use `seq` to preserve event ordering client-side.
+
+### 5.4 Do not infer completion from transport only
+- Use emitted event types (`agent_end`, etc.) and state polling (`GET /sessions/{id}`) for robust completion detection.
+
+## 6. Tooling Safety and Execution Policy
+
+### 6.1 Start with built-ins only
+- Current service intentionally uses built-ins first:
+  - `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`
+
+### 6.2 Keep bash allowlist strict
+- The service includes a command allowlist policy hook.
+- Add only necessary command prefixes for your workload.
+- Reject broad shells or destructive command families by default.
+
+### 6.3 Prefer narrow working directories
+- Use the smallest possible `cwd` scope to reduce accidental file impact.
+- Segment workspaces per app/project.
+
+### 6.4 Expect truncation in large outputs
+- Built-in tools can truncate output for safety/perf.
+- Handle large-output workflows by paging/chunking instead of assuming full payloads.
+
+## 7. Models and Thinking Levels
+
+### 7.1 Set model explicitly per session when needed
+- Use `POST /model` to pin provider/model where determinism matters.
+- Validate available models in your provisioning layer.
+
+### 7.2 Use conservative thinking levels first
+- Default to lower-cost levels for routine tasks.
+- Raise thinking level only for complex reasoning paths.
+
+### 7.3 Handle model errors as user-visible decisions
+- Map `MODEL_ERROR` to actionable UI: re-select model, verify credentials, retry with fallback.
+
+## 8. Error Handling Contract
+
+### 8.1 Use canonical error codes, not message parsing
+- Service returns stable codes:
+  - `AUTH_INVALID`
+  - `SESSION_NOT_FOUND`
+  - `SESSION_BUSY`
+  - `POLICY_DENIED`
+  - `TOOL_EXEC_ERROR`
+  - `MODEL_ERROR`
+  - `INTERNAL_ERROR`
+
+### 8.2 Retry only when appropriate
+- Respect `retryable` field in error payloads.
+- Typical strategy:
+  - retryable true: bounded backoff retries
+  - retryable false: surface to user/system control path
+
+### 8.3 Separate policy denial from execution failure
+- `POLICY_DENIED`: blocked by safety rule; do not blind-retry.
+- `TOOL_EXEC_ERROR`: command/tool failed; may retry after state/input fix.
+
+## 9. Extension Layer Best Practices
+
+### 9.1 Keep extensions product-focused
+- Use extensions for guardrails, commands, renderers, and policy-specific behavior.
+- Avoid duplicating core agent/session behavior in your host app.
+
+### 9.2 Persist reconstruction state in entries
+- Use `appendEntry(...)` for state that must survive reload/resume.
+- Reconstruct in `session_start` from prior entries.
+
+### 9.3 Keep custom message rendering lightweight
+- Renderers should be deterministic and cheap.
+- Avoid expensive synchronous logic in rendering paths.
+
+### 9.4 Use commands for repeatable workflows
+- Provide concise product commands (for example `/plan`) for common user intents.
+
+## 10. Reliability and Operational Hardening
+
+### 10.1 Run continuous type and integration checks
+- Keep package-level typecheck and tests in CI.
+- Keep workspace-level typecheck as a separate gate.
+
+### 10.2 Cover critical runtime edges
+- Must-have scenarios:
+  - prompt streaming path
+  - steer vs follow-up semantics
+  - abort during streaming
+  - branch/fork/switch correctness
+  - SSE ordering and reconnect behavior
+  - policy denied and auth invalid paths
+
+### 10.3 Instrument key service metrics
+- Track:
+  - active sessions
+  - SSE connections
+  - prompt latency
+  - tool failure rates
+  - abort rates
+  - policy-denied counts
+  - model error rates
+
+### 10.4 Define capacity boundaries explicitly
+- Limit maximum concurrent sessions per instance.
+- Cap SSE connections per instance.
+- Use horizontal scaling only after session isolation strategy is clear.
+
+## 11. Recommended Client Integration Pattern
+
+### 11.1 Startup
+1. Create session.
+2. Open SSE stream.
+3. Render current state and messages.
+
+### 11.2 User turn
+1. Submit `prompt`.
+2. Stream/render incremental events.
+3. Allow `steer`/`follow-up` while active.
+4. Use `abort` when user cancels.
+
+### 11.3 Recovery
+1. On disconnect, reconnect SSE.
+2. Fetch `GET /sessions/{id}` and `GET /messages`.
+3. Reconcile UI from server state, not local assumptions.
+
+## 12. Anti-Patterns to Avoid
+
+- Sending concurrent `prompt` calls to the same session.
+- Implementing a second event model before confirming native event payloads are insufficient.
+- Replacing JSONL persistence before proving product needs.
+- Granting unrestricted shell access in production.
+- Treating `POLICY_DENIED` as transient and auto-retrying.
+- Ignoring heartbeat and disconnect events on SSE streams.
+
+## 13. Minimal Production Readiness Checklist
+
+- [ ] `X-API-Key` enforced at service and gateway.
+- [ ] TLS termination and network restrictions configured.
+- [ ] Session `cwd` isolation strategy documented.
+- [ ] Bash allowlist reviewed and approved.
+- [ ] SSE reconnect/reconciliation implemented client-side.
+- [ ] Canonical error-code handling implemented.
+- [ ] Typecheck + tests green in CI.
+- [ ] Observability dashboards and alerts in place.
+
+## 14. Reference Files
+
+- Runtime behavior: `packages/agent-service/src/runtime.ts`
+- HTTP + SSE contract: `packages/agent-service/src/http.ts`
+- Session/backend composition: `packages/agent-service/src/registry.ts`
+- Policy adapter: `packages/agent-service/src/policy.ts`
+- Product extension layer: `packages/agent-service/src/extensions/product-extension.ts`
+- Optional enhancement decisions: `packages/agent-service/docs/optional-evaluation.md`

--- a/packages/agent-service/docs/optional-evaluation.md
+++ b/packages/agent-service/docs/optional-evaluation.md
@@ -1,0 +1,13 @@
+# Optional Enhancements Evaluation
+
+## External searchable index mirror
+Decision: No-go for MVP.
+Rationale: SessionManager JSONL already provides authoritative persistence and branching semantics. Additional index would add synchronization risk before product validation.
+
+## RPC compatibility adapter for non-Node consumers
+Decision: No-go for MVP, keep as next increment.
+Rationale: HTTP + SSE is now complete and stable for Node-first integration. RPC adapter should only be added when a non-Node client is committed.
+
+## Advanced provider/proxy registration and telemetry pipeline
+Decision: No-go for MVP.
+Rationale: Current SDK-backed model selection and canonical error mapping are sufficient. Telemetry/proxy complexity is deferred until operational scale requires it.

--- a/packages/agent-service/package.json
+++ b/packages/agent-service/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "@mariozechner/pi-agent-service",
+	"version": "0.54.2",
+	"description": "HTTP + SSE host service for pi-coding-agent sessions",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc -p tsconfig.build.json",
+		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
+		"test": "vitest --run",
+		"typecheck": "tsc --noEmit -p tsconfig.build.json",
+		"prepublishOnly": "npm run clean && npm run build"
+	},
+	"dependencies": {
+		"@mariozechner/pi-coding-agent": "^0.54.2",
+		"@mariozechner/pi-tui": "^0.54.2"
+	},
+	"devDependencies": {
+		"@types/node": "^24.3.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.2.4"
+	},
+	"keywords": [
+		"agent",
+		"service",
+		"http",
+		"sse",
+		"sdk"
+	],
+	"author": "Mario Zechner",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/badlogic/pi-mono.git",
+		"directory": "packages/agent-service"
+	},
+	"engines": {
+		"node": ">=20.0.0"
+	}
+}

--- a/packages/agent-service/src/errors.ts
+++ b/packages/agent-service/src/errors.ts
@@ -1,0 +1,79 @@
+import type { JsonObject, ServiceErrorCode, ServiceErrorShape } from "./types.js";
+
+export class ServiceError extends Error {
+	readonly code: ServiceErrorCode;
+	readonly retryable: boolean;
+	readonly details: JsonObject;
+	readonly status: number;
+
+	constructor(code: ServiceErrorCode, message: string, status: number, retryable: boolean, details: JsonObject = {}) {
+		super(message);
+		this.name = "ServiceError";
+		this.code = code;
+		this.retryable = retryable;
+		this.details = details;
+		this.status = status;
+	}
+
+	toResponse(): ServiceErrorShape {
+		return {
+			code: this.code,
+			message: this.message,
+			retryable: this.retryable,
+			details: this.details,
+		};
+	}
+}
+
+function getMessage(error: Error | string): string {
+	if (typeof error === "string") return error;
+	return error.message;
+}
+
+export function toServiceError(error: Error | string): ServiceError {
+	if (error instanceof ServiceError) return error;
+
+	const message = getMessage(error);
+
+	if (message.includes("SESSION_BUSY")) {
+		return new ServiceError("SESSION_BUSY", message, 409, false);
+	}
+
+	if (message.includes("POLICY_DENIED")) {
+		return new ServiceError("POLICY_DENIED", message, 403, false);
+	}
+
+	if (message.includes("No API key") || message.includes("Model not found") || message.includes("set_model")) {
+		return new ServiceError("MODEL_ERROR", message, 400, false);
+	}
+
+	if (message.includes("Tool") || message.includes("Command exited") || message.includes("timed out")) {
+		return new ServiceError("TOOL_EXEC_ERROR", message, 422, true);
+	}
+
+	return new ServiceError("INTERNAL_ERROR", message, 500, true);
+}
+
+export function authError(): ServiceError {
+	return new ServiceError("AUTH_INVALID", "Invalid API key", 401, false);
+}
+
+export function sessionNotFoundError(sessionId: string): ServiceError {
+	return new ServiceError("SESSION_NOT_FOUND", `Session not found: ${sessionId}`, 404, false, { sessionId });
+}
+
+export function sessionBusyError(): ServiceError {
+	return new ServiceError("SESSION_BUSY", "SESSION_BUSY: prompt already in progress", 409, false);
+}
+
+export function modelNotFoundError(provider: string, modelId: string): ServiceError {
+	return new ServiceError("MODEL_ERROR", `Model not found: ${provider}/${modelId}`, 400, false, {
+		provider,
+		modelId,
+	});
+}
+
+export function parseErrorMessage(error: Error | string): string {
+	if (typeof error === "string") return error;
+	return error.message;
+}

--- a/packages/agent-service/src/extensions/product-extension.ts
+++ b/packages/agent-service/src/extensions/product-extension.ts
@@ -1,0 +1,146 @@
+import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { Box, Text } from "@mariozechner/pi-tui";
+import { isCommandAllowed } from "../policy.js";
+import type { BashPolicyConfig } from "../types.js";
+
+interface PlanMessageDetails {
+	goal: string;
+	requestedAt: number;
+}
+
+interface GuardrailState {
+	blockedCount: number;
+	lastBlockedCommand?: string;
+}
+
+interface PlanStateEntry {
+	goal: string;
+	requestedAt: number;
+}
+
+interface CustomSessionEntry {
+	type: string;
+	customType?: string;
+	data?: GuardrailState | PlanStateEntry;
+}
+
+export interface ProductExtensionConfig {
+	bashPolicy: BashPolicyConfig;
+}
+
+function toPlanText(goal: string, timestamp: number): string {
+	return `Plan requested: ${goal} (${new Date(timestamp).toISOString()})`;
+}
+
+function extractBashCommand(event: { toolName: string; input: object }): string | undefined {
+	if (event.toolName !== "bash") return undefined;
+	const input = event.input as { command?: string };
+	if (typeof input.command !== "string") return undefined;
+	return input.command;
+}
+
+function restoreGuardrailState(entries: CustomSessionEntry[]): GuardrailState {
+	const latest = [...entries]
+		.reverse()
+		.find((entry) => entry.type === "custom" && entry.customType === "agent-service-guardrail");
+	if (!latest || !latest.data) {
+		return { blockedCount: 0 };
+	}
+	const data = latest.data as GuardrailState;
+	return {
+		blockedCount: typeof data.blockedCount === "number" ? data.blockedCount : 0,
+		lastBlockedCommand: typeof data.lastBlockedCommand === "string" ? data.lastBlockedCommand : undefined,
+	};
+}
+
+export const productExtension = (config: ProductExtensionConfig): ExtensionFactory => {
+	return (pi: ExtensionAPI): void => {
+		let state: GuardrailState = { blockedCount: 0 };
+
+		pi.on("session_start", (_event, ctx) => {
+			const entries = ctx.sessionManager.getEntries() as CustomSessionEntry[];
+			state = restoreGuardrailState(entries);
+			if (ctx.hasUI) {
+				ctx.ui.setStatus("guardrails", `blocked:${state.blockedCount}`);
+			}
+		});
+
+		pi.on("tool_call", (event, ctx) => {
+			const command = extractBashCommand(event);
+			if (!command) return;
+			if (isCommandAllowed(command, config.bashPolicy.allowedPrefixes)) return;
+			state = {
+				blockedCount: state.blockedCount + 1,
+				lastBlockedCommand: command,
+			};
+			pi.appendEntry("agent-service-guardrail", state);
+			if (ctx.hasUI) {
+				ctx.ui.setStatus("guardrails", `blocked:${state.blockedCount}`);
+			}
+			return {
+				block: true,
+				reason: `POLICY_DENIED: command blocked by allowlist: ${command}`,
+			};
+		});
+
+		pi.on("tool_result", (event) => {
+			if (!event.isError) return;
+			pi.events.emit("agent-service:tool-error", {
+				toolName: event.toolName,
+				timestamp: Date.now(),
+			});
+		});
+
+		const onUserBash = pi.on as (
+			event: string,
+			handler: (event: { command: string }) => { block: true; reason: string } | undefined,
+		) => void;
+		onUserBash("user_bash", (event) => {
+			if (isCommandAllowed(event.command, config.bashPolicy.allowedPrefixes)) return;
+			state = {
+				blockedCount: state.blockedCount + 1,
+				lastBlockedCommand: event.command,
+			};
+			pi.appendEntry("agent-service-guardrail", state);
+			return {
+				block: true,
+				reason: `POLICY_DENIED: command blocked by allowlist: ${event.command}`,
+			};
+		});
+
+		pi.registerMessageRenderer<PlanMessageDetails>("agent-service-plan", (message, options, theme) => {
+			const details = message.details;
+			const goal = details?.goal ?? (typeof message.content === "string" ? message.content : "plan");
+			const requestedAt = details?.requestedAt ?? Date.now();
+			const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+			let text = `${theme.fg("accent", "[plan]")} ${goal}`;
+			if (options.expanded) {
+				text += `\n${theme.fg("dim", new Date(requestedAt).toISOString())}`;
+			}
+			box.addChild(new Text(text, 0, 0));
+			return box;
+		});
+
+		pi.registerCommand("plan", {
+			description: "Create a plan from the provided goal",
+			handler: async (args) => {
+				const goal = args.trim().length > 0 ? args.trim() : "current task";
+				const requestedAt = Date.now();
+				const details: PlanMessageDetails = { goal, requestedAt };
+				pi.appendEntry("agent-service-plan", details);
+				pi.sendMessage(
+					{
+						customType: "agent-service-plan",
+						content: toPlanText(goal, requestedAt),
+						display: true,
+						details,
+					},
+					{ triggerTurn: false },
+				);
+				pi.sendUserMessage(`Create a concise execution plan for: ${goal}`);
+			},
+		});
+	};
+};
+
+export { extractBashCommand, restoreGuardrailState, toPlanText };

--- a/packages/agent-service/src/http.ts
+++ b/packages/agent-service/src/http.ts
@@ -1,0 +1,281 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { authError, ServiceError, toServiceError } from "./errors.js";
+import { getOptionalBoolean, getOptionalString, getString, parseJsonObject } from "./json.js";
+import type { AgentRuntimeRegistry } from "./registry.js";
+import type {
+	CreateSessionRequest,
+	JsonObject,
+	RuntimeSessionView,
+	ServiceConfig,
+	ServiceErrorShape,
+	SetThinkingLevelRequest,
+} from "./types.js";
+
+interface RequestContext {
+	request: IncomingMessage;
+	response: ServerResponse;
+	path: string[];
+	query: URLSearchParams;
+}
+
+export interface AgentServiceHttpServer {
+	server: Server;
+	listen(port: number, host?: string): Promise<void>;
+	close(): Promise<void>;
+}
+
+const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh"]);
+
+function parsePath(request: IncomingMessage): { path: string[]; query: URLSearchParams } {
+	const origin = `http://${request.headers.host ?? "localhost"}`;
+	const parsed = new URL(request.url ?? "/", origin);
+	return {
+		path: parsed.pathname.split("/").filter((part) => part.length > 0),
+		query: parsed.searchParams,
+	};
+}
+
+function getHeaderApiKey(request: IncomingMessage): string {
+	const header = request.headers["x-api-key"];
+	if (typeof header === "string") return header;
+	if (Array.isArray(header) && header.length > 0) return header[0];
+	return "";
+}
+
+function writeJson(response: ServerResponse, status: number, payload: object): void {
+	response.statusCode = status;
+	response.setHeader("content-type", "application/json; charset=utf-8");
+	response.end(JSON.stringify(payload));
+}
+
+function writeError(response: ServerResponse, error: ServiceError): void {
+	const payload: ServiceErrorShape = error.toResponse();
+	writeJson(response, error.status, payload);
+}
+
+async function readBody(request: IncomingMessage): Promise<JsonObject> {
+	const chunks: string[] = [];
+	for await (const chunk of request) {
+		chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+	}
+	return parseJsonObject(chunks.join(""));
+}
+
+function asRuntimeView(
+	runtimeId: string,
+	state: ReturnType<ReturnType<typeof AgentRuntimeRegistry.prototype.getSession>["getState"]>,
+): RuntimeSessionView {
+	return {
+		id: runtimeId,
+		state,
+	};
+}
+
+function requireThinkingLevel(payload: JsonObject): SetThinkingLevelRequest {
+	const value = getString(payload.level, "level");
+	if (!THINKING_LEVELS.has(value)) {
+		throw new ServiceError("MODEL_ERROR", `Invalid thinking level: ${value}`, 400, false);
+	}
+	return { level: value as SetThinkingLevelRequest["level"] };
+}
+
+function mapCreateSessionRequest(payload: JsonObject): CreateSessionRequest {
+	return {
+		cwd: getOptionalString(payload.cwd),
+		agentDir: getOptionalString(payload.agentDir),
+		sessionDir: getOptionalString(payload.sessionDir),
+		sessionPath: getOptionalString(payload.sessionPath),
+		continueRecent: getOptionalBoolean(payload.continueRecent),
+		provider: getOptionalString(payload.provider),
+		modelId: getOptionalString(payload.modelId),
+		thinkingLevel: getOptionalString(payload.thinkingLevel) as CreateSessionRequest["thinkingLevel"],
+	};
+}
+
+function setSseHeaders(response: ServerResponse): void {
+	response.statusCode = 200;
+	response.setHeader("content-type", "text/event-stream");
+	response.setHeader("cache-control", "no-cache");
+	response.setHeader("connection", "keep-alive");
+	response.setHeader("x-accel-buffering", "no");
+}
+
+function writeSseEvent(response: ServerResponse, eventName: string, id: string, payload: object): void {
+	response.write(`id: ${id}\n`);
+	response.write(`event: ${eventName}\n`);
+	response.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+export function createAgentServiceHttpServer(
+	registry: AgentRuntimeRegistry,
+	config: ServiceConfig,
+): AgentServiceHttpServer {
+	const heartbeatMs = config.heartbeatMs ?? 10000;
+
+	const server = createServer(async (request, response) => {
+		try {
+			if (getHeaderApiKey(request) !== config.apiKey) {
+				throw authError();
+			}
+
+			const { path, query } = parsePath(request);
+			const context: RequestContext = { request, response, path, query };
+			await routeRequest(context, registry);
+		} catch (error) {
+			if (response.headersSent) {
+				response.end();
+				return;
+			}
+			const mapped =
+				error instanceof ServiceError
+					? error
+					: toServiceError(error instanceof Error ? error : "INTERNAL_ERROR: unhandled failure");
+			writeError(response, mapped);
+		}
+	});
+
+	return {
+		server,
+		listen(port: number, host = "127.0.0.1"): Promise<void> {
+			return new Promise((resolve, reject) => {
+				server.listen(port, host, () => resolve());
+				server.once("error", reject);
+			});
+		},
+		close(): Promise<void> {
+			return new Promise((resolve, reject) => {
+				server.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		},
+	};
+
+	async function routeRequest(context: RequestContext, runtimeRegistry: AgentRuntimeRegistry): Promise<void> {
+		const { request, response, path } = context;
+		if (path[0] !== "v1") {
+			throw new ServiceError("INTERNAL_ERROR", "Not found", 404, false);
+		}
+
+		if (request.method === "POST" && path.length === 2 && path[1] === "sessions") {
+			const payload = await readBody(request);
+			const runtime = await runtimeRegistry.createSession(mapCreateSessionRequest(payload));
+			writeJson(response, 201, asRuntimeView(runtime.id, runtime.getState()));
+			return;
+		}
+
+		if (path.length < 3 || path[1] !== "sessions") {
+			throw new ServiceError("INTERNAL_ERROR", "Not found", 404, false);
+		}
+
+		const runtime = runtimeRegistry.getSession(path[2]);
+
+		if (request.method === "GET" && path.length === 3) {
+			writeJson(response, 200, asRuntimeView(path[2], runtime.getState()));
+			return;
+		}
+
+		if (request.method === "GET" && path.length === 4 && path[3] === "messages") {
+			writeJson(response, 200, { sessionId: path[2], messages: runtime.getMessages() });
+			return;
+		}
+
+		if (request.method === "GET" && path.length === 5 && path[3] === "events" && path[4] === "stream") {
+			setSseHeaders(response);
+			response.write(`: connected\n\n`);
+			const unsubscribe = runtime.subscribe((event) => {
+				writeSseEvent(response, "session_event", String(event.seq), event);
+			});
+			const heartbeat = setInterval(() => {
+				writeSseEvent(response, "heartbeat", String(Date.now()), { ts: new Date().toISOString() });
+			}, heartbeatMs);
+			request.on("close", () => {
+				clearInterval(heartbeat);
+				unsubscribe();
+				if (!response.writableEnded) {
+					response.end();
+				}
+			});
+			return;
+		}
+
+		if (request.method !== "POST") {
+			throw new ServiceError("INTERNAL_ERROR", "Not found", 404, false);
+		}
+
+		const payload = await readBody(request);
+
+		switch (path.slice(3).join("/")) {
+			case "prompt": {
+				const text = getString(payload.text, "text");
+				const streamingBehavior = getOptionalString(payload.streamingBehavior);
+				const promptResult = runtime.prompt(text, {
+					streamingBehavior: streamingBehavior as "steer" | "followUp" | undefined,
+				});
+				writeJson(response, 202, promptResult);
+				return;
+			}
+			case "steer": {
+				const text = getString(payload.text, "text");
+				await runtime.steer(text);
+				writeJson(response, 200, { ok: true });
+				return;
+			}
+			case "follow-up": {
+				const text = getString(payload.text, "text");
+				await runtime.followUp(text);
+				writeJson(response, 200, { ok: true });
+				return;
+			}
+			case "abort": {
+				await runtime.abort();
+				writeJson(response, 200, { ok: true });
+				return;
+			}
+			case "model": {
+				const provider = getString(payload.provider, "provider");
+				const modelId = getString(payload.modelId, "modelId");
+				await runtime.setModel(provider, modelId);
+				writeJson(response, 200, { ok: true });
+				return;
+			}
+			case "thinking-level": {
+				const requestPayload = requireThinkingLevel(payload);
+				runtime.setThinkingLevel(requestPayload.level);
+				writeJson(response, 200, { ok: true });
+				return;
+			}
+			case "fork": {
+				const entryId = getString(payload.entryId, "entryId");
+				const result = await runtime.fork(entryId);
+				writeJson(response, 200, result);
+				return;
+			}
+			case "tree/navigate": {
+				const targetId = getString(payload.targetId, "targetId");
+				const result = await runtime.navigateTree({
+					targetId,
+					summarize: getOptionalBoolean(payload.summarize),
+					customInstructions: getOptionalString(payload.customInstructions),
+					replaceInstructions: getOptionalBoolean(payload.replaceInstructions),
+					label: getOptionalString(payload.label),
+				});
+				writeJson(response, 200, result);
+				return;
+			}
+			case "switch": {
+				const sessionPath = getString(payload.sessionPath, "sessionPath");
+				const result = await runtime.switchSession(sessionPath);
+				writeJson(response, 200, result);
+				return;
+			}
+			default: {
+				throw new ServiceError("INTERNAL_ERROR", "Not found", 404, false);
+			}
+		}
+	}
+}

--- a/packages/agent-service/src/index.ts
+++ b/packages/agent-service/src/index.ts
@@ -1,0 +1,55 @@
+export {
+	authError,
+	modelNotFoundError,
+	parseErrorMessage,
+	ServiceError,
+	sessionBusyError,
+	toServiceError,
+} from "./errors.js";
+export {
+	extractBashCommand,
+	type ProductExtensionConfig,
+	productExtension,
+	restoreGuardrailState,
+	toPlanText,
+} from "./extensions/product-extension.js";
+export { createAgentServiceHttpServer } from "./http.js";
+export { createPolicyBashSpawnHook, isCommandAllowed, normalizeCommand, normalizePolicyConfig } from "./policy.js";
+export {
+	AgentRuntimeRegistry,
+	buildSessionManager,
+	createDefaultBackendFactory,
+	type DefaultBackendFactoryOptions,
+	type SessionBackendFactory,
+} from "./registry.js";
+export { AgentRuntime, type AgentSessionBackend, CodingAgentSessionBackend, createRuntime } from "./runtime.js";
+export { AgentService, createAgentService } from "./service.js";
+export type {
+	BashPolicyConfig,
+	CreateSessionRequest,
+	FollowUpRequest,
+	ForkRequest,
+	JsonArray,
+	JsonObject,
+	JsonPrimitive,
+	JsonValue,
+	NavigateTreeRequest,
+	NewSessionRequest,
+	PromptRequest,
+	RuntimeForkResult,
+	RuntimeMessagesView,
+	RuntimeNavigateResult,
+	RuntimeNewSessionResult,
+	RuntimePromptResult,
+	RuntimeSessionView,
+	RuntimeState,
+	RuntimeSwitchSessionResult,
+	ServiceConfig,
+	ServiceErrorCode,
+	ServiceErrorShape,
+	SessionEventEnvelope,
+	SetModelRequest,
+	SetThinkingLevelRequest,
+	SteerRequest,
+	SwitchSessionRequest,
+} from "./types.js";

--- a/packages/agent-service/src/json.ts
+++ b/packages/agent-service/src/json.ts
@@ -1,0 +1,53 @@
+import type { JsonArray, JsonObject, JsonValue } from "./types.js";
+
+export function isJsonObject(value: JsonValue): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseJsonObject(payload: string): JsonObject {
+	if (payload.trim().length === 0) return {};
+	const value = JSON.parse(payload) as JsonValue;
+	if (!isJsonObject(value)) {
+		throw new Error("Request body must be a JSON object");
+	}
+	return value;
+}
+
+export function getString(value: JsonValue | undefined, fieldName: string): string {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new Error(`Invalid field: ${fieldName}`);
+	}
+	return value;
+}
+
+export function getOptionalString(value: JsonValue | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "string") {
+		throw new Error("Invalid string field");
+	}
+	return value;
+}
+
+export function getOptionalBoolean(value: JsonValue | undefined): boolean | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "boolean") {
+		throw new Error("Invalid boolean field");
+	}
+	return value;
+}
+
+export function getOptionalJsonObject(value: JsonValue | undefined): JsonObject | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+		return value;
+	}
+	throw new Error("Invalid object field");
+}
+
+export function getOptionalJsonArray(value: JsonValue | undefined): JsonArray | undefined {
+	if (value === undefined) return undefined;
+	if (Array.isArray(value)) {
+		return value;
+	}
+	throw new Error("Invalid array field");
+}

--- a/packages/agent-service/src/policy.ts
+++ b/packages/agent-service/src/policy.ts
@@ -1,0 +1,57 @@
+import type { BashSpawnContext, BashSpawnHook } from "@mariozechner/pi-coding-agent";
+import type { BashPolicyConfig } from "./types.js";
+
+const DEFAULT_ALLOWED_PREFIXES = [
+	"ls",
+	"pwd",
+	"cat",
+	"head",
+	"tail",
+	"sed",
+	"awk",
+	"rg",
+	"grep",
+	"find",
+	"git status",
+	"git diff",
+	"npm test",
+	"npm run",
+	"pnpm test",
+	"pnpm run",
+	"yarn test",
+	"yarn run",
+	"node",
+	"tsx",
+	"tsgo",
+];
+
+export function normalizePolicyConfig(policy?: BashPolicyConfig): BashPolicyConfig {
+	if (!policy || policy.allowedPrefixes.length === 0) {
+		return { allowedPrefixes: [...DEFAULT_ALLOWED_PREFIXES] };
+	}
+	return {
+		allowedPrefixes: [...policy.allowedPrefixes],
+	};
+}
+
+export function normalizeCommand(command: string): string {
+	return command.trim().replace(/\s+/g, " ");
+}
+
+export function isCommandAllowed(command: string, allowedPrefixes: readonly string[]): boolean {
+	const normalized = normalizeCommand(command);
+	if (normalized.length === 0) return false;
+	return allowedPrefixes.some((prefix) => {
+		const normalizedPrefix = normalizeCommand(prefix);
+		return normalized === normalizedPrefix || normalized.startsWith(`${normalizedPrefix} `);
+	});
+}
+
+export function createPolicyBashSpawnHook(policy: BashPolicyConfig): BashSpawnHook {
+	return (context: BashSpawnContext): BashSpawnContext => {
+		if (!isCommandAllowed(context.command, policy.allowedPrefixes)) {
+			throw new Error(`POLICY_DENIED: command blocked by allowlist: ${context.command}`);
+		}
+		return context;
+	};
+}

--- a/packages/agent-service/src/registry.ts
+++ b/packages/agent-service/src/registry.ts
@@ -1,0 +1,132 @@
+import { resolve } from "node:path";
+import {
+	createAgentSession,
+	createBashTool,
+	createEditTool,
+	createFindTool,
+	createGrepTool,
+	createLsTool,
+	createReadTool,
+	createWriteTool,
+	DefaultResourceLoader,
+	SessionManager,
+} from "@mariozechner/pi-coding-agent";
+import { sessionNotFoundError } from "./errors.js";
+import { productExtension } from "./extensions/product-extension.js";
+import { createPolicyBashSpawnHook, normalizePolicyConfig } from "./policy.js";
+import { type AgentRuntime, type AgentSessionBackend, CodingAgentSessionBackend, createRuntime } from "./runtime.js";
+import type { BashPolicyConfig, CreateSessionRequest } from "./types.js";
+
+export interface DefaultBackendFactoryOptions {
+	defaultCwd?: string;
+	defaultAgentDir?: string;
+	defaultSessionDir?: string;
+	bashPolicy?: BashPolicyConfig;
+}
+
+export type SessionBackendFactory = (request: CreateSessionRequest) => Promise<AgentSessionBackend>;
+
+export function buildSessionManager(
+	cwd: string,
+	request: CreateSessionRequest,
+	defaultSessionDir?: string,
+): SessionManager {
+	const sessionDir = request.sessionDir ?? defaultSessionDir;
+	if (request.sessionPath) {
+		return SessionManager.open(request.sessionPath, sessionDir);
+	}
+	if (request.continueRecent) {
+		return SessionManager.continueRecent(cwd, sessionDir);
+	}
+	return SessionManager.create(cwd, sessionDir);
+}
+
+export function createDefaultBackendFactory(options: DefaultBackendFactoryOptions = {}): SessionBackendFactory {
+	const bashPolicy = normalizePolicyConfig(options.bashPolicy);
+
+	return async (request: CreateSessionRequest): Promise<AgentSessionBackend> => {
+		const cwd = resolve(request.cwd ?? options.defaultCwd ?? process.cwd());
+		const agentDir = request.agentDir ?? options.defaultAgentDir;
+		const sessionManager = buildSessionManager(cwd, request, options.defaultSessionDir);
+
+		const resourceLoader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			extensionFactories: [productExtension({ bashPolicy })],
+		});
+		await resourceLoader.reload();
+
+		const tools = [
+			createReadTool(cwd),
+			createBashTool(cwd, { spawnHook: createPolicyBashSpawnHook(bashPolicy) }),
+			createEditTool(cwd),
+			createWriteTool(cwd),
+			createGrepTool(cwd),
+			createFindTool(cwd),
+			createLsTool(cwd),
+		];
+
+		const result = await createAgentSession({
+			cwd,
+			agentDir,
+			sessionManager,
+			resourceLoader,
+			tools,
+		});
+
+		const backend = new CodingAgentSessionBackend(result.session);
+
+		if (request.provider && request.modelId) {
+			await backend.setModel(request.provider, request.modelId);
+		}
+		if (request.thinkingLevel) {
+			backend.setThinkingLevel(request.thinkingLevel);
+		}
+
+		return backend;
+	};
+}
+
+export class AgentRuntimeRegistry {
+	private readonly runtimes: Map<string, AgentRuntime> = new Map();
+	private readonly backendFactory: SessionBackendFactory;
+
+	constructor(backendFactory: SessionBackendFactory) {
+		this.backendFactory = backendFactory;
+	}
+
+	async createSession(request: CreateSessionRequest): Promise<AgentRuntime> {
+		const backend = await this.backendFactory(request);
+		const runtime = createRuntime({ backend });
+		this.runtimes.set(runtime.id, runtime);
+		return runtime;
+	}
+
+	getSession(sessionId: string): AgentRuntime {
+		const runtime = this.runtimes.get(sessionId);
+		if (!runtime) {
+			throw sessionNotFoundError(sessionId);
+		}
+		return runtime;
+	}
+
+	listSessions(): AgentRuntime[] {
+		return [...this.runtimes.values()];
+	}
+
+	disposeSession(sessionId: string): void {
+		const runtime = this.runtimes.get(sessionId);
+		if (!runtime) {
+			return;
+		}
+		runtime.dispose();
+		this.runtimes.delete(sessionId);
+	}
+
+	dispose(): void {
+		for (const runtime of this.runtimes.values()) {
+			runtime.dispose();
+		}
+		this.runtimes.clear();
+	}
+}

--- a/packages/agent-service/src/runtime.ts
+++ b/packages/agent-service/src/runtime.ts
@@ -1,0 +1,309 @@
+import { randomUUID } from "node:crypto";
+import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+import { modelNotFoundError, sessionBusyError } from "./errors.js";
+import type {
+	RuntimeForkResult,
+	RuntimeNavigateResult,
+	RuntimeNewSessionResult,
+	RuntimePromptResult,
+	RuntimeState,
+	RuntimeSwitchSessionResult,
+	SessionEventEnvelope,
+} from "./types.js";
+
+export interface AvailableModel {
+	provider: string;
+	modelId: string;
+}
+
+export interface AgentSessionBackend {
+	prompt(text: string, options?: { streamingBehavior?: "steer" | "followUp"; source?: "rpc" }): Promise<void>;
+	steer(text: string): Promise<void>;
+	followUp(text: string): Promise<void>;
+	abort(): Promise<void>;
+	setModel(provider: string, modelId: string): Promise<void>;
+	setThinkingLevel(level: ThinkingLevel): void;
+	newSession(options?: { parentSession?: string }): Promise<boolean>;
+	switchSession(sessionPath: string): Promise<boolean>;
+	fork(entryId: string): Promise<{ selectedText: string; cancelled: boolean }>;
+	navigateTree(options: {
+		targetId: string;
+		summarize?: boolean;
+		customInstructions?: string;
+		replaceInstructions?: boolean;
+		label?: string;
+	}): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntryId?: string }>;
+	getState(): RuntimeState;
+	getMessages(): AgentMessage[];
+	getAvailableModels(): Promise<AvailableModel[]>;
+	subscribe(listener: (event: AgentSessionEvent) => void): () => void;
+	dispose(): void;
+}
+
+export class CodingAgentSessionBackend implements AgentSessionBackend {
+	private readonly session: AgentSession;
+
+	constructor(session: AgentSession) {
+		this.session = session;
+	}
+
+	prompt(text: string, options?: { streamingBehavior?: "steer" | "followUp"; source?: "rpc" }): Promise<void> {
+		return this.session.prompt(text, options);
+	}
+
+	steer(text: string): Promise<void> {
+		return this.session.steer(text);
+	}
+
+	followUp(text: string): Promise<void> {
+		return this.session.followUp(text);
+	}
+
+	abort(): Promise<void> {
+		return this.session.abort();
+	}
+
+	async setModel(provider: string, modelId: string): Promise<void> {
+		const models = await this.session.modelRegistry.getAvailable();
+		const model = models.find((candidate) => candidate.provider === provider && candidate.id === modelId);
+		if (!model) {
+			throw modelNotFoundError(provider, modelId);
+		}
+		await this.session.setModel(model);
+	}
+
+	setThinkingLevel(level: ThinkingLevel): void {
+		this.session.setThinkingLevel(level);
+	}
+
+	async newSession(options?: { parentSession?: string }): Promise<boolean> {
+		return this.session.newSession(options);
+	}
+
+	switchSession(sessionPath: string): Promise<boolean> {
+		return this.session.switchSession(sessionPath);
+	}
+
+	fork(entryId: string): Promise<{ selectedText: string; cancelled: boolean }> {
+		return this.session.fork(entryId);
+	}
+
+	async navigateTree(options: {
+		targetId: string;
+		summarize?: boolean;
+		customInstructions?: string;
+		replaceInstructions?: boolean;
+		label?: string;
+	}): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntryId?: string }> {
+		const result = await this.session.navigateTree(options.targetId, {
+			summarize: options.summarize,
+			customInstructions: options.customInstructions,
+			replaceInstructions: options.replaceInstructions,
+			label: options.label,
+		});
+		return {
+			editorText: result.editorText,
+			cancelled: result.cancelled,
+			aborted: result.aborted,
+			summaryEntryId: result.summaryEntry?.id,
+		};
+	}
+
+	getState(): RuntimeState {
+		return {
+			sessionId: this.session.sessionId,
+			sessionFile: this.session.sessionFile,
+			sessionName: this.session.sessionName,
+			modelProvider: this.session.model?.provider,
+			modelId: this.session.model?.id,
+			thinkingLevel: this.session.thinkingLevel,
+			isStreaming: this.session.isStreaming,
+			isCompacting: this.session.isCompacting,
+			pendingMessageCount: this.session.pendingMessageCount,
+			messageCount: this.session.messages.length,
+			isBusy: false,
+		};
+	}
+
+	getMessages(): AgentMessage[] {
+		return this.session.messages;
+	}
+
+	async getAvailableModels(): Promise<AvailableModel[]> {
+		const models = await this.session.modelRegistry.getAvailable();
+		return models.map((model) => ({ provider: model.provider, modelId: model.id }));
+	}
+
+	subscribe(listener: (event: AgentSessionEvent) => void): () => void {
+		return this.session.subscribe(listener);
+	}
+
+	dispose(): void {
+		this.session.dispose();
+	}
+}
+
+export type RuntimeEventListener = (event: SessionEventEnvelope) => void;
+
+export class AgentRuntime {
+	readonly id: string;
+	private readonly backend: AgentSessionBackend;
+	private readonly listeners: Set<RuntimeEventListener> = new Set();
+	private readonly unsubscribeBackend: () => void;
+	private seq = 0;
+	private runId = randomUUID();
+	private activePrompt: Promise<void> | undefined;
+	private abortInFlight: Promise<void> | undefined;
+
+	constructor(id: string, backend: AgentSessionBackend) {
+		this.id = id;
+		this.backend = backend;
+		this.unsubscribeBackend = this.backend.subscribe((event) => {
+			this.emit(event);
+		});
+	}
+
+	prompt(text: string, options?: { streamingBehavior?: "steer" | "followUp" }): RuntimePromptResult {
+		if (this.activePrompt) {
+			throw sessionBusyError();
+		}
+
+		const nextRunId = randomUUID();
+		this.runId = nextRunId;
+
+		const promptPromise = this.backend
+			.prompt(text, {
+				streamingBehavior: options?.streamingBehavior,
+				source: "rpc",
+			})
+			.catch(() => {})
+			.finally(() => {
+				if (this.activePrompt === promptPromise) {
+					this.activePrompt = undefined;
+				}
+			});
+
+		this.activePrompt = promptPromise;
+		return { runId: nextRunId };
+	}
+
+	steer(text: string): Promise<void> {
+		return this.backend.steer(text);
+	}
+
+	followUp(text: string): Promise<void> {
+		return this.backend.followUp(text);
+	}
+
+	async abort(): Promise<void> {
+		if (this.abortInFlight) {
+			await this.abortInFlight;
+			return;
+		}
+
+		const currentAbort = this.backend.abort().finally(() => {
+			if (this.abortInFlight === currentAbort) {
+				this.abortInFlight = undefined;
+			}
+			this.activePrompt = undefined;
+		});
+
+		this.abortInFlight = currentAbort;
+		await currentAbort;
+	}
+
+	async setModel(provider: string, modelId: string): Promise<void> {
+		const available = await this.backend.getAvailableModels();
+		const exists = available.some((model) => model.provider === provider && model.modelId === modelId);
+		if (!exists) {
+			throw modelNotFoundError(provider, modelId);
+		}
+		await this.backend.setModel(provider, modelId);
+	}
+
+	setThinkingLevel(level: ThinkingLevel): void {
+		this.backend.setThinkingLevel(level);
+	}
+
+	async newSession(options?: { parentSession?: string }): Promise<RuntimeNewSessionResult> {
+		const success = await this.backend.newSession(options);
+		return { cancelled: !success };
+	}
+
+	async switchSession(sessionPath: string): Promise<RuntimeSwitchSessionResult> {
+		const success = await this.backend.switchSession(sessionPath);
+		return { cancelled: !success };
+	}
+
+	async fork(entryId: string): Promise<RuntimeForkResult> {
+		const result = await this.backend.fork(entryId);
+		return {
+			selectedText: result.selectedText,
+			cancelled: result.cancelled,
+		};
+	}
+
+	async navigateTree(options: {
+		targetId: string;
+		summarize?: boolean;
+		customInstructions?: string;
+		replaceInstructions?: boolean;
+		label?: string;
+	}): Promise<RuntimeNavigateResult> {
+		const result = await this.backend.navigateTree(options);
+		return {
+			editorText: result.editorText,
+			cancelled: result.cancelled,
+			aborted: result.aborted,
+			summaryEntryId: result.summaryEntryId,
+		};
+	}
+
+	subscribe(listener: RuntimeEventListener): () => void {
+		this.listeners.add(listener);
+		return () => {
+			this.listeners.delete(listener);
+		};
+	}
+
+	getState(): RuntimeState {
+		const base = this.backend.getState();
+		return {
+			...base,
+			activeRunId: this.runId,
+			isBusy: this.activePrompt !== undefined,
+		};
+	}
+
+	getMessages(): AgentMessage[] {
+		return this.backend.getMessages();
+	}
+
+	dispose(): void {
+		this.unsubscribeBackend();
+		this.listeners.clear();
+		this.backend.dispose();
+	}
+
+	private emit(event: AgentSessionEvent): void {
+		const envelope: SessionEventEnvelope = {
+			seq: ++this.seq,
+			sessionId: this.id,
+			runId: this.runId,
+			ts: new Date().toISOString(),
+			event,
+		};
+		for (const listener of this.listeners) {
+			listener(envelope);
+		}
+	}
+}
+
+export interface RuntimeFactoryInput {
+	backend: AgentSessionBackend;
+}
+
+export function createRuntime(input: RuntimeFactoryInput): AgentRuntime {
+	return new AgentRuntime(randomUUID(), input.backend);
+}

--- a/packages/agent-service/src/service.ts
+++ b/packages/agent-service/src/service.ts
@@ -1,0 +1,40 @@
+import { type AgentServiceHttpServer, createAgentServiceHttpServer } from "./http.js";
+import { AgentRuntimeRegistry, createDefaultBackendFactory } from "./registry.js";
+import type { ServiceConfig } from "./types.js";
+
+export class AgentService {
+	private readonly registry: AgentRuntimeRegistry;
+	private readonly httpServer: AgentServiceHttpServer;
+
+	constructor(config: ServiceConfig) {
+		const backendFactory = createDefaultBackendFactory({
+			defaultCwd: config.defaultCwd,
+			defaultAgentDir: config.defaultAgentDir,
+			defaultSessionDir: config.defaultSessionDir,
+			bashPolicy: config.bashPolicy,
+		});
+		this.registry = new AgentRuntimeRegistry(backendFactory);
+		this.httpServer = createAgentServiceHttpServer(this.registry, config);
+	}
+
+	async listen(port: number, host?: string): Promise<void> {
+		await this.httpServer.listen(port, host);
+	}
+
+	async close(): Promise<void> {
+		await this.httpServer.close();
+		this.registry.dispose();
+	}
+
+	getServer() {
+		return this.httpServer.server;
+	}
+
+	getRegistry(): AgentRuntimeRegistry {
+		return this.registry;
+	}
+}
+
+export function createAgentService(config: ServiceConfig): AgentService {
+	return new AgentService(config);
+}

--- a/packages/agent-service/src/types.ts
+++ b/packages/agent-service/src/types.ts
@@ -1,0 +1,146 @@
+import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+export type JsonObject = { [key: string]: JsonValue };
+export type JsonArray = JsonValue[];
+
+export type ServiceErrorCode =
+	| "AUTH_INVALID"
+	| "SESSION_NOT_FOUND"
+	| "SESSION_BUSY"
+	| "POLICY_DENIED"
+	| "TOOL_EXEC_ERROR"
+	| "MODEL_ERROR"
+	| "INTERNAL_ERROR";
+
+export interface ServiceErrorShape {
+	code: ServiceErrorCode;
+	message: string;
+	retryable: boolean;
+	details: JsonObject;
+}
+
+export interface SessionEventEnvelope {
+	seq: number;
+	sessionId: string;
+	runId: string;
+	ts: string;
+	event: AgentSessionEvent;
+}
+
+export interface PromptRequest {
+	text: string;
+	streamingBehavior?: "steer" | "followUp";
+}
+
+export interface SteerRequest {
+	text: string;
+}
+
+export interface FollowUpRequest {
+	text: string;
+}
+
+export interface SetModelRequest {
+	provider: string;
+	modelId: string;
+}
+
+export interface SetThinkingLevelRequest {
+	level: ThinkingLevel;
+}
+
+export interface ForkRequest {
+	entryId: string;
+}
+
+export interface NavigateTreeRequest {
+	targetId: string;
+	summarize?: boolean;
+	customInstructions?: string;
+	replaceInstructions?: boolean;
+	label?: string;
+}
+
+export interface NewSessionRequest {
+	parentSession?: string;
+}
+
+export interface SwitchSessionRequest {
+	sessionPath: string;
+}
+
+export interface CreateSessionRequest {
+	cwd?: string;
+	agentDir?: string;
+	sessionDir?: string;
+	sessionPath?: string;
+	continueRecent?: boolean;
+	provider?: string;
+	modelId?: string;
+	thinkingLevel?: ThinkingLevel;
+}
+
+export interface RuntimeState {
+	sessionId: string;
+	sessionFile?: string;
+	sessionName?: string;
+	modelProvider?: string;
+	modelId?: string;
+	thinkingLevel: ThinkingLevel;
+	isStreaming: boolean;
+	isCompacting: boolean;
+	pendingMessageCount: number;
+	messageCount: number;
+	activeRunId?: string;
+	isBusy: boolean;
+}
+
+export interface RuntimeForkResult {
+	selectedText: string;
+	cancelled: boolean;
+}
+
+export interface RuntimeNavigateResult {
+	editorText?: string;
+	cancelled: boolean;
+	aborted?: boolean;
+	summaryEntryId?: string;
+}
+
+export interface RuntimeNewSessionResult {
+	cancelled: boolean;
+}
+
+export interface RuntimeSwitchSessionResult {
+	cancelled: boolean;
+}
+
+export interface RuntimePromptResult {
+	runId: string;
+}
+
+export interface RuntimeSessionView {
+	id: string;
+	state: RuntimeState;
+}
+
+export interface RuntimeMessagesView {
+	sessionId: string;
+	messages: AgentMessage[];
+}
+
+export interface BashPolicyConfig {
+	allowedPrefixes: string[];
+}
+
+export interface ServiceConfig {
+	apiKey: string;
+	heartbeatMs?: number;
+	defaultCwd?: string;
+	defaultAgentDir?: string;
+	defaultSessionDir?: string;
+	bashPolicy?: BashPolicyConfig;
+}

--- a/packages/agent-service/test/extension.test.ts
+++ b/packages/agent-service/test/extension.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { extractBashCommand, restoreGuardrailState, toPlanText } from "../src/extensions/product-extension.js";
+
+describe("product extension helpers", () => {
+	it("extracts bash command from bash tool call", () => {
+		const command = extractBashCommand({
+			toolName: "bash",
+			input: { command: "npm test" },
+		});
+		expect(command).toBe("npm test");
+	});
+
+	it("restores guardrail state from custom session entries", () => {
+		const state = restoreGuardrailState([
+			{ type: "custom", customType: "agent-service-guardrail", data: { blockedCount: 1, lastBlockedCommand: "rm" } },
+			{ type: "custom", customType: "agent-service-guardrail", data: { blockedCount: 2, lastBlockedCommand: "mv" } },
+		]);
+		expect(state.blockedCount).toBe(2);
+		expect(state.lastBlockedCommand).toBe("mv");
+	});
+
+	it("builds deterministic plan message text", () => {
+		const timestamp = Date.UTC(2026, 1, 24, 10, 0, 0);
+		const text = toPlanText("build API", timestamp);
+		expect(text).toContain("build API");
+		expect(text).toContain("2026-02-24T10:00:00.000Z");
+	});
+});

--- a/packages/agent-service/test/http.test.ts
+++ b/packages/agent-service/test/http.test.ts
@@ -1,0 +1,202 @@
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAgentServiceHttpServer } from "../src/http.js";
+import { AgentRuntimeRegistry } from "../src/registry.js";
+import { TestBackend } from "./test-backend.js";
+
+interface HttpFixture {
+	baseUrl: string;
+	registry: AgentRuntimeRegistry;
+	http: ReturnType<typeof createAgentServiceHttpServer>;
+	backends: TestBackend[];
+}
+
+function createFixture(): HttpFixture {
+	const backends: TestBackend[] = [];
+	const registry = new AgentRuntimeRegistry(async () => {
+		const backend = new TestBackend();
+		backends.push(backend);
+		return backend;
+	});
+	const http = createAgentServiceHttpServer(registry, {
+		apiKey: "secret-key",
+		heartbeatMs: 50,
+	});
+	return {
+		baseUrl: "",
+		registry,
+		http,
+		backends,
+	};
+}
+
+async function readJson(response: Response): Promise<{ [key: string]: string | number | boolean | object | null }> {
+	return (await response.json()) as { [key: string]: string | number | boolean | object | null };
+}
+
+async function readUntil(reader: ReadableStreamDefaultReader<Uint8Array>, needle: string): Promise<string> {
+	const decoder = new TextDecoder();
+	const end = Date.now() + 3000;
+	let aggregate = "";
+	while (Date.now() < end) {
+		const chunk = await reader.read();
+		if (chunk.done) {
+			break;
+		}
+		aggregate += decoder.decode(chunk.value, { stream: true });
+		if (aggregate.includes(needle)) {
+			return aggregate;
+		}
+	}
+	throw new Error(`Did not receive SSE payload containing: ${needle}`);
+}
+
+describe("HTTP API", () => {
+	let fixture: HttpFixture;
+
+	beforeEach(async () => {
+		fixture = createFixture();
+		await fixture.http.listen(0, "127.0.0.1");
+		const address = fixture.http.server.address() as AddressInfo;
+		fixture.baseUrl = `http://127.0.0.1:${address.port}`;
+	});
+
+	afterEach(async () => {
+		fixture.registry.dispose();
+		await fixture.http.close();
+	});
+
+	it("rejects invalid API key", async () => {
+		const response = await fetch(`${fixture.baseUrl}/v1/sessions`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "wrong-key",
+			},
+			body: JSON.stringify({}),
+		});
+
+		expect(response.status).toBe(401);
+		const body = await readJson(response);
+		expect(body.code).toBe("AUTH_INVALID");
+	});
+
+	it("supports create, prompt, busy gating, steer/follow-up, abort and model errors", async () => {
+		const createResponse = await fetch(`${fixture.baseUrl}/v1/sessions`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "secret-key",
+			},
+			body: JSON.stringify({}),
+		});
+		expect(createResponse.status).toBe(201);
+		const created = await readJson(createResponse);
+		const sessionId = created.id as string;
+
+		const firstPrompt = await fetch(`${fixture.baseUrl}/v1/sessions/${sessionId}/prompt`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "secret-key",
+			},
+			body: JSON.stringify({ text: "hello" }),
+		});
+		expect(firstPrompt.status).toBe(202);
+
+		const secondPrompt = await fetch(`${fixture.baseUrl}/v1/sessions/${sessionId}/prompt`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "secret-key",
+			},
+			body: JSON.stringify({ text: "another" }),
+		});
+		expect(secondPrompt.status).toBe(409);
+		const secondBody = await readJson(secondPrompt);
+		expect(secondBody.code).toBe("SESSION_BUSY");
+
+		const steerResponse = await fetch(`${fixture.baseUrl}/v1/sessions/${sessionId}/steer`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "secret-key",
+			},
+			body: JSON.stringify({ text: "steer text" }),
+		});
+		expect(steerResponse.status).toBe(200);
+
+		const followResponse = await fetch(`${fixture.baseUrl}/v1/sessions/${sessionId}/follow-up`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "secret-key",
+			},
+			body: JSON.stringify({ text: "follow text" }),
+		});
+		expect(followResponse.status).toBe(200);
+
+		setTimeout(() => {
+			fixture.backends[0]?.completeAbort();
+		}, 20);
+		const abortResponse = await fetch(`${fixture.baseUrl}/v1/sessions/${sessionId}/abort`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "secret-key",
+			},
+			body: JSON.stringify({}),
+		});
+		expect(abortResponse.status).toBe(200);
+
+		const modelResponse = await fetch(`${fixture.baseUrl}/v1/sessions/${sessionId}/model`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "secret-key",
+			},
+			body: JSON.stringify({ provider: "anthropic", modelId: "nope" }),
+		});
+		expect(modelResponse.status).toBe(400);
+		const modelBody = await readJson(modelResponse);
+		expect(modelBody.code).toBe("MODEL_ERROR");
+	});
+
+	it("streams SSE events with monotonic sequence IDs", async () => {
+		const createResponse = await fetch(`${fixture.baseUrl}/v1/sessions`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "secret-key",
+			},
+			body: JSON.stringify({}),
+		});
+		const created = await readJson(createResponse);
+		const sessionId = created.id as string;
+
+		const eventStream = await fetch(`${fixture.baseUrl}/v1/sessions/${sessionId}/events/stream`, {
+			headers: {
+				"x-api-key": "secret-key",
+			},
+		});
+		expect(eventStream.status).toBe(200);
+		expect(eventStream.body).not.toBeNull();
+		const reader = eventStream.body!.getReader();
+
+		await fetch(`${fixture.baseUrl}/v1/sessions/${sessionId}/prompt`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-api-key": "secret-key",
+			},
+			body: JSON.stringify({ text: "trigger stream" }),
+		});
+
+		const streamText = await readUntil(reader, '"type":"agent_start"');
+		expect(streamText).toContain("event: session_event");
+		expect(streamText).toContain('"seq":1');
+
+		fixture.backends[0]?.completePrompt();
+		await reader.cancel();
+	});
+});

--- a/packages/agent-service/test/policy.test.ts
+++ b/packages/agent-service/test/policy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { createPolicyBashSpawnHook, isCommandAllowed, normalizePolicyConfig } from "../src/policy.js";
+
+describe("policy", () => {
+	it("allows configured command prefixes and blocks others", () => {
+		const allowed = ["ls", "git status", "npm test"];
+		expect(isCommandAllowed("ls -la", allowed)).toBe(true);
+		expect(isCommandAllowed("git status --short", allowed)).toBe(true);
+		expect(isCommandAllowed("rm -rf /", allowed)).toBe(false);
+	});
+
+	it("normalizes default policy when not configured", () => {
+		const normalized = normalizePolicyConfig();
+		expect(normalized.allowedPrefixes.length).toBeGreaterThan(0);
+		expect(normalized.allowedPrefixes.includes("ls")).toBe(true);
+	});
+
+	it("spawn hook throws POLICY_DENIED for blocked command", () => {
+		const hook = createPolicyBashSpawnHook({ allowedPrefixes: ["ls"] });
+		expect(() => hook({ command: "ls", cwd: "/tmp", env: {} })).not.toThrow();
+		expect(() => hook({ command: "rm -rf /tmp/x", cwd: "/tmp", env: {} })).toThrow(/POLICY_DENIED/);
+	});
+});

--- a/packages/agent-service/test/registry.test.ts
+++ b/packages/agent-service/test/registry.test.ts
@@ -1,0 +1,26 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildSessionManager } from "../src/registry.js";
+
+describe("registry/session manager", () => {
+	it("creates, opens and resumes JSONL session files deterministically", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "agent-service-registry-"));
+		const sessionDir = ".sessions";
+		try {
+			const first = buildSessionManager(cwd, {}, sessionDir);
+			first.appendModelChange("openai", "gpt-test");
+			const firstPath = first.getSessionFile();
+			expect(firstPath).toBeDefined();
+
+			const opened = buildSessionManager(cwd, { sessionPath: firstPath }, sessionDir);
+			expect(basename(opened.getSessionFile() ?? "")).toBe(basename(firstPath ?? ""));
+
+			const resumed = buildSessionManager(cwd, { continueRecent: true }, sessionDir);
+			expect((resumed.getSessionFile() ?? "").endsWith(".jsonl")).toBe(true);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/agent-service/test/runtime.test.ts
+++ b/packages/agent-service/test/runtime.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { ServiceError } from "../src/errors.js";
+import { AgentRuntime } from "../src/runtime.js";
+import { TestBackend } from "./test-backend.js";
+
+async function settle(): Promise<void> {
+	await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe("AgentRuntime", () => {
+	it("enforces busy gate and allows steer/followUp during active prompt", async () => {
+		const backend = new TestBackend();
+		const runtime = new AgentRuntime("runtime-1", backend);
+
+		const first = runtime.prompt("first prompt");
+		expect(first.runId.length).toBeGreaterThan(0);
+
+		try {
+			runtime.prompt("second prompt");
+			expect.unreachable("expected SESSION_BUSY");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ServiceError);
+			const mapped = error as ServiceError;
+			expect(mapped.code).toBe("SESSION_BUSY");
+		}
+
+		await runtime.steer("steer now");
+		await runtime.followUp("follow later");
+		expect(backend.steerCalls).toEqual(["steer now"]);
+		expect(backend.followUpCalls).toEqual(["follow later"]);
+
+		backend.completePrompt();
+		await settle();
+		const second = runtime.prompt("third prompt");
+		expect(second.runId.length).toBeGreaterThan(0);
+		backend.completePrompt();
+	});
+
+	it("abort is idempotent while prompt is active", async () => {
+		const backend = new TestBackend();
+		const runtime = new AgentRuntime("runtime-2", backend);
+
+		runtime.prompt("will abort");
+		const abortA = runtime.abort();
+		const abortB = runtime.abort();
+
+		expect(backend.abortCallCount).toBe(1);
+		backend.completeAbort();
+		await Promise.all([abortA, abortB]);
+	});
+
+	it("passes through newSession, switch, fork and navigateTree", async () => {
+		const backend = new TestBackend();
+		const runtime = new AgentRuntime("runtime-3", backend);
+
+		const newSession = await runtime.newSession({ parentSession: "/tmp/parent.jsonl" });
+		expect(newSession.cancelled).toBe(false);
+
+		const switched = await runtime.switchSession("/tmp/target.jsonl");
+		expect(switched.cancelled).toBe(false);
+		expect(backend.switchCalls).toEqual(["/tmp/target.jsonl"]);
+
+		const fork = await runtime.fork("entry-1");
+		expect(fork.selectedText).toBe("forked");
+		expect(fork.cancelled).toBe(false);
+
+		const nav = await runtime.navigateTree({ targetId: "entry-2", summarize: true, label: "branch" });
+		expect(nav.cancelled).toBe(false);
+		expect(nav.summaryEntryId).toBe("sum-1");
+		expect(backend.navigateCalls).toEqual(["entry-2"]);
+	});
+
+	it("emits monotonic sequence IDs and forwards compaction events", async () => {
+		const backend = new TestBackend();
+		const runtime = new AgentRuntime("runtime-4", backend);
+		const received: number[] = [];
+		const eventTypes: string[] = [];
+
+		const unsubscribe = runtime.subscribe((event) => {
+			received.push(event.seq);
+			eventTypes.push(event.event.type);
+		});
+
+		backend.emit({ type: "agent_start" });
+		backend.emit({
+			type: "auto_compaction_end",
+			result: undefined,
+			aborted: false,
+			willRetry: false,
+		});
+		backend.emit({ type: "agent_end", messages: [] });
+
+		unsubscribe();
+		expect(received).toEqual([1, 2, 3]);
+		expect(eventTypes).toEqual(["agent_start", "auto_compaction_end", "agent_end"]);
+	});
+
+	it("returns MODEL_ERROR when selected model does not exist", async () => {
+		const backend = new TestBackend();
+		backend.availableModels = [{ provider: "openai", modelId: "gpt-a" }];
+		const runtime = new AgentRuntime("runtime-5", backend);
+
+		await expect(runtime.setModel("anthropic", "claude-x")).rejects.toMatchObject({ code: "MODEL_ERROR" });
+	});
+});

--- a/packages/agent-service/test/test-backend.ts
+++ b/packages/agent-service/test/test-backend.ts
@@ -1,0 +1,154 @@
+import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+import type { AgentSessionBackend, AvailableModel } from "../src/runtime.js";
+import type { RuntimeState } from "../src/types.js";
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = () => {};
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+export class TestBackend implements AgentSessionBackend {
+	private listeners: Set<(event: AgentSessionEvent) => void> = new Set();
+	private promptDeferred: { promise: Promise<void>; resolve: () => void } | undefined;
+	private abortDeferred: { promise: Promise<void>; resolve: () => void } | undefined;
+
+	readonly steerCalls: string[] = [];
+	readonly followUpCalls: string[] = [];
+	readonly modelCalls: Array<{ provider: string; modelId: string }> = [];
+	readonly switchCalls: string[] = [];
+	readonly forkCalls: string[] = [];
+	readonly navigateCalls: string[] = [];
+	readonly messages: AgentMessage[] = [];
+
+	state: RuntimeState = {
+		sessionId: "session-local",
+		sessionFile: "/tmp/session.jsonl",
+		sessionName: "test-session",
+		modelProvider: "openai",
+		modelId: "gpt-test",
+		thinkingLevel: "medium",
+		isStreaming: false,
+		isCompacting: false,
+		pendingMessageCount: 0,
+		messageCount: 0,
+		isBusy: false,
+	};
+
+	availableModels: AvailableModel[] = [{ provider: "openai", modelId: "gpt-test" }];
+	newSessionResult = true;
+	switchSessionResult = true;
+	forkResult = { selectedText: "forked", cancelled: false };
+	navigateResult = { editorText: "editor", cancelled: false, aborted: false, summaryEntryId: "sum-1" };
+	abortCallCount = 0;
+
+	prompt(_text: string): Promise<void> {
+		this.state.isStreaming = true;
+		this.emit({ type: "agent_start" });
+		this.promptDeferred = createDeferred();
+		return this.promptDeferred.promise.then(() => {
+			this.state.isStreaming = false;
+			this.emit({ type: "agent_end", messages: [] });
+		});
+	}
+
+	completePrompt(): void {
+		if (this.promptDeferred) {
+			this.promptDeferred.resolve();
+			this.promptDeferred = undefined;
+		}
+	}
+
+	steer(text: string): Promise<void> {
+		this.steerCalls.push(text);
+		return Promise.resolve();
+	}
+
+	followUp(text: string): Promise<void> {
+		this.followUpCalls.push(text);
+		return Promise.resolve();
+	}
+
+	abort(): Promise<void> {
+		this.abortCallCount += 1;
+		if (!this.abortDeferred) {
+			this.abortDeferred = createDeferred();
+		}
+		return this.abortDeferred.promise.then(() => {
+			this.completePrompt();
+		});
+	}
+
+	completeAbort(): void {
+		if (this.abortDeferred) {
+			this.abortDeferred.resolve();
+			this.abortDeferred = undefined;
+		}
+	}
+
+	setModel(provider: string, modelId: string): Promise<void> {
+		this.modelCalls.push({ provider, modelId });
+		this.state.modelProvider = provider;
+		this.state.modelId = modelId;
+		return Promise.resolve();
+	}
+
+	setThinkingLevel(level: ThinkingLevel): void {
+		this.state.thinkingLevel = level;
+	}
+
+	newSession(): Promise<boolean> {
+		return Promise.resolve(this.newSessionResult);
+	}
+
+	switchSession(sessionPath: string): Promise<boolean> {
+		this.switchCalls.push(sessionPath);
+		return Promise.resolve(this.switchSessionResult);
+	}
+
+	fork(entryId: string): Promise<{ selectedText: string; cancelled: boolean }> {
+		this.forkCalls.push(entryId);
+		return Promise.resolve(this.forkResult);
+	}
+
+	navigateTree(options: {
+		targetId: string;
+		summarize?: boolean;
+		customInstructions?: string;
+		replaceInstructions?: boolean;
+		label?: string;
+	}): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntryId?: string }> {
+		this.navigateCalls.push(options.targetId);
+		return Promise.resolve(this.navigateResult);
+	}
+
+	getState(): RuntimeState {
+		return { ...this.state };
+	}
+
+	getMessages(): AgentMessage[] {
+		return [...this.messages];
+	}
+
+	getAvailableModels(): Promise<AvailableModel[]> {
+		return Promise.resolve([...this.availableModels]);
+	}
+
+	subscribe(listener: (event: AgentSessionEvent) => void): () => void {
+		this.listeners.add(listener);
+		return () => {
+			this.listeners.delete(listener);
+		};
+	}
+
+	dispose(): void {}
+
+	emit(event: AgentSessionEvent): void {
+		for (const listener of this.listeners) {
+			listener(event);
+		}
+	}
+}

--- a/packages/agent-service/test/truncation.test.ts
+++ b/packages/agent-service/test/truncation.test.ts
@@ -1,0 +1,12 @@
+import { truncateTail } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+
+describe("tool truncation behavior", () => {
+	it("truncates oversized output and reports metadata", () => {
+		const lines = Array.from({ length: 4000 }, (_, index) => `line-${index}`).join("\n");
+		const result = truncateTail(lines, { maxLines: 100, maxBytes: 8 * 1024 });
+		expect(result.truncated).toBe(true);
+		expect(result.outputLines).toBeLessThanOrEqual(100);
+		expect(result.outputBytes).toBeLessThanOrEqual(8 * 1024);
+	});
+});

--- a/packages/agent-service/tsconfig.build.json
+++ b/packages/agent-service/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"target": "ES2024",
+		"lib": ["ES2024"],
+		"baseUrl": ".",
+		"paths": {
+			"@mariozechner/pi-ai": ["../ai/src/index.ts"],
+			"@mariozechner/pi-ai/*": ["../ai/src/*"],
+			"@mariozechner/pi-agent-core": ["../agent/src/index.ts"],
+			"@mariozechner/pi-agent-core/*": ["../agent/src/*"],
+			"@mariozechner/pi-coding-agent": ["../coding-agent/src/index.ts"],
+			"@mariozechner/pi-coding-agent/*": ["../coding-agent/src/*"],
+			"@mariozechner/pi-tui": ["../tui/src/index.ts"],
+			"@mariozechner/pi-tui/*": ["../tui/src/*"]
+		}
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "**/*.d.ts", "src/**/*.d.ts"]
+}

--- a/packages/agent-service/vitest.config.ts
+++ b/packages/agent-service/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+
+export default defineConfig({
+	resolve: {
+		alias: [
+			{ find: /^stream\/promises$/, replacement: "node:stream/promises" },
+			{ find: /^stream$/, replacement: "node:stream" },
+			{ find: /^@mariozechner\/pi-ai$/, replacement: `${root}packages/ai/src/index.ts` },
+			{ find: /^@mariozechner\/pi-ai\/(.*)$/, replacement: `${root}packages/ai/src/$1` },
+			{ find: /^@mariozechner\/pi-agent-core$/, replacement: `${root}packages/agent/src/index.ts` },
+			{ find: /^@mariozechner\/pi-agent-core\/(.*)$/, replacement: `${root}packages/agent/src/$1` },
+			{ find: /^@mariozechner\/pi-coding-agent$/, replacement: `${root}packages/coding-agent/src/index.ts` },
+			{ find: /^@mariozechner\/pi-coding-agent\/(.*)$/, replacement: `${root}packages/coding-agent/src/$1` },
+			{ find: /^@mariozechner\/pi-tui$/, replacement: `${root}packages/tui/src/index.ts` },
+			{ find: /^@mariozechner\/pi-tui\/(.*)$/, replacement: `${root}packages/tui/src/$1` },
+		],
+	},
+	test: {
+		environment: "node",
+		include: ["test/**/*.test.ts"],
+	},
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
 			"@mariozechner/pi-tui/*": ["./packages/tui/src/*"],
 			"@mariozechner/pi-web-ui": ["./packages/web-ui/src/index.ts"],
 			"@mariozechner/pi-web-ui/*": ["./packages/web-ui/src/*"],
+			"@mariozechner/pi-agent-service": ["./packages/agent-service/src/index.ts"],
+			"@mariozechner/pi-agent-service/*": ["./packages/agent-service/src/*"],
 			"@mariozechner/pi-agent-old": ["./packages/agent-old/src/index.ts"],
 			"@mariozechner/pi-agent-old/*": ["./packages/agent-old/src/*"]
 		}


### PR DESCRIPTION
## Summary
- add new `packages/agent-service` package with SDK-first runtime, session registry, policy adapter, extension layer, and HTTP+SSE transport
- add detailed user guide: `packages/agent-service/docs/BEST_PRACTICES.md`
- add tests for runtime behavior, policy, registry/session behavior, truncation, and HTTP+SSE flows

## Validation
- `npm run -w @mariozechner/pi-agent-service typecheck`
- `npm run -w @mariozechner/pi-agent-service test`
- `npm exec tsgo -- --noEmit -p tsconfig.json`
- `rg -n "\\bany\\b|\\bunknown\\b" packages/agent-service/src packages/agent-service/test` (no matches)
