### PR TITLE
fix(coding-agent): prevent duplicate session prefixes and /tree freezes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/tree` freezing the TUI on sessions with duplicate or malformed entries, as deferred persistence could duplicate the session prefix on first flush. Tree and context traversal now handle duplicate IDs and cyclic parent chains gracefully.
+
 ## [0.55.1] - 2026-02-26
 
 ### New Features

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -337,8 +337,10 @@ export function buildSessionContext(
 
 	// Walk from leaf to root, collecting path
 	const path: SessionEntry[] = [];
+	const visitedEntryIds = new Set<string>();
 	let current: SessionEntry | undefined = leaf;
-	while (current) {
+	while (current && !visitedEntryIds.has(current.id)) {
+		visitedEntryIds.add(current.id);
 		path.unshift(current);
 		current = current.parentId ? byId.get(current.parentId) : undefined;
 	}
@@ -799,9 +801,7 @@ export class SessionManager {
 		}
 
 		if (!this.flushed) {
-			for (const e of this.fileEntries) {
-				appendFileSync(this.sessionFile, `${JSON.stringify(e)}\n`);
-			}
+			this._rewriteFile();
 			this.flushed = true;
 		} else {
 			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
@@ -1020,9 +1020,11 @@ export class SessionManager {
 	 */
 	getBranch(fromId?: string): SessionEntry[] {
 		const path: SessionEntry[] = [];
+		const visitedEntryIds = new Set<string>();
 		const startId = fromId ?? this.leafId;
 		let current = startId ? this.byId.get(startId) : undefined;
-		while (current) {
+		while (current && !visitedEntryIds.has(current.id)) {
+			visitedEntryIds.add(current.id);
 			path.unshift(current);
 			current = current.parentId ? this.byId.get(current.parentId) : undefined;
 		}
@@ -1061,19 +1063,83 @@ export class SessionManager {
 	 */
 	getTree(): SessionTreeNode[] {
 		const entries = this.getEntries();
+		// Malformed files can contain duplicate IDs. Keep the last occurrence so tree
+		// building matches byId/Map overwrite semantics and remains deterministic.
+		const seenEntryIds = new Set<string>();
+		const uniqueEntries: SessionEntry[] = [];
+		for (let index = entries.length - 1; index >= 0; index--) {
+			const entry = entries[index];
+			if (seenEntryIds.has(entry.id)) {
+				continue;
+			}
+			seenEntryIds.add(entry.id);
+			uniqueEntries.push(entry);
+		}
+		uniqueEntries.reverse();
+
+		const entryById = new Map<string, SessionEntry>();
+		for (const entry of uniqueEntries) {
+			entryById.set(entry.id, entry);
+		}
+
 		const nodeMap = new Map<string, SessionTreeNode>();
 		const roots: SessionTreeNode[] = [];
 
 		// Create nodes with resolved labels
-		for (const entry of entries) {
+		for (const entry of uniqueEntries) {
 			const label = this.labelsById.get(entry.id);
 			nodeMap.set(entry.id, { entry, children: [], label });
 		}
 
+		const cycleStatusByEntryId = new Map<string, boolean>();
+		const wouldCreateCycle = (entry: SessionEntry): boolean => {
+			const cachedStatus = cycleStatusByEntryId.get(entry.id);
+			if (cachedStatus !== undefined) {
+				return cachedStatus;
+			}
+
+			const traversedEntryIds: string[] = [entry.id];
+			const visitedParentIds = new Set<string>([entry.id]);
+			let parentId = entry.parentId;
+			while (parentId !== null) {
+				if (visitedParentIds.has(parentId)) {
+					for (const traversedId of traversedEntryIds) {
+						cycleStatusByEntryId.set(traversedId, true);
+					}
+					return true;
+				}
+
+				const cachedParentStatus = cycleStatusByEntryId.get(parentId);
+				if (cachedParentStatus !== undefined) {
+					for (const traversedId of traversedEntryIds) {
+						cycleStatusByEntryId.set(traversedId, cachedParentStatus);
+					}
+					return cachedParentStatus;
+				}
+
+				const parentEntry = entryById.get(parentId);
+				if (!parentEntry || parentEntry.parentId === null || parentEntry.parentId === parentEntry.id) {
+					for (const traversedId of traversedEntryIds) {
+						cycleStatusByEntryId.set(traversedId, false);
+					}
+					return false;
+				}
+
+				visitedParentIds.add(parentId);
+				traversedEntryIds.push(parentId);
+				parentId = parentEntry.parentId;
+			}
+
+			for (const traversedId of traversedEntryIds) {
+				cycleStatusByEntryId.set(traversedId, false);
+			}
+			return false;
+		};
+
 		// Build tree
-		for (const entry of entries) {
+		for (const entry of uniqueEntries) {
 			const node = nodeMap.get(entry.id)!;
-			if (entry.parentId === null || entry.parentId === entry.id) {
+			if (entry.parentId === null || entry.parentId === entry.id || wouldCreateCycle(entry)) {
 				roots.push(node);
 			} else {
 				const parent = nodeMap.get(entry.parentId);
@@ -1088,11 +1154,21 @@ export class SessionManager {
 
 		// Sort children by timestamp (oldest first, newest at bottom)
 		// Use iterative approach to avoid stack overflow on deep trees
+		const visitedNodeIds = new Set<string>();
 		const stack: SessionTreeNode[] = [...roots];
 		while (stack.length > 0) {
 			const node = stack.pop()!;
+			if (visitedNodeIds.has(node.entry.id)) {
+				continue;
+			}
+			visitedNodeIds.add(node.entry.id);
 			node.children.sort((a, b) => new Date(a.entry.timestamp).getTime() - new Date(b.entry.timestamp).getTime());
-			stack.push(...node.children);
+			for (let index = node.children.length - 1; index >= 0; index--) {
+				const child = node.children[index];
+				if (!visitedNodeIds.has(child.entry.id)) {
+					stack.push(child);
+				}
+			}
 		}
 
 		return roots;

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -264,5 +264,25 @@ describe("buildSessionContext", () => {
 			// Should only get the orphan since parent chain is broken
 			expect(ctx.messages).toHaveLength(1);
 		});
+
+		it("terminates on two-node parent cycles", () => {
+			const entries: SessionEntry[] = [msg("a", "b", "user", "from-a"), msg("b", "a", "assistant", "from-b")];
+
+			const ctx = buildSessionContext(entries, "b");
+			expect(ctx.messages).toHaveLength(2);
+			expect(ctx.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+		});
+
+		it("terminates on longer parent cycles", () => {
+			const entries: SessionEntry[] = [
+				msg("a", "c", "user", "cycle-a"),
+				msg("b", "a", "assistant", "cycle-b"),
+				msg("c", "b", "user", "cycle-c"),
+			];
+
+			const ctx = buildSessionContext(entries, "c");
+			expect(ctx.messages).toHaveLength(3);
+			expect(ctx.messages.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+		});
 	});
 });

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -205,4 +205,167 @@ describe("SessionManager.setSessionFile with corrupted files", () => {
 		expect(sm2.getSessionId()).toBe(sessionId);
 		expect(sm2.getHeader()?.type).toBe("session");
 	});
+
+	it("rewrites deferred pre-assistant state instead of duplicating the existing session prefix", () => {
+		const sessionFile = join(tempDir, "preassistant-prefix.jsonl");
+		writeFileSync(
+			sessionFile,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "session-1",
+					timestamp: "2026-02-24T21:10:41.329Z",
+					cwd: tempDir,
+				}),
+				JSON.stringify({
+					type: "model_change",
+					id: "root0001",
+					parentId: null,
+					timestamp: "2026-02-24T21:10:42.000Z",
+					provider: "openai-codex",
+					modelId: "gpt-5.3-codex",
+				}),
+				JSON.stringify({
+					type: "thinking_level_change",
+					id: "child0001",
+					parentId: "root0001",
+					timestamp: "2026-02-24T21:10:43.000Z",
+					thinkingLevel: "xhigh",
+				}),
+				"",
+			].join("\n"),
+		);
+
+		const session = SessionManager.open(sessionFile, tempDir);
+		session.appendCustomEntry("plan-mode", { enabled: false });
+		session.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "ready" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		});
+
+		const lines = readFileSync(sessionFile, "utf-8").trim().split("\n").filter(Boolean);
+		const records = lines.map((line) => JSON.parse(line));
+
+		expect(records.filter((record) => record.type === "session")).toHaveLength(1);
+
+		const entryIds = records
+			.filter((record) => record.type !== "session")
+			.map((record) => record.id)
+			.filter((id): id is string => typeof id === "string");
+		expect(new Set(entryIds).size).toBe(entryIds.length);
+	});
+
+	it("deduplicates duplicate entry IDs when building tree from malformed files", () => {
+		const malformedFile = join(tempDir, "duplicate-ids.jsonl");
+		writeFileSync(
+			malformedFile,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "session-2",
+					timestamp: "2026-02-24T21:10:41.329Z",
+					cwd: tempDir,
+				}),
+				JSON.stringify({
+					type: "custom",
+					customType: "marker",
+					id: "root0001",
+					parentId: null,
+					timestamp: "2026-02-24T21:10:42.000Z",
+				}),
+				JSON.stringify({
+					type: "custom",
+					customType: "marker",
+					id: "child0001",
+					parentId: "root0001",
+					timestamp: "2026-02-24T21:10:43.000Z",
+				}),
+				JSON.stringify({
+					type: "custom",
+					customType: "marker",
+					id: "root0001",
+					parentId: null,
+					timestamp: "2026-02-24T21:10:42.000Z",
+				}),
+				JSON.stringify({
+					type: "custom",
+					customType: "marker",
+					id: "child0001",
+					parentId: "root0001",
+					timestamp: "2026-02-24T21:10:43.000Z",
+				}),
+				JSON.stringify({
+					type: "custom",
+					customType: "marker",
+					id: "leaf0001",
+					parentId: "child0001",
+					timestamp: "2026-02-24T21:10:44.000Z",
+				}),
+				"",
+			].join("\n"),
+		);
+
+		const session = SessionManager.open(malformedFile, tempDir);
+		const tree = session.getTree();
+
+		expect(tree).toHaveLength(1);
+		expect(tree[0].entry.id).toBe("root0001");
+		expect(tree[0].children).toHaveLength(1);
+		expect(tree[0].children[0].entry.id).toBe("child0001");
+		expect(tree[0].children[0].children).toHaveLength(1);
+		expect(tree[0].children[0].children[0].entry.id).toBe("leaf0001");
+	});
+
+	it("breaks malformed parent cycles into roots when building a tree", () => {
+		const malformedFile = join(tempDir, "parent-cycle.jsonl");
+		writeFileSync(
+			malformedFile,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "session-3",
+					timestamp: "2026-02-24T21:10:41.329Z",
+					cwd: tempDir,
+				}),
+				JSON.stringify({
+					type: "custom",
+					customType: "marker",
+					id: "cycle-a",
+					parentId: "cycle-b",
+					timestamp: "2026-02-24T21:10:42.000Z",
+				}),
+				JSON.stringify({
+					type: "custom",
+					customType: "marker",
+					id: "cycle-b",
+					parentId: "cycle-a",
+					timestamp: "2026-02-24T21:10:43.000Z",
+				}),
+				"",
+			].join("\n"),
+		);
+
+		const session = SessionManager.open(malformedFile, tempDir);
+		const tree = session.getTree();
+
+		expect(tree).toHaveLength(2);
+		expect(tree.map((node) => node.entry.id).sort()).toEqual(["cycle-a", "cycle-b"]);
+		expect(tree.every((node) => node.children.length === 0)).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { describe, expect, it } from "vitest";
 import { type CustomEntry, SessionManager } from "../../src/core/session-manager.js";
 import { assistantMsg, userMsg } from "../utilities.js";
@@ -158,6 +161,48 @@ describe("SessionManager append and tree traversal", () => {
 			const path = session.getBranch(id2);
 			expect(path).toHaveLength(2);
 			expect(path.map((e) => e.id)).toEqual([id1, id2]);
+		});
+
+		it("terminates on malformed parent cycles when traversing a branch", () => {
+			const tempDir = join(tmpdir(), `session-cycle-${Date.now()}`);
+			mkdirSync(tempDir, { recursive: true });
+			const sessionFile = join(tempDir, "cycle-branch.jsonl");
+
+			try {
+				writeFileSync(
+					sessionFile,
+					[
+						JSON.stringify({
+							type: "session",
+							version: 3,
+							id: "session-cycle",
+							timestamp: "2026-02-27T11:00:00.000Z",
+							cwd: tempDir,
+						}),
+						JSON.stringify({
+							type: "custom",
+							customType: "marker",
+							id: "cycle-a",
+							parentId: "cycle-b",
+							timestamp: "2026-02-27T11:00:01.000Z",
+						}),
+						JSON.stringify({
+							type: "custom",
+							customType: "marker",
+							id: "cycle-b",
+							parentId: "cycle-a",
+							timestamp: "2026-02-27T11:00:02.000Z",
+						}),
+						"",
+					].join("\n"),
+				);
+
+				const session = SessionManager.open(sessionFile, tempDir);
+				const path = session.getBranch("cycle-b");
+				expect(path.map((entry) => entry.id)).toEqual(["cycle-a", "cycle-b"]);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
 		});
 	});
 


### PR DESCRIPTION
## Problem

`/tree` freezes the TUI permanently (no input or paint until the tab is closed) on some sessions.  The affected sessions' `.jsonl` files contain duplicated session headers and duplicate entry IDs.  `/tree` does synchronous traversals that assume a well-formed tree, so duplicates and cycles cause non-terminating loops on the UI thread.

## How duplicated headers happen

Extensions can call `pi.appendEntry(...)` before the first assistant message.  For example, `examples/extensions/preset.ts` persists state on `turn_start`, which fires before the assistant responds.  Session persistence is deferred until the first assistant message.  When that flush fires, `_persist()` appends the full in-memory `fileEntries` to disk, but the file already has content from those early `appendEntry` calls.  Result: duplicated session header, prefix entries, and entry IDs.

The added test `"rewrites deferred pre-assistant state instead of duplicating the existing session prefix"` reproduces this directly.

## Fix

This prevents the duplication and hardens traversal so that existing malformed sessions don't hang.

**Persistence**: first deferred flush now rewrites the file instead of appending, so early extension entries are preserved without duplication.

**Traversal guards**:
- `buildSessionContext()` and `getBranch()`: visited-ID set terminates leaf-to-root walks on cycles
- `getTree()`: dedupes entries by ID (last occurrence wins), breaks parent cycles into roots, memoizes cycle detection for large sessions

## Validation

- `npm run check`
- `cd packages/coding-agent && npx vitest run test/session-manager/file-operations.test.ts`
- `cd packages/coding-agent && npx vitest run test/session-manager/build-context.test.ts`
- `cd packages/coding-agent && npx vitest run test/session-manager/tree-traversal.test.ts`