### PR TITLE
fix(coding-agent): refresh extension tools after session_start

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed extension tools registered asynchronously during `session_start` not being propagated to the agent tool set, which could lead to `Tool not found` errors at runtime.
+
 ## [0.55.1] - 2026-02-26
 
 ### New Features

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1782,6 +1782,7 @@ export class AgentSession {
 			this._applyExtensionBindings(this._extensionRunner);
 			await this._extensionRunner.emit({ type: "session_start" });
 			await this.extendResourcesFromExtensions("startup");
+			this._refreshExtensionTools();
 		}
 	}
 
@@ -1958,6 +1959,40 @@ export class AgentSession {
 		);
 	}
 
+	private _refreshExtensionTools(): void {
+		if (!this._extensionRunner) {
+			return;
+		}
+
+		const registeredTools = this._extensionRunner.getAllRegisteredTools();
+		const allCustomTools = [
+			...registeredTools,
+			...this._customTools.map((def) => ({ definition: def, extensionPath: "<sdk>" })),
+		];
+		const wrappedExtensionTools = wrapRegisteredTools(allCustomTools, this._extensionRunner);
+
+		const toolRegistry = new Map(this._baseToolRegistry);
+		for (const tool of wrappedExtensionTools as AgentTool[]) {
+			toolRegistry.set(tool.name, tool);
+		}
+
+		const currentActiveToolNames = this.getActiveToolNames();
+		const extensionToolNames = new Set(wrappedExtensionTools.map((tool) => tool.name));
+		const activeBaseTools = currentActiveToolNames
+			.filter((name) => this._baseToolRegistry.has(name) && !extensionToolNames.has(name))
+			.map((name) => this._baseToolRegistry.get(name) as AgentTool);
+		const activeToolsArray: AgentTool[] = [...activeBaseTools, ...(wrappedExtensionTools as AgentTool[])];
+
+		const wrappedActiveTools = wrapToolsWithExtensions(activeToolsArray, this._extensionRunner);
+		this.agent.setTools(wrappedActiveTools as AgentTool[]);
+
+		const wrappedAllTools = wrapToolsWithExtensions(Array.from(toolRegistry.values()), this._extensionRunner);
+		this._toolRegistry = new Map(wrappedAllTools.map((tool) => [tool.name, tool]));
+
+		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+		this.agent.setSystemPrompt(this._baseSystemPrompt);
+	}
+
 	private _buildRuntime(options: {
 		activeToolNames?: string[];
 		flagValues?: Map<string, boolean | string>;
@@ -2069,6 +2104,7 @@ export class AgentSession {
 		if (this._extensionRunner && hasBindings) {
 			await this._extensionRunner.emit({ type: "session_start" });
 			await this.extendResourcesFromExtensions("reload");
+			this._refreshExtensionTools();
 		}
 	}
 

--- a/packages/coding-agent/test/agent-session-extension-tools.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-tools.test.ts
@@ -1,0 +1,115 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@mariozechner/pi-agent-core";
+import { getModel } from "@mariozechner/pi-ai";
+import { Type } from "@sinclair/typebox";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { createExtensionRuntime } from "../src/core/extensions/loader.js";
+import type { Extension } from "../src/core/extensions/types.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import type { ResourceLoader } from "../src/core/resource-loader.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+
+describe("AgentSession extension tool refresh", () => {
+	let tempDir: string;
+	let session: AgentSession | undefined;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-extension-tools-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (session) {
+			session.dispose();
+		}
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("includes tools registered asynchronously during session_start", async () => {
+		const asyncToolName = "async_extension_tool";
+
+		const extension: Extension = {
+			path: "<test-extension>",
+			resolvedPath: "<test-extension>",
+			handlers: new Map(),
+			tools: new Map(),
+			messageRenderers: new Map(),
+			commands: new Map(),
+			flags: new Map(),
+			shortcuts: new Map(),
+		};
+
+		extension.handlers.set("session_start", [
+			async () => {
+				await Promise.resolve();
+				extension.tools.set(asyncToolName, {
+					definition: {
+						name: asyncToolName,
+						label: "Async Extension Tool",
+						description: "Tool registered after async setup",
+						parameters: Type.Object({}),
+						execute: async () => ({
+							content: [{ type: "text", text: "ok" }],
+							details: {},
+						}),
+					},
+					extensionPath: extension.path,
+				});
+			},
+		]);
+
+		const resourceLoader: ResourceLoader = {
+			getExtensions: () => ({
+				extensions: [extension],
+				errors: [],
+				runtime: createExtensionRuntime(),
+			}),
+			getSkills: () => ({ skills: [], diagnostics: [] }),
+			getPrompts: () => ({ prompts: [], diagnostics: [] }),
+			getThemes: () => ({ themes: [], diagnostics: [] }),
+			getAgentsFiles: () => ({ agentsFiles: [] }),
+			getSystemPrompt: () => undefined,
+			getAppendSystemPrompt: () => [],
+			getPathMetadata: () => new Map(),
+			extendResources: () => {},
+			reload: async () => {},
+		};
+
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: "Test",
+				tools: [],
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader,
+		});
+
+		await session.bindExtensions({});
+
+		expect(session.getAllTools().map((tool) => tool.name)).toContain(asyncToolName);
+		expect(session.getActiveToolNames()).toContain(asyncToolName);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes extension tools registered asynchronously during `session_start` not being propagated to the agent tool set.

This was observed with MCP-style startup flows (e.g. bridge connects asynchronously, then calls `pi.registerTool(...)`), where tools appeared in extension state (`/mcp`) but LLM tool calls failed with `Tool not found`.

## Root cause

`AgentSession` initialized tools in `_buildRuntime()` before `session_start`:

1. `_buildRuntime()` creates `ExtensionRunner` and snapshots tools via `getAllRegisteredTools()`
2. `session_start` runs later
3. async `registerTool()` during `session_start` updates extension maps
4. agent/runtime tool set is not refreshed after startup event completion

So extension registration state and agent-exposed tool state could diverge.

## Changes

- Added `AgentSession._refreshExtensionTools()` to resync tools without rebuilding `ExtensionRunner`
  - re-collect extension + SDK custom tools
  - preserve active base tools
  - refresh `agent.setTools(...)`
  - refresh internal `_toolRegistry`
  - rebuild base system prompt from active tools
- Call `_refreshExtensionTools()` after startup/reload `session_start` processing:
  - `bindExtensions()`
  - `reload()`

## Tests

- Added regression test: `packages/coding-agent/test/agent-session-extension-tools.test.ts`
  - extension registers a tool after an async boundary in `session_start`
  - verifies tool visibility in both `getAllTools()` and active tools after `bindExtensions()`

## Changelog

- Added `Unreleased` fix entry in `packages/coding-agent/CHANGELOG.md`

## Validation

- `npm run check`
- Manual repro command (before/after):
  - `./pi-test.sh --print --no-session -e /tmp/async-tool-repro-status.js "/repro-status"`
  - before: `registeredInSessionStart=true`, `visibleInAllTools=false`, `visibleInActiveTools=false`
  - after: `registeredInSessionStart=true`, `visibleInAllTools=true`, `visibleInActiveTools=true`
