### PR TITLE
fix(agent): terminate EventStream on async loop error

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed silent hang when async agent loop throws: added `.catch()` to fire-and-forget async IIFEs in `agentLoop()` and `agentLoopContinue()` so that `EventStream` is properly terminated with an `agent_end` error event instead of leaving `for-await` consumers blocked indefinitely
+
 ## [0.55.1] - 2026-02-26
 
 ## [0.55.0] - 2026-02-24

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -49,7 +49,9 @@ export function agentLoop(
 		}
 
 		await runLoop(currentContext, newMessages, config, signal, stream, streamFn);
-	})();
+	})().catch((err) => {
+		terminateStreamOnError(stream, err);
+	});
 
 	return stream;
 }
@@ -86,7 +88,9 @@ export function agentLoopContinue(
 		stream.push({ type: "turn_start" });
 
 		await runLoop(currentContext, newMessages, config, signal, stream, streamFn);
-	})();
+	})().catch((err) => {
+		terminateStreamOnError(stream, err);
+	});
 
 	return stream;
 }
@@ -96,6 +100,34 @@ function createAgentStream(): EventStream<AgentEvent, AgentMessage[]> {
 		(event: AgentEvent) => event.type === "agent_end",
 		(event: AgentEvent) => (event.type === "agent_end" ? event.messages : []),
 	);
+}
+
+/**
+ * Terminate an agent stream after an unexpected error in the async loop.
+ * Pushes an agent_end event with an error message so consumers (for-await)
+ * don't hang indefinitely waiting for events that will never arrive.
+ */
+function terminateStreamOnError(stream: EventStream<AgentEvent, AgentMessage[]>, err: unknown): void {
+	const errorMessage: AgentMessage = {
+		role: "assistant",
+		content: [{ type: "text", text: "" }],
+		provider: "",
+		model: "",
+		api: "" as any,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "error",
+		errorMessage: err instanceof Error ? err.message : String(err),
+		timestamp: Date.now(),
+	} as AgentMessage;
+	stream.push({ type: "agent_end", messages: [errorMessage] });
+	stream.end([errorMessage]);
 }
 
 /**

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -414,6 +414,173 @@ describe("agentLoop with AgentMessage", () => {
 	});
 });
 
+describe("agentLoop error handling", () => {
+	it("should terminate stream with error when streamFn throws synchronously", async () => {
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [],
+		};
+
+		const userPrompt: AgentMessage = createUserMessage("Hello");
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		const streamFn = () => {
+			throw new Error("Connection refused");
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+
+		// Stream should terminate with agent_end containing error
+		const agentEnd = events.find((e) => e.type === "agent_end");
+		expect(agentEnd).toBeDefined();
+		if (agentEnd?.type === "agent_end") {
+			expect(agentEnd.messages.length).toBe(1);
+			const errorMsg = agentEnd.messages[0] as AssistantMessage;
+			expect(errorMsg.stopReason).toBe("error");
+			expect(errorMsg.errorMessage).toBe("Connection refused");
+		}
+
+		expect(messages.length).toBe(1);
+		expect((messages[0] as AssistantMessage).stopReason).toBe("error");
+	});
+
+	it("should terminate stream with error when convertToLlm throws", async () => {
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [],
+		};
+
+		const userPrompt: AgentMessage = createUserMessage("Hello");
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: () => {
+				throw new Error("Invalid message format");
+			},
+		};
+
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage([{ type: "text", text: "should not reach here" }]);
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+
+		const agentEnd = events.find((e) => e.type === "agent_end");
+		expect(agentEnd).toBeDefined();
+		if (agentEnd?.type === "agent_end") {
+			const errorMsg = agentEnd.messages[0] as AssistantMessage;
+			expect(errorMsg.stopReason).toBe("error");
+			expect(errorMsg.errorMessage).toBe("Invalid message format");
+		}
+
+		expect(messages.length).toBe(1);
+	});
+
+	it("should terminate stream with error when getApiKey throws", async () => {
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [],
+		};
+
+		const userPrompt: AgentMessage = createUserMessage("Hello");
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			getApiKey: async () => {
+				throw new Error('No API key found for provider "anthropic"');
+			},
+		};
+
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage([{ type: "text", text: "should not reach here" }]);
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+
+		const agentEnd = events.find((e) => e.type === "agent_end");
+		expect(agentEnd).toBeDefined();
+		if (agentEnd?.type === "agent_end") {
+			const errorMsg = agentEnd.messages[0] as AssistantMessage;
+			expect(errorMsg.stopReason).toBe("error");
+			expect(errorMsg.errorMessage).toContain("No API key found");
+		}
+
+		expect(messages.length).toBe(1);
+	});
+
+	it("should terminate agentLoopContinue stream on error", async () => {
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [createUserMessage("Hello")],
+			tools: [],
+		};
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: () => {
+				throw new Error("conversion error");
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoopContinue(context, config, undefined, () => {
+			const s = new MockAssistantStream();
+			queueMicrotask(() => {
+				s.push({ type: "done", reason: "stop", message: createAssistantMessage([{ type: "text", text: "x" }]) });
+			});
+			return s;
+		});
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		expect(messages.length).toBe(1);
+		expect((messages[0] as AssistantMessage).stopReason).toBe("error");
+		expect((messages[0] as AssistantMessage).errorMessage).toBe("conversion error");
+	});
+});
+
 describe("agentLoopContinue with AgentMessage", () => {
 	it("should throw when context has no messages", () => {
 		const context: AgentContext = {


### PR DESCRIPTION
agentLoop() and agentLoopContinue() use fire-and-forget async IIFEs to drive the agent loop. If runLoop() throws (e.g. from getApiKey, convertToLlm, or a synchronous streamFn error), the rejected promise was unhandled: stream.end() was never called, leaving for-await consumers in agent.ts blocked indefinitely.

Add .catch() handlers that push an agent_end event with the error message and call stream.end(), so the EventStream always terminates.

Depending on the host process's unhandledRejection policy, the old behavior manifested as either:
- process.exit(1) for non-suppressed errors
- silent hang for suppressed errors (AbortError, transient network)