### PR TITLE
fix(subagent): make subagent spawn work on win32

### DIFF
--- a/packages/coding-agent/examples/extensions/subagent/index.ts
+++ b/packages/coding-agent/examples/extensions/subagent/index.ts
@@ -284,7 +284,14 @@ async function runSingleAgent(
 		let wasAborted = false;
 
 		const exitCode = await new Promise<number>((resolve) => {
-			const proc = spawn("pi", args, { cwd: cwd ?? defaultCwd, shell: false, stdio: ["ignore", "pipe", "pipe"] });
+			const isWindows = process.platform === "win32";
+			const spawnCommand = isWindows ? "cmd.exe" : "pi";
+			const spawnArgs = isWindows ? ["/d", "/s", "/c", "pi", ...args] : args;
+			const proc = spawn(spawnCommand, spawnArgs, {
+				cwd: cwd ?? defaultCwd,
+				shell: false,
+				stdio: ["ignore", "pipe", "pipe"],
+			});
 			let buffer = "";
 
 			const processLine = (line: string) => {


### PR DESCRIPTION
## Summary

Fixes `subagent` process spawning on Windows (`win32`).

Previously the extension used:

```ts
spawn("pi", args, { shell: false })
```

On Windows, this can fail with `spawn pi ENOENT` because `pi` is typically a `.cmd` shim and is not directly executable via `CreateProcess` when spawned this way.

This change adds a platform-specific spawn path:

- **win32**: `cmd.exe /d /s /c pi ...args`
- **others**: keep `spawn("pi", args, ...)`

## Why

Without this, subagent calls fail silently/with no output on Windows environments where only the command shim is available.

## Scope

- `packages/coding-agent/examples/extensions/subagent/index.ts`
- minimal, targeted change (8 insertions, 1 deletion)

## Validation

Validated in a Windows environment by running single and parallel subagent invocations after the change; both succeeded.
