### PR TITLE
fix: regenerate lockfile for missing strip-ansi@7 resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
 			"dependencies": {
 				"@mariozechner/jiti": "^2.6.5",
 				"@mariozechner/pi-coding-agent": "^0.30.2",
-				"get-east-asian-width": "^1.4.0",
-				"koffi": "^2.15.1"
+				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.3.5",
@@ -6093,6 +6092,7 @@
 			"integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
 			"hasInstallScript": true,
 			"license": "MIT",
+			"optional": true,
 			"funding": {
 				"url": "https://liberapay.com/Koromix"
 			}
@@ -8553,6 +8553,7 @@
 				"marked": "^15.0.12",
 				"minimatch": "^10.2.3",
 				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
 				"yaml": "^2.8.2"
 			},
 			"bin": {
@@ -8617,6 +8618,33 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
+			}
+		},
+		"packages/coding-agent/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"packages/coding-agent/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"packages/coding-agent/node_modules/undici-types": {
@@ -8695,7 +8723,6 @@
 				"@types/mime-types": "^2.1.4",
 				"chalk": "^5.5.0",
 				"get-east-asian-width": "^1.3.0",
-				"koffi": "^2.9.0",
 				"marked": "^15.0.12",
 				"mime-types": "^3.0.1"
 			},
@@ -8705,6 +8732,9 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
 			}
 		},
 		"packages/tui/node_modules/mime-db": {


### PR DESCRIPTION
Commit c04708a7 added strip-ansi@^7.1.0 to coding-agent/package.json but did not update the lockfile. npm ci fails in CI because strip-ansi@7.2.0 and ansi-regex@6.2.2 are missing from the lock.