### PR TITLE
feat: add github-copilot gpt-5.3-codex

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -904,6 +904,42 @@ async function generateModels() {
 	];
 	allModels.push(...codexModels);
 
+	// Add missing GitHub Copilot GPT-5.3 models
+	const COPILOT_BASE_URL = "https://api.individual.githubcopilot.com";
+	const copilotGpt53Models: Model<Api>[] = [
+		{
+			id: "gpt-5.3",
+			name: "GPT-5.3",
+			api: "openai-responses",
+			provider: "github-copilot",
+			baseUrl: COPILOT_BASE_URL,
+			headers: { ...COPILOT_STATIC_HEADERS },
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		},
+		{
+			id: "gpt-5.3-codex",
+			name: "GPT-5.3-Codex",
+			api: "openai-responses",
+			provider: "github-copilot",
+			baseUrl: COPILOT_BASE_URL,
+			headers: { ...COPILOT_STATIC_HEADERS },
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		},
+	];
+	for (const model of copilotGpt53Models) {
+		if (!allModels.some((candidate) => candidate.provider === "github-copilot" && candidate.id === model.id)) {
+			allModels.push(model);
+		}
+	}
+
 	// Add missing Grok models
 	if (!allModels.some(m => m.provider === "xai" && m.id === "grok-code-fast-1")) {
 		allModels.push({

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -12,6 +12,66 @@ for (const [provider, models] of Object.entries(MODELS)) {
 	modelRegistry.set(provider, providerModels);
 }
 
+function registerFallbackModel(model: Model<Api>): void {
+	const providerModels = modelRegistry.get(model.provider) ?? new Map<string, Model<Api>>();
+	if (!providerModels.has(model.id)) {
+		providerModels.set(model.id, model);
+	}
+	if (!modelRegistry.has(model.provider)) {
+		modelRegistry.set(model.provider, providerModels);
+	}
+}
+
+const COPILOT_FALLBACK_HEADERS = {
+	"User-Agent": "GitHubCopilotChat/0.35.0",
+	"Editor-Version": "vscode/1.107.0",
+	"Editor-Plugin-Version": "copilot-chat/0.35.0",
+	"Copilot-Integration-Id": "vscode-chat",
+} as const;
+
+const COPILOT_GPT53_FALLBACK_MODELS: Model<"openai-responses">[] = [
+	{
+		id: "gpt-5.3",
+		name: "GPT-5.3",
+		api: "openai-responses",
+		provider: "github-copilot",
+		baseUrl: "https://api.individual.githubcopilot.com",
+		headers: { ...COPILOT_FALLBACK_HEADERS },
+		reasoning: true,
+		input: ["text", "image"],
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 272000,
+		maxTokens: 128000,
+	},
+	{
+		id: "gpt-5.3-codex",
+		name: "GPT-5.3-Codex",
+		api: "openai-responses",
+		provider: "github-copilot",
+		baseUrl: "https://api.individual.githubcopilot.com",
+		headers: { ...COPILOT_FALLBACK_HEADERS },
+		reasoning: true,
+		input: ["text", "image"],
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 272000,
+		maxTokens: 128000,
+	},
+];
+
+for (const model of COPILOT_GPT53_FALLBACK_MODELS) {
+	registerFallbackModel(model);
+}
+
 type ModelApi<
 	TProvider extends KnownProvider,
 	TModelId extends keyof (typeof MODELS)[TProvider],

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -21,7 +21,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"google-gemini-cli": "gemini-2.5-pro",
 	"google-antigravity": "gemini-3-pro-high",
 	"google-vertex": "gemini-3-pro-preview",
-	"github-copilot": "gpt-4o",
+	"github-copilot": "gpt-5.3-codex",
 	openrouter: "openai/gpt-5.1-codex",
 	"vercel-ai-gateway": "anthropic/claude-opus-4-6",
 	xai: "grok-4-fast-non-reasoning",


### PR DESCRIPTION
 ## Summary                                                              
                                                                      
 Add GitHub Copilot support for gpt-5.3 and gpt-5.3-codex in local    
 model resolution, and set the Copilot default model to               
 gpt-5.3-codex.                                                       
                                                                      
 This follows the same source-of-truth approach as prior model        
 additions: update generator/runtime/default-resolution logic rather  
 than patching generated output directly.                             
                                                                      
## Changes                                                              
                                                                      
 ### packages/ai/scripts/generate-models.ts                           
                                                                      
 - Add fallback model definitions for:                                
     - github-copilot/gpt-5.3                                         
     - github-copilot/gpt-5.3-codex                                   
 - Add dedupe guard so these are only inserted when missing from      
 upstream catalog data.                                               
                                                                      
 ### packages/ai/src/models.ts                                        
                                                                      
 - Add runtime fallback registration for the same two Copilot models  
 to handle catalog lag safely.                                        
 - Preserve non-destructive behavior: fallback only registers when    
 missing.                                                             
                                                                      
 ### packages/coding-agent/src/core/model-resolver.ts                 
                                                                      
 - Change default model for github-copilot:                           
     - from gpt-4o                                                    
     - to gpt-5.3-codex                                               
                                                                      
## Why                                                                  
                                                                      
 Upstream catalog data does not currently expose gpt-5.3-codex for    
 GitHub Copilot.                                                      
 Without these changes, the model is unavailable in selection/default 
 flows for local development.                                         
                                                                      
## Validation                                                           
                                                                      
 - npm run check (repo root) passes.                                  
 - ./pi-test.sh --list-models github-copilot shows:                   
     - gpt-5.3                                                        
     - gpt-5.3-codex                                             