### PR TITLE
fix(coding-agent): queue messages during branch summarization

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -508,9 +508,13 @@ export class AgentSession {
 		}
 	}
 
-	/** Whether auto-compaction is currently running */
+	/** Whether compaction or branch summarization is currently running */
 	get isCompacting(): boolean {
-		return this._autoCompactionAbortController !== undefined || this._compactionAbortController !== undefined;
+		return (
+			this._autoCompactionAbortController !== undefined ||
+			this._compactionAbortController !== undefined ||
+			this._branchSummaryAbortController !== undefined
+		);
 	}
 
 	/** All messages including custom types like BashExecutionMessage */

--- a/packages/coding-agent/test/agent-session-tree-navigation.test.ts
+++ b/packages/coding-agent/test/agent-session-tree-navigation.test.ts
@@ -193,6 +193,10 @@ describe.skipIf(!API_KEY)("AgentSession tree navigation e2e", () => {
 
 		// Abort after a short delay (let the LLM call start)
 		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		// isCompacting should be true during branch summarization
+		expect(session.isCompacting).toBe(true);
+
 		session.abortBranchSummary();
 
 		const result = await navigationPromise;


### PR DESCRIPTION
Messages submitted while a branch summary was being generated were processed immediately instead of being queued. This happened because `isCompacting` only checked compaction abort controllers, not the branch summary abort controller.

Include `_branchSummaryAbortController` in the `isCompacting` getter so all existing guards (message queueing, reload blocking) also apply during branch summarization.