### PR TITLE
fix: allow Vertex AI to use GCP Metadata Server for Application Default Credentials

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -39,10 +39,11 @@ function hasVertexAdcCredentials(): boolean {
 		if (gacPath) {
 			cachedVertexAdcCredentialsExists = _existsSync(gacPath);
 		} else {
-			// Fall back to default ADC path (lazy evaluation)
-			cachedVertexAdcCredentialsExists = _existsSync(
-				_join(_homedir(), ".config", "gcloud", "application_default_credentials.json"),
-			);
+			// If not explicitly set, the environment might be a GCP runtime (GCE, Cloud Run, GKE)
+			// relying on the Metadata Server. Because we cannot synchronously check the Metadata
+			// Server here, we return true to delegate the actual auth resolution and error handling 
+			// to the official Google Cloud SDK under the hood.
+			cachedVertexAdcCredentialsExists = true;
 		}
 	}
 	return cachedVertexAdcCredentialsExists;


### PR DESCRIPTION
## Problem
Currently, `hasVertexAdcCredentials()` synchronously checks the filesystem for Application Default Credentials (ADC) files using `fs.existsSync()`. This logic completely breaks deployments on native Google Cloud environments (Google Compute Engine, Cloud Run, GKE, App Engine). In these environments, ADC does not use local files; it relies dynamically on the local GCP Metadata Server (`169.254.169.254`). Because the local `~/.config/` file is missing, the check fails, and the `google-vertex` provider is incorrectly marked as unauthenticated.

## Fix
It is an anti-pattern to reimplement Google's ADC resolution synchronously in user-land because checking the Metadata Server requires an asynchronous network request.

This PR updates the logic:

1. If `GOOGLE_APPLICATION_CREDENTIALS` is explicitly set, we still check if the file exists (catching explicit misconfigurations early).
2. If it is not set, we skip the strict `~/.config/...` file check and return true.

This safely delegates the final credential validation to the official `@google-cloud/vertexai SDK`. If a user is running locally and simply forgot to log in, the Google SDK will naturally throw its standard, descriptive auth error (`"Could not load the default credentials"`), which is the correct and expected behavior.