### PR TITLE
fix: pass custom tools as baseToolsOverride in createAgentSession

### DIFF
--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -243,6 +243,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		? options.tools.map((t) => t.name).filter((n): n is ToolName => n in allTools)
 		: defaultActiveToolNames;
 
+	// Convert tools array to baseToolsOverride record so that _buildRuntime()
+	// uses the caller's tool instances (e.g. custom BashOperations) instead of
+	// recreating defaults via createAllTools().
+	const baseToolsOverride: Record<string, Tool> | undefined = options.tools
+		? Object.fromEntries(options.tools.map((t) => [t.name, t]))
+		: undefined;
+
 	let agent: Agent;
 
 	// Create convertToLlm wrapper that filters images if blockImages is enabled (defense-in-depth)
@@ -354,6 +361,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		customTools: options.customTools,
 		modelRegistry,
 		initialActiveToolNames,
+		baseToolsOverride,
 		extensionRunnerRef,
 	});
 	const extensionsResult = resourceLoader.getExtensions();


### PR DESCRIPTION
## Problem

When callers pass custom `Tool[]` via `createAgentSession({ tools })`, the tools array is only used for **name filtering** (to decide which tool names are active). The actual tool instances are silently discarded — `AgentSession` internally recreates all tools via `createAllTools()` using `defaultBashOperations`.

This means custom `BashOperations` (e.g. a platform-specific shell layer with PowerShell + Git Bash fallback on Windows) are never used by the SDK's bash tool, even though the caller explicitly constructed and passed them.

## Root Cause

In `sdk.ts`, `options.tools` is only used to extract active tool names:

```typescript
const initialActiveToolNames: ToolName[] = options.tools
  ? options.tools.map((t) => t.name).filter(...)
  : defaultActiveToolNames;
```

The actual `Tool` objects (with their custom `operations`) are never forwarded to `AgentSession`.

## Fix

Convert the `options.tools` array into a `baseToolsOverride` record and pass it to `AgentSession`, so that `_buildRuntime()` uses the caller's tool instances instead of recreating defaults:

```typescript
const baseToolsOverride: Record<string, Tool> | undefined = options.tools
  ? Object.fromEntries(options.tools.map((t) => [t.name, t]))
  : undefined;

const session = new AgentSession({
  // ... existing fields ...
  baseToolsOverride,  // ← NEW
});
```

This is a minimal, backwards-compatible change:
- When `options.tools` is not provided → `baseToolsOverride` is `undefined` → existing behavior unchanged
- When `options.tools` is provided → the caller's tool instances are used, honoring custom `BashOperations`

## Use Case

Our Electron app creates platform-specific `BashOperations` (PowerShell primary + Git Bash fallback on Windows) and passes them via `createBashTool(cwd, { operations: platformOps })`. Without this fix, we had to monkey-patch `session._baseToolsOverride` + `session._buildRuntime()` after creation, which depends on private API.