### PR TITLE
feat: add temperature support

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -85,6 +85,12 @@ export interface AgentOptions {
 	 * Default: 60000 (60 seconds). Set to 0 to disable the cap.
 	 */
 	maxRetryDelayMs?: number;
+
+	/**
+	 * Sampling temperature (0–2). Lower values are more deterministic, higher values more creative.
+	 * Not all providers/models support this parameter.
+	 */
+	temperature?: number;
 }
 
 export class Agent {
@@ -115,6 +121,7 @@ export class Agent {
 	private resolveRunningPrompt?: () => void;
 	private _thinkingBudgets?: ThinkingBudgets;
 	private _maxRetryDelayMs?: number;
+	private _temperature?: number;
 
 	constructor(opts: AgentOptions = {}) {
 		this._state = { ...this._state, ...opts.initialState };
@@ -127,6 +134,7 @@ export class Agent {
 		this.getApiKey = opts.getApiKey;
 		this._thinkingBudgets = opts.thinkingBudgets;
 		this._maxRetryDelayMs = opts.maxRetryDelayMs;
+		this._temperature = opts.temperature;
 	}
 
 	/**
@@ -171,6 +179,20 @@ export class Agent {
 	 */
 	set maxRetryDelayMs(value: number | undefined) {
 		this._maxRetryDelayMs = value;
+	}
+
+	/**
+	 * Get the current sampling temperature.
+	 */
+	get temperature(): number | undefined {
+		return this._temperature;
+	}
+
+	/**
+	 * Set the sampling temperature (0–2).
+	 */
+	set temperature(value: number | undefined) {
+		this._temperature = value;
 	}
 
 	get state(): AgentState {
@@ -409,6 +431,7 @@ export class Agent {
 			sessionId: this._sessionId,
 			thinkingBudgets: this._thinkingBudgets,
 			maxRetryDelayMs: this._maxRetryDelayMs,
+			temperature: this._temperature,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
 			getApiKey: this.getApiKey,

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -18,6 +18,7 @@ Edit directly or use `/settings` for common options.
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
 | `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` |
+| `temperature` | number | - | Sampling temperature 0–2 (lower = more deterministic, higher = more creative) |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -16,6 +16,7 @@ export interface Args {
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
 	thinking?: ThinkingLevel;
+	temperature?: number;
 	continue?: boolean;
 	resume?: boolean;
 	help?: boolean;
@@ -118,6 +119,13 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 					),
 				);
 			}
+		} else if (arg === "--temperature" && i + 1 < args.length) {
+			const val = parseFloat(args[++i]);
+			if (!isNaN(val) && val >= 0 && val <= 2) {
+				result.temperature = val;
+			} else {
+				console.error(chalk.yellow(`Warning: Invalid temperature "${args[i]}". Must be a number between 0 and 2.`));
+			}
 		} else if (arg === "--print" || arg === "-p") {
 			result.print = true;
 		} else if (arg === "--export" && i + 1 < args.length) {
@@ -206,6 +214,7 @@ ${chalk.bold("Options:")}
   --tools <tools>                Comma-separated list of tools to enable (default: read,bash,edit,write)
                                  Available: read, bash, edit, write, grep, find, ls
   --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh
+  --temperature <number>         Sampling temperature 0–2 (lower = more deterministic)
   --extension, -e <path>         Load an extension file (can be used multiple times)
   --no-extensions, -ne           Disable extension discovery (explicit -e paths still work)
   --skill <path>                 Load a skill file or directory (can be used multiple times)

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -53,6 +53,8 @@ export interface CreateAgentSessionOptions {
 	model?: Model<any>;
 	/** Thinking level. Default: from settings, else 'medium' (clamped to model capabilities) */
 	thinkingLevel?: ThinkingLevel;
+	/** Sampling temperature (0–2). Default: from settings, else provider default. Not all providers support this. */
+	temperature?: number;
 	/** Models available for cycling (Ctrl+P in interactive mode) */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel: ThinkingLevel }>;
 
@@ -284,6 +286,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	const extensionRunnerRef: { current?: ExtensionRunner } = {};
 
+	const temperature = options.temperature ?? settingsManager.getTemperature();
+
 	agent = new Agent({
 		initialState: {
 			systemPrompt: "",
@@ -291,6 +295,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			thinkingLevel,
 			tools: [],
 		},
+		temperature,
 		convertToLlm: convertToLlmWithBlockImages,
 		sessionId: sessionManager.getSessionId(),
 		transformContext: async (messages) => {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -82,6 +82,7 @@ export interface Settings {
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
 	doubleEscapeAction?: "fork" | "tree" | "none"; // Action for double-escape with empty editor (default: "tree")
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
+	temperature?: number; // Sampling temperature (0–2). Lower = more deterministic, higher = more creative.
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
@@ -430,6 +431,16 @@ export class SettingsManager {
 	setDefaultThinkingLevel(level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh"): void {
 		this.globalSettings.defaultThinkingLevel = level;
 		this.markModified("defaultThinkingLevel");
+		this.save();
+	}
+
+	getTemperature(): number | undefined {
+		return this.settings.temperature;
+	}
+
+	setTemperature(temperature: number): void {
+		this.globalSettings.temperature = temperature;
+		this.markModified("temperature");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -451,6 +451,11 @@ function buildSessionOptions(
 		options.thinkingLevel = parsed.thinking;
 	}
 
+	// Temperature from CLI
+	if (parsed.temperature !== undefined) {
+		options.temperature = parsed.temperature;
+	}
+
 	// Scoped models for Ctrl+P cycling - fill in default thinking level for models without explicit level
 	if (scopedModels.length > 0) {
 		const defaultThinkingLevel = settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;


### PR DESCRIPTION
## Summary

- Exposes sampling temperature (0–2) through the full stack so users can control how deterministic or creative model responses are
- Priority order: CLI flag > SDK option > `settings.json` > provider default

## Changes

**`packages/agent`**
- `AgentOptions.temperature?: number` — new constructor option
- Stored as `_temperature` private field with getter/setter
- Passed into `AgentLoopConfig` so it flows to `StreamOptions` → providers

**`packages/coding-agent`**
- `CreateAgentSessionOptions.temperature?: number` — SDK entry point
- `Settings.temperature?: number` + `getTemperature()` / `setTemperature()` in `SettingsManager`
- `--temperature <number>` CLI flag with 0–2 validation
- `buildSessionOptions()` in `main.ts` wires CLI arg through to session options
- `createAgentSession()` resolves: `options.temperature ?? settingsManager.getTemperature()`
- Docs: `settings.md` updated with new field

## Usage

```bash
# CLI
pi --temperature 0.2 "Write a function"

# settings.json
{ "temperature": 0.5 }
```

```typescript
// SDK
const { session } = await createAgentSession({ temperature: 0.7 });
```

## Test plan

- [ ] `--temperature 0.5` sets temperature on agent, provider receives it
- [ ] `--temperature 3` prints a warning and is ignored
- [ ] `settings.json` `temperature` field is picked up when no CLI flag is set
- [ ] CLI flag overrides settings value
- [ ] SDK `temperature` option overrides settings value
- [ ] Omitting temperature entirely uses provider default (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)