### PR TITLE
fix(ai): flush pending tool calls at end of transformMessages

### DIFF
--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -163,5 +163,23 @@ export function transformMessages<TApi extends Api>(
 		}
 	}
 
+	// Final flush: insert synthetic results for any tool calls still pending at end of array.
+	// This happens when a session is interrupted mid-tool-execution (timeout, crash, abort)
+	// and the conversation ends with an assistant message containing unresolved tool calls.
+	if (pendingToolCalls.length > 0) {
+		for (const tc of pendingToolCalls) {
+			if (!existingToolResultIds.has(tc.id)) {
+				result.push({
+					role: "toolResult",
+					toolCallId: tc.id,
+					toolName: tc.name,
+					content: [{ type: "text", text: "No result provided" }],
+					isError: true,
+					timestamp: Date.now(),
+				} as ToolResultMessage);
+			}
+		}
+	}
+
 	return result;
 }


### PR DESCRIPTION
## Summary

`transformMessages()` in `packages/ai/src/providers/transform-messages.ts` fails to insert synthetic `toolResult` entries for orphaned tool calls when the conversation **ends** with an assistant message containing unresolved tool calls.

## Problem

The function tracks `pendingToolCalls` from assistant messages and inserts synthetic `toolResult` entries when encountering a subsequent **user message** or **next assistant message**. However, if the conversation ends with an assistant message containing tool calls (e.g., session interrupted mid-tool-execution via timeout, crash, or abort), there is no final flush after the loop — those `tool_use` IDs never get matching `tool_result` blocks.

This causes Anthropic API to reject the request with:
```
tool_use ids were found without tool_result blocks immediately after: <id>
```

Once this happens, the session is permanently stuck — every subsequent request fails with the same error because the corrupted history is replayed each time.

## Fix

Add the same orphan-flush logic after the for-loop ends, consistent with the two existing flush sites (at user-message and next-assistant boundaries). One-line diff, zero behavioral change for well-formed transcripts.