### PR TITLE
fix(coding-agent): add missing strip-ansi dependency

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -55,6 +55,7 @@
 		"marked": "^15.0.12",
 		"minimatch": "^10.2.3",
 		"proper-lockfile": "^4.1.2",
+		"strip-ansi": "^7.1.0",
 		"yaml": "^2.8.2"
 	},
 	"overrides": {


### PR DESCRIPTION
## Summary

`strip-ansi` is imported in three source files but not declared in `packages/coding-agent/package.json` dependencies:

- `src/core/bash-executor.ts`
- `src/modes/interactive/components/bash-execution.ts`
- `src/modes/interactive/components/tool-execution.ts`

This causes `ERR_MODULE_NOT_FOUND` at runtime when used with strict package managers like pnpm that do not hoist undeclared dependencies. It started affecting consumers after the 0.55.3 release.

## Fix

Added `"strip-ansi": "^7.1.0"` to `dependencies` in `packages/coding-agent/package.json`.