### PR TITLE
fix(pi-ai): add 'default' export condition for Node.js v24 compatibility

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -8,15 +8,18 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
 		},
 		"./oauth": {
 			"types": "./oauth.d.ts",
-			"import": "./oauth.js"
+			"import": "./oauth.js",
+			"default": "./oauth.js"
 		},
 		"./bedrock-provider": {
 			"types": "./bedrock-provider.d.ts",
-			"import": "./bedrock-provider.js"
+			"import": "./bedrock-provider.js",
+			"default": "./bedrock-provider.js"
 		}
 	},
 	"bin": {


### PR DESCRIPTION
## Problem

Extensions that import from `@mariozechner/pi-ai` fail to load on **Node.js v24** with:

```
Failed to load extension: Cannot find module '@mariozechner/pi-ai'
```

## Root Cause

The extension loader in `pi-coding-agent` builds jiti aliases via `resolveWorkspaceOrSpecifier()`, which falls back to bare specifiers (e.g., `"@mariozechner/pi-ai"`) when not in a workspace. jiti then needs to resolve these specifiers using its internal CJS resolver.

`pi-ai's` `package.json` exports only have `"types"` and `"import"` conditions — no `"default"` or `"require"`:

```json
"exports": {
  ".": {
    "types": "./dist/index.d.ts",
    "import": "./dist/index.js"
  }
}
```

Node.js v24's `require.resolve()` (used internally by jiti) cannot resolve packages that lack a `"default"` or `"require"` export condition. The `"exports"` field takes precedence over `"main"`.

Other `@mariozechner` packages (`pi-tui`, `pi-agent-core`) resolve fine because they either have no `exports` field (falling back to `main`) or have CJS-compatible export conditions.

## Fix

Add `"default"` conditions to all export entries in `packages/ai/package.json`. Since the package is ESM-only, the `"default"` points to the same files as `"import"`.

## Environment

- pi v0.56.0
- Node.js v24.12.0
- Windows 11 (also affects any OS with Node >= v24)

## Note

This is a partial fix for the broader extension loading issue. The loader's `resolveWorkspaceOrSpecifier()` returns bare specifiers as alias values instead of resolved file paths, which means jiti's CJS resolver must handle the resolution. Adding `"default"` conditions makes that resolution work. A more complete fix would be to have `resolveWorkspaceOrSpecifier()` use `require.resolve()` as a fallback instead of returning the bare specifier.