### PR TITLE
fix(coding-agent): strip all control characters from session display text

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -440,7 +440,7 @@ class SessionList implements Component, Focusable {
 			// Session display text (name or first message)
 			const hasName = !!session.name;
 			const displayText = session.name ?? session.firstMessage;
-			const normalizedMessage = displayText.replace(/\n/g, " ").trim();
+			const normalizedMessage = displayText.replace(/[\x00-\x1f\x7f]/g, " ").trim();
 
 			// Right side: message count and age
 			const age = formatSessionDate(session.modified);


### PR DESCRIPTION
The session selector only stripped newlines from the display text. Other control characters would still show up and garble the session list.

I came across this bug when I wanted to resume a session and my first prompt in the session contained characters which were not replaced and broke the session picker UI.

[![asciicast-pi-fix](https://asciinema.org/a/PEIhPUo4NLTQlGc9.svg)](https://asciinema.org/a/PEIhPUo4NLTQlGc9)