### PR TITLE
fix: shutdown and rebuild extensions on session switch

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1136,8 +1136,6 @@ export class AgentSession {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
 	}): Promise<boolean> {
-		const previousSessionFile = this.sessionFile;
-
 		// Emit session_before_switch event with reason "new" (can be cancelled)
 		if (this._extensionRunner?.hasHandlers("session_before_switch")) {
 			const result = (await this._extensionRunner.emit({
@@ -1152,6 +1150,11 @@ export class AgentSession {
 
 		this._disconnectFromAgent();
 		await this.abort();
+
+		// Shutdown extensions before resetting so they can clean up their state
+		const previousFlagValues = this._extensionRunner?.getFlagValues();
+		await this._extensionRunner?.emit({ type: "session_shutdown" });
+
 		this.agent.reset();
 		this.sessionManager.newSession({ parentSession: options?.parentSession });
 		this.agent.sessionId = this.sessionManager.getSessionId();
@@ -1160,6 +1163,13 @@ export class AgentSession {
 		this._pendingNextTurnMessages = [];
 
 		this.sessionManager.appendThinkingLevelChange(this.thinkingLevel);
+
+		// Rebuild runtime to reinitialize extensions for the new session
+		this._buildRuntime({
+			activeToolNames: this.getActiveToolNames(),
+			flagValues: previousFlagValues,
+			includeAllExtensionTools: true,
+		});
 
 		// Run setup callback if provided (e.g., to append initial messages)
 		if (options?.setup) {
@@ -1171,13 +1181,15 @@ export class AgentSession {
 
 		this._reconnectToAgent();
 
-		// Emit session_switch event with reason "new" to extensions
-		if (this._extensionRunner) {
-			await this._extensionRunner.emit({
-				type: "session_switch",
-				reason: "new",
-				previousSessionFile,
-			});
+		// Start extensions in the new session context
+		const hasBindings =
+			this._extensionUIContext ||
+			this._extensionCommandContextActions ||
+			this._extensionShutdownHandler ||
+			this._extensionErrorListener;
+		if (this._extensionRunner && hasBindings) {
+			await this._extensionRunner.emit({ type: "session_start" });
+			await this.extendResourcesFromExtensions("reload");
 		}
 
 		// Emit session event to custom tools


### PR DESCRIPTION
## Problem

When switching sessions via `/new`, `newSession()` does not emit `session_shutdown` or call `_buildRuntime()`. This causes the `ExtensionRunner` and all extension state to persist across sessions. Any processes spawned by extensions (e.g. subagent tool) continue running and deliver results to the new session instead of being terminated.

## Fix

Align `newSession()` cleanup with the existing `reload()` pattern:

1. Emit `session_shutdown` so extensions can clean up their state
2. Call `_buildRuntime()` to reinitialize the extension runtime for the new session
3. Emit `session_start` and reload extension resources after reconnect

## Changes

Single file: `packages/coding-agent/src/core/agent-session.ts`