### PR TITLE
proposal: skills can specify a preferred model or a model 'size' 

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -285,6 +285,8 @@ export interface VercelGatewayRouting {
 	order?: string[];
 }
 
+export type ModelSize = "small" | "medium" | "large";
+
 // Model interface for the unified model system
 export interface Model<TApi extends Api> {
 	id: string;
@@ -302,6 +304,7 @@ export interface Model<TApi extends Api> {
 	};
 	contextWindow: number;
 	maxTokens: number;
+	size?: ModelSize;
 	headers?: Record<string, string>;
 	/** Compatibility overrides for OpenAI-compatible APIs. If not set, auto-detected from baseUrl. */
 	compat?: TApi extends "openai-completions"

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -146,6 +146,8 @@ Per the [Agent Skills specification](https://agentskills.io/specification#frontm
 | `metadata` | No | Arbitrary key-value mapping. |
 | `allowed-tools` | No | Space-delimited list of pre-approved tools (experimental). |
 | `disable-model-invocation` | No | When `true`, skill is hidden from system prompt. Users must use `/skill:name`. |
+| `model` | No | Model to use for `/skill:name` turns (for example `anthropic/claude-opus-4-1`). |
+| `model_size` | No | Model size to use for `/skill:name` turns: `small`, `medium`, or `large`. Used when `model` is not set, or as a fallback when the specified `model` cannot be resolved or has no usable credentials. |
 
 ### Name Rules
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -23,7 +23,7 @@ import type {
 	AgentTool,
 	ThinkingLevel,
 } from "@mariozechner/pi-agent-core";
-import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@mariozechner/pi-ai";
+import type { Api, AssistantMessage, ImageContent, Message, Model, TextContent } from "@mariozechner/pi-ai";
 import { isContextOverflow, modelsAreEqual, resetApiProviders, supportsXhigh } from "@mariozechner/pi-ai";
 import { getDocsPath } from "../config.js";
 import { theme } from "../modes/interactive/theme/theme.js";
@@ -71,6 +71,7 @@ import {
 } from "./extensions/index.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
+import { resolveCliModel } from "./model-resolver.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.js";
@@ -756,92 +757,104 @@ export class AgentSession {
 			return;
 		}
 
-		// Flush any pending bash messages before the new prompt
-		this._flushPendingBashMessages();
-
-		// Validate model
-		if (!this.model) {
-			throw new Error(
-				"No model selected.\n\n" +
-					`Use /login or set an API key environment variable. See ${join(getDocsPath(), "providers.md")}\n\n` +
-					"Then use /model to select a model.",
-			);
+		const previousModel = this.model;
+		const turnModelOverride = await this._resolveSkillModelOverride(currentText);
+		if (turnModelOverride && (!previousModel || !modelsAreEqual(turnModelOverride, previousModel))) {
+			this.agent.setModel(turnModelOverride);
 		}
 
-		// Validate API key
-		const apiKey = await this._modelRegistry.getApiKey(this.model);
-		if (!apiKey) {
-			const isOAuth = this._modelRegistry.isUsingOAuth(this.model);
-			if (isOAuth) {
+		try {
+			// Flush any pending bash messages before the new prompt
+			this._flushPendingBashMessages();
+
+			// Validate model
+			if (!this.model) {
 				throw new Error(
-					`Authentication failed for "${this.model.provider}". ` +
-						`Credentials may have expired or network is unavailable. ` +
-						`Run '/login ${this.model.provider}' to re-authenticate.`,
+					"No model selected.\n\n" +
+						`Use /login or set an API key environment variable. See ${join(getDocsPath(), "providers.md")}\n\n` +
+						"Then use /model to select a model.",
 				);
 			}
-			throw new Error(
-				`No API key found for ${this.model.provider}.\n\n` +
-					`Use /login or set an API key environment variable. See ${join(getDocsPath(), "providers.md")}`,
-			);
-		}
 
-		// Check if we need to compact before sending (catches aborted responses)
-		const lastAssistant = this._findLastAssistantMessage();
-		if (lastAssistant) {
-			await this._checkCompaction(lastAssistant, false);
-		}
+			// Validate API key
+			const apiKey = await this._modelRegistry.getApiKey(this.model);
+			if (!apiKey) {
+				const isOAuth = this._modelRegistry.isUsingOAuth(this.model);
+				if (isOAuth) {
+					throw new Error(
+						`Authentication failed for "${this.model.provider}". ` +
+							`Credentials may have expired or network is unavailable. ` +
+							`Run '/login ${this.model.provider}' to re-authenticate.`,
+					);
+				}
+				throw new Error(
+					`No API key found for ${this.model.provider}.\n\n` +
+						`Use /login or set an API key environment variable. See ${join(getDocsPath(), "providers.md")}`,
+				);
+			}
 
-		// Build messages array (custom message if any, then user message)
-		const messages: AgentMessage[] = [];
+			// Check if we need to compact before sending (catches aborted responses)
+			const lastAssistant = this._findLastAssistantMessage();
+			if (lastAssistant) {
+				await this._checkCompaction(lastAssistant, false);
+			}
 
-		// Add user message
-		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
-		if (currentImages) {
-			userContent.push(...currentImages);
-		}
-		messages.push({
-			role: "user",
-			content: userContent,
-			timestamp: Date.now(),
-		});
+			// Build messages array (custom message if any, then user message)
+			const messages: AgentMessage[] = [];
 
-		// Inject any pending "nextTurn" messages as context alongside the user message
-		for (const msg of this._pendingNextTurnMessages) {
-			messages.push(msg);
-		}
-		this._pendingNextTurnMessages = [];
+			// Add user message
+			const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
+			if (currentImages) {
+				userContent.push(...currentImages);
+			}
+			messages.push({
+				role: "user",
+				content: userContent,
+				timestamp: Date.now(),
+			});
 
-		// Emit before_agent_start extension event
-		if (this._extensionRunner) {
-			const result = await this._extensionRunner.emitBeforeAgentStart(
-				expandedText,
-				currentImages,
-				this._baseSystemPrompt,
-			);
-			// Add all custom messages from extensions
-			if (result?.messages) {
-				for (const msg of result.messages) {
-					messages.push({
-						role: "custom",
-						customType: msg.customType,
-						content: msg.content,
-						display: msg.display,
-						details: msg.details,
-						timestamp: Date.now(),
-					});
+			// Inject any pending "nextTurn" messages as context alongside the user message
+			for (const msg of this._pendingNextTurnMessages) {
+				messages.push(msg);
+			}
+			this._pendingNextTurnMessages = [];
+
+			// Emit before_agent_start extension event
+			if (this._extensionRunner) {
+				const result = await this._extensionRunner.emitBeforeAgentStart(
+					expandedText,
+					currentImages,
+					this._baseSystemPrompt,
+				);
+				// Add all custom messages from extensions
+				if (result?.messages) {
+					for (const msg of result.messages) {
+						messages.push({
+							role: "custom",
+							customType: msg.customType,
+							content: msg.content,
+							display: msg.display,
+							details: msg.details,
+							timestamp: Date.now(),
+						});
+					}
+				}
+				// Apply extension-modified system prompt, or reset to base
+				if (result?.systemPrompt) {
+					this.agent.setSystemPrompt(result.systemPrompt);
+				} else {
+					// Ensure we're using the base prompt (in case previous turn had modifications)
+					this.agent.setSystemPrompt(this._baseSystemPrompt);
 				}
 			}
-			// Apply extension-modified system prompt, or reset to base
-			if (result?.systemPrompt) {
-				this.agent.setSystemPrompt(result.systemPrompt);
-			} else {
-				// Ensure we're using the base prompt (in case previous turn had modifications)
-				this.agent.setSystemPrompt(this._baseSystemPrompt);
+
+			await this.agent.prompt(messages);
+			await this.waitForRetry();
+		} finally {
+			if (turnModelOverride && previousModel && !modelsAreEqual(turnModelOverride, previousModel)) {
+				this.agent.setModel(previousModel);
 			}
 		}
-
-		await this.agent.prompt(messages);
-		await this.waitForRetry();
 	}
 
 	/**
@@ -904,6 +917,68 @@ export class AgentSession {
 			});
 			return text; // Return original on error
 		}
+	}
+
+	private async _resolveSkillModelOverride(text: string): Promise<Model<Api> | undefined> {
+		if (!text.startsWith("/skill:")) return undefined;
+
+		const spaceIndex = text.indexOf(" ");
+		const skillName = spaceIndex === -1 ? text.slice(7) : text.slice(7, spaceIndex);
+		const skill = this.resourceLoader.getSkills().skills.find((s) => s.name === skillName);
+		if (!skill) return undefined;
+
+		if (skill.model) {
+			const { model } = resolveCliModel({
+				cliModel: skill.model,
+				modelRegistry: this._modelRegistry,
+			});
+			if (model && (await this._modelRegistry.getApiKey(model))) {
+				return model;
+			}
+		}
+
+		if (!skill.modelSize) return undefined;
+		const availableModels = await this._modelRegistry.getAvailable();
+
+		// Prefer keeping the current model if its registry entry matches the requested size.
+		if (this.model) {
+			const current = availableModels.find((available) => modelsAreEqual(available, this.model));
+			if (current?.size === skill.modelSize) {
+				return current;
+			}
+		}
+
+		const sizeMatched = availableModels.filter((model) => model.size === skill.modelSize);
+		if (sizeMatched.length === 0) return undefined;
+
+		const currentProvider = (this.model as any)?.provider as string | undefined;
+
+		// Prefer models from the same provider as the current model, if any.
+		if (currentProvider) {
+			const sameProvider = sizeMatched.filter(
+				(model) => (model as any).provider === currentProvider,
+			);
+			if (sameProvider.length > 0) {
+				sameProvider.sort((a, b) => {
+					const aId = String((a as any).id ?? "");
+					const bId = String((b as any).id ?? "");
+					return aId.localeCompare(bId);
+				});
+				return sameProvider[0];
+			}
+		}
+
+		// Fall back to a deterministic choice among all size-matched models.
+		const sorted = sizeMatched.slice().sort((a, b) => {
+			const aProvider = String((a as any).provider ?? "");
+			const bProvider = String((b as any).provider ?? "");
+			const byProvider = aProvider.localeCompare(bProvider);
+			if (byProvider !== 0) return byProvider;
+			const aId = String((a as any).id ?? "");
+			const bId = String((b as any).id ?? "");
+			return aId.localeCompare(bId);
+		});
+		return sorted[0];
 	}
 
 	/**

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -10,6 +10,7 @@ import {
 	getProviders,
 	type KnownProvider,
 	type Model,
+	type ModelSize,
 	type OAuthProviderInterface,
 	type OpenAICompletionsCompat,
 	type OpenAIResponsesCompat,
@@ -81,6 +82,7 @@ const ModelDefinitionSchema = Type.Object({
 	),
 	contextWindow: Type.Optional(Type.Number()),
 	maxTokens: Type.Optional(Type.Number()),
+	size: Type.Optional(Type.Union([Type.Literal("small"), Type.Literal("medium"), Type.Literal("large")])),
 	headers: Type.Optional(Type.Record(Type.String(), Type.String())),
 	compat: Type.Optional(OpenAICompatSchema),
 });
@@ -100,6 +102,7 @@ const ModelOverrideSchema = Type.Object({
 	),
 	contextWindow: Type.Optional(Type.Number()),
 	maxTokens: Type.Optional(Type.Number()),
+	size: Type.Optional(Type.Union([Type.Literal("small"), Type.Literal("medium"), Type.Literal("large")])),
 	headers: Type.Optional(Type.Record(Type.String(), Type.String())),
 	compat: Type.Optional(OpenAICompatSchema),
 });
@@ -187,6 +190,7 @@ function applyModelOverride(model: Model<Api>, override: ModelOverride): Model<A
 	if (override.input !== undefined) result.input = override.input as ("text" | "image")[];
 	if (override.contextWindow !== undefined) result.contextWindow = override.contextWindow;
 	if (override.maxTokens !== undefined) result.maxTokens = override.maxTokens;
+	if (override.size !== undefined) result.size = override.size as ModelSize;
 
 	// Merge cost (partial override)
 	if (override.cost) {
@@ -481,6 +485,7 @@ export class ModelRegistry {
 					cost: modelDef.cost ?? defaultCost,
 					contextWindow: modelDef.contextWindow ?? 128000,
 					maxTokens: modelDef.maxTokens ?? 16384,
+					size: modelDef.size,
 					headers,
 					compat: modelDef.compat,
 				} as Model<Api>);
@@ -637,6 +642,7 @@ export class ModelRegistry {
 					cost: modelDef.cost,
 					contextWindow: modelDef.contextWindow,
 					maxTokens: modelDef.maxTokens,
+					size: modelDef.size,
 					headers,
 					compat: modelDef.compat,
 				} as Model<Api>);
@@ -685,6 +691,7 @@ export interface ProviderConfigInput {
 		cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
 		contextWindow: number;
 		maxTokens: number;
+		size?: ModelSize;
 		headers?: Record<string, string>;
 		compat?: Model<Api>["compat"];
 	}>;

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -67,6 +67,8 @@ export interface SkillFrontmatter {
 	name?: string;
 	description?: string;
 	"disable-model-invocation"?: boolean;
+	model?: string;
+	model_size?: "small" | "medium" | "large";
 	[key: string]: unknown;
 }
 
@@ -77,6 +79,8 @@ export interface Skill {
 	baseDir: string;
 	source: string;
 	disableModelInvocation: boolean;
+	model?: string;
+	modelSize?: "small" | "medium" | "large";
 }
 
 export interface LoadSkillsResult {
@@ -269,6 +273,13 @@ function loadSkillFromFile(
 				baseDir: skillDir,
 				source,
 				disableModelInvocation: frontmatter["disable-model-invocation"] === true,
+				model: typeof frontmatter.model === "string" ? frontmatter.model.trim() || undefined : undefined,
+				modelSize:
+					frontmatter.model_size === "small" ||
+					frontmatter.model_size === "medium" ||
+					frontmatter.model_size === "large"
+						? frontmatter.model_size
+						: undefined,
 			},
 			diagnostics,
 		};

--- a/packages/coding-agent/test/agent-session-skill-model-selection.test.ts
+++ b/packages/coding-agent/test/agent-session-skill-model-selection.test.ts
@@ -1,0 +1,266 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@mariozechner/pi-agent-core";
+import { type Api, type AssistantMessage, type AssistantMessageEvent, EventStream, getModel, type Model } from "@mariozechner/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { createExtensionRuntime } from "../src/core/extensions/loader.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import type { Skill } from "../src/core/skills.js";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createAssistantMessage(model: Model<Api>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "ok" }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("AgentSession skill model selection", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-skill-model-selection-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		writeFileSync(
+			join(tempDir, "models.json"),
+			JSON.stringify({
+				providers: {
+					anthropic: {
+						modelOverrides: {
+							"claude-haiku-4-5": { size: "small" },
+							"claude-sonnet-4-5": { size: "medium" },
+							"claude-opus-4-1": { size: "large" },
+						},
+					},
+				},
+			}),
+		);
+	});
+
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	function createSession(skills: Skill[]) {
+		const selectedModels: string[] = [];
+		const initialModel = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: initialModel,
+				systemPrompt: "Test",
+				tools: [],
+			},
+			streamFn: (model) => {
+				selectedModels.push(`${model.provider}/${model.id}`);
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: createAssistantMessage(model) });
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage(model) });
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, join(tempDir, "models.json"));
+
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: {
+				getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
+				getSkills: () => ({ skills, diagnostics: [] }),
+				getPrompts: () => ({ prompts: [], diagnostics: [] }),
+				getThemes: () => ({ themes: [], diagnostics: [] }),
+				getAgentsFiles: () => ({ agentsFiles: [] }),
+				getSystemPrompt: () => undefined,
+				getAppendSystemPrompt: () => [],
+				getPathMetadata: () => new Map(),
+				extendResources: () => {},
+				reload: async () => {},
+			},
+		});
+
+		return { session, selectedModels, modelRegistry };
+	}
+
+	it("uses a model matching skill model_size for that turn and restores afterwards", async () => {
+		const skillPath = join(tempDir, "skills", "size-skill", "SKILL.md");
+		mkdirSync(join(tempDir, "skills", "size-skill"), { recursive: true });
+		writeFileSync(
+			skillPath,
+			`---
+name: size-skill
+description: Skill that chooses a large model.
+model_size: large
+---
+Use a large model.`,
+		);
+
+		const { session, selectedModels } = createSession([
+			{
+				name: "size-skill",
+				description: "Skill that chooses a large model.",
+				filePath: skillPath,
+				baseDir: join(tempDir, "skills", "size-skill"),
+				source: "test",
+				disableModelInvocation: false,
+				modelSize: "large",
+			},
+		]);
+
+		await session.prompt("/skill:size-skill");
+		await session.prompt("plain turn");
+
+		expect(selectedModels[0]).toBe("anthropic/claude-opus-4-1");
+		expect(selectedModels[1]).toBe("anthropic/claude-sonnet-4-5");
+	});
+
+	it("prefers skill model over skill model_size", async () => {
+		const skillPath = join(tempDir, "skills", "specific-model-skill", "SKILL.md");
+		mkdirSync(join(tempDir, "skills", "specific-model-skill"), { recursive: true });
+		writeFileSync(
+			skillPath,
+			`---
+name: specific-model-skill
+description: Skill with explicit model and model_size.
+model: anthropic/claude-opus-4-1
+model_size: large
+---
+Prefer explicit model.`,
+		);
+
+		const { session, selectedModels } = createSession([
+			{
+				name: "specific-model-skill",
+				description: "Skill with explicit model and model_size.",
+				filePath: skillPath,
+				baseDir: join(tempDir, "skills", "specific-model-skill"),
+				source: "test",
+				disableModelInvocation: false,
+				model: "anthropic/claude-opus-4-1",
+				modelSize: "large",
+			},
+		]);
+
+		await session.prompt("/skill:specific-model-skill");
+
+		expect(selectedModels[0]).toBe("anthropic/claude-opus-4-1");
+	});
+
+	it("falls back to model_size when configured model cannot be resolved", async () => {
+		const skillPath = join(tempDir, "skills", "fallback-size-skill", "SKILL.md");
+		mkdirSync(join(tempDir, "skills", "fallback-size-skill"), { recursive: true });
+		writeFileSync(
+			skillPath,
+			`---
+name: fallback-size-skill
+description: Skill with unknown model and valid model_size.
+model: anthropic/does-not-exist
+model_size: small
+---
+Fallback to size.`,
+		);
+
+		const { session, selectedModels } = createSession([
+			{
+				name: "fallback-size-skill",
+				description: "Skill with unknown model and valid model_size.",
+				filePath: skillPath,
+				baseDir: join(tempDir, "skills", "fallback-size-skill"),
+				source: "test",
+				disableModelInvocation: false,
+				model: "anthropic/does-not-exist",
+				modelSize: "small",
+			},
+		]);
+
+		await session.prompt("/skill:fallback-size-skill");
+
+		expect(selectedModels[0]).toBe("anthropic/claude-haiku-4-5");
+	});
+
+	it("keeps current model when requested model_size has no available match", async () => {
+		const skillPath = join(tempDir, "skills", "missing-size-skill", "SKILL.md");
+		mkdirSync(join(tempDir, "skills", "missing-size-skill"), { recursive: true });
+		writeFileSync(
+			skillPath,
+			`---
+name: missing-size-skill
+description: Skill with unavailable model size.
+model_size: large
+---
+No large model available.`,
+		);
+
+		const { session, selectedModels, modelRegistry } = createSession([
+			{
+				name: "missing-size-skill",
+				description: "Skill with unavailable model size.",
+				filePath: skillPath,
+				baseDir: join(tempDir, "skills", "missing-size-skill"),
+				source: "test",
+				disableModelInvocation: false,
+				modelSize: "large",
+			},
+		]);
+
+		writeFileSync(
+			join(tempDir, "models.json"),
+			JSON.stringify({
+				providers: {
+					anthropic: {
+						modelOverrides: {
+							"claude-haiku-4-5": { size: "small" },
+							"claude-sonnet-4-5": { size: "medium" },
+						},
+					},
+				},
+			}),
+		);
+		modelRegistry.refresh();
+
+		await session.prompt("/skill:missing-size-skill");
+
+		expect(selectedModels[0]).toBe("anthropic/claude-sonnet-4-5");
+	});
+});

--- a/packages/coding-agent/test/fixtures/skills/invalid-model-size/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/invalid-model-size/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: invalid-model-size
+description: Skill with invalid model_size value.
+model_size: giant
+---
+
+# Invalid Model Size
+
+This skill uses an unsupported model_size value.

--- a/packages/coding-agent/test/fixtures/skills/model-selection/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/model-selection/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: model-selection
+description: Skill with model selection metadata.
+model: anthropic/claude-opus-4-1
+model_size: large
+---
+
+# Model Selection Skill
+
+This skill is used to test model and model_size frontmatter parsing.

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -188,6 +188,29 @@ describe("skills", () => {
 			expect(skills).toHaveLength(1);
 			expect(skills[0].disableModelInvocation).toBe(false);
 		});
+
+		it("should parse model and model_size frontmatter fields", () => {
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: join(fixturesDir, "model-selection"),
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].model).toBe("anthropic/claude-opus-4-1");
+			expect(skills[0].modelSize).toBe("large");
+			expect(diagnostics).toHaveLength(0);
+		});
+
+		it("should ignore invalid model_size frontmatter values", () => {
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: join(fixturesDir, "invalid-model-size"),
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].modelSize).toBeUndefined();
+			expect(diagnostics).toHaveLength(0);
+		});
 	});
 
 	describe("formatSkillsForPrompt", () => {


### PR DESCRIPTION
> [!IMPORTANT]
> This is a clanker-driven rough draft, mainly to bring "code" instead of just "talk" to the table. If this sounds like a good idea, I will re-write it (with agents sure, but with more thought to the implementation). Do not judge too much the code here, let's discuss the idea. 

## The usecase

The most frequent thing I can think of is that I have a `/skill:git` skill with some specifics of how I use git (adding signoffs, running some scripts before some actions, etc). 
Very often what I do is run 

```shell
> /skill:git commit and create a pull request
``` 

Now usually Gemini Flash, or Haiku or GPT 5.1 Mini are all fairly capable models for doing what is required of this step. When I am in the middle of a session, having just used the agent to write some code using one of the big guys (Opus, 5.3 High) I do not want to waste the big guy firepower on this step, and do this git commit step using a smaller model. 

It is like walking around with two cameras, one with a long lens and one with a short lens. 
<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/00b72720-96dd-4527-ab94-c70bb76f7f5c" />

## The contours of the solution 

Here's how I think it can be achieved. 

### 1. Skills can include optional metadata about preferred model or model size 

Example 
```markdown
---
name: Git Operations
description: Git Related Operations and How to Perform Them 
model: claude-haiku-4.5 
model_size: small 
---

# Git Operations 

... 

## Guidlines

We always squash up multiple small changes in this repo...... 

```

The skill can specify an exact model itself, or it can specify a model size and model sizes can be `small`, `medium` or `big` 

### 2. In Model Definitions Add Size Tag 

We can define the model size in model properties, but more likely we will inject it via `modelOverrides` because we will be tagging existing models from providers with these sizes. 

```json
{
  "providers": {
    "openrouter": {
      "modelOverrides": {
        "anthropic/claude-sonnet-4": {
          "size": "medium"
        }
      }
    }
  }
}
```

### 3. Pi uses this information when processing the skill

Simple algorithm is this -  

1. When Pi sees `/skill` invoked, checks if the this skill has model or model size preferred
2. If `model` or `model_size` is specified, see if that model is available (and API key works)
   1. If model not specified, or model is not usable/available; check if `model_size` exist
   2. If `model_size` is specified use a deterministic way (to prevent randomness in each invocation) 
       1. check if current model is same size; if yes use it 
       2. if not; check if current provider has a model of this size, then use that
       3. if not; go through all available models in deterministic order, and find a model of this size 
3. For all executions of this current turn continue to use this newly picked model, but keep reference to previous model
4. When this turn is exhausted, then revert to previous model, and go back to waiting for user prompt. 
