### PR TITLE
fix(ai): enforce non-empty normalized tool ids in OpenAI responses/completions

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -27,6 +27,7 @@ import type {
 	ToolResultMessage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
@@ -479,18 +480,24 @@ export function convertMessages(
 	const params: ChatCompletionMessageParam[] = [];
 
 	const normalizeToolCallId = (id: string): string => {
-		// Handle pipe-separated IDs from OpenAI Responses API
-		// Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =)
-		// These come from providers like github-copilot, openai-codex, opencode
-		// Extract just the call_id part and normalize it
-		if (id.includes("|")) {
-			const [callId] = id.split("|");
-			// Sanitize to allowed chars and truncate to 40 chars (OpenAI limit)
-			return callId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 40);
+		const raw = id == null ? "" : String(id);
+		const sanitize = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "_").replace(/_+$/, "");
+		const fallback = `call_auto_${shortHash(raw || "empty")}`;
+
+		if (raw.includes("|")) {
+			const [callIdRaw] = raw.split("|");
+			let out = sanitize(callIdRaw || "");
+			if (!out) out = fallback;
+			if (out.length > 40) out = out.slice(0, 40).replace(/_+$/, "") || fallback;
+			return out;
 		}
 
-		if (model.provider === "openai") return id.length > 40 ? id.slice(0, 40) : id;
-		return id;
+		if (model.provider === "openai") {
+			let out = sanitize(raw);
+			if (!out) out = fallback;
+			return out.length > 40 ? out.slice(0, 40).replace(/_+$/, "") || fallback : out;
+		}
+		return raw;
 	};
 
 	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id));

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -90,22 +90,31 @@ export function convertResponsesMessages<TApi extends Api>(
 ): ResponseInput {
 	const messages: ResponseInput = [];
 
+	const normalizeResponsesToolIds = (id: string): { callId: string; itemId: string; combined: string } => {
+		const raw = id == null ? "" : String(id);
+		const parts = raw.split("|");
+		const rawCallId = (parts.shift() || "").trim();
+		const rawItemId = (parts.join("_") || "").trim();
+		const sanitize = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "_").replace(/_+$/, "");
+		const callFallback = `call_auto_${shortHash(raw || "empty")}`;
+		let callId = sanitize(rawCallId);
+		if (!callId) callId = callFallback;
+		if (callId.length > 64) callId = callId.slice(0, 64).replace(/_+$/, "") || callFallback;
+
+		let itemId = sanitize(rawItemId);
+		if (!itemId) itemId = `fc_${callId}`;
+		if (!itemId.startsWith("fc")) {
+			itemId = `fc_${itemId}`;
+		}
+		if (itemId.length > 64) itemId = itemId.slice(0, 64).replace(/_+$/, "");
+		if (!itemId) itemId = "fc_call_auto_fix";
+
+		return { callId, itemId, combined: `${callId}|${itemId}` };
+	};
+
 	const normalizeToolCallId = (id: string): string => {
 		if (!allowedToolCallProviders.has(model.provider)) return id;
-		if (!id.includes("|")) return id;
-		const [callId, itemId] = id.split("|");
-		const sanitizedCallId = callId.replace(/[^a-zA-Z0-9_-]/g, "_");
-		let sanitizedItemId = itemId.replace(/[^a-zA-Z0-9_-]/g, "_");
-		// OpenAI Responses API requires item id to start with "fc"
-		if (!sanitizedItemId.startsWith("fc")) {
-			sanitizedItemId = `fc_${sanitizedItemId}`;
-		}
-		// Truncate to 64 chars and strip trailing underscores (OpenAI Codex rejects them)
-		let normalizedCallId = sanitizedCallId.length > 64 ? sanitizedCallId.slice(0, 64) : sanitizedCallId;
-		let normalizedItemId = sanitizedItemId.length > 64 ? sanitizedItemId.slice(0, 64) : sanitizedItemId;
-		normalizedCallId = normalizedCallId.replace(/_+$/, "");
-		normalizedItemId = normalizedItemId.replace(/_+$/, "");
-		return `${normalizedCallId}|${normalizedItemId}`;
+		return normalizeResponsesToolIds(id).combined;
 	};
 
 	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
@@ -184,8 +193,8 @@ export function convertResponsesMessages<TApi extends Api>(
 					} satisfies ResponseOutputMessage);
 				} else if (block.type === "toolCall") {
 					const toolCall = block as ToolCall;
-					const [callId, itemIdRaw] = toolCall.id.split("|");
-					let itemId: string | undefined = itemIdRaw;
+					const { callId, itemId: normalizedItemId } = normalizeResponsesToolIds(toolCall.id);
+					let itemId: string | undefined = normalizedItemId;
 
 					// For different-model messages, set id to undefined to avoid pairing validation.
 					// OpenAI tracks which fc_xxx IDs were paired with rs_xxx reasoning items.
@@ -215,7 +224,7 @@ export function convertResponsesMessages<TApi extends Api>(
 
 			// Always send function_call_output with text (or placeholder if only images)
 			const hasText = textResult.length > 0;
-			const [callId] = msg.toolCallId.split("|");
+			const { callId } = normalizeResponsesToolIds(msg.toolCallId);
 			messages.push({
 				type: "function_call_output",
 				call_id: callId,

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -23,7 +23,7 @@ export function transformMessages<TApi extends Api>(
 		// Handle toolResult messages - normalize toolCallId if we have a mapping
 		if (msg.role === "toolResult") {
 			const normalizedId = toolCallIdMap.get(msg.toolCallId);
-			if (normalizedId && normalizedId !== msg.toolCallId) {
+			if (normalizedId !== undefined && normalizedId !== msg.toolCallId) {
 				return { ...msg, toolCallId: normalizedId };
 			}
 			return msg;


### PR DESCRIPTION
# Upstream PR Submission Pack (pi-ai 0.55.3 closure)

## Target repository
`badlogic/pi-mono` (package: `packages/ai`)

## PR title
fix(openai): enforce non-empty normalized tool call ids across responses/completions

## PR summary
This PR closes a class of tool-call replay failures caused by edge-case tool IDs that sanitize to empty or become mismatched between assistant tool calls and tool results.

### Root cause
- Existing normalization in responses/completions was sanitize/truncate-only and did not guarantee non-empty fallback IDs.
- `transform-messages` used a truthy guard that can drop toolResult remapping when normalized id is falsy.

### What changed
1. `openai-responses-shared`: add robust ID normalizer with deterministic non-empty fallbacks and apply it consistently to both `function_call` and `function_call_output` writes.
2. `openai-completions`: harden `normalizeToolCallId` to avoid empty outputs for pipe-separated and openai paths.
3. `transform-messages`: replace truthy guard with explicit undefined check so remapping is not skipped.

### Why
- Prevent invalid payloads (`call_id` / `id` empty) and call/result mismatches in replay paths.
- Preserve behavior for already-valid IDs.

## Repro cases addressed
- `toolCall.id = "|||"` (degenerate pipe form)
- IDs with only invalid chars after sanitize
- overlength IDs with special chars
- cross-model replay where assistant/tool result mapping diverges

## Test matrix (must-pass)
- Valid ID unchanged
- Degenerate `|||` yields non-empty deterministic fallback
- overlength/special IDs become valid bounded IDs
- responses: function_call and function_call_output use same normalized call id
- completions: assistant tool id and tool_result tool_call_id stay pair-preserving
- transform: remapping applied when normalized value is edge-case (no truthy drop)

## Notes
- Local operational patch was validated on OpenClaw 2026.3.2 + `@mariozechner/pi-ai@0.55.3`.
- Backup-and-rollback path exists for production safety.

## Attached local analysis artifacts
- `codex-compat/closure-report-0.55.3.md`
- `codex-compat/pr-plan-0.55.3.md`
- `codex-compat/patch-pi-ai-callid-closure-v0553.js`
