### PR TITLE
feat(examples): make example extensions installable via pi install

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
 		"tsx": "^4.20.3",
 		"typescript": "^5.9.2"
 	},
+	"keywords": ["pi-package"],
+	"pi": {
+		"extensions": ["./packages/coding-agent/examples/extensions"]
+	},
 	"engines": {
 		"node": ">=20.0.0"
 	},

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -2,15 +2,20 @@
 
 Example extensions for pi-coding-agent.
 
-## Usage
+## Install
 
 ```bash
-# Load an extension with --extension flag
-pi --extension examples/extensions/permission-gate.ts
+# Install all examples as a pi package
+pi install git:github.com/badlogic/pi-mono
 
-# Or copy to extensions directory for auto-discovery
+# Or load a single extension for a one-off test
+pi -e ./packages/coding-agent/examples/extensions/hello.ts
+
+# Or copy individual extensions to your extensions directory
 cp permission-gate.ts ~/.pi/agent/extensions/
 ```
+
+Extensions with external dependencies (`with-deps/`, `custom-provider-*/`, `sandbox/`) need `npm install` in their directory before use.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Add a `pi` manifest to the root `package.json` so that all example extensions can be installed with:

```bash
pi install git:github.com/badlogic/pi-mono
```

## Motivation

Currently there's no way to install the example extensions via `pi install`. Users must manually copy individual files or use `pi -e ./path.ts` one at a time.

## How it works

The root `package.json` gets `pi.extensions: ["./packages/coding-agent/examples/extensions"]`. Since `extensions/` has no `package.json` of its own, pi's auto-discovery kicks in and finds:

- All 55 top-level `.ts` extension files
- Subdirectory extensions without deps (`doom-overlay/`, `dynamic-resources/`, `plan-mode/`, `subagent/`) via `index.ts`
- Subdirectory extensions with deps (`with-deps/`, `custom-provider-*/`, `sandbox/`) via their own `pi` manifests

## Changes

- **`package.json`** (root) — add `pi` manifest with `pi-package` keyword
- **`packages/coding-agent/examples/extensions/README.md`** — update usage section with `pi install` instructions