### PR TITLE
feat(tui): fuzzy search across path separators in autocomplete

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "child_process";
 import { readdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { basename, dirname, join } from "path";
-import { fuzzyFilter } from "./fuzzy.js";
+import { fuzzyFilter, fuzzyMatch } from "./fuzzy.js";
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
 
@@ -84,6 +84,20 @@ function buildCompletionValue(
 	return `${openQuote}${path}${closeQuote}`;
 }
 
+// Escape special regex characters
+function escapeRegex(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Convert a query string into a fuzzy regex pattern
+// e.g., "srcautocom" -> "s.*r.*c.*a.*u.*t.*o.*c.*o.*m"
+function toFuzzyRegex(query: string): string {
+	return query
+		.split("")
+		.map((ch) => escapeRegex(ch))
+		.join(".*");
+}
+
 // Use fd to walk directory tree (fast, respects .gitignore)
 function walkDirectoryWithFd(
 	baseDir: string,
@@ -110,9 +124,9 @@ function walkDirectoryWithFd(
 		".git/**",
 	];
 
-	// Add query as pattern if provided
+	// Add query as fuzzy regex pattern if provided
 	if (query) {
-		args.push(query);
+		args.push(toFuzzyRegex(query));
 	}
 
 	const result = spawnSync(fdPath, args, {
@@ -614,26 +628,35 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 	}
 
-	// Score an entry against the query (higher = better match)
-	// isDirectory adds bonus to prioritize folders
-	private scoreEntry(filePath: string, query: string, isDirectory: boolean): number {
-		const fileName = basename(filePath);
-		const lowerFileName = fileName.toLowerCase();
-		const lowerQuery = query.toLowerCase();
+	// Score an entry against the query using fuzzy matching
+	// Returns null if no match, otherwise a numeric score (lower = better, matching fuzzyMatch convention)
+	// isDirectory gets a bonus (subtracted from score so directories rank higher)
+	private scoreEntry(filePath: string, query: string, isDirectory: boolean): number | null {
+		const pathWithoutTrailingSlash = filePath.endsWith("/") ? filePath.slice(0, -1) : filePath;
+		const fileName = basename(pathWithoutTrailingSlash);
 
-		let score = 0;
+		// Try matching against filename first, then full path
+		const fileNameMatch = fuzzyMatch(query, fileName);
+		const pathMatch = fuzzyMatch(query, pathWithoutTrailingSlash);
 
-		// Exact filename match (highest)
-		if (lowerFileName === lowerQuery) score = 100;
-		// Filename starts with query
-		else if (lowerFileName.startsWith(lowerQuery)) score = 80;
-		// Substring match in filename
-		else if (lowerFileName.includes(lowerQuery)) score = 50;
-		// Substring match in full path
-		else if (filePath.toLowerCase().includes(lowerQuery)) score = 30;
+		if (!fileNameMatch.matches && !pathMatch.matches) {
+			return null;
+		}
 
-		// Directories get a bonus to appear first
-		if (isDirectory && score > 0) score += 10;
+		// Use best (lowest) score; filename matches get a bonus (-50)
+		let score: number;
+		if (fileNameMatch.matches && pathMatch.matches) {
+			score = Math.min(fileNameMatch.score - 50, pathMatch.score);
+		} else if (fileNameMatch.matches) {
+			score = fileNameMatch.score - 50;
+		} else {
+			score = pathMatch.score;
+		}
+
+		// Directories get a bonus
+		if (isDirectory) {
+			score -= 10;
+		}
 
 		return score;
 	}
@@ -655,12 +678,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const scoredEntries = entries
 				.map((entry) => ({
 					...entry,
-					score: fdQuery ? this.scoreEntry(entry.path, fdQuery, entry.isDirectory) : 1,
+					score: fdQuery ? this.scoreEntry(entry.path, fdQuery, entry.isDirectory) : 0,
 				}))
-				.filter((entry) => entry.score > 0);
+				.filter((entry) => entry.score !== null);
 
-			// Sort by score (descending) and take top 20
-			scoredEntries.sort((a, b) => b.score - a.score);
+			// Sort by score (ascending, lower is better) and take top 20
+			scoredEntries.sort((a, b) => (a.score ?? 0) - (b.score ?? 0));
 			const topEntries = scoredEntries.slice(0, 20);
 
 			// Build suggestions

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -329,6 +329,47 @@ describe("CombinedAutocompleteProvider", () => {
 			const applied = provider.applyCompletion([line], 0, cursorCol, item!, result!.prefix);
 			assert.strictEqual(applied.lines[0], '@"my folder/test.txt" ');
 		});
+
+		test("fuzzy matches across path separators", () => {
+			setupFolder(baseDir, {
+				files: {
+					"src/autocomplete.ts": "export {};",
+					"src/other.ts": "export {};",
+					"lib/something.ts": "export {};",
+				},
+			});
+
+			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
+			const line = "@srcautocom";
+			const result = provider.getSuggestions([line], 0, line.length);
+
+			assert.notEqual(result, null, "Should return fuzzy matched suggestions");
+			const values = result?.items.map((item) => item.value);
+			assert.ok(values?.includes("@src/autocomplete.ts"), "Should find src/autocomplete.ts via fuzzy match");
+			assert.ok(!values?.includes("@src/other.ts"), "Should not include non-matching files");
+			assert.ok(!values?.includes("@lib/something.ts"), "Should not include non-matching files");
+		});
+
+		test("fuzzy matches partial filename characters", () => {
+			setupFolder(baseDir, {
+				files: {
+					"packages/tui/src/autocomplete.ts": "export {};",
+					"packages/ai/src/stream.ts": "export {};",
+				},
+			});
+
+			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
+			const line = "@tuiauto";
+			const result = provider.getSuggestions([line], 0, line.length);
+
+			assert.notEqual(result, null, "Should return fuzzy matched suggestions");
+			const values = result?.items.map((item) => item.value);
+			assert.ok(
+				values?.includes("@packages/tui/src/autocomplete.ts"),
+				"Should find packages/tui/src/autocomplete.ts via fuzzy match",
+			);
+			assert.ok(!values?.includes("@packages/ai/src/stream.ts"), "Should not include non-matching files");
+		});
 	});
 
 	describe("quoted path completion", () => {


### PR DESCRIPTION
Add fuzzy matching for @ file autocomplete so queries like `@srcautocom` find `src/autocomplete.ts`. Converts queries to
 fuzzy regex patterns for fd and uses fuzzyMatch for scoring instead of simple substring matching.

 ### Changes

 - packages/tui/src/autocomplete.ts: Convert queries to fuzzy regex for fd, replace substring scoring with
 fuzzyMatch-based scoring
 - packages/tui/test/autocomplete.test.ts: Add tests for fuzzy matching across path separators and nested paths