### PR TITLE
fix(tui): @ autocomplete for absolute and home directory paths

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -448,6 +448,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	}
 
 	private resolveScopedFuzzyQuery(rawQuery: string): { baseDir: string; query: string; displayBase: string } | null {
+		// Bare ~ without slash - treat as home directory listing
+		if (rawQuery === "~") {
+			return { baseDir: homedir(), query: "", displayBase: "~/" };
+		}
+
 		const slashIndex = rawQuery.lastIndexOf("/");
 		if (slashIndex === -1) {
 			return null;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -958,7 +958,7 @@ export class Editor implements Component, Focusable {
 				}
 			}
 			// Also auto-trigger when typing letters in a slash command context
-			else if (/[a-zA-Z0-9.\-_]/.test(char)) {
+			else if (/[a-zA-Z0-9.\-_~/]/.test(char)) {
 				const currentLine = this.state.lines[this.state.cursorLine] || "";
 				const textBeforeCursor = currentLine.slice(0, this.state.cursorCol);
 				// Check if we're in a slash command (with or without space for arguments)

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -329,6 +329,64 @@ describe("CombinedAutocompleteProvider", () => {
 			const applied = provider.applyCompletion([line], 0, cursorCol, item!, result!.prefix);
 			assert.strictEqual(applied.lines[0], '@"my folder/test.txt" ');
 		});
+
+		test("bare @~ returns home directory contents", () => {
+			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
+			const line = "@~";
+			const result = provider.getSuggestions([line], 0, line.length);
+
+			assert.notEqual(result, null, "Should return suggestions for bare ~ (home directory)");
+			assert.ok(result!.items.length > 0, "Home directory should have entries");
+			assert.strictEqual(result!.prefix, "@~");
+		});
+
+		test("@~/ returns home directory contents", () => {
+			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
+			const line = "@~/";
+			const result = provider.getSuggestions([line], 0, line.length);
+
+			assert.notEqual(result, null, "Should return suggestions for ~/");
+			assert.ok(result!.items.length > 0, "Home directory should have entries");
+			assert.strictEqual(result!.prefix, "@~/");
+		});
+
+		test("@/ returns root directory contents", () => {
+			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
+			const line = "@/";
+			const result = provider.getSuggestions([line], 0, line.length);
+
+			assert.notEqual(result, null, "Should return suggestions for /");
+			assert.ok(result!.items.length > 0, "Root directory should have entries");
+			assert.strictEqual(result!.prefix, "@/");
+		});
+
+		test("@~/. filters to dotfiles in home directory", () => {
+			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
+			const line = "@~/.";
+			const result = provider.getSuggestions([line], 0, line.length);
+
+			assert.notEqual(result, null, "Should return dotfile suggestions from home");
+			assert.ok(result!.items.length > 0, "Home directory should have dotfiles");
+			// All results should be under ~/
+			for (const item of result!.items) {
+				assert.ok(item.description?.startsWith("~/"), `Expected ~/... path, got: ${item.description}`);
+			}
+		});
+
+		test("scopes fuzzy search to absolute directory paths", () => {
+			setupFolder(outsideDir, {
+				files: {
+					"target.ts": "export {};",
+				},
+			});
+
+			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
+			const line = `@${outsideDir}/tar`;
+			const result = provider.getSuggestions([line], 0, line.length);
+
+			const values = result?.items.map((item) => item.value);
+			assert.ok(values?.includes(`@${outsideDir}/target.ts`));
+		});
 	});
 
 	describe("quoted path completion", () => {


### PR DESCRIPTION
## Problem

Typing `@~/.dotfiles` or `@/etc/hosts` in the editor to reference files outside cwd does not work. The autocomplete popup cancels after `@~` and never comes back.

## Root Cause

Two bugs in `packages/tui`:

1. **`autocomplete.ts` `resolveScopedFuzzyQuery`**: Bare `~` (without trailing `/`) returns `null` because `lastIndexOf("/")` is `-1`. This causes the fuzzy search to fall back to cwd-based `fd` where `~` matches nothing → autocomplete returns empty → popup cancels.

2. **`editor.ts` `insertCharacter`**: The re-trigger regex `/[a-zA-Z0-9.\-_]/` excludes `~` and `/`. After autocomplete cancels (from bug 1), typing `/` cannot re-trigger it in an `@` context, so the popup stays dead.

## Fix

1. Handle bare `~` in `resolveScopedFuzzyQuery` by returning `{ baseDir: homedir(), query: "", displayBase: "~/" }` before checking for slashes.

2. Add `~` and `/` to the re-trigger character class: `/[a-zA-Z0-9.\-_~/]/`. These only fire when in an `@` file reference context (checked by the existing regex guard), so slash commands are unaffected.

## Sequence after fix

- `@` → triggers autocomplete, shows cwd results
- `~` → `updateAutocomplete()` → `resolveScopedFuzzyQuery("~")` now returns home dir → shows home contents
- `/` → continues updating → scoped to `~/`
- `.dotfiles` → filters to matching entries

Tests added for `@~`, `@~/`, `@/`, `@~/.`, and absolute directory paths.