### PR TITLE
fix(tui): render list tokens inside blockquotes

### DIFF
--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -408,6 +408,19 @@ export class Markdown implements Component {
 					result += this.renderInlineTokens(token.tokens || [], resolvedStyleContext);
 					break;
 
+				case "list":
+					// List tokens inside blockquotes — delegate to block renderer,
+					// then apply quote styling to each rendered line
+					result += this.renderList(token as any, 0)
+						.map((line) => applyText(line))
+						.join("\n");
+					break;
+
+				case "space":
+					// Blank line between block elements inside a blockquote
+					result += "\n";
+					break;
+
 				case "strong": {
 					const boldContent = this.renderInlineTokens(token.tokens || [], resolvedStyleContext);
 					result += this.theme.bold(boldContent) + stylePrefix;

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -814,6 +814,75 @@ bar`,
 			assert.ok(!allOutput.includes("\x1b[33m"), "Should NOT have yellow color from default style");
 		});
 
+		it("should render list items inside blockquotes", () => {
+			const markdown = new Markdown(
+				`> - first item\n> - second item\n> - third item`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80);
+			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+
+			// All non-empty content lines must have the quote border
+			const contentLines = plainLines.filter((line) => line.length > 0);
+			assert.ok(contentLines.length > 0, "Should produce content lines");
+			for (const line of contentLines) {
+				assert.ok(line.startsWith("│ "), `Expected quote border on: "${line}"`);
+			}
+
+			// All list items must be present
+			const allPlain = plainLines.join("\n");
+			assert.ok(allPlain.includes("first item"), "Should render first item");
+			assert.ok(allPlain.includes("second item"), "Should render second item");
+			assert.ok(allPlain.includes("third item"), "Should render third item");
+		});
+
+		it("should render ordered list items inside blockquotes", () => {
+			const markdown = new Markdown(
+				`> 1. first\n> 2. second`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80);
+			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const contentLines = plainLines.filter((line) => line.length > 0);
+
+			assert.ok(contentLines.length > 0, "Should produce content lines");
+			for (const line of contentLines) {
+				assert.ok(line.startsWith("│ "), `Expected quote border on: "${line}"`);
+			}
+			const allPlain = plainLines.join("\n");
+			assert.ok(allPlain.includes("first"), "Should render first item");
+			assert.ok(allPlain.includes("second"), "Should render second item");
+		});
+
+		it("should preserve separation between paragraph and list inside blockquote", () => {
+			const markdown = new Markdown(
+				`> intro\n>\n> - item one\n> - item two`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80);
+			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const allPlain = plainLines.join("\n");
+
+			assert.ok(allPlain.includes("intro"), "Should render intro paragraph");
+			assert.ok(allPlain.includes("item one"), "Should render item one");
+			assert.ok(allPlain.includes("item two"), "Should render item two");
+
+			// intro and item one must be on separate lines
+			const introIdx = plainLines.findIndex((l) => l.includes("intro"));
+			const itemIdx = plainLines.findIndex((l) => l.includes("item one"));
+			assert.ok(introIdx !== -1 && itemIdx !== -1, "Both intro and item one must exist");
+			assert.ok(introIdx < itemIdx, "intro should come before item one");
+		});
+
 		it("should render inline formatting inside blockquotes and reapply quote styling after", () => {
 			const markdown = new Markdown("> Quote with **bold** and `code`", 0, 0, defaultMarkdownTheme);
 


### PR DESCRIPTION
## Problem

When a blockquote contains a list (`> - item`), the marked tokenizer produces a block-level `list` token inside the blockquote's token array. `renderInlineTokens()` had no `case` for `list`, so the content was silently dropped — leaving only the `│` border with nothing after it.

This is related to #1073 (which fixed `paragraph` tokens in blockquotes) but `list` tokens were not covered.

## Reproduction

```markdown
> - first item
> - second item
```

Renders as just `│` with no content.

## Fix

- Add `case "list"` in `renderInlineTokens()` that delegates to `renderList()` and applies the active quote style (`theme.quote`) to each rendered line
- Add `case "space"` to preserve blank-line separation between a paragraph and a following list inside the same blockquote

## Tests

Added three regression cases to `markdown.test.ts`:
- unordered list inside blockquote
- ordered list inside blockquote
- paragraph + blank line + list (separation preserved)

All 404 tests pass.