### PR TITLE
feat(coding-agent): flush registerProvider immediately, add unregisterProvider

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `pi.unregisterProvider(name)` removes a dynamically registered provider and its models from the registry without requiring `/reload`. Built-in models that were overridden by the provider are restored.
+
+### Fixed
+
+- `pi.registerProvider()` now takes effect immediately when called after the initial extension load phase (e.g. from a command handler). Previously the registration sat in a pending queue that was never flushed until the next `/reload`.
+
 ## [0.55.1] - 2026-02-26
 
 ### New Features

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1161,6 +1161,8 @@ pi.events.emit("my:event", { ... });
 
 Register or override a model provider dynamically. Useful for proxies, custom endpoints, or team-wide model configurations.
 
+Calls made during the extension factory function are queued and applied once the runner initialises. Calls made after that — for example from a command handler following a user setup flow — take effect immediately without requiring a `/reload`.
+
 ```typescript
 // Register a new provider with custom models
 pi.registerProvider("my-proxy", {
@@ -1220,6 +1222,21 @@ pi.registerProvider("corporate-ai", {
 - `streamSimple` - Custom streaming implementation for non-standard APIs.
 
 See [custom-provider.md](custom-provider.md) for advanced topics: custom streaming APIs, OAuth details, model definition reference.
+
+### pi.unregisterProvider(name)
+
+Remove a previously registered provider and its models. Built-in models that were overridden by the provider are restored. Has no effect if the provider was not registered.
+
+Like `registerProvider`, this takes effect immediately when called after the initial load phase, so a `/reload` is not required.
+
+```typescript
+pi.registerCommand("my-setup-teardown", {
+  description: "Remove the custom proxy provider",
+  handler: async (_args, _ctx) => {
+    pi.unregisterProvider("my-proxy");
+  },
+});
+```
 
 ## State Management
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -259,11 +259,16 @@ export class ExtensionRunner {
 		this.compactFn = contextActions.compact;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
 
-		// Process provider registrations queued during extension loading
+		// Flush provider registrations queued during extension loading
 		for (const { name, config } of this.runtime.pendingProviderRegistrations) {
 			this.modelRegistry.registerProvider(name, config);
 		}
 		this.runtime.pendingProviderRegistrations = [];
+
+		// From this point on, provider registration/unregistration takes effect immediately
+		// without requiring a /reload.
+		this.runtime.registerProvider = (name, config) => this.modelRegistry.registerProvider(name, config);
+		this.runtime.unregisterProvider = (name) => this.modelRegistry.unregisterProvider(name);
 	}
 
 	bindCommandContext(actions?: ExtensionCommandContextActions): void {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1071,6 +1071,11 @@ export interface ExtensionAPI {
 	 * If `oauth` is provided: registers OAuth provider for /login support.
 	 * If `streamSimple` is provided: registers a custom API stream handler.
 	 *
+	 * During initial extension load this call is queued and applied once the
+	 * runner has bound its context. After that it takes effect immediately, so
+	 * it is safe to call from command handlers or event callbacks without
+	 * requiring a `/reload`.
+	 *
 	 * @example
 	 * // Register a new provider with custom models
 	 * pi.registerProvider("my-proxy", {
@@ -1111,6 +1116,21 @@ export interface ExtensionAPI {
 	 * });
 	 */
 	registerProvider(name: string, config: ProviderConfig): void;
+
+	/**
+	 * Unregister a previously registered provider.
+	 *
+	 * Removes all models belonging to the named provider and restores any
+	 * built-in models that were overridden by it. Has no effect if the provider
+	 * was not registered by this extension API.
+	 *
+	 * Like `registerProvider`, this takes effect immediately when called after
+	 * the initial load phase.
+	 *
+	 * @example
+	 * pi.unregisterProvider("my-proxy");
+	 */
+	unregisterProvider(name: string): void;
 
 	/** Shared event bus for extension communication. */
 	events: EventBus;
@@ -1247,6 +1267,14 @@ export interface ExtensionRuntimeState {
 	flagValues: Map<string, boolean | string>;
 	/** Provider registrations queued during extension loading, processed when runner binds */
 	pendingProviderRegistrations: Array<{ name: string; config: ProviderConfig }>;
+	/**
+	 * Register or unregister a provider.
+	 *
+	 * Before bindCore(): queues registrations / removes from queue.
+	 * After bindCore(): calls ModelRegistry directly for immediate effect.
+	 */
+	registerProvider: (name: string, config: ProviderConfig) => void;
+	unregisterProvider: (name: string) => void;
 }
 
 /**

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -540,6 +540,20 @@ export class ModelRegistry {
 		this.applyProviderConfig(providerName, config);
 	}
 
+	/**
+	 * Unregister a previously registered provider.
+	 *
+	 * Removes the provider from the registry and reloads models from disk so that
+	 * built-in models overridden by this provider are restored to their original state.
+	 * Has no effect if the provider was never registered.
+	 */
+	unregisterProvider(providerName: string): void {
+		if (!this.registeredProviders.has(providerName)) return;
+		this.registeredProviders.delete(providerName);
+		this.customProviderApiKeys.delete(providerName);
+		this.refresh();
+	}
+
 	private applyProviderConfig(providerName: string, config: ProviderConfigInput): void {
 		// Register OAuth provider if provided
 		if (config.oauth) {


### PR DESCRIPTION
## Problem

`pi.registerProvider()` pushed to a `pendingProviderRegistrations` queue that was only flushed once during `bindCore()` at startup. Any call after that (e.g. from a command handler following a setup flow) sat dead in the queue until the next `/reload`.

## Changes

**`model-registry.ts`** — Added `ModelRegistry.unregisterProvider(name)`: removes the provider from `registeredProviders`, clears its API key, then calls `refresh()` so built-in models that were overridden are restored.

**`extensions/types.ts`** — Added `registerProvider` and `unregisterProvider` fields to `ExtensionRuntimeState` so the runner can swap them out after bind. Added `pi.unregisterProvider()` to `ExtensionAPI`.

**`extensions/loader.ts`** — `createExtensionRuntime()` initialises `registerProvider` as a queue-push closure and `unregisterProvider` as a queue-removal closure. `createExtensionAPI` delegates both to the runtime instead of touching the queue directly.

**`extensions/runner.ts`** — In `bindCore()`, after flushing the pending queue, both functions are replaced with direct `ModelRegistry` calls. From that point every `pi.registerProvider()` / `pi.unregisterProvider()` call takes effect immediately.

**`docs/extensions.md`** — Updated `pi.registerProvider` section to document the immediate-flush behaviour; added `pi.unregisterProvider` section with example.

**`CHANGELOG.md`** — Added `Added` and `Fixed` entries under `[Unreleased]`.