### PR TITLE
fix(coding-agent): avoid misleading no-api-key errors during auth lock contention

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -81,6 +81,12 @@ import { buildSystemPrompt } from "./system-prompt.js";
 import type { BashOperations } from "./tools/bash.js";
 import { createAllTools } from "./tools/index.js";
 
+function isLockHeldError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const code = (error as { code?: string }).code;
+	return code === "ELOCKED" || /lock file is already being held/i.test(error.message);
+}
+
 // ============================================================================
 // Skill Block Parsing
 // ============================================================================
@@ -871,6 +877,16 @@ export class AgentSession {
 		// Validate API key
 		const apiKey = await this._modelRegistry.getApiKey(this.model);
 		if (!apiKey) {
+			const authErrors = this._modelRegistry.authStorage.drainErrors();
+			const lockError = authErrors.find(isLockHeldError);
+			if (lockError) {
+				throw new Error(
+					`Could not read credentials for "${this.model.provider}" because another pi process is holding the auth/settings lock.\n\n` +
+						`Please retry in a moment. If this keeps happening, reduce concurrent pi startup fan-out.\n\n` +
+						`Original error: ${lockError.message}`,
+				);
+			}
+
 			const isOAuth = this._modelRegistry.isUsingOAuth(this.model);
 			if (isOAuth) {
 				throw new Error(

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -19,6 +19,14 @@ import lockfile from "proper-lockfile";
 import { getAgentDir } from "../config.js";
 import { resolveConfigValue } from "./resolve-config-value.js";
 
+function isLockHeldError(error: unknown): boolean {
+	if (!(error instanceof Error)) {
+		return false;
+	}
+	const maybeCode = (error as { code?: string }).code;
+	return maybeCode === "ELOCKED" || /lock file is already being held/i.test(error.message);
+}
+
 export type ApiKeyCredential = {
 	type: "api_key";
 	key: string;
@@ -57,6 +65,12 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
 			writeFileSync(this.authPath, "{}", "utf-8");
 			chmodSync(this.authPath, 0o600);
 		}
+	}
+
+	readUnlocked(): string | undefined {
+		this.ensureParentDir();
+		this.ensureFileExists();
+		return existsSync(this.authPath) ? readFileSync(this.authPath, "utf-8") : undefined;
 	}
 
 	withLock<T>(fn: (current: string | undefined) => LockResult<T>): T {
@@ -227,6 +241,19 @@ export class AuthStorage {
 			this.data = this.parseStorageData(content);
 			this.loadError = null;
 		} catch (error) {
+			// During parallel startup another pi process may hold the auth lock.
+			// Fall back to an unlocked read so model discovery/auth checks still work.
+			if (isLockHeldError(error) && this.storage instanceof FileAuthStorageBackend) {
+				try {
+					const unlockedContent = this.storage.readUnlocked();
+					this.data = this.parseStorageData(unlockedContent);
+					this.loadError = null;
+					return;
+				} catch {
+					// Ignore fallback failures and surface the original lock error below.
+				}
+			}
+
 			this.loadError = error as Error;
 			this.recordError(error);
 		}

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -421,6 +421,24 @@ describe("AuthStorage", () => {
 			const secondDrain = authStorage.drainErrors();
 			expect(secondDrain).toHaveLength(0);
 		});
+
+		test("falls back to unlocked read when startup lock is held", async () => {
+			writeAuthJson({
+				"openai-codex": { type: "api_key", key: "codex-test-key" },
+			});
+
+			const release = lockfile.lockSync(authJsonPath, { realpath: false });
+			try {
+				authStorage = AuthStorage.create(authJsonPath);
+			} finally {
+				release();
+			}
+
+			const apiKey = await authStorage.getApiKey("openai-codex");
+			expect(apiKey).toBe("codex-test-key");
+			expect(authStorage.hasAuth("openai-codex")).toBe(true);
+			expect(authStorage.drainErrors()).toHaveLength(0);
+		});
 	});
 
 	describe("runtime overrides", () => {


### PR DESCRIPTION
## Summary
This addresses lock-contention behavior where parallel `pi` startups can surface a misleading auth error (`No API key found for openai-codex`) even when OAuth credentials are valid.

### What changed
- **Auth reload fallback during startup lock contention**
  - In `AuthStorage.reload()`, if `withLock()` fails with `ELOCKED` / `Lock file is already being held`, we now fall back to a best-effort unlocked read of `auth.json`.
  - This keeps in-memory auth state populated during parallel startup and prevents providers from disappearing during model resolution.

- **Clearer runtime error when lock contention still blocks credential access**
  - In `AgentSession.prompt()`, when API key resolution fails, we now inspect recent auth errors.
  - If a lock-held error is present, we throw a lock-specific message instead of the generic API key guidance.

- **Regression test**
  - Added `falls back to unlocked read when startup lock is held` in `test/auth-storage.test.ts`.

## Why
In parallel subagent fan-out, multiple `pi` processes contend for shared `~/.pi/agent/auth.json` / settings locks. One process can fail startup auth loading due lock contention, then later emit a misleading "No API key" error. This PR preserves credential visibility and improves fallback messaging.

## Testing
- `pnpm vitest --run test/auth-storage.test.ts`

## Linked issue
Closes #1871
