### PR TITLE
perf(coding-agent): cache ModelsConfig validator

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -26,6 +26,7 @@ import type { AuthStorage } from "./auth-storage.js";
 import { clearConfigValueCache, resolveConfigValue, resolveHeaders } from "./resolve-config-value.js";
 
 const Ajv = (AjvModule as any).default || AjvModule;
+const ajv = new Ajv();
 
 // Schema for OpenRouter routing preferences
 const OpenRouterRoutingSchema = Type.Object({
@@ -117,6 +118,8 @@ const ProviderConfigSchema = Type.Object({
 const ModelsConfigSchema = Type.Object({
 	providers: Type.Record(Type.String(), ProviderConfigSchema),
 });
+
+ajv.addSchema(ModelsConfigSchema, "ModelsConfig");
 
 type ModelsConfig = Static<typeof ModelsConfigSchema>;
 
@@ -343,8 +346,7 @@ export class ModelRegistry {
 			const config: ModelsConfig = JSON.parse(content);
 
 			// Validate schema
-			const ajv = new Ajv();
-			const validate = ajv.compile(ModelsConfigSchema);
+			const validate = ajv.getSchema("ModelsConfig")!;
 			if (!validate(config)) {
 				const errors =
 					validate.errors?.map((e: any) => `  - ${e.instancePath || "root"}: ${e.message}`).join("\n") ||


### PR DESCRIPTION
Ajv schema compilation is somewhat costly. 

This speeds up starting pi when a models.json is preset, as the validator function for the data doesn't get built (and JITed by the runtime, etc.) twice.