### PR TITLE
ai: treat inception as non-standard openai-compat for role mapping

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -771,6 +771,8 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 	const isNonStandard =
 		provider === "cerebras" ||
 		baseUrl.includes("cerebras.ai") ||
+		provider === "inception" ||
+		baseUrl.includes("inceptionlabs.ai") ||
 		provider === "xai" ||
 		baseUrl.includes("api.x.ai") ||
 		provider === "mistral" ||


### PR DESCRIPTION
## Summary
Treat Inception (`provider=inception` / `*.inceptionlabs.ai`) as non-standard for OpenAI-completions compat detection.

This disables `supportsDeveloperRole` by default for Inception so reasoning models send the system prompt with role=`system` rather than role=`developer`.

## Why
Inception Mercury currently rejects `developer` role messages with 400 validation errors.

## Change
- `packages/ai/src/providers/openai-completions.ts`
  - add `provider === "inception"`
  - add `baseUrl.includes("inceptionlabs.ai")`
  - to the `isNonStandard` detection set

## Linked issue
- Fixes #1848
