### PR TITLE
fix(ai): support gemini-3.1-flash-lite-preview and 3.1 thinking matching

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -823,6 +823,27 @@ async function generateModels() {
 		});
 	}
 
+	// Add missing Gemini 3.1 Flash Lite Preview until models.dev lists it.
+	if (!allModels.some(m => m.provider === "google" && m.id === "gemini-3.1-flash-lite-preview")) {
+		allModels.push({
+			id: "gemini-3.1-flash-lite-preview",
+			name: "Gemini 3.1 Flash Lite Preview",
+			api: "google-generative-ai",
+			baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+			provider: "google",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 1048576,
+			maxTokens: 65536,
+		});
+	}
+
 	// OpenAI Codex (ChatGPT OAuth) models
 	// NOTE: These are not fetched from models.dev; we keep a small, explicit list to avoid aliases.
 	// Context window is based on observed server limits (400s above ~272k), not marketing numbers.

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -3188,6 +3188,23 @@ export const MODELS = {
 			contextWindow: 1048576,
 			maxTokens: 65536,
 		} satisfies Model<"google-generative-ai">,
+		"gemini-3.1-flash-lite-preview": {
+			id: "gemini-3.1-flash-lite-preview",
+			name: "Gemini 3.1 Flash Lite Preview",
+			api: "google-generative-ai",
+			provider: "google",
+			baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 1048576,
+			maxTokens: 65536,
+		} satisfies Model<"google-generative-ai">,
 		"gemini-3.1-pro-preview-customtools": {
 			id: "gemini-3.1-pro-preview-customtools",
 			name: "Gemini 3.1 Pro Preview Custom Tools",

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -416,11 +416,11 @@ function buildParams(
 type ClampedThinkingLevel = Exclude<PiThinkingLevel, "xhigh">;
 
 function isGemini3ProModel(model: Model<"google-generative-ai">): boolean {
-	return model.id.includes("3-pro");
+	return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());
 }
 
 function isGemini3FlashModel(model: Model<"google-generative-ai">): boolean {
-	return model.id.includes("3-flash");
+	return /gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
 }
 
 function getGemini3ThinkingLevel(

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -386,11 +386,11 @@ function buildParams(
 type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh">;
 
 function isGemini3ProModel(model: Model<"google-generative-ai">): boolean {
-	return model.id.includes("3-pro");
+	return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());
 }
 
 function isGemini3FlashModel(model: Model<"google-generative-ai">): boolean {
-	return model.id.includes("3-flash");
+	return /gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
 }
 
 function getGemini3ThinkingLevel(


### PR DESCRIPTION
## Summary

This PR adds official support for `gemini-3.1-flash-lite-preview` and fixes Gemini 3.1 model matching for Google providers.

### Changes

1. Added `gemini-3.1-flash-lite-preview` to `MODELS.google` in `packages/ai/src/models.generated.ts`.
2. Added a static fallback in `packages/ai/scripts/generate-models.ts` so the model remains available until `models.dev` includes it.
3. Updated Gemini 3 model detection in:
   - `packages/ai/src/providers/google.ts`
   - `packages/ai/src/providers/google-vertex.ts`

Old logic used `includes("3-pro")` / `includes("3-flash")`, which misses `gemini-3.1-*` IDs.
New logic uses regex matching to support `gemini-3`, `gemini-3.1`, and future `gemini-3.x` variants.

## Verification

- `npm run check` (passes in this branch)
- `npm test` in `packages/ai`
  - non-provider/unit tests pass
  - provider/e2e tests requiring valid external credentials fail in this environment (e.g. Groq 401), unrelated to this change

## Issue

Fixes #1785
