### PR TITLE
fix: handle model_context_window_exceeded stop reason

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -729,6 +729,10 @@ function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"]): Sto
 			return "toolUse";
 		case "content_filter":
 			return "error";
+		// Modern APIs (Anthropic, AWS Bedrock, ZhipuAI/GLM) return this when the context
+		// window is exceeded. Map to "length" to trigger overflow recovery mechanisms.
+		case "model_context_window_exceeded":
+			return "length";
 		default: {
 			const _exhaustive: never = reason;
 			throw new Error(`Unhandled stop reason: ${_exhaustive}`);


### PR DESCRIPTION
## Summary

Modern AI APIs (Anthropic, AWS Bedrock, ZhipuAI/GLM) return `model_context_window_exceeded` as a `finish_reason` when the context window is exceeded. Previously, this caused an unhandled exception that crashed the agent loop.

## Changes

- Added support for `model_context_window_exceeded` stop reason in `mapStopReason()` function
- Maps the new stop reason to `"length"` to trigger existing overflow recovery mechanisms
- Includes inline documentation explaining the mapping rationale

## Impact

This fix prevents abrupt agent failures when context limits are reached with modern models like GLM-4.7, enabling downstream frameworks (e.g., OpenClaw) to properly handle context overflow through their existing compression and retry mechanisms.

## Related

- Resolves crashes reported in OpenClaw when using ZhipuAI GLM models
- Aligns with modern OpenAI-compatible API standards