### PR TITLE
fix(ai): disable stream_options for Google in openai-completions

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -760,6 +760,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 
 	const useMaxTokens = baseUrl.includes("chutes.ai");
 
+	const isGoogle = provider === "google" || baseUrl.includes("generativelanguage.googleapis.com");
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
 	const isGroq = provider === "groq" || baseUrl.includes("groq.com");
 
@@ -778,7 +779,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		supportsDeveloperRole: !isNonStandard,
 		supportsReasoningEffort: !isGrok && !isZai,
 		reasoningEffortMap,
-		supportsUsageInStreaming: true,
+		supportsUsageInStreaming: !isGoogle,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: false,
 		requiresAssistantAfterToolResult: false,


### PR DESCRIPTION
## Summary

- Google's OpenAI-compatible endpoint does not support `stream_options: { include_usage: true }`
- Currently `supportsUsageInStreaming` is hardcoded to `true` for all providers, so `stream_options` is always sent
- Google silently ignores this today, but it may cause errors (e.g. 402) if stricter validation is enforced in the future
- This adds `isGoogle` detection and sets `supportsUsageInStreaming: !isGoogle`

Only affects users routing Google/Gemini through the `openai-completions` provider. The native `google-generative-ai` provider is unaffected.

## Changes

- Added `isGoogle` detection (`provider === "google"` or URL contains `generativelanguage.googleapis.com`)
- Changed `supportsUsageInStreaming: true` → `supportsUsageInStreaming: !isGoogle`

## Test plan

- [x] Verified `tsgo --noEmit` passes (only pre-existing unrelated error in `coding-agent/cli.ts`)
- [x] Existing tests (`tool-choice`, `tool-result-images`) pass
- [ ] Manual test: confirm Google Gemini via openai-completions no longer sends `stream_options`

cc @badlogic

🤖 Generated with [Claude Code](https://claude.com/claude-code)