### PR TITLE
feat: add packages/ai-server — local HTTP bridge for pi-ai

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,6 +1762,10 @@
 			"resolved": "packages/ai",
 			"link": true
 		},
+		"node_modules/@mariozechner/pi-ai-server": {
+			"resolved": "packages/ai-server",
+			"link": true
+		},
 		"node_modules/@mariozechner/pi-coding-agent": {
 			"resolved": "packages/coding-agent",
 			"link": true
@@ -8434,6 +8438,39 @@
 			"engines": {
 				"node": ">=20.0.0"
 			}
+		},
+		"packages/ai-server": {
+			"name": "@mariozechner/pi-ai-server",
+			"version": "0.1.0",
+			"dependencies": {
+				"@mariozechner/pi-ai": "*"
+			},
+			"bin": {
+				"pi-ai-server": "dist/server.js"
+			},
+			"devDependencies": {
+				"@types/node": "^24.3.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"packages/ai-server/node_modules/@types/node": {
+			"version": "24.10.13",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
+			"integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
+		},
+		"packages/ai-server/node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"packages/ai/node_modules/@types/node": {
 			"version": "24.10.13",

--- a/packages/ai-server/README.md
+++ b/packages/ai-server/README.md
@@ -1,0 +1,191 @@
+# @mariozechner/pi-ai-server
+
+A lightweight local HTTP server that exposes [`@mariozechner/pi-ai`](../ai) over HTTP, so non-JavaScript projects (e.g. Python) can use its unified LLM API and OAuth authentication.
+
+## Quick Start
+
+```bash
+# 1. Build (from monorepo root)
+cd packages/ai && npm run build
+cd ../ai-server && npm run build
+
+# 2. (OAuth providers only) Log in first
+node ../ai/dist/cli.js login google-gemini-cli
+
+# 3. Start the server
+node dist/server.js
+# → pi-ai-server listening on http://127.0.0.1:3456
+```
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3456` | Port to listen on |
+| `HOST` | `127.0.0.1` | Host to bind to |
+| `AUTH_FILE` | `packages/ai/auth.json` | Path to OAuth credentials file |
+
+---
+
+## API Reference
+
+### `GET /providers`
+
+Returns all supported providers and their authentication status.
+
+```bash
+curl http://127.0.0.1:3456/providers
+```
+
+```json
+[
+  { "id": "google-gemini-cli", "authType": "oauth", "authenticated": true },
+  { "id": "openai-codex",      "authType": "oauth", "authenticated": false },
+  { "id": "openai",            "authType": "apiKey", "authenticated": null },
+  { "id": "google",            "authType": "apiKey", "authenticated": null },
+  { "id": "xai",               "authType": "apiKey", "authenticated": null },
+  { "id": "minimax",           "authType": "apiKey", "authenticated": null },
+  { "id": "kimi-coding",       "authType": "apiKey", "authenticated": null }
+]
+```
+
+---
+
+### `POST /auth/token`
+
+Get a valid API key for an OAuth provider. Automatically refreshes expired tokens and saves updated credentials to `auth.json`.
+
+```bash
+curl -X POST http://127.0.0.1:3456/auth/token \
+  -H "Content-Type: application/json" \
+  -d '{"providerId": "google-gemini-cli"}'
+```
+
+```json
+{ "providerId": "google-gemini-cli", "apiKey": "..." }
+```
+
+> Returns `401` if the provider has never been logged in. Run `node ../ai/dist/cli.js login <providerId>` first.
+
+---
+
+### `POST /complete`
+
+Run a non-streaming LLM completion. Returns the full `AssistantMessage` when done.
+
+```bash
+curl -X POST http://127.0.0.1:3456/complete \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": {
+      "id": "gemini-2.0-flash",
+      "api": "google-gemini-cli",
+      "provider": "google-gemini-cli",
+      "baseUrl": "",
+      "reasoning": false,
+      "input": ["text"],
+      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+      "contextWindow": 1000000,
+      "maxTokens": 8192
+    },
+    "context": {
+      "messages": [{"role": "user", "content": "Hello!", "timestamp": 0}]
+    },
+    "options": { "apiKey": "<token from /auth/token>" }
+  }'
+```
+
+```json
+{
+  "role": "assistant",
+  "content": [{ "type": "text", "text": "Hello! How can I help you today?" }],
+  "usage": { "input": 10, "output": 12, "totalTokens": 22, ... },
+  "stopReason": "stop"
+}
+```
+
+---
+
+### `POST /stream`
+
+Same request body as `/complete`. Returns a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) stream.
+
+Each SSE event carries an `AssistantMessageEvent` object. The stream ends with an `event: done` or `event: error` event.
+
+```
+event: message
+data: {"type":"start","partial":{...}}
+
+event: message
+data: {"type":"text_delta","delta":"Hello","contentIndex":0,...}
+
+event: done
+data: {"type":"done","reason":"stop","message":{...}}
+```
+
+---
+
+## Supported Providers
+
+| Provider ID | Auth Type | Notes |
+|-------------|-----------|-------|
+| `google-gemini-cli` | OAuth | Free via Google account; run `login` first |
+| `openai-codex` | OAuth | Requires ChatGPT Plus/Pro subscription |
+| `openai` | API Key | Pass key in `options.apiKey` |
+| `google` | API Key | Gemini API key |
+| `xai` | API Key | Grok API key |
+| `minimax` / `minimax-cn` | API Key | MiniMax API key |
+| `kimi-coding` | API Key | Kimi API key |
+
+---
+
+## Python Example
+
+A complete example using only Python's standard library (`urllib`) is available at [`examples/python_client.py`](examples/python_client.py).
+
+```python
+import json, urllib.request
+
+# 1. Get OAuth token
+req = urllib.request.Request(
+    "http://127.0.0.1:3456/auth/token",
+    data=json.dumps({"providerId": "google-gemini-cli"}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+with urllib.request.urlopen(req) as r:
+    api_key = json.loads(r.read())["apiKey"]
+
+# 2. Complete
+req = urllib.request.Request(
+    "http://127.0.0.1:3456/complete",
+    data=json.dumps({
+        "model": {
+            "id": "gemini-2.0-flash", "api": "google-gemini-cli",
+            "provider": "google-gemini-cli", "baseUrl": "",
+            "reasoning": False, "input": ["text"],
+            "cost": {"input":0,"output":0,"cacheRead":0,"cacheWrite":0},
+            "contextWindow": 1000000, "maxTokens": 8192,
+        },
+        "context": {
+            "messages": [{"role": "user", "content": "Hello!", "timestamp": 0}]
+        },
+        "options": {"apiKey": api_key},
+    }).encode(),
+    headers={"Content-Type": "application/json"},
+)
+with urllib.request.urlopen(req) as r:
+    msg = json.loads(r.read())
+    print(msg["content"][0]["text"])
+```
+
+---
+
+## Development
+
+```bash
+# Watch mode
+npm run dev
+
+# Run directly (no build needed with tsx)
+npx tsx src/server.ts
+```

--- a/packages/ai-server/examples/python_client.py
+++ b/packages/ai-server/examples/python_client.py
@@ -1,0 +1,227 @@
+"""
+pi-ai-server Python client example
+===================================
+Requires: pip install requests   (or use the urllib fallback below)
+
+Start the server first:
+  cd packages/ai-server && node dist/server.js
+
+Then run this script:
+  python3 examples/python_client.py
+"""
+
+import json
+import urllib.request
+import urllib.error
+
+SERVER = "http://127.0.0.1:3456"
+
+
+# ─── Low-level helpers (no pip required) ──────────────────────────────────────
+
+def post(path: str, data: dict) -> dict:
+    """POST JSON to the server and return parsed response."""
+    body = json.dumps(data).encode()
+    req = urllib.request.Request(
+        f"{SERVER}{path}",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def get(path: str) -> dict:
+    """GET JSON from the server."""
+    with urllib.request.urlopen(f"{SERVER}{path}") as resp:
+        return json.loads(resp.read().decode())
+
+
+def stream(path: str, data: dict):
+    """POST and yield Server-Sent Events as parsed dicts."""
+    body = json.dumps(data).encode()
+    req = urllib.request.Request(
+        f"{SERVER}{path}",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        buf = ""
+        event_type = "message"
+        for raw_line in resp:
+            line = raw_line.decode("utf-8").rstrip("\n\r")
+            if line.startswith("event:"):
+                event_type = line[len("event:"):].strip()
+            elif line.startswith("data:"):
+                buf = line[len("data:"):].strip()
+            elif line == "" and buf:
+                yield event_type, json.loads(buf)
+                buf = ""
+                event_type = "message"
+
+
+# ─── Example 1: List providers ────────────────────────────────────────────────
+
+def example_list_providers():
+    print("=== Providers ===")
+    providers = get("/providers")
+    for p in providers:
+        auth_status = (
+            "✓ authenticated" if p["authenticated"]
+            else "✗ not logged in" if p["authType"] == "oauth"
+            else "(api key required)"
+        )
+        print(f"  {p['id']:<25} [{p['authType']}]  {auth_status}")
+    print()
+
+
+# ─── Example 2: OAuth token (Gemini CLI / OpenAI Codex) ───────────────────────
+
+def example_get_oauth_token(provider_id: str) -> str:
+    """Get a valid API key for an OAuth provider (auto-refreshes if expired)."""
+    print(f"=== Get OAuth token for {provider_id} ===")
+    result = post("/auth/token", {"providerId": provider_id})
+    api_key = result["apiKey"]
+    print(f"  Got apiKey: {api_key[:40]}...")
+    print()
+    return api_key
+
+
+# ─── Example 3: Complete (non-streaming) ──────────────────────────────────────
+
+def example_complete_openai(api_key: str):
+    """Use OpenAI with a plain API key."""
+    print("=== Complete (OpenAI GPT-4o-mini) ===")
+    result = post("/complete", {
+        "model": {
+            "id": "gpt-4o-mini",
+            "name": "GPT-4o Mini",
+            "api": "openai-completions",
+            "provider": "openai",
+            "baseUrl": "https://api.openai.com/v1",
+            "reasoning": False,
+            "input": ["text"],
+            "cost": {"input": 0.15, "output": 0.6, "cacheRead": 0, "cacheWrite": 0},
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+        },
+        "context": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Say hello in one sentence.",
+                    "timestamp": 0,
+                }
+            ]
+        },
+        "options": {
+            "apiKey": api_key,
+        },
+    })
+    text_blocks = [b["text"] for b in result["content"] if b["type"] == "text"]
+    print(f"  Response: {''.join(text_blocks)}")
+    print(f"  Tokens: {result['usage']['totalTokens']}")
+    print()
+
+
+def example_complete_gemini_cli(api_key: str):
+    """Use Gemini CLI with the OAuth API key obtained from /auth/token."""
+    print("=== Complete (Gemini CLI) ===")
+    result = post("/complete", {
+        "model": {
+            "id": "gemini-2.0-flash",
+            "name": "Gemini 2.0 Flash",
+            "api": "google-gemini-cli",
+            "provider": "google-gemini-cli",
+            "baseUrl": "",
+            "reasoning": False,
+            "input": ["text", "image"],
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            "contextWindow": 1000000,
+            "maxTokens": 8192,
+        },
+        "context": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Say hello in one sentence.",
+                    "timestamp": 0,
+                }
+            ]
+        },
+        "options": {
+            "apiKey": api_key,  # The JSON string returned by /auth/token
+        },
+    })
+    text_blocks = [b["text"] for b in result["content"] if b["type"] == "text"]
+    print(f"  Response: {''.join(text_blocks)}")
+    print(f"  Tokens: {result['usage']['totalTokens']}")
+    print()
+
+
+# ─── Example 4: Streaming ─────────────────────────────────────────────────────
+
+def example_stream_gemini_cli(api_key: str):
+    """Stream a Gemini CLI response via SSE."""
+    print("=== Stream (Gemini CLI) ===")
+    print("  Response: ", end="", flush=True)
+    for event_type, event in stream("/stream", {
+        "model": {
+            "id": "gemini-2.0-flash",
+            "name": "Gemini 2.0 Flash",
+            "api": "google-gemini-cli",
+            "provider": "google-gemini-cli",
+            "baseUrl": "",
+            "reasoning": False,
+            "input": ["text", "image"],
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            "contextWindow": 1000000,
+            "maxTokens": 8192,
+        },
+        "context": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Count from 1 to 5, one number per line.",
+                    "timestamp": 0,
+                }
+            ]
+        },
+        "options": {"apiKey": api_key},
+    }):
+        if event.get("type") == "text_delta":
+            print(event.get("delta", ""), end="", flush=True)
+        elif event_type == "done":
+            break
+        elif event_type == "error":
+            print(f"\n  Error: {event}")
+            break
+    print("\n")
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    # 1. List providers
+    example_list_providers()
+
+    # 2. Demo with OpenAI (set your API key here or via env)
+    import os
+    openai_key = os.environ.get("OPENAI_API_KEY", "")
+    if openai_key:
+        example_complete_openai(openai_key)
+    else:
+        print("⚠  Skipping OpenAI example (set OPENAI_API_KEY env var to enable)\n")
+
+    # 3. Demo with Gemini CLI OAuth (requires prior `pi-ai login google-gemini-cli`)
+    try:
+        gemini_key = example_get_oauth_token("google-gemini-cli")
+        example_complete_gemini_cli(gemini_key)
+        example_stream_gemini_cli(gemini_key)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"⚠  Gemini CLI skipped: {body}\n")
+    except Exception as e:
+        print(f"⚠  Gemini CLI skipped: {e}\n")

--- a/packages/ai-server/package.json
+++ b/packages/ai-server/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@mariozechner/pi-ai-server",
+    "version": "0.1.0",
+    "description": "Local HTTP server exposing @mariozechner/pi-ai for Python and other non-JS clients",
+    "type": "module",
+    "main": "./dist/server.js",
+    "bin": {
+        "pi-ai-server": "./dist/server.js"
+    },
+    "scripts": {
+        "clean": "rm -rf dist",
+        "build": "tsgo -p tsconfig.build.json",
+        "dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
+        "start": "node dist/server.js"
+    },
+    "dependencies": {
+        "@mariozechner/pi-ai": "*"
+    },
+    "devDependencies": {
+        "@types/node": "^24.3.0"
+    },
+    "engines": {
+        "node": ">=20.0.0"
+    }
+}

--- a/packages/ai-server/src/auth.ts
+++ b/packages/ai-server/src/auth.ts
@@ -1,0 +1,45 @@
+import type { OAuthCredentials } from "@mariozechner/pi-ai";
+import { getOAuthApiKey } from "@mariozechner/pi-ai";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
+
+// Default auth file: packages/ai/auth.json (same file used by pi-ai CLI)
+const DEFAULT_AUTH_FILE = resolve(fileURLToPath(import.meta.url), "../../../ai/auth.json");
+
+export function getAuthFile(): string {
+	return process.env.AUTH_FILE ?? DEFAULT_AUTH_FILE;
+}
+
+export type AuthStore = Record<string, { type: "oauth" } & OAuthCredentials>;
+
+export function loadAuth(authFile: string): AuthStore {
+	if (!existsSync(authFile)) return {};
+	try {
+		return JSON.parse(readFileSync(authFile, "utf-8")) as AuthStore;
+	} catch {
+		return {};
+	}
+}
+
+export function saveAuth(authFile: string, auth: AuthStore): void {
+	writeFileSync(authFile, JSON.stringify(auth, null, 2), "utf-8");
+}
+
+/**
+ * Get a valid API key for an OAuth provider.
+ * Automatically refreshes expired tokens and saves updated credentials.
+ * Returns null if no credentials are stored for the provider.
+ */
+export async function getAndRefreshApiKey(providerId: string): Promise<string | null> {
+	const authFile = getAuthFile();
+	const auth = loadAuth(authFile);
+	const result = await getOAuthApiKey(providerId, auth as Record<string, OAuthCredentials>);
+	if (!result) return null;
+
+	// Persist refreshed credentials
+	auth[providerId] = { type: "oauth", ...result.newCredentials };
+	saveAuth(authFile, auth);
+
+	return result.apiKey;
+}

--- a/packages/ai-server/src/server.ts
+++ b/packages/ai-server/src/server.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+
+/**
+ * pi-ai-server: Local HTTP bridge for @mariozechner/pi-ai
+ *
+ * Endpoints:
+ *   GET  /providers        List supported providers and their auth status
+ *   POST /auth/token       Get (and auto-refresh) an OAuth API key
+ *   POST /complete         Run completeSimple() and return AssistantMessage JSON
+ *   POST /stream           Stream via streamSimple() as Server-Sent Events
+ *
+ * Supported providers:
+ *   OAuth:   openai-codex, google-gemini-cli
+ *   API key: openai, google, xai, minimax, kimi-coding
+ */
+
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { completeSimple, getOAuthProviders, streamSimple } from "@mariozechner/pi-ai";
+import { createServer, type IncomingMessage, type ServerResponse } from "http";
+import { getAndRefreshApiKey, getAuthFile, loadAuth } from "./auth.js";
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const PORT = parseInt(process.env.PORT ?? "3456", 10);
+const HOST = process.env.HOST ?? "127.0.0.1";
+
+// OAuth providers we support (subset of all pi-ai OAuth providers)
+const OAUTH_PROVIDER_IDS = new Set(["openai-codex", "google-gemini-cli"]);
+
+// API-key providers we support
+const APIKEY_PROVIDERS = ["openai", "google", "xai", "minimax", "minimax-cn", "kimi-coding"] as const;
+
+// ─── HTTP helpers ─────────────────────────────────────────────────────────────
+
+function readBody(req: IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		req.on("data", (c: Buffer) => chunks.push(c));
+		req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+		req.on("error", reject);
+	});
+}
+
+function json(res: ServerResponse, status: number, data: unknown): void {
+	const body = JSON.stringify(data);
+	res.writeHead(status, {
+		"Content-Type": "application/json",
+		"Access-Control-Allow-Origin": "*",
+	});
+	res.end(body);
+}
+
+function err(res: ServerResponse, status: number, message: string): void {
+	json(res, status, { error: message });
+}
+
+async function parseBody<T>(req: IncomingMessage, res: ServerResponse): Promise<T | null> {
+	try {
+		const raw = await readBody(req);
+		return JSON.parse(raw) as T;
+	} catch {
+		err(res, 400, "Invalid JSON body");
+		return null;
+	}
+}
+
+// ─── Route handlers ───────────────────────────────────────────────────────────
+
+/**
+ * GET /providers
+ * Returns all supported providers with their type and auth status.
+ */
+async function handleProviders(res: ServerResponse): Promise<void> {
+	const authFile = getAuthFile();
+	const auth = loadAuth(authFile);
+	const oauthProviders = getOAuthProviders().filter((p) => OAUTH_PROVIDER_IDS.has(p.id));
+
+	const result = [
+		// OAuth providers: check if credentials exist in auth.json
+		...oauthProviders.map((p) => ({
+			id: p.id,
+			name: p.name,
+			authType: "oauth",
+			authenticated: p.id in auth,
+		})),
+		// API key providers
+		...APIKEY_PROVIDERS.map((id) => ({
+			id,
+			name: id,
+			authType: "apiKey",
+			authenticated: null, // Not tracked server-side
+		})),
+	];
+
+	json(res, 200, result);
+}
+
+/**
+ * POST /auth/token
+ * Body: { "providerId": "google-gemini-cli" }
+ * Returns: { "apiKey": "...", "providerId": "..." }
+ */
+async function handleAuthToken(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	const body = await parseBody<{ providerId?: string }>(req, res);
+	if (!body) return;
+
+	const { providerId } = body;
+	if (!providerId) {
+		err(res, 400, 'Missing required field: "providerId"');
+		return;
+	}
+	if (!OAUTH_PROVIDER_IDS.has(providerId)) {
+		err(
+			res,
+			400,
+			`Provider "${providerId}" is not an OAuth provider. OAuth providers: ${[...OAUTH_PROVIDER_IDS].join(", ")}`,
+		);
+		return;
+	}
+
+	try {
+		const apiKey = await getAndRefreshApiKey(providerId);
+		if (!apiKey) {
+			err(res, 401, `No credentials found for "${providerId}". Run: npx @mariozechner/pi-ai login ${providerId}`);
+			return;
+		}
+		json(res, 200, { providerId, apiKey });
+	} catch (e) {
+		err(res, 500, e instanceof Error ? e.message : String(e));
+	}
+}
+
+/**
+ * POST /complete
+ * Body: {
+ *   model: Model,
+ *   context: Context,
+ *   options?: SimpleStreamOptions   // apiKey must be set for non-OAuth providers
+ * }
+ * Returns: AssistantMessage
+ */
+async function handleComplete(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	const body = await parseBody<{
+		model?: Model<string>;
+		context?: Context;
+		options?: SimpleStreamOptions;
+	}>(req, res);
+	if (!body) return;
+
+	const { model, context, options } = body;
+	if (!model) {
+		err(res, 400, 'Missing required field: "model"');
+		return;
+	}
+	if (!context) {
+		err(res, 400, 'Missing required field: "context"');
+		return;
+	}
+
+	try {
+		const message = await completeSimple(model, context, options);
+		json(res, 200, message);
+	} catch (e) {
+		err(res, 500, e instanceof Error ? e.message : String(e));
+	}
+}
+
+/**
+ * POST /stream
+ * Same body as /complete. Response is text/event-stream (SSE).
+ * Each event: `data: <AssistantMessageEvent JSON>\n\n`
+ * Final event on done/error: `event: done\ndata: <JSON>\n\n`
+ */
+async function handleStream(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	const body = await parseBody<{
+		model?: Model<string>;
+		context?: Context;
+		options?: SimpleStreamOptions;
+	}>(req, res);
+	if (!body) return;
+
+	const { model, context, options } = body;
+	if (!model) {
+		err(res, 400, 'Missing required field: "model"');
+		return;
+	}
+	if (!context) {
+		err(res, 400, 'Missing required field: "context"');
+		return;
+	}
+
+	res.writeHead(200, {
+		"Content-Type": "text/event-stream",
+		"Cache-Control": "no-cache",
+		Connection: "keep-alive",
+		"Access-Control-Allow-Origin": "*",
+	});
+
+	const sendEvent = (eventType: string, data: unknown): void => {
+		res.write(`event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+	};
+
+	try {
+		const eventStream = streamSimple(model, context, options);
+
+		for await (const event of eventStream) {
+			const isDone = event.type === "done" || event.type === "error";
+			sendEvent(isDone ? event.type : "message", event);
+			if (isDone) break;
+		}
+	} catch (e) {
+		sendEvent("error", { type: "error", error: e instanceof Error ? e.message : String(e) });
+	} finally {
+		res.end();
+	}
+}
+
+// ─── Router ───────────────────────────────────────────────────────────────────
+
+async function router(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	const method = req.method ?? "GET";
+	const url = req.url ?? "/";
+	const path = url.split("?")[0];
+
+	// CORS preflight
+	if (method === "OPTIONS") {
+		res.writeHead(204, {
+			"Access-Control-Allow-Origin": "*",
+			"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+			"Access-Control-Allow-Headers": "Content-Type",
+		});
+		res.end();
+		return;
+	}
+
+	if (method === "GET" && path === "/providers") return handleProviders(res);
+	if (method === "POST" && path === "/auth/token") return handleAuthToken(req, res);
+	if (method === "POST" && path === "/complete") return handleComplete(req, res);
+	if (method === "POST" && path === "/stream") return handleStream(req, res);
+
+	err(res, 404, `Unknown route: ${method} ${path}`);
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+const server = createServer((req, res) => {
+	router(req, res).catch((e) => {
+		console.error("Unhandled error:", e);
+		if (!res.headersSent) {
+			err(res, 500, "Internal server error");
+		}
+	});
+});
+
+server.listen(PORT, HOST, () => {
+	console.log(`pi-ai-server listening on http://${HOST}:${PORT}`);
+	console.log(`Auth file: ${getAuthFile()}`);
+	console.log();
+	console.log("Endpoints:");
+	console.log(`  GET  http://${HOST}:${PORT}/providers`);
+	console.log(`  POST http://${HOST}:${PORT}/auth/token`);
+	console.log(`  POST http://${HOST}:${PORT}/complete`);
+	console.log(`  POST http://${HOST}:${PORT}/stream`);
+});

--- a/packages/ai-server/tsconfig.build.json
+++ b/packages/ai-server/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}


### PR DESCRIPTION
Exposes @mariozechner/pi-ai over HTTP so Python and other non-JS projects can use its unified LLM API and OAuth authentication.

Endpoints:
  GET  /providers      list providers and auth status
  POST /auth/token     get/refresh OAuth API key (auto-refresh)
  POST /complete       non-streaming LLM completion
  POST /stream         SSE streaming LLM completion

Supported providers:
  OAuth:   google-gemini-cli, openai-codex
  API key: openai, google, xai, minimax, minimax-cn, kimi-coding