### PR TITLE
fix(ai): normalize baseUrl for openai-responses provider

### DIFF
--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -143,6 +143,13 @@ export const streamSimpleOpenAIResponses: StreamFunction<"openai-responses", Sim
 	} satisfies OpenAIResponsesOptions);
 };
 
+function normalizeResponsesBaseUrl(baseUrl: string | undefined): string | undefined {
+	if (!baseUrl || baseUrl.trim().length === 0) return undefined;
+	const normalized = baseUrl.replace(/\/+$/, "");
+	if (/\/v\d+$/.test(normalized)) return normalized;
+	return `${normalized}/v1`;
+}
+
 function createClient(
 	model: Model<"openai-responses">,
 	context: Context,
@@ -175,7 +182,7 @@ function createClient(
 
 	return new OpenAI({
 		apiKey,
-		baseURL: model.baseUrl,
+		baseURL: normalizeResponsesBaseUrl(model.baseUrl),
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: headers,
 	});


### PR DESCRIPTION
## Summary

- When a custom provider's `baseUrl` omits the version path (e.g. `https://example.com` instead of `https://example.com/v1`), the OpenAI SDK concatenates `baseURL + "/responses"` directly, resulting in requests hitting the wrong endpoint (returns HTML instead of JSON/SSE), causing empty payloads and `No reply from agent` errors.
- Added `normalizeResponsesBaseUrl()` that auto-appends `/v1` when the URL doesn't already end with a version segment (`/v1`, `/v2`, etc.), consistent with how `resolveCodexUrl()` handles URL normalization in `openai-codex-responses.ts`.
- Handles edge cases: trailing slashes, empty/undefined input, already-versioned URLs.

## Reproduction

1. Configure a custom provider with `api: "openai-responses"` and `baseUrl: "https://example.com"` (no `/v1`)
2. Requests go to `https://example.com/responses` instead of `https://example.com/v1/responses`
3. Server returns HTML (frontend page) instead of JSON/SSE
4. Agent reports `No reply from agent`, `payloads=[]`, `lastCallUsage` all zeros

## Test plan

- [x] Verified with `node -e` unit tests: all 5 input scenarios produce correct output
- [ ] Integration test: restart OpenClaw with a `baseUrl` missing `/v1` and confirm agents return valid payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)