### PR TITLE
fix(openai-codex): fall back to root-level accountId fields in JWT

### DIFF
--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -286,8 +286,11 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 
 function getAccountId(accessToken: string): string | null {
 	const payload = decodeJwt(accessToken);
-	const auth = payload?.[JWT_CLAIM_PATH];
-	const accountId = auth?.chatgpt_account_id;
+	if (!payload) return null;
+	const accountId =
+		payload[JWT_CLAIM_PATH]?.chatgpt_account_id ??
+		payload.chatgpt_account_id ??
+		payload.account_id;
 	return typeof accountId === "string" && accountId.length > 0 ? accountId : null;
 }
 


### PR DESCRIPTION
## Problem

`getAccountId()` only looks for `chatgpt_account_id` under the nested `https://api.openai.com/auth` JWT claim path. When OpenAI issues tokens with a different structure — `chatgpt_account_id` at the root, or using the alternate field name `account_id` — the function returns `null` and throws:

```
Error: Failed to extract accountId from token
```

This silently breaks the entire Codex login flow for affected users.

## Solution

Add two fallback lookups with `??` chaining:

1. `payload.chatgpt_account_id` — root-level variant (observed in some experimental token responses)
2. `payload.account_id` — alternate field name for forward compatibility

The primary lookup is unchanged; fallbacks are only reached when the standard path returns `undefined`.

## Test matrix

| Token structure | Before | After |
|---|---|---|
| Nested `https://api.openai.com/auth`.chatgpt_account_id | ✅ | ✅ |
| Root-level `chatgpt_account_id` | ❌ null | ✅ |
| Root-level `account_id` | ❌ null | ✅ |
| No account field | null | null |

## Risk

Low. The change is purely additive — existing behavior is preserved for standard tokens. No new dependencies introduced.