### PR TITLE
fix(tui): load koffi via createRequire in ESM

### DIFF
--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1,6 +1,9 @@
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import { setKittyProtocolActive } from "./keys.js";
 import { StdinBuffer } from "./stdin-buffer.js";
+
+const cjsRequire = createRequire(import.meta.url);
 
 /**
  * Minimal terminal interface for TUI
@@ -176,7 +179,7 @@ export class ProcessTerminal implements Terminal {
 			// Dynamic require to avoid bundling koffi's 74MB of cross-platform
 			// native binaries into every compiled binary. Koffi is only needed
 			// on Windows for VT input support.
-			const koffi = require("koffi");
+			const koffi = cjsRequire("koffi");
 			const k32 = koffi.load("kernel32.dll");
 			const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
 			const GetConsoleMode = k32.func("bool __stdcall GetConsoleMode(void*, _Out_ uint32_t*)");


### PR DESCRIPTION
The previous lazy-loading change switched to require("koffi") inside enableWindowsVTInput(). In ESM, require is undefined, so the call threw and VT input mode was silently not enabled on Windows.

Use createRequire(import.meta.url) at module scope and cjsRequire("koffi") at the call site. This keeps koffi externalized for Bun binaries while restoring Windows VT input behavior, including multiline paste handling.