### PR TITLE
fix(ai): handle redacted_thinking in adaptive thinking path

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -506,6 +506,7 @@ export class Agent {
 				const onlyEmpty = !partial.content.some(
 					(c) =>
 						(c.type === "thinking" && c.thinking.trim().length > 0) ||
+						(c.type === "redactedThinking" && c.data.trim().length > 0) ||
 						(c.type === "text" && c.text.trim().length > 0) ||
 						(c.type === "toolCall" && c.name.trim().length > 0),
 				);

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `redacted_thinking` blocks being silently dropped — they are now captured during streaming, preserved in `AssistantMessage.content` as `redactedThinking`, passed back to the API in multi-turn/tool-use conversations, and handled correctly in cross-model message transformation.
+- Fixed `interleaved-thinking-2025-05-14` beta header being sent for Opus 4.6 and Sonnet 4.6, where interleaved thinking is automatic with adaptive thinking and the header is deprecated on Opus 4.6.
+- Fixed temperature being sent alongside extended thinking, which is incompatible with both adaptive and budget-based thinking modes.
+
 ## [0.55.1] - 2026-02-26
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -14,6 +14,7 @@ import type {
 	ImageContent,
 	Message,
 	Model,
+	RedactedThinkingContent,
 	SimpleStreamOptions,
 	StopReason,
 	StreamFunction,
@@ -240,7 +241,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			const anthropicStream = client.messages.stream({ ...params, stream: true }, { signal: options?.signal });
 			stream.push({ type: "start", partial: output });
 
-			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
+			type Block = (
+				| ThinkingContent
+				| RedactedThinkingContent
+				| TextContent
+				| (ToolCall & { partialJson: string })
+			) & {
+				index: number;
+			};
 			const blocks = output.content as Block[];
 
 			for await (const event of anthropicStream) {
@@ -269,6 +277,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 							type: "thinking",
 							thinking: "",
 							thinkingSignature: "",
+							index: event.index,
+						};
+						output.content.push(block);
+						stream.push({ type: "thinking_start", contentIndex: output.content.length - 1, partial: output });
+					} else if (event.content_block.type === "redacted_thinking") {
+						const block: Block = {
+							type: "redactedThinking",
+							data: event.content_block.data,
 							index: event.index,
 						};
 						output.content.push(block);
@@ -350,6 +366,13 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 								type: "thinking_end",
 								contentIndex: index,
 								content: block.thinking,
+								partial: output,
+							});
+						} else if (block.type === "redactedThinking") {
+							stream.push({
+								type: "thinking_end",
+								contentIndex: index,
+								content: "",
 								partial: output,
 							});
 						} else if (block.type === "toolCall") {
@@ -496,10 +519,15 @@ function createClient(
 	optionsHeaders?: Record<string, string>,
 	dynamicHeaders?: Record<string, string>,
 ): { client: Anthropic; isOAuthToken: boolean } {
+	// Adaptive thinking models (Opus 4.6, Sonnet 4.6) have interleaved thinking built-in.
+	// The beta header is deprecated on Opus 4.6 and redundant on Sonnet 4.6 with adaptive
+	// thinking, so skip it for all adaptive-thinking-capable models.
+	const needsInterleavedBeta = interleavedThinking && !supportsAdaptiveThinking(model.id);
+
 	// Copilot: Bearer auth, selective betas (no fine-grained-tool-streaming)
 	if (model.provider === "github-copilot") {
 		const betaFeatures: string[] = [];
-		if (interleavedThinking) {
+		if (needsInterleavedBeta) {
 			betaFeatures.push("interleaved-thinking-2025-05-14");
 		}
 
@@ -524,7 +552,7 @@ function createClient(
 	}
 
 	const betaFeatures = ["fine-grained-tool-streaming-2025-05-14"];
-	if (interleavedThinking) {
+	if (needsInterleavedBeta) {
 		betaFeatures.push("interleaved-thinking-2025-05-14");
 	}
 
@@ -611,7 +639,8 @@ function buildParams(
 		];
 	}
 
-	if (options?.temperature !== undefined) {
+	// Temperature is incompatible with extended thinking (adaptive or budget-based).
+	if (options?.temperature !== undefined && !options?.thinkingEnabled) {
 		params.temperature = options.temperature;
 	}
 
@@ -739,6 +768,11 @@ function convertMessages(
 							signature: block.thinkingSignature,
 						});
 					}
+				} else if (block.type === "redactedThinking") {
+					blocks.push({
+						type: "redacted_thinking",
+						data: block.data,
+					});
 				} else if (block.type === "toolCall") {
 					blocks.push({
 						type: "tool_use",

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -38,6 +38,13 @@ export function transformMessages<TApi extends Api>(
 				assistantMsg.model === model.id;
 
 			const transformedContent = assistantMsg.content.flatMap((block) => {
+				if (block.type === "redactedThinking") {
+					// Redacted thinking is opaque encrypted content — only valid for the same model.
+					// Drop it for cross-model to avoid API errors.
+					if (isSameModel) return block;
+					return [];
+				}
+
 				if (block.type === "thinking") {
 					// For same model: keep thinking blocks with signatures (needed for replay)
 					// even if the thinking text is empty (OpenAI encrypted reasoning)

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -130,6 +130,11 @@ export interface ThinkingContent {
 	thinkingSignature?: string; // e.g., for OpenAI responses, the reasoning item ID
 }
 
+export interface RedactedThinkingContent {
+	type: "redactedThinking";
+	data: string; // opaque encrypted payload, must be passed back to the API unmodified
+}
+
 export interface ImageContent {
 	type: "image";
 	data: string; // base64 encoded image data
@@ -169,7 +174,7 @@ export interface UserMessage {
 
 export interface AssistantMessage {
 	role: "assistant";
-	content: (TextContent | ThinkingContent | ToolCall)[];
+	content: (TextContent | ThinkingContent | RedactedThinkingContent | ToolCall)[];
 	api: Api;
 	provider: Provider;
 	model: string;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `redacted_thinking` blocks not being rendered in the TUI or HTML export — they now display as `[Reasoning encrypted for safety]` in thinking text style.
+
 ## [0.55.1] - 2026-02-26
 
 ### New Features

--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -1160,6 +1160,11 @@
                   <div class="thinking-text">${escapeHtml(block.thinking)}</div>
                   <div class="thinking-collapsed">Thinking ...</div>
                 </div>`;
+              } else if (block.type === 'redactedThinking') {
+                html += `<div class="thinking-block">
+                  <div class="thinking-text">[Reasoning encrypted for safety]</div>
+                  <div class="thinking-collapsed">Thinking ...</div>
+                </div>`;
               }
             }
 

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -48,7 +48,10 @@ export class AssistantMessageComponent extends Container {
 		this.contentContainer.clear();
 
 		const hasVisibleContent = message.content.some(
-			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
+			(c) =>
+				(c.type === "text" && c.text.trim()) ||
+				(c.type === "thinking" && c.thinking.trim()) ||
+				c.type === "redactedThinking",
 		);
 
 		if (hasVisibleContent) {
@@ -67,7 +70,12 @@ export class AssistantMessageComponent extends Container {
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
 				const hasVisibleContentAfter = message.content
 					.slice(i + 1)
-					.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
+					.some(
+						(c) =>
+							(c.type === "text" && c.text.trim()) ||
+							(c.type === "thinking" && c.thinking.trim()) ||
+							c.type === "redactedThinking",
+					);
 
 				if (this.hideThinkingBlock) {
 					// Show static "Thinking..." label when hidden
@@ -86,6 +94,21 @@ export class AssistantMessageComponent extends Container {
 					if (hasVisibleContentAfter) {
 						this.contentContainer.addChild(new Spacer(1));
 					}
+				}
+			} else if (content.type === "redactedThinking") {
+				const hasVisibleContentAfter = message.content
+					.slice(i + 1)
+					.some(
+						(c) =>
+							(c.type === "text" && c.text.trim()) ||
+							(c.type === "thinking" && c.thinking.trim()) ||
+							c.type === "redactedThinking",
+					);
+				this.contentContainer.addChild(
+					new Text(theme.italic(theme.fg("thinkingText", "[Reasoning encrypted for safety]")), 1, 0),
+				);
+				if (hasVisibleContentAfter) {
+					this.contentContainer.addChild(new Spacer(1));
 				}
 			}
 		}


### PR DESCRIPTION
fixes 3 issues in the adaptive thinking path for opus 4.6 / sonnet 4.6:

- handle `redacted_thinking` blocks end to end (streaming, message history, replay, tui, html export).
- only send `interleaved-thinking-2025-05-14` for non-adaptive models.
- do not send `temperature` when thinking is enabled.