### PR TITLE
fix(codex): add HTTP proxy support for openai-codex-responses provider

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -6,6 +6,20 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
 	});
 }
 
+// Proxy support: Node.js fetch() does not respect HTTP_PROXY/HTTPS_PROXY env vars.
+// We lazily create an undici EnvHttpProxyAgent when proxy env vars are present.
+let _proxyReady: Promise<void> | null = null;
+let _proxyDispatcher: import("undici").Dispatcher | null = null;
+if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
+	_proxyReady = import("undici")
+		.then((m) => {
+			if (process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.ALL_PROXY) {
+				_proxyDispatcher = new m.EnvHttpProxyAgent();
+			}
+		})
+		.catch(() => {});
+}
+
 import type { Tool as OpenAITool, ResponseInput, ResponseStreamEvent } from "openai/resources/responses/responses.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { supportsXhigh } from "../models.js";
@@ -181,12 +195,15 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				}
 
 				try {
+					// Ensure proxy dispatcher is initialized before first network call
+					if (_proxyReady) await _proxyReady;
 					response = await fetch(resolveCodexUrl(model.baseUrl), {
 						method: "POST",
 						headers,
 						body: bodyJson,
 						signal: options?.signal,
-					});
+						...(_proxyDispatcher ? { dispatcher: _proxyDispatcher } : {}),
+					} as RequestInit);
 
 					if (response.ok) {
 						break;


### PR DESCRIPTION
## Problem

The `openai-codex-responses` provider uses bare `fetch()` to call `https://chatgpt.com/backend-api/codex/responses`. However, Node.js native `fetch()` does **not** respect `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` environment variables.

This causes persistent `fetch failed` errors when running behind:
- Corporate firewalls/proxies
- VPNs that route traffic through a local SOCKS/HTTP proxy
- Regions with network restrictions (e.g., China/GFW where `chatgpt.com` DNS is poisoned)

### Reproduction

1. Set `HTTPS_PROXY=http://127.0.0.1:7890` (or any proxy)
2. Configure `openai-codex` as the model provider
3. Send any message → all requests fail with `fetch failed`

The same `fetch()` call succeeds when an `undici.EnvHttpProxyAgent` is passed as `dispatcher`.

## Fix

Lazily initialize an `undici.EnvHttpProxyAgent` when proxy env vars are detected, and pass it as a `dispatcher` option to `fetch()`.

```typescript
// Lazy init (module scope)
let _proxyReady: Promise<void> | null = null;
let _proxyDispatcher: import("undici").Dispatcher | null = null;
if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
    _proxyReady = import("undici")
        .then((m) => {
            if (process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.ALL_PROXY) {
                _proxyDispatcher = new m.EnvHttpProxyAgent();
            }
        })
        .catch(() => {});
}

// Before fetch
if (_proxyReady) await _proxyReady;
response = await fetch(url, {
    ...opts,
    ...(_proxyDispatcher ? { dispatcher: _proxyDispatcher } : {}),
} as RequestInit);
```

### Design decisions

- **Dynamic import** (`import("undici")`) — follows the existing pattern for `import("node:os")` in the same file; doesn't break browser/Vite builds
- **Lazy await** — `_proxyReady` is awaited before the first fetch, eliminating race conditions. Subsequent calls are zero-cost (Promise already resolved)
- **No-op without proxy** — when no proxy env vars are set, `_proxyDispatcher` remains `null` and fetch behavior is unchanged
- **`as RequestInit` cast** — `dispatcher` is an undici extension not in the standard `RequestInit` type

## Note

The existing `utils/http-proxy.js` module sets a global dispatcher via `setGlobalDispatcher()`, but it's loaded asynchronously and not guaranteed to complete before the first `openai-codex-responses` fetch. This per-request dispatcher approach is more reliable.

## Test plan

- [x] Verified in production: OpenClaw gateway with `HTTPS_PROXY` set, `openai-codex/gpt-5.3-codex` model responds correctly after patch
- [x] Verified without proxy env vars: no behavioral change (dispatcher is null, fetch is unmodified)