### PR TITLE
fix(anthropic): add stable conversation cache breakpoint

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -783,6 +783,32 @@ function convertMessages(
 		}
 	}
 
+	// Add a stable cache breakpoint further back in conversation history.
+	// The last-message breakpoint (below) shifts position every turn because tool_result
+	// blocks have role "user" in Anthropic's format — so every tool call moves it.
+	// This causes Anthropic to miss the previous cache entry and rewrite the entire
+	// conversation as a new cache entry on each API call in a tool-call chain.
+	// By placing a stable breakpoint MIN_STABLE_GAP messages from the end, we ensure
+	// Anthropic can reuse the cached conversation prefix across multiple turns.
+	const MIN_STABLE_GAP = 6;
+	if (cacheControl && params.length > MIN_STABLE_GAP) {
+		for (let i = params.length - MIN_STABLE_GAP - 1; i >= 1; i--) {
+			if (params[i].role === "user") {
+				const content = params[i].content;
+				if (Array.isArray(content) && content.length > 0) {
+					const lastBlock = content[content.length - 1];
+					if (
+						lastBlock &&
+						(lastBlock.type === "text" || lastBlock.type === "image" || lastBlock.type === "tool_result")
+					) {
+						(lastBlock as any).cache_control = cacheControl;
+					}
+				}
+				break;
+			}
+		}
+	}
+
 	// Add cache_control to the last user message to cache conversation history
 	if (cacheControl && params.length > 0) {
 		const lastMessage = params[params.length - 1];


### PR DESCRIPTION
## Summary

The existing `cache_control` placement on the last user message in `convertMessages()` shifts position with every API call. Since `tool_result` blocks have `role: "user"` in Anthropic's message format, every tool call moves the breakpoint — causing the full conversation history to be rewritten as a new cache entry on each API call in a tool-call chain.

**Current behavior (2 breakpoints):**
```
Call 1 (user msg):     [system ✓] [history...] [user_msg ✓]
Call 2 (tool_result):  [system ✓] [history...] [user_msg] [asst] [tool_result_1 ✓]     → breakpoint moved
Call 3 (tool_result):  [system ✓] [history...] [user_msg] [asst] [tr_1] [asst] [tool_result_2 ✓]  → moved again
```

Each call's breakpoint is at a different position. Anthropic can't find the previous cache entry and falls back to the system prompt breakpoint — rewriting the entire conversation as a new cache entry every single call.

**Cost impact:** Every call in a tool-call chain pays the full cache write cost for the conversation history (at $3.75/MTok). A typical agentic turn with 5-10 tool calls generates 5-10 API calls in rapid succession, each rewriting the same conversation.

**Why the last few percent matter enormously:** A single full cache miss can cost 10x or more compared to a cache-hit call. Even if only 1 out of 5 calls in a tool chain misses the cache, that one miss can dominate the total cost of the entire turn. Going from 95% to 99%+ hit rate is the difference between occasional expensive spikes and consistently cheap calls.

## Fix

Add a **third, stable cache breakpoint** on a user message `MIN_STABLE_GAP` (6) messages from the end. This breakpoint stays fixed across multiple tool-call rounds:

```
Turn N:   [system ✓] [msg1] ... [msgN-6 ✓ STABLE] ... [msgN ✓]
Turn N+1: [system ✓] [msg1] ... [msgN-6 ✓ STABLE] ... [msgN] [msgN+1 ✓]
                                  ↑ Anthropic finds this and reads from cache
```

**Why `MIN_STABLE_GAP = 6`:**
- A typical tool-use turn generates 2-3 messages (assistant + tool_result, sometimes multiple)
- Gap of 6 means the breakpoint survives 2-3 complete tool-use rounds before shifting
- When it shifts, only the small delta between old and new position is a cache miss — not the entire conversation

## Testing

Verified over 100+ API calls in an OpenClaw deployment:

| Scenario | Before | After |
|----------|--------|-------|
| Multi-tool-call chain (5+ sequential) | ~88% avg hit rate | 99.7% avg |
| Normal user message → tool calls | 85-95% | 99.5-99.9% |
| After compaction (cold start) | 0% (expected) | 0% (expected) |

This is most impactful during **tool-call chains** (multiple API calls in seconds), but also benefits regular chat turns when `extended-cache-ttl` keeps the cache warm between messages.
