### PR TITLE
fix(tui): add ctrl+enter keybinding support

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ctrl+enter keybinding not working in terminals without Kitty protocol by adding modifyOtherKeys format support ([#1872](https://github.com/badlogic/pi-mono/issues/1872))
+
 ## [0.56.2] - 2026-03-05
 
 ### Added

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -767,6 +767,20 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 				}
 				return false;
 			}
+			if (ctrl && !shift && !alt) {
+				// CSI u sequences (standard Kitty protocol)
+				if (
+					matchesKittySequence(data, CODEPOINTS.enter, MODIFIERS.ctrl) ||
+					matchesKittySequence(data, CODEPOINTS.kpEnter, MODIFIERS.ctrl)
+				) {
+					return true;
+				}
+				// xterm modifyOtherKeys format (fallback when Kitty protocol not enabled)
+				if (matchesModifyOtherKeys(data, CODEPOINTS.enter, MODIFIERS.ctrl)) {
+					return true;
+				}
+				return false;
+			}
 			if (alt && !ctrl && !shift) {
 				// CSI u sequences (standard Kitty protocol)
 				if (

--- a/packages/tui/test/issue-1872-ctrl-enter.test.ts
+++ b/packages/tui/test/issue-1872-ctrl-enter.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Test for issue #1872: ctrl+enter keybinding not working
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { matchesKey, setKittyProtocolActive } from '../src/keys.js';
+
+describe('Issue #1872: ctrl+enter keybinding', () => {
+	it('should match ctrl+enter with modifyOtherKeys sequence', () => {
+		setKittyProtocolActive(false);
+
+		// modifyOtherKeys format: ESC [ codepoint ; modifier u
+		// enter = 13, ctrl modifier = 5 (4+1)
+		const modifyOtherKeysSequence = '\x1b[13;5u';
+
+		const matches = matchesKey(modifyOtherKeysSequence, 'ctrl+enter');
+
+		// After fix, this should match
+		assert.strictEqual(matches, true, 'ctrl+enter should match modifyOtherKeys sequence');
+	});
+
+	it('should match ctrl+enter with Kitty protocol', () => {
+		setKittyProtocolActive(true);
+
+		const kittySequence = '\x1b[13;5u';
+		const matches = matchesKey(kittySequence, 'ctrl+enter');
+
+		// This works because of the Kitty protocol fallback
+		assert.strictEqual(matches, true, 'ctrl+enter should match with Kitty protocol');
+
+		setKittyProtocolActive(false);
+	});
+
+	it('should not confuse plain enter with ctrl+enter', () => {
+		setKittyProtocolActive(false);
+
+		const plainEnter = '\r';
+
+		const matchesCtrlEnter = matchesKey(plainEnter, 'ctrl+enter');
+		const matchesEnter = matchesKey(plainEnter, 'enter');
+
+		assert.strictEqual(matchesCtrlEnter, false, 'plain enter should not match ctrl+enter');
+		assert.strictEqual(matchesEnter, true, 'plain enter should match enter');
+	});
+});


### PR DESCRIPTION
## Summary

- **Bug**: ctrl+enter keybinding not working in most terminals
- **Root cause**: `packages/tui/src/keys.ts` only supports ctrl+enter via Kitty protocol, no modifyOtherKeys or legacy sequence support
- **Fix**: Add modifyOtherKeys format support for ctrl+enter

Fixes #1872

## Problem

Users cannot configure ctrl+enter as the submit keybinding because it's not recognized in terminals without Kitty protocol support (macOS Terminal, iTerm2, xterm, tmux).

**Root cause analysis:**
In `packages/tui/src/keys.ts:748-801`, the enter key handling has special cases for:
- shift+enter (with modifyOtherKeys and legacy sequences)
- alt+enter (with modifyOtherKeys and legacy sequences)
- plain enter (with legacy sequences)

But ctrl+enter only falls through to the Kitty protocol fallback at line 798-801, with no modifyOtherKeys support.

**Before fix:**
- User sets `{"submit": ["ctrl+enter"]}` in keybindings.json
- Pressing ctrl+enter does nothing (or sends plain enter in some terminals)
- Only works in Kitty terminal with protocol enabled

## Changes

- `packages/tui/src/keys.ts` — Add ctrl+enter handling with modifyOtherKeys and Kitty protocol support (lines 770-783)
- `packages/tui/CHANGELOG.md` — Document the fix
- `packages/tui/test/issue-1872-ctrl-enter.test.ts` — Add regression test

**After fix:**
- ctrl+enter recognized via modifyOtherKeys format (`\x1b[13;5u`)
- ctrl+enter recognized via Kitty protocol
- Works in terminals supporting either protocol

## Test plan

- [x] New test: `test/issue-1872-ctrl-enter.test.ts` covers modifyOtherKeys, Kitty protocol, and plain enter distinction
- [x] Follows same pattern as existing shift+enter and alt+enter handling
- [x] No changes to existing keybinding behavior

## Effect on User Experience

**Before:** Users cannot use ctrl+enter as submit key in most terminals (macOS Terminal, iTerm2, xterm, tmux)
**After:** ctrl+enter works in all terminals supporting modifyOtherKeys or Kitty protocol