### PR TITLE
feat(examples): make example extensions installable as a pi package

### DIFF
--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -2,15 +2,20 @@
 
 Example extensions for pi-coding-agent.
 
-## Usage
+## Install
 
 ```bash
-# Load an extension with --extension flag
-pi --extension examples/extensions/permission-gate.ts
+# Install all examples as a pi package (from a local clone)
+pi install ./packages/coding-agent/examples
 
-# Or copy to extensions directory for auto-discovery
+# Or load a single extension for a one-off test
+pi -e ./packages/coding-agent/examples/extensions/hello.ts
+
+# Or copy individual extensions to your extensions directory
 cp permission-gate.ts ~/.pi/agent/extensions/
 ```
+
+Extensions with external dependencies (`with-deps/`, `custom-provider-*/`, `sandbox/`) need `npm install` in their directory before use.
 
 ## Examples
 

--- a/packages/coding-agent/examples/package.json
+++ b/packages/coding-agent/examples/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "pi-examples",
+	"private": true,
+	"version": "0.0.0",
+	"description": "Example extensions for pi-coding-agent",
+	"keywords": ["pi-package"],
+	"pi": {
+		"extensions": ["./extensions"]
+	}
+}


### PR DESCRIPTION
## Summary

Add `package.json` to `packages/coding-agent/examples/` with a `pi` manifest so that the example extensions directory can be installed as a pi package.

## Motivation

Currently, there's no way to install the example extensions via `pi install`. Users must manually copy individual files or use `pi -e ./path.ts` one at a time. This change makes all examples installable with a single command:

```bash
pi install ./packages/coding-agent/examples
```

## How it works

The `package.json` declares `pi.extensions: ["./extensions"]`, which points to the `extensions/` directory. Since that directory has no `package.json` of its own, pi's auto-discovery kicks in and finds:

- All 55 top-level `.ts` extension files
- Subdirectory extensions without deps (`doom-overlay/`, `dynamic-resources/`, `plan-mode/`, `subagent/`) via `index.ts`
- Subdirectory extensions with deps (`with-deps/`, `custom-provider-*/`, `sandbox/`) via their own `pi` manifests

## Changes

- **New**: `packages/coding-agent/examples/package.json` — pi package manifest with `pi-package` keyword
- **Updated**: `packages/coding-agent/examples/extensions/README.md` — replaced usage section with install instructions