### PR TITLE
fix(ai): use skip_thought_signature_validator for unsigned Gemini 3 tool calls

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -138,28 +138,25 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 				} else if (block.type === "toolCall") {
 					const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.thoughtSignature);
 					// Gemini 3 requires thoughtSignature on all function calls when thinking mode is enabled.
-					// When replaying history from providers without thought signatures (e.g. Claude via Antigravity),
-					// convert unsigned function calls to text to avoid API validation errors.
-					// We include a note telling the model this is historical context to prevent mimicry.
+					// If missing (e.g., from Claude or older models), we use the Google Cloud Code Assist
+					// sentinel value to bypass signature validation. This avoids text-fallback hallucinations.
 					const isGemini3 = model.id.toLowerCase().includes("gemini-3");
-					if (isGemini3 && !thoughtSignature) {
-						const argsStr = JSON.stringify(block.arguments ?? {}, null, 2);
-						parts.push({
-							text: `[Historical context: a different model called tool "${block.name}" with arguments: ${argsStr}. Do not mimic this format - use proper function calling.]`,
-						});
-					} else {
-						const part: Part = {
-							functionCall: {
-								name: block.name,
-								args: block.arguments ?? {},
-								...(requiresToolCallId(model.id) ? { id: block.id } : {}),
-							},
-						};
-						if (thoughtSignature) {
-							part.thoughtSignature = thoughtSignature;
-						}
-						parts.push(part);
+
+					const part: Part = {
+						functionCall: {
+							name: block.name,
+							args: block.arguments ?? {},
+							...(requiresToolCallId(model.id) ? { id: block.id } : {}),
+						},
+					};
+
+					if (thoughtSignature) {
+						part.thoughtSignature = thoughtSignature;
+					} else if (isGemini3) {
+						part.thoughtSignature = "skip_thought_signature_validator";
 					}
+
+					parts.push(part);
 				}
 			}
 

--- a/packages/ai/test/google-shared-gemini3-unsigned-tool-call.test.ts
+++ b/packages/ai/test/google-shared-gemini3-unsigned-tool-call.test.ts
@@ -3,7 +3,7 @@ import { convertMessages } from "../src/providers/google-shared.js";
 import type { Context, Model } from "../src/types.js";
 
 describe("google-shared convertMessages", () => {
-	it("converts unsigned tool calls to text for Gemini 3", () => {
+	it("adds skip_thought_signature_validator for unsigned tool calls in Gemini 3", () => {
 		const model: Model<"google-generative-ai"> = {
 			id: "gemini-3-pro-preview",
 			name: "Gemini 3 Pro Preview",
@@ -60,13 +60,9 @@ describe("google-shared convertMessages", () => {
 		}
 
 		expect(toolTurn).toBeTruthy();
-		expect(toolTurn?.parts?.some((p) => p.functionCall !== undefined)).toBe(false);
-
-		const text = toolTurn?.parts?.map((p) => p.text ?? "").join("\n");
-		// Should contain historical context note to prevent mimicry
-		expect(text).toContain("Historical context");
-		expect(text).toContain("bash");
-		expect(text).toContain("ls -la");
-		expect(text).toContain("Do not mimic this format");
+		const functionCallPart = toolTurn?.parts?.find((p) => p.functionCall !== undefined);
+		expect(functionCallPart).toBeDefined();
+		expect(functionCallPart?.functionCall?.name).toBe("bash");
+		expect(functionCallPart?.thoughtSignature).toBe("skip_thought_signature_validator");
 	});
 });


### PR DESCRIPTION
# fix(ai): use skip_thought_signature_validator for unsigned Gemini 3 tool calls

## Problem

Gemini 3 models return tool calls without `thought_signatures`, which causes validation errors when these unsigned function calls are included in subsequent API requests. The current workaround converts prior function calls to text-format historical notes, which loses structured function call context and can cause hallucinations when the model sees its own tool use described as prose rather than as actual API calls.

## Root Cause

The Gemini API supports a sentinel value `skip_thought_signature_validator` as an officially documented feature for skipping thought signature validation. This is used by:

- [gemini-cli](https://github.com/google-gemini/gemini-cli)
- Google .NET SDK (`PredictionServiceChatClient.cs`)
- [opencode-antigravity-auth](https://github.com/nicobailon/opencode-antigravity-auth) ([`src/constants.ts:201`](https://github.com/nicobailon/opencode-antigravity-auth/blob/main/src/constants.ts), [`src/plugin/request-helpers.ts:1166`](https://github.com/nicobailon/opencode-antigravity-auth/blob/main/src/plugin/request-helpers.ts))

See also: https://ai.google.dev/gemini-api/docs/thought-signatures

## Fix

Replace the text-fallback conversion with the `skip_thought_signature_validator` sentinel value. For Gemini 3 model responses that contain unsigned function calls, set `thoughtSignature: "skip_thought_signature_validator"` on the function call parts. This preserves proper function call structure in the API payload and avoids hallucination from text-format historical context notes.

## Testing

- ✅ New test: `google-shared-gemini3-unsigned-tool-call.test.ts` — verifies sentinel is applied to unsigned function calls
- ✅ Biome lint clean
- ✅ TypeScript typecheck clean
