### PR TITLE
fix(tui): prevent dollar sign corruption in paste marker expansion

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -829,7 +829,7 @@ export class Editor implements Component, Focusable {
 		let result = this.state.lines.join("\n");
 		for (const [pasteId, pasteContent] of this.pastes) {
 			const markerRegex = new RegExp(`\\[paste #${pasteId}( (\\+\\d+ lines|\\d+ chars))?\\]`, "g");
-			result = result.replace(markerRegex, pasteContent);
+			result = result.replace(markerRegex, () => pasteContent);
 		}
 		return result;
 	}
@@ -1074,7 +1074,7 @@ export class Editor implements Component, Focusable {
 		let result = this.state.lines.join("\n").trim();
 		for (const [pasteId, pasteContent] of this.pastes) {
 			const markerRegex = new RegExp(`\\[paste #${pasteId}( (\\+\\d+ lines|\\d+ chars))?\\]`, "g");
-			result = result.replace(markerRegex, pasteContent);
+			result = result.replace(markerRegex, () => pasteContent);
 		}
 
 		this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1505,6 +1505,45 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.getText(), "hello| world");
 		});
 
+		it("preserves dollar signs in pasted content during getExpandedText", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+
+			// Paste content with $1, $2, $& patterns that JavaScript's
+			// String.replace() would interpret as regex backreferences
+			const lines = Array.from({ length: 15 }, (_, i) => `Row ${i}: $${i + 1}${(i + 1) * 100}.00`);
+			const pasteContent = lines.join("\n");
+
+			// Simulate bracketed paste (>10 lines triggers marker collapse)
+			editor.handleInput(`\x1b[200~${pasteContent}\x1b[201~`);
+
+			// Editor should show a collapsed marker
+			assert.ok(editor.getText().includes("[paste #1"));
+
+			// getExpandedText() must return the original content with $ signs intact
+			const expanded = editor.getExpandedText();
+			assert.ok(expanded.includes("$1100.00"), `Expected $1100.00 but got: ${expanded.substring(0, 200)}`);
+			assert.ok(expanded.includes("$2200.00"), `Expected $2200.00 but got: ${expanded.substring(0, 200)}`);
+			assert.strictEqual(expanded, pasteContent);
+		});
+
+		it("preserves dollar signs in pasted content during submit", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+
+			const lines = Array.from({ length: 15 }, (_, i) => `Row ${i}: $${i + 1}${(i + 1) * 100}.00`);
+			const pasteContent = lines.join("\n");
+
+			let submittedText = "";
+			editor.onSubmit = (text: string) => { submittedText = text; };
+
+			// Simulate bracketed paste (>10 lines triggers marker collapse)
+			editor.handleInput(`\x1b[200~${pasteContent}\x1b[201~`);
+			// Trigger submit (Enter key)
+			editor.handleInput("\r");
+			assert.ok(submittedText.includes("$1100.00"), `Submit: expected $1100.00 but got: ${submittedText.substring(0, 200)}`);
+			assert.ok(submittedText.includes("$2200.00"), `Submit: expected $2200.00 but got: ${submittedText.substring(0, 200)}`);
+			assert.strictEqual(submittedText, pasteContent);
+		});
+
 		it("undoes insertTextAtCursor atomically", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 


### PR DESCRIPTION
## Bug

When pasting text (>10 lines) containing dollar amounts into the editor, `$1` and `$2`
patterns in the pasted content are silently corrupted during marker expansion.

### Steps to reproduce

1. Copy text containing `$1,257.01` or any `$1...`/`$2...` pattern (15+ lines)
2. Paste into the pi editor — it collapses into `[paste #1 +181 lines]`
3. Press Enter to submit

**Expected:** The submitted text contains `$1,257.01`
**Actual:** The submitted text contains `+181 lines257.01`

### Root cause

Both `getExpandedText()` and `submitValue()` in `Editor` expand paste markers using:

```ts
result = result.replace(markerRegex, pasteContent);
```

The marker regex contains capture groups: `( (\+\d+ lines|\d+ chars))?`

JavaScript's `String.prototype.replace()` interprets `$1`, `$2`, `$&`, `` $` ``, and `$'`
in the replacement string as special substitution patterns ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement)).

So `$1` in the pasted content (e.g., `$1,257.01`) gets replaced with capture group 1's
match text (` +181 lines`), producing ` +181 lines,257.01`.

### Fix

Use a function replacement to bypass all special pattern interpretation:

```ts
result = result.replace(markerRegex, () => pasteContent);
```

### Tests

Added two test cases that paste content containing `$1`, `$2` patterns and verify
they survive both `getExpandedText()` and `submitValue()` expansion without corruption.

All 403 tests pass.