### PR TITLE
fix: handle undefined message.content in estimateTokens

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -256,7 +256,7 @@ export function estimateTokens(message: AgentMessage): number {
 		case "toolResult": {
 			if (typeof message.content === "string") {
 				chars = message.content.length;
-			} else {
+			} else if (Array.isArray(message.content)) {
 				for (const block of message.content) {
 					if (block.type === "text" && block.text) {
 						chars += block.text.length;
@@ -266,6 +266,7 @@ export function estimateTokens(message: AgentMessage): number {
 					}
 				}
 			}
+			// undefined/null content → 0 tokens
 			return Math.ceil(chars / 4);
 		}
 		case "bashExecution": {


### PR DESCRIPTION
estimateTokens() for custom/toolResult messages assumed content was either a string or an array, but it can also be undefined (e.g. custom extension messages with no content). This caused a TypeError: 'message.content is not iterable'.

Changed else to else if (Array.isArray(message.content)) so undefined content falls through and returns 0 tokens.