### PR TITLE
fix(tui): prevent TypeError crash in fuzzyMatch when inputs are non-string

### DIFF
--- a/packages/tui/src/fuzzy.ts
+++ b/packages/tui/src/fuzzy.ts
@@ -10,6 +10,8 @@ export interface FuzzyMatch {
 }
 
 export function fuzzyMatch(query: string, text: string): FuzzyMatch {
+	if (typeof query !== "string") query = String(query ?? "");
+	if (typeof text !== "string") text = String(text ?? "");
 	const queryLower = query.toLowerCase();
 	const textLower = text.toLowerCase();
 
@@ -109,7 +111,9 @@ export function fuzzyFilter<T>(items: T[], query: string, getText: (item: T) => 
 	const results: { item: T; totalScore: number }[] = [];
 
 	for (const item of items) {
-		const text = getText(item);
+		const rawText = getText(item);
+		if (rawText == null) continue;
+		const text = typeof rawText === "string" ? rawText : String(rawText);
 		let totalScore = 0;
 		let allMatch = true;
 

--- a/packages/tui/test/fuzzy.test.ts
+++ b/packages/tui/test/fuzzy.test.ts
@@ -58,6 +58,32 @@ describe("fuzzyMatch", () => {
 		const result = fuzzyMatch("codex52", "gpt-5.2-codex");
 		assert.strictEqual(result.matches, true);
 	});
+
+	it("handles non-string text without throwing", () => {
+		// Extensions/plugins may pass non-string values via getText callbacks at runtime
+		const unsafeFuzzyMatch = fuzzyMatch as any;
+		const result = unsafeFuzzyMatch("test", undefined);
+		assert.strictEqual(result.matches, false);
+	});
+
+	it("handles non-string query without throwing", () => {
+		const unsafeFuzzyMatch = fuzzyMatch as any;
+		const result = unsafeFuzzyMatch(undefined, "test");
+		assert.strictEqual(result.matches, true);
+		assert.strictEqual(result.score, 0);
+	});
+
+	it("handles null inputs without throwing", () => {
+		const unsafeFuzzyMatch = fuzzyMatch as any;
+		const result = unsafeFuzzyMatch(null, null);
+		assert.strictEqual(result.matches, true); // both coerce to ""
+	});
+
+	it("coerces numeric inputs to strings", () => {
+		const unsafeFuzzyMatch = fuzzyMatch as any;
+		const result = unsafeFuzzyMatch("12", 123);
+		assert.strictEqual(result.matches, true);
+	});
 });
 
 describe("fuzzyFilter", () => {
@@ -94,5 +120,19 @@ describe("fuzzyFilter", () => {
 		assert.strictEqual(result.length, 2);
 		assert.ok(result.map((r) => r.name).includes("foo"));
 		assert.ok(result.map((r) => r.name).includes("foobar"));
+	});
+
+	it("skips items where getText returns null or undefined", () => {
+		const items = [{ name: "foo" }, { name: undefined }, { name: null }, { name: "bar" }];
+		const result = fuzzyFilter(items, "foo", (item: any) => item.name);
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0]!.name, "foo");
+	});
+
+	it("coerces non-string getText return values", () => {
+		const items = [{ name: 123 }, { name: "test456" }];
+		const result = fuzzyFilter(items, "12", (item: any) => item.name);
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0]!.name, 123);
 	});
 });


### PR DESCRIPTION
## Problem

`fuzzyMatch` crashes with a `TypeError` when it receives a non-string value as `query` or `text`:

```
TypeError: text.toLowerCase is not a function
    at fuzzyMatch (fuzzy.ts:14)
    at fuzzyFilter (fuzzy.ts:117)
    at CombinedAutocompleteProvider.getSuggestions (autocomplete.ts:239)
    at RawPasteEditor.updateAutocomplete (editor.ts)
    at RawPasteEditor.insertCharacter (editor.ts)
```

This crashes pi entirely — the process exits and the user loses their session.

### Root cause

\`CombinedAutocompleteProvider.getSuggestions()\` builds a command list from multiple sources (builtin commands, prompt templates, extension commands, skill commands) and passes them through \`fuzzyFilter\` with \`getText: (item) => item.name\`. If any item's \`name\` resolves to a non-string value at runtime (e.g. \`undefined\`, \`null\`, or a number), \`.toLowerCase()\` throws.

While the TypeScript types declare \`query: string\` and \`text: string\`, the actual runtime values come from extension/plugin-provided data that isn't validated at the boundary. The autocomplete provider's \`commands\` array is assembled from 4 different sources — any of which could produce unexpected types:

1. **Extension commands** — from \`extensionRunner.getRegisteredCommands()\`
2. **Skill commands** — from YAML frontmatter \`name\` fields (YAML can parse \`name: 123\` as a number)
3. **Prompt templates** — from filesystem \`basename()\` (always string, but defensive coding is warranted)
4. **Builtin commands** — hardcoded (safe)

With many extensions installed (21+ packages, 110+ skills), the combinatorial surface makes it likely that at least one source will occasionally produce a non-string value.

## Fix

### \`fuzzyMatch\` (2 lines)
Add runtime type coercion at the top of the function:
\`\`\`ts
if (typeof query !== "string") query = String(query ?? "");
if (typeof text !== "string") text = String(text ?? "");
\`\`\`

### \`fuzzyFilter\` (3 lines)
Defensively handle \`getText\` return values:
\`\`\`ts
const rawText = getText(item);
if (rawText == null) continue;  // skip null/undefined items
const text = typeof rawText === "string" ? rawText : String(rawText);
\`\`\`

### Tests (6 new)
- \`fuzzyMatch\`: handles undefined text, undefined query, null/null, numeric inputs
- \`fuzzyFilter\`: skips null/undefined getText results, coerces numeric getText results

## Verification

- All 18 tests pass (12 existing + 6 new): \`node --test --import tsx test/fuzzy.test.ts\`
- Biome lint clean: \`biome check --error-on-warnings packages/tui/\`
- TUI package type-checks: \`tsgo --noEmit --project packages/tui/tsconfig.build.json\`

## Impact

- **Scope**: \`packages/tui/src/fuzzy.ts\` and \`packages/tui/test/fuzzy.test.ts\` only
- **Behavioral change**: None for valid string inputs. Non-string inputs are now coerced/skipped instead of crashing.
- **Risk**: Minimal — the coercion is a strict superset of the previous behavior for all string inputs.