### PR TITLE
fix(coding-agent): ignore SIGINT while process is suspended

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2607,8 +2607,14 @@ export class InteractiveMode {
 	}
 
 	private handleCtrlZ(): void {
+		// Ignore SIGINT while suspended so Ctrl+C in the terminal does not
+		// kill the backgrounded process. The handler is removed on resume.
+		const ignoreSigint = () => {};
+		process.on("SIGINT", ignoreSigint);
+
 		// Set up handler to restore TUI when resumed
 		process.once("SIGCONT", () => {
+			process.removeListener("SIGINT", ignoreSigint);
 			this.ui.start();
 			this.ui.requestRender(true);
 		});


### PR DESCRIPTION
When the user suspends pi with Ctrl+Z, pressing Ctrl+C in the terminal kills the backgrounded process because no SIGINT handler is active. This adds a no-op SIGINT handler before suspending and removes it on resume.

**Change:** `packages/coding-agent/src/modes/interactive/interactive-mode.ts` -- `handleCtrlZ()`

- Register a no-op `SIGINT` handler before sending `SIGTSTP`
- Remove it in the `SIGCONT` callback when the process resumes