### PR TITLE
fix(coding-agent): detect GNU screen TERM values and downgrade to 256color

### DIFF
--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -174,6 +174,11 @@ function detectColorMode(): ColorMode {
 	if (process.env.TERM_PROGRAM === "Apple_Terminal") {
 		return "256color";
 	}
+	// GNU screen doesn't support truecolor unless explicitly opted in via COLORTERM=truecolor.
+	// TERM under screen is typically "screen", "screen-256color", or "screen.xterm-256color".
+	if (term === "screen" || term.startsWith("screen-") || term.startsWith("screen.")) {
+		return "256color";
+	}
 	// Assume truecolor for everything else - virtually all modern terminals support it
 	return "truecolor";
 }


### PR DESCRIPTION
## Problem

When running pi under GNU screen, most info/status messages get a bright green background.

The cause is a specific misparsing chain:

1. The dark theme's `dim` color is `#666666` = RGB(102, 102, 102)
2. `detectColorMode()` falls through to `return "truecolor"` for `screen`/`screen-256color`/`screen.xterm-256color` TERM values, since none of them match the existing dumb/linux/Apple_Terminal exceptions
3. pi emits `\x1b[38;2;102;102;102m` (truecolor foreground SGR sequence)
4. screen (without truecolor support) misparses the semicolon-separated parameters as individual SGR codes: `38` (ignored), `2` (faint), `102` (**SGR 102 = bright green background**)
5. The active bright green background then fills every subsequent `\x1b[2K` line-erase

## Fix

`detectColorMode()` now returns `"256color"` for TERM values of `screen`, `screen-*` (e.g. `screen-256color`), and `screen.*` (e.g. `screen.xterm-256color`).

The existing `COLORTERM=truecolor`/`24bit` check at the top of the function is unaffected, so users who have properly configured screen's truecolor passthrough and explicitly set `COLORTERM=truecolor` still get truecolor mode.