### PR TITLE
feat(ai): add builtinTypes support for provider-specific tool wire formats

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -839,14 +839,21 @@ function convertMessages(
 	return params;
 }
 
-function convertTools(tools: Tool[], isOAuthToken: boolean): Anthropic.Messages.Tool[] {
+function convertTools(tools: Tool[], isOAuthToken: boolean): any[] {
 	if (!tools) return [];
 
 	return tools.map((tool) => {
+		const toolName = isOAuthToken ? toClaudeCodeName(tool.name) : tool.name;
+
+		const builtin = tool.builtinTypes?.anthropic;
+		if (builtin) {
+			return { ...builtin, name: toolName };
+		}
+
 		const jsonSchema = tool.parameters as any; // TypeBox already generates JSON Schema
 
 		return {
-			name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
+			name: toolName,
 			description: tool.description,
 			input_schema: {
 				type: "object" as const,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -202,6 +202,10 @@ export interface Tool<TParameters extends TSchema = TSchema> {
 	name: string;
 	description: string;
 	parameters: TParameters;
+	/** Provider-specific built-in tool type overrides.
+	 * Key: provider name ("anthropic", "openai", etc.)
+	 * Value: provider-specific wire format object (e.g., { type: "memory_20250818" }) */
+	builtinTypes?: Record<string, unknown>;
 }
 
 export interface Context {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -345,6 +345,8 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	promptGuidelines?: string[];
 	/** Parameter schema (TypeBox) */
 	parameters: TParams;
+	/** @see Tool.builtinTypes */
+	builtinTypes?: Record<string, unknown>;
 
 	/** Execute the tool. */
 	execute(

--- a/packages/coding-agent/src/core/extensions/wrapper.ts
+++ b/packages/coding-agent/src/core/extensions/wrapper.ts
@@ -17,6 +17,7 @@ export function wrapRegisteredTool(registeredTool: RegisteredTool, runner: Exten
 		label: definition.label,
 		description: definition.description,
 		parameters: definition.parameters,
+		builtinTypes: definition.builtinTypes,
 		execute: (toolCallId, params, signal, onUpdate) =>
 			definition.execute(toolCallId, params, signal, onUpdate, runner.createContext()),
 	};


### PR DESCRIPTION
Hey! First time contributor here. I'm working on a memory extension and ran into this, hope this is the right approach, happy to adjust if not.

Anthropic/Claude has a few built-in tool types (e.g., `memory_20250818`, `web_search_20250305`) that use a different wire format (`{ type: "memory_20250818", name: "memory" }`) instead of function tools (`{ name: "memory", input_schema: {...} }`). These currently don't work because `convertTools()` always converts every tool to the function tool format with `input_schema`.

This adds a `builtinTypes` field to `Tool` so extensions can declare built-in types via `registerTool()`:

```
registerTool({
    name: "memory",
    builtinTypes: { anthropic: { type: "memory_20250818" } },
    ...
})
```

## Changes

- Add optional `builtinTypes?: Record<string, unknown>` to `Tool` interace
- Update Anthropic `convertTools()` to emit built-in wire format when `builtinTypes.anthropic` is present
- Add `builtinTypes` to `ToolDefinition` and propagate through `wrapRegisteredTool()`