### PR TITLE
fix(coding-agent): allow custom model names in model selector

### DIFF
--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -43,6 +43,14 @@ export interface ScopedModel {
 }
 
 /**
+ * Get the display name for a model.
+ * Uses the model's name field if available, falls back to id.
+ */
+export function getModelDisplayName(model: Model<Api>): string {
+	return model.name || model.id;
+}
+
+/**
  * Helper to check if a model ID looks like an alias (no date suffix)
  * Dates are typically in format: -20241022 or -20250929
  */

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -10,6 +10,7 @@ import {
 	type TUI,
 } from "@mariozechner/pi-tui";
 import type { ModelRegistry } from "../../../core/model-registry.js";
+import { getModelDisplayName } from "../../../core/model-resolver.js";
 import type { SettingsManager } from "../../../core/settings-manager.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
@@ -236,15 +237,16 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			const isSelected = i === this.selectedIndex;
 			const isCurrent = modelsAreEqual(this.currentModel, item.model);
 
+			const displayName = getModelDisplayName(item.model);
 			let line = "";
 			if (isSelected) {
 				const prefix = theme.fg("accent", "→ ");
-				const modelText = `${item.id}`;
+				const modelText = `${displayName}`;
 				const providerBadge = theme.fg("muted", `[${item.provider}]`);
 				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
 				line = `${prefix + theme.fg("accent", modelText)} ${providerBadge}${checkmark}`;
 			} else {
-				const modelText = `  ${item.id}`;
+				const modelText = `  ${displayName}`;
 				const providerBadge = theme.fg("muted", `[${item.provider}]`);
 				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
 				line = `${modelText} ${providerBadge}${checkmark}`;

--- a/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
@@ -10,6 +10,7 @@ import {
 	Spacer,
 	Text,
 } from "@mariozechner/pi-tui";
+import { getModelDisplayName } from "../../../core/model-resolver.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 
@@ -203,7 +204,8 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 			const item = this.filteredItems[i]!;
 			const isSelected = i === this.selectedIndex;
 			const prefix = isSelected ? theme.fg("accent", "→ ") : "  ";
-			const modelText = isSelected ? theme.fg("accent", item.model.id) : item.model.id;
+			const displayName = getModelDisplayName(item.model);
+			const modelText = isSelected ? theme.fg("accent", displayName) : displayName;
 			const providerBadge = theme.fg("muted", ` [${item.model.provider}]`);
 			const status = allEnabled ? "" : item.enabled ? theme.fg("success", " ✓") : theme.fg("dim", " ✗");
 			this.listContainer.addChild(new Text(`${prefix}${modelText}${providerBadge}${status}`, 0, 0));

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
 	defaultModelPerProvider,
 	findInitialModel,
+	getModelDisplayName,
 	parseModelPattern,
 	resolveCliModel,
 } from "../src/core/model-resolver.js";
@@ -386,5 +387,18 @@ describe("default model selection", () => {
 
 		expect(result.model?.provider).toBe("vercel-ai-gateway");
 		expect(result.model?.id).toBe("anthropic/claude-opus-4-6");
+	});
+});
+
+describe("getModelDisplayName", () => {
+	test("uses name field when available", () => {
+		const model = mockModels[0]; // claude-sonnet-4-5 with name "Claude Sonnet 4.5"
+		expect(getModelDisplayName(model)).toBe("Claude Sonnet 4.5");
+	});
+
+	test("falls back to id when name is missing", () => {
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const { name: _name, ...modelWithoutName } = mockModels[0];
+		expect(getModelDisplayName(modelWithoutName as (typeof mockModels)[0])).toBe("claude-sonnet-4-5");
 	});
 });


### PR DESCRIPTION
EDIT: I see where the original model name is shown now. Totally missed it before... oops!

> NOTE: Relevant discussion [here](https://github.com/badlogic/pi-mono/discussions/1663). I read the contribution guidelines for newcomes after putting together the pull request. I am leaving the pull request here, as I believe it meets expectations.

This pull request fixes custom model names not working in the model selectors (both of them: scoped and non-scoped). Now, the value will work as the [existing docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/models.md#full-example) imply that they should.

- Extracted model name display logic into own function: `getModelDisplayName()`
  - This was done to make the feature testable, in order to prevent regressions from re-occurring in the future.

- Updated both model selectors (scoped and non-scoped) to use the new function.

- Added a couple regression tests.

Final result: Shows the model name (e.g. "Kimi K2.5") in the model selectors instead of the ID (e.g. "k2p5") when the "name" field is set.