### PR TITLE
fix(openai-completions): use optional chaining on chunk.choices

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -167,7 +167,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 					calculateCost(model, output.usage);
 				}
 
-				const choice = chunk.choices[0];
+				const choice = chunk.choices?.[0];
 				if (!choice) continue;
 
 				if (choice.finish_reason) {


### PR DESCRIPTION
## Summary

- Use optional chaining (`chunk.choices?.[0]`) instead of direct access (`chunk.choices[0]`) when iterating streaming chunks in `streamOpenAICompletions`

## Problem

Some OpenAI-compatible providers (e.g. DeepInfra) send streaming chunks that contain `usage` data but no `choices` array. The final chunk in a stream, or error-state chunks, may have `choices` set to `undefined` or omit it entirely.

Accessing `chunk.choices[0]` on such chunks throws:
```
Cannot read properties of undefined (reading '0')
```

## Fix

The existing null guard (`if (!choice) continue`) on the next line already handles `undefined` choices correctly — the only issue is that `chunk.choices` itself can be `undefined`, so we need optional chaining to safely access index `[0]`.

```diff
- const choice = chunk.choices[0];
+ const choice = chunk.choices?.[0];
```

## Test plan

- [x] Verified fix resolves the crash with DeepInfra Llama-3.3-70B-Instruct-Turbo streaming responses
- [x] No behavior change for providers that always include `choices` in chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)