### PR TITLE
fix(web-ui): use tsc instead of tsgo to fix Lit class field shadowing

### DIFF
--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -11,7 +11,7 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "tsgo -p tsconfig.build.json && tailwindcss -i ./src/app.css -o ./dist/app.css --minify",
+		"build": "tsc -p tsconfig.build.json && tailwindcss -i ./src/app.css -o ./dist/app.css --minify",
 		"dev": "concurrently --names \"build,example\" --prefix-colors \"cyan,green\" \"tsc -p tsconfig.build.json --watch --preserveWatchOutput\" \"tailwindcss -i ./src/app.css -o ./dist/app.css --watch\" \"npm run dev --prefix example\"",
 		"dev:tsc": "concurrently --names \"build\" --prefix-colors \"cyan\" \"tsc -p tsconfig.build.json --watch --preserveWatchOutput\" \"tailwindcss -i ./src/app.css -o ./dist/app.css --watch\"",
 		"check": "biome check --write --error-on-warnings . && tsc --noEmit && cd example && biome check --write --error-on-warnings . && tsc --noEmit"

--- a/packages/web-ui/src/dialogs/SettingsDialog.ts
+++ b/packages/web-ui/src/dialogs/SettingsDialog.ts
@@ -1,5 +1,6 @@
 import { i18n } from "@mariozechner/mini-lit";
-import { Dialog, DialogContent, DialogHeader } from "@mariozechner/mini-lit/dist/Dialog.js";
+import { DialogContent, DialogHeader } from "@mariozechner/mini-lit/dist/Dialog.js";
+import { DialogBase } from "@mariozechner/mini-lit/dist/DialogBase.js";
 import { Input } from "@mariozechner/mini-lit/dist/Input.js";
 import { Label } from "@mariozechner/mini-lit/dist/Label.js";
 import { Switch } from "@mariozechner/mini-lit/dist/Switch.js";
@@ -113,20 +114,17 @@ export class ProxyTab extends SettingsTab {
 }
 
 @customElement("settings-dialog")
-export class SettingsDialog extends LitElement {
+export class SettingsDialog extends DialogBase {
 	@property({ type: Array, attribute: false }) tabs: SettingsTab[] = [];
-	@state() private isOpen = false;
 	@state() private activeTabIndex = 0;
 
-	protected createRenderRoot() {
-		return this;
-	}
+	protected override modalWidth = "min(1000px, 90vw)";
+	protected override modalHeight = "min(800px, 90vh)";
 
 	static async open(tabs: SettingsTab[]) {
 		const dialog = new SettingsDialog();
 		dialog.tabs = tabs;
-		dialog.isOpen = true;
-		document.body.appendChild(dialog);
+		dialog.open();
 	}
 
 	private setActiveTab(index: number) {
@@ -163,52 +161,42 @@ export class SettingsDialog extends LitElement {
 		`;
 	}
 
-	render() {
+	protected override renderContent(): TemplateResult {
 		if (this.tabs.length === 0) {
 			return html``;
 		}
 
-		return Dialog({
-			isOpen: this.isOpen,
-			onClose: () => {
-				this.isOpen = false;
-				this.remove();
-			},
-			width: "min(1000px, 90vw)",
-			height: "min(800px, 90vh)",
-			backdropClassName: "bg-black/50 backdrop-blur-sm",
-			children: html`
-				${DialogContent({
-					className: "h-full p-6",
-					children: html`
-						<div class="flex flex-col h-full overflow-hidden">
-							<!-- Header -->
-							<div class="pb-4 flex-shrink-0">${DialogHeader({ title: i18n("Settings") })}</div>
+		return html`
+			${DialogContent({
+				className: "h-full p-6",
+				children: html`
+					<div class="flex flex-col h-full overflow-hidden">
+						<!-- Header -->
+						<div class="pb-4 flex-shrink-0">${DialogHeader({ title: i18n("Settings") })}</div>
 
-							<!-- Mobile Tabs -->
-							<div class="md:hidden flex flex-shrink-0 pb-4">
-								${this.tabs.map((tab, index) => this.renderMobileTab(tab, index))}
+						<!-- Mobile Tabs -->
+						<div class="md:hidden flex flex-shrink-0 pb-4">
+							${this.tabs.map((tab, index) => this.renderMobileTab(tab, index))}
+						</div>
+
+						<!-- Layout -->
+						<div class="flex flex-1 overflow-hidden">
+							<!-- Sidebar (desktop only) -->
+							<div class="hidden md:block w-64 flex-shrink-0 space-y-1">
+								${this.tabs.map((tab, index) => this.renderSidebarItem(tab, index))}
 							</div>
 
-							<!-- Layout -->
-							<div class="flex flex-1 overflow-hidden">
-								<!-- Sidebar (desktop only) -->
-								<div class="hidden md:block w-64 flex-shrink-0 space-y-1">
-									${this.tabs.map((tab, index) => this.renderSidebarItem(tab, index))}
-								</div>
-
-								<!-- Content -->
-								<div class="flex-1 overflow-y-auto md:pl-6">
-									${this.tabs.map(
-										(tab, index) =>
-											html`<div style="display: ${this.activeTabIndex === index ? "block" : "none"}">${tab}</div>`,
-									)}
-								</div>
+							<!-- Content -->
+							<div class="flex-1 overflow-y-auto md:pl-6">
+								${this.tabs.map(
+									(tab, index) =>
+										html`<div style="display: ${this.activeTabIndex === index ? "block" : "none"}">${tab}</div>`,
+								)}
 							</div>
 						</div>
-					`,
-				})}
-			`,
-		});
+					</div>
+				`,
+			})}
+		`;
 	}
 }


### PR DESCRIPTION
## Summary

- **Switch web-ui build from `tsgo` to `tsc`** — `tsgo` does not respect `useDefineForClassFields: false`, causing native ES2022 class fields to shadow Lit's reactive property accessors. This broke all `@state()`/`@property()` decorated fields across 23 web-ui components (78 instances) — state changes never triggered re-renders.
- **Fix SettingsDialog to extend `DialogBase`** instead of manually managing dialog state with `LitElement`, matching the pattern used by all other dialogs (SessionListDialog, CustomProviderDialog, etc.)

The `dev` script already used `tsc`, so this aligns the `build` script with it.

## Test plan

- [ ] Run `cd packages/web-ui && npm run build` — should succeed
- [ ] Run `cd packages/web-ui/example && npm run dev` — open http://localhost:5173
- [ ] Click the gear/settings icon — Settings dialog should open
- [ ] Verify Providers & Models tab renders cloud providers and custom provider controls
- [ ] Verify Proxy tab renders toggle and URL input
- [ ] Run `npm run check` from repo root — should pass