### PR TITLE
feat: WSL clipboard image support via PowerShell fallback

### DIFF
--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -1,4 +1,8 @@
 import { spawnSync } from "child_process";
+import { randomUUID } from "crypto";
+import { readFileSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 import { clipboard } from "./clipboard-native.js";
 import { loadPhoton } from "./photon.js";
@@ -134,6 +138,60 @@ function readClipboardImageViaWlPaste(): ClipboardImage | null {
 	return { bytes: data.stdout, mimeType: baseMimeType(selectedType) };
 }
 
+function isWSL(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (env.WSL_DISTRO_NAME || env.WSLENV) {
+		return true;
+	}
+	try {
+		const release = readFileSync("/proc/version", "utf-8");
+		return /microsoft|wsl/i.test(release);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * On WSL, the Linux clipboard (Wayland/X11) doesn't receive image data from
+ * Windows screenshots (Win+Shift+S). PowerShell can access the Windows clipboard
+ * directly, so we use it as a fallback.
+ */
+function readClipboardImageViaPowerShell(): ClipboardImage | null {
+	const tmpFile = join(tmpdir(), `pi-wsl-clip-${randomUUID()}.png`);
+
+	// Convert WSL path to Windows path for PowerShell
+	const winPathResult = runCommand("wslpath", ["-w", tmpFile], { timeoutMs: DEFAULT_LIST_TIMEOUT_MS });
+	if (!winPathResult.ok) {
+		return null;
+	}
+	const winPath = winPathResult.stdout.toString("utf-8").trim();
+
+	const psScript = `Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $img.Save('${winPath}'); Write-Output 'ok' } else { Write-Output 'empty' }`;
+
+	const result = runCommand("powershell.exe", ["-NoProfile", "-command", psScript], {
+		timeoutMs: 5000,
+	});
+
+	if (!result.ok) {
+		return null;
+	}
+
+	const output = result.stdout.toString("utf-8").trim();
+	if (output !== "ok") {
+		return null;
+	}
+
+	try {
+		const bytes = readFileSync(tmpFile);
+		unlinkSync(tmpFile);
+		if (bytes.length === 0) {
+			return null;
+		}
+		return { bytes: new Uint8Array(bytes), mimeType: "image/png" };
+	} catch {
+		return null;
+	}
+}
+
 function readClipboardImageViaXclip(): ClipboardImage | null {
 	const targets = runCommand("xclip", ["-selection", "clipboard", "-t", "TARGETS", "-o"], {
 		timeoutMs: DEFAULT_LIST_TIMEOUT_MS,
@@ -176,6 +234,10 @@ export async function readClipboardImage(options?: {
 
 	if (platform === "linux" && isWaylandSession(env)) {
 		image = readClipboardImageViaWlPaste() ?? readClipboardImageViaXclip();
+		// WSL: Linux clipboard doesn't receive Windows screenshot images — try PowerShell
+		if (!image && isWSL(env)) {
+			image = readClipboardImageViaPowerShell();
+		}
 	} else {
 		if (!clipboard || !clipboard.hasImage()) {
 			return null;

--- a/packages/coding-agent/test/clipboard-image.test.ts
+++ b/packages/coding-agent/test/clipboard-image.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => {
 			hasImage: vi.fn<() => boolean>(),
 			getImageBinary: vi.fn<() => Promise<Uint8Array | null>>(),
 		},
+		readFileSync: vi.fn(),
+		unlinkSync: vi.fn(),
 	};
 });
 
@@ -20,6 +22,15 @@ vi.mock("child_process", () => {
 vi.mock("../src/utils/clipboard-native.js", () => {
 	return {
 		clipboard: mocks.clipboard,
+	};
+});
+
+vi.mock("fs", async (importOriginal) => {
+	const actual = (await importOriginal()) as typeof import("fs");
+	return {
+		...actual,
+		readFileSync: mocks.readFileSync,
+		unlinkSync: mocks.unlinkSync,
 	};
 });
 
@@ -52,6 +63,8 @@ describe("readClipboardImage", () => {
 		mocks.spawnSync.mockReset();
 		mocks.clipboard.hasImage.mockReset();
 		mocks.clipboard.getImageBinary.mockReset();
+		mocks.readFileSync.mockReset();
+		mocks.unlinkSync.mockReset();
 	});
 
 	test("Wayland: uses wl-paste and never calls clipboard", async () => {
@@ -132,5 +145,77 @@ describe("readClipboardImage", () => {
 		const { readClipboardImage } = await import("../src/utils/clipboard-image.js");
 		const result = await readClipboardImage({ platform: "linux", env: {} });
 		expect(result).toBeNull();
+	});
+
+	test("WSL: falls back to PowerShell when wl-paste and xclip fail", async () => {
+		mocks.clipboard.hasImage.mockImplementation(() => {
+			throw new Error("clipboard.hasImage should not be called on Wayland");
+		});
+
+		const enoent = new Error("spawn ENOENT");
+		(enoent as { code?: string }).code = "ENOENT";
+
+		const fakeImageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+		mocks.spawnSync.mockImplementation((command, args, _options) => {
+			if (command === "wl-paste" || command === "xclip") {
+				return spawnError(enoent);
+			}
+			if (command === "wslpath") {
+				return spawnOk(Buffer.from("C:\\tmp\\test.png\n", "utf-8"));
+			}
+			if (command === "powershell.exe") {
+				return spawnOk(Buffer.from("ok\n", "utf-8"));
+			}
+			throw new Error(`Unexpected spawnSync call: ${command} ${(args as string[]).join(" ")}`);
+		});
+
+		mocks.readFileSync.mockReturnValue(fakeImageBytes);
+		mocks.unlinkSync.mockReturnValue(undefined);
+
+		const { readClipboardImage } = await import("../src/utils/clipboard-image.js");
+		const result = await readClipboardImage({
+			platform: "linux",
+			env: { WAYLAND_DISPLAY: "1", WSL_DISTRO_NAME: "Ubuntu" },
+		});
+
+		expect(result).not.toBeNull();
+		expect(result?.mimeType).toBe("image/png");
+		expect(Array.from(result?.bytes ?? [])).toEqual([0x89, 0x50, 0x4e, 0x47]);
+
+		const psCall = mocks.spawnSync.mock.calls.find(([cmd]) => cmd === "powershell.exe");
+		expect(psCall).toBeDefined();
+	});
+
+	test("WSL: does not use PowerShell when wl-paste succeeds", async () => {
+		mocks.clipboard.hasImage.mockImplementation(() => {
+			throw new Error("clipboard.hasImage should not be called on Wayland");
+		});
+
+		mocks.spawnSync.mockImplementation((command, args, _options) => {
+			if (command === "wl-paste" && args[0] === "--list-types") {
+				return spawnOk(Buffer.from("image/png\n", "utf-8"));
+			}
+			if (command === "wl-paste" && args[0] === "--type") {
+				return spawnOk(Buffer.from([4, 5, 6]));
+			}
+			if (command === "powershell.exe") {
+				throw new Error("powershell.exe should not be called when wl-paste succeeds");
+			}
+			throw new Error(`Unexpected spawnSync call: ${command} ${(args as string[]).join(" ")}`);
+		});
+
+		const { readClipboardImage } = await import("../src/utils/clipboard-image.js");
+		const result = await readClipboardImage({
+			platform: "linux",
+			env: { WAYLAND_DISPLAY: "1", WSL_DISTRO_NAME: "Ubuntu" },
+		});
+
+		expect(result).not.toBeNull();
+		expect(result?.mimeType).toBe("image/png");
+		expect(Array.from(result?.bytes ?? [])).toEqual([4, 5, 6]);
+
+		const psCall = mocks.spawnSync.mock.calls.find(([cmd]) => cmd === "powershell.exe");
+		expect(psCall).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Fixes #1722

On WSL, `wl-paste`/`xclip` can't see Windows clipboard contents, so pasting a Win+Shift+S screenshot silently fails. This adds a PowerShell fallback — when both Linux clipboard tools come up empty and we detect WSL (via env vars or `/proc/version`), we shell out to `powershell.exe` to save the clipboard image to a temp file and read it back.

Two new tests cover the happy path (PowerShell fallback kicks in) and the short-circuit (wl-paste succeeds, PowerShell never called).

`npm run check` and `./test.sh` pass clean.

Wrote this with Claude Code.