### PR TITLE
fix(ai): fix oauth subpath type entry

### DIFF
--- a/packages/ai/oauth.d.ts
+++ b/packages/ai/oauth.d.ts
@@ -1,1 +1,1 @@
-export * from "./src/oauth.js";
+export * from "./dist/oauth.js";


### PR DESCRIPTION
`packages/ai/oauth.d.ts` points to `./src/oauth.js`, but that file is not published.

This changes it to `./dist/oauth.js`, matching the runtime wrapper and the published package contents.
