### PR TITLE
fix(coding-agent): preserve thinking preference through non-reasoning model switches

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1315,12 +1315,14 @@ export class AgentSession {
 		}
 
 		const previousModel = this.model;
+		const preferredThinkingLevel = this._getPreferredThinkingLevelForModelSwitch();
 		this.agent.setModel(model);
 		this.sessionManager.appendModelChange(model.provider, model.id);
 		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
 
-		// Re-clamp thinking level for new model's capabilities
-		this.setThinkingLevel(this.thinkingLevel);
+		// Model switches may clamp the effective session level, but they should not
+		// overwrite the user's saved default thinking preference.
+		this.setThinkingLevel(preferredThinkingLevel, false);
 
 		await this._emitModelSelect(model, previousModel, "set");
 	}
@@ -1371,6 +1373,7 @@ export class AgentSession {
 		const len = scopedModels.length;
 		const nextIndex = direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
 		const next = scopedModels[nextIndex];
+		const preferredThinkingLevel = next.thinkingLevel ?? this._getPreferredThinkingLevelForModelSwitch();
 
 		// Apply model
 		this.agent.setModel(next.model);
@@ -1380,8 +1383,8 @@ export class AgentSession {
 		// Apply thinking level.
 		// - Explicit scoped model thinking level overrides current session level
 		// - Undefined scoped model thinking level inherits current session level
-		// setThinkingLevel clamps to model capabilities.
-		this.setThinkingLevel(next.thinkingLevel ?? this.thinkingLevel);
+		// - Model-switch clamping should not rewrite the saved default preference
+		this.setThinkingLevel(preferredThinkingLevel, false);
 
 		await this._emitModelSelect(next.model, currentModel, "cycle");
 
@@ -1405,12 +1408,14 @@ export class AgentSession {
 			throw new Error(`No API key for ${nextModel.provider}/${nextModel.id}`);
 		}
 
+		const preferredThinkingLevel = this._getPreferredThinkingLevelForModelSwitch();
 		this.agent.setModel(nextModel);
 		this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
 		this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
 
-		// Re-clamp thinking level for new model's capabilities
-		this.setThinkingLevel(this.thinkingLevel);
+		// Model switches may clamp the effective session level, but they should not
+		// overwrite the user's saved default thinking preference.
+		this.setThinkingLevel(preferredThinkingLevel, false);
 
 		await this._emitModelSelect(nextModel, currentModel, "cycle");
 
@@ -1426,9 +1431,8 @@ export class AgentSession {
 	 * Clamps to model capabilities based on available thinking levels.
 	 * Saves to session and settings only if the level actually changes.
 	 */
-	setThinkingLevel(level: ThinkingLevel): void {
-		const availableLevels = this.getAvailableThinkingLevels();
-		const effectiveLevel = availableLevels.includes(level) ? level : this._clampThinkingLevel(level, availableLevels);
+	setThinkingLevel(level: ThinkingLevel, persistDefault: boolean = true): void {
+		const effectiveLevel = this._resolveThinkingLevel(level);
 
 		// Only persist if actually changing
 		const isChanging = effectiveLevel !== this.agent.state.thinkingLevel;
@@ -1437,7 +1441,9 @@ export class AgentSession {
 
 		if (isChanging) {
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
-			this.settingsManager.setDefaultThinkingLevel(effectiveLevel);
+			if (persistDefault) {
+				this.settingsManager.setDefaultThinkingLevel(effectiveLevel);
+			}
 		}
 	}
 
@@ -1478,6 +1484,18 @@ export class AgentSession {
 	 */
 	supportsThinking(): boolean {
 		return !!this.model?.reasoning;
+	}
+
+	private _getPreferredThinkingLevelForModelSwitch(): ThinkingLevel {
+		if (!this.supportsThinking() && this.thinkingLevel === "off") {
+			return this.settingsManager.getDefaultThinkingLevel() ?? "off";
+		}
+		return this.thinkingLevel;
+	}
+
+	private _resolveThinkingLevel(level: ThinkingLevel): ThinkingLevel {
+		const availableLevels = this.getAvailableThinkingLevels();
+		return availableLevels.includes(level) ? level : this._clampThinkingLevel(level, availableLevels);
 	}
 
 	private _clampThinkingLevel(level: ThinkingLevel, availableLevels: ThinkingLevel[]): ThinkingLevel {
@@ -2526,13 +2544,11 @@ export class AgentSession {
 		const defaultThinkingLevel = this.settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;
 
 		if (hasThinkingEntry) {
-			// Restore thinking level if saved (setThinkingLevel clamps to model capabilities)
-			this.setThinkingLevel(sessionContext.thinkingLevel as ThinkingLevel);
+			// Restore session state without mutating persisted defaults or duplicating
+			// session history.
+			this.agent.setThinkingLevel(this._resolveThinkingLevel(sessionContext.thinkingLevel as ThinkingLevel));
 		} else {
-			const availableLevels = this.getAvailableThinkingLevels();
-			const effectiveLevel = availableLevels.includes(defaultThinkingLevel)
-				? defaultThinkingLevel
-				: this._clampThinkingLevel(defaultThinkingLevel, availableLevels);
+			const effectiveLevel = this._resolveThinkingLevel(defaultThinkingLevel);
 			this.agent.setThinkingLevel(effectiveLevel);
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
 		}

--- a/packages/coding-agent/test/agent-session-model-switch-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-model-switch-thinking.test.ts
@@ -1,0 +1,110 @@
+import { Agent, type ThinkingLevel } from "@mariozechner/pi-agent-core";
+import { getModel } from "@mariozechner/pi-ai";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { assistantMsg, createTestResourceLoader, userMsg } from "./utilities.js";
+
+const reasoningModel = getModel("anthropic", "claude-sonnet-4-5")!;
+const nonReasoningModel = getModel("anthropic", "claude-3-5-haiku-latest")!;
+
+function createSession({
+	thinkingLevel = "high",
+	defaultThinkingLevel = thinkingLevel,
+	scopedModels,
+}: {
+	thinkingLevel?: ThinkingLevel;
+	defaultThinkingLevel?: ThinkingLevel;
+	scopedModels?: Array<{ model: typeof reasoningModel; thinkingLevel?: ThinkingLevel }>;
+} = {}) {
+	const settingsManager = SettingsManager.inMemory({ defaultThinkingLevel });
+	const sessionManager = SessionManager.inMemory();
+	const authStorage = AuthStorage.inMemory();
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	const session = new AgentSession({
+		agent: new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: reasoningModel,
+				systemPrompt: "You are a helpful assistant.",
+				tools: [],
+				thinkingLevel,
+			},
+		}),
+		sessionManager,
+		settingsManager,
+		cwd: process.cwd(),
+		modelRegistry: new ModelRegistry(authStorage, undefined),
+		resourceLoader: createTestResourceLoader(),
+		scopedModels,
+	});
+
+	return { session, sessionManager, settingsManager };
+}
+
+describe("AgentSession model switching", () => {
+	it("preserves the saved thinking preference through non-reasoning models", async () => {
+		const { session, sessionManager, settingsManager } = createSession({
+			scopedModels: [{ model: reasoningModel }, { model: nonReasoningModel }],
+		});
+
+		try {
+			await session.setModel(nonReasoningModel);
+			expect(session.thinkingLevel).toBe("off");
+			expect(settingsManager.getDefaultThinkingLevel()).toBe("high");
+
+			await session.setModel(reasoningModel);
+			expect(session.thinkingLevel).toBe("high");
+
+			await session.cycleModel();
+			expect(session.thinkingLevel).toBe("off");
+			expect(settingsManager.getDefaultThinkingLevel()).toBe("high");
+
+			await session.cycleModel();
+			expect(session.thinkingLevel).toBe("high");
+			expect(settingsManager.getDefaultThinkingLevel()).toBe("high");
+			expect(
+				sessionManager
+					.getEntries()
+					.filter((entry) => entry.type === "thinking_level_change")
+					.map((entry) => entry.thinkingLevel),
+			).toEqual(["off", "high", "off", "high"]);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("restores saved session thinking without overwriting the default", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-test-"));
+		const resumedSessionManager = SessionManager.create(tempDir, tempDir);
+		resumedSessionManager.appendMessage(userMsg("hello"));
+		resumedSessionManager.appendMessage(assistantMsg("hi"));
+		resumedSessionManager.appendModelChange(reasoningModel.provider, reasoningModel.id);
+		resumedSessionManager.appendThinkingLevelChange("low");
+
+		const sessionPath = resumedSessionManager.getSessionFile();
+		const { session, settingsManager, sessionManager } = createSession();
+
+		try {
+			expect(sessionPath).toBeDefined();
+			await session.switchSession(sessionPath!);
+			expect(session.thinkingLevel).toBe("low");
+			expect(settingsManager.getDefaultThinkingLevel()).toBe("high");
+			expect(
+				sessionManager
+					.getEntries()
+					.filter((entry) => entry.type === "thinking_level_change")
+					.map((entry) => entry.thinkingLevel),
+			).toEqual(["low"]);
+		} finally {
+			session.dispose();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Switching to a non-reasoning model currently clamps session thinking to `off` via `setThinkingLevel(...)`, and that also persists `defaultThinkingLevel`. Switching back to a reasoning model then leaves thinking off because the saved preference was overwritten.

Keep the clamp for the live session, but do not persist it during model switches. When switching back from a non-reasoning model, restore the saved default thinking level instead. Also keep session resume from mutating the default or appending a duplicate thinking entry when the session already has a saved `thinking_level_change`.

Add a focused regression test covering reasoning -> non-reasoning -> reasoning via both `setModel()` and `cycleModel()`, plus resume behavior with a saved thinking level.

fixes #1864
