### PR TITLE
fix(coding-agent): correct execute param order in extensions README

### DIFF
--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -154,7 +154,7 @@ export default function (pi: ExtensionAPI) {
     parameters: Type.Object({
       name: Type.String({ description: "Name to greet" }),
     }),
-    async execute(toolCallId, params, onUpdate, ctx, signal) {
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
       return {
         content: [{ type: "text", text: `Hello, ${params.name}!` }],
         details: {},


### PR DESCRIPTION
 The `ToolDefinition.execute` signature in `packages/coding-agent/src/core/extensions/types.ts` is:

 ```typescript
   execute(toolCallId, params, signal, onUpdate, ctx)
 ```

 The README example had `signal` and `onUpdate` swapped.

Every other example in the repo uses the correct order and the main extension docs at docs/extensions.md also show the correct order throughout.