### PR TITLE
feat(coding-agent/extensions): add invokeCommand API for shortcut flows

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -960,6 +960,30 @@ When not streaming, the message is sent immediately and triggers a new turn. Whe
 
 See [send-user-message.ts](../examples/extensions/send-user-message.ts) for a complete example.
 
+### pi.invokeCommand(name, args?)
+
+Invoke a registered extension command programmatically. Returns `false` if the command is not found.
+
+This is useful from shortcut handlers, where you want to reuse command logic that requires `ExtensionCommandContext` methods (`switchSession`, `newSession`, `fork`, `reload`, etc.).
+
+```typescript
+pi.registerCommand("switch-workspace", {
+  description: "Switch to a workspace session",
+  handler: async (args, ctx) => {
+    await ctx.waitForIdle();
+    await ctx.switchSession(args);
+  },
+});
+
+pi.registerShortcut("ctrl+shift+w", {
+  description: "Switch workspace",
+  handler: async () => {
+    const ok = await pi.invokeCommand("switch-workspace", "/path/to/session.jsonl");
+    if (!ok) throw new Error("switch-workspace command is not registered");
+  },
+});
+```
+
 ### pi.appendEntry(customType, data?)
 
 Persist extension state (does NOT participate in LLM context).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -845,15 +845,10 @@ export class AgentSession {
 	}
 
 	/**
-	 * Try to execute an extension command. Returns true if command was found and executed.
+	 * Execute an extension command by name. Returns true if command was found and executed.
 	 */
-	private async _tryExecuteExtensionCommand(text: string): Promise<boolean> {
+	private async _executeExtensionCommand(commandName: string, args: string): Promise<boolean> {
 		if (!this._extensionRunner) return false;
-
-		// Parse command name and args
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
 
 		const command = this._extensionRunner.getCommand(commandName);
 		if (!command) return false;
@@ -873,6 +868,17 @@ export class AgentSession {
 			});
 			return true;
 		}
+	}
+
+	/**
+	 * Try to execute an extension command from slash-command text.
+	 */
+	private async _tryExecuteExtensionCommand(text: string): Promise<boolean> {
+		// Parse command name and args
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+		return this._executeExtensionCommand(commandName, args);
 	}
 
 	/**
@@ -1908,6 +1914,7 @@ export class AgentSession {
 						});
 					});
 				},
+				invokeCommand: async (name, args) => this._executeExtensionCommand(name, args ?? ""),
 				appendEntry: (customType, data) => {
 					this.sessionManager.appendCustomEntry(customType, data);
 				},

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -112,6 +112,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 	return {
 		sendMessage: notInitialized,
 		sendUserMessage: notInitialized,
+		invokeCommand: () => Promise.reject(new Error("Extension runtime not initialized")),
 		appendEntry: notInitialized,
 		setSessionName: notInitialized,
 		getSessionName: notInitialized,
@@ -195,6 +196,10 @@ function createExtensionAPI(
 
 		sendUserMessage(content, options): void {
 			runtime.sendUserMessage(content, options);
+		},
+
+		invokeCommand(name: string, args?: string): Promise<boolean> {
+			return runtime.invokeCommand(name, args);
 		},
 
 		appendEntry(customType: string, data?: unknown): void {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -237,6 +237,7 @@ export class ExtensionRunner {
 		// Copy actions into the shared runtime (all extension APIs reference this)
 		this.runtime.sendMessage = actions.sendMessage;
 		this.runtime.sendUserMessage = actions.sendUserMessage;
+		this.runtime.invokeCommand = actions.invokeCommand;
 		this.runtime.appendEntry = actions.appendEntry;
 		this.runtime.setSessionName = actions.setSessionName;
 		this.runtime.getSessionName = actions.getSessionName;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1015,6 +1015,9 @@ export interface ExtensionAPI {
 		options?: { deliverAs?: "steer" | "followUp" },
 	): void;
 
+	/** Invoke a registered extension command by name. Returns false if command does not exist. */
+	invokeCommand(name: string, args?: string): Promise<boolean>;
+
 	/** Append a custom entry to the session for state persistence (not sent to LLM). */
 	appendEntry<T = unknown>(customType: string, data?: T): void;
 
@@ -1214,6 +1217,8 @@ export type SendUserMessageHandler = (
 	options?: { deliverAs?: "steer" | "followUp" },
 ) => void;
 
+export type InvokeCommandHandler = (name: string, args?: string) => Promise<boolean>;
+
 export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
 
 export type SetSessionNameHandler = (name: string) => void;
@@ -1256,6 +1261,7 @@ export interface ExtensionRuntimeState {
 export interface ExtensionActions {
 	sendMessage: SendMessageHandler;
 	sendUserMessage: SendUserMessageHandler;
+	invokeCommand: InvokeCommandHandler;
 	appendEntry: AppendEntryHandler;
 	setSessionName: SetSessionNameHandler;
 	getSessionName: GetSessionNameHandler;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -26,6 +26,7 @@ describe("ExtensionRunner", () => {
 		sessionManager = SessionManager.inMemory();
 		const authStorage = AuthStorage.create(path.join(tempDir, "auth.json"));
 		modelRegistry = new ModelRegistry(authStorage);
+		delete (globalThis as any).invokeResult;
 	});
 
 	afterEach(() => {
@@ -343,6 +344,132 @@ describe("ExtensionRunner", () => {
 
 			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("conflicts with built-in command"));
 			warnSpy.mockRestore();
+		});
+	});
+
+	describe("invokeCommand API", () => {
+		it("lets shortcuts invoke commands with command-context session controls", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.registerCommand("switch-cmd", {
+						handler: async (_args, ctx) => {
+							await ctx.switchSession("/tmp/next-session.jsonl");
+						},
+					});
+					pi.registerShortcut("ctrl+shift+w", {
+						handler: async () => {
+							await pi.invokeCommand("switch-cmd", "");
+						},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "invoke.ts"), extCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			const switchSessionSpy = vi.fn(async () => ({ cancelled: false }));
+
+			runner.bindCommandContext({
+				waitForIdle: async () => {},
+				newSession: async () => ({ cancelled: false }),
+				fork: async () => ({ cancelled: false }),
+				navigateTree: async () => ({ cancelled: false }),
+				switchSession: switchSessionSpy,
+				reload: async () => {},
+			});
+
+			runner.bindCore(
+				{
+					sendMessage: () => {},
+					sendUserMessage: () => {},
+					invokeCommand: async (name, args) => {
+						const command = runner.getCommand(name);
+						if (!command) return false;
+						await command.handler(args ?? "", runner.createCommandContext());
+						return true;
+					},
+					appendEntry: () => {},
+					setSessionName: () => {},
+					getSessionName: () => undefined,
+					setLabel: () => {},
+					getActiveTools: () => [],
+					getAllTools: () => [],
+					setActiveTools: () => {},
+					getCommands: () => [],
+					setModel: async () => true,
+					getThinkingLevel: () => "off",
+					setThinkingLevel: () => {},
+				},
+				{
+					getModel: () => undefined,
+					isIdle: () => true,
+					abort: () => {},
+					hasPendingMessages: () => false,
+					shutdown: () => {},
+					getContextUsage: () => undefined,
+					compact: () => {},
+					getSystemPrompt: () => "",
+				},
+			);
+
+			const shortcuts = runner.getShortcuts(DEFAULT_KEYBINDINGS);
+			const shortcut = shortcuts.get("ctrl+shift+w");
+			expect(shortcut).toBeDefined();
+			await shortcut!.handler(runner.createContext());
+
+			expect(switchSessionSpy).toHaveBeenCalledWith("/tmp/next-session.jsonl");
+		});
+
+		it("returns false when invoking a missing command", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.registerShortcut("ctrl+shift+w", {
+						handler: async () => {
+							globalThis.invokeResult = await pi.invokeCommand("missing-cmd", "args");
+						},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "invoke-missing.ts"), extCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			runner.bindCore(
+				{
+					sendMessage: () => {},
+					sendUserMessage: () => {},
+					invokeCommand: async (name) => !!runner.getCommand(name),
+					appendEntry: () => {},
+					setSessionName: () => {},
+					getSessionName: () => undefined,
+					setLabel: () => {},
+					getActiveTools: () => [],
+					getAllTools: () => [],
+					setActiveTools: () => {},
+					getCommands: () => [],
+					setModel: async () => true,
+					getThinkingLevel: () => "off",
+					setThinkingLevel: () => {},
+				},
+				{
+					getModel: () => undefined,
+					isIdle: () => true,
+					abort: () => {},
+					hasPendingMessages: () => false,
+					shutdown: () => {},
+					getContextUsage: () => undefined,
+					compact: () => {},
+					getSystemPrompt: () => "",
+				},
+			);
+
+			const shortcuts = runner.getShortcuts(DEFAULT_KEYBINDINGS);
+			const shortcut = shortcuts.get("ctrl+shift+w");
+			expect(shortcut).toBeDefined();
+			await shortcut!.handler(runner.createContext());
+
+			expect((globalThis as any).invokeResult).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- add `pi.invokeCommand(name, args?)` to the extension API
- wire runtime/runner plumbing so command invocation executes with `ExtensionCommandContext`
- document the new API in `docs/extensions.md`
- add tests for shortcut -> invokeCommand -> command session-control flow and missing command behavior

## Why
Shortcut handlers currently receive `ExtensionContext`, which does not expose session control methods like `switchSession`/`newSession`. This API lets shortcuts reuse command handlers (which do run with `ExtensionCommandContext`) without prompt-parser hacks.

## Verification
- npm --workspace @mariozechner/pi-coding-agent run build
- npm --workspace @mariozechner/pi-coding-agent test -- test/extensions-runner.test.ts test/extensions-discovery.test.ts
