### PR TITLE
fix(coding-agent): harden RPC JSONL framing

### DIFF
--- a/packages/coding-agent/src/modes/rpc/jsonl.ts
+++ b/packages/coding-agent/src/modes/rpc/jsonl.ts
@@ -1,0 +1,39 @@
+import type { Readable } from "node:stream";
+
+export function serializeRpcJsonLine(obj: unknown): string {
+	return `${JSON.stringify(obj).replaceAll("\u2028", "\\u2028").replaceAll("\u2029", "\\u2029")}\n`;
+}
+
+export function attachLfLineReader(stream: Readable, onLine: (line: string) => void): () => void {
+	let buffer = "";
+
+	const onData = (chunk: string | Buffer) => {
+		buffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+
+		while (true) {
+			const newlineIndex = buffer.indexOf("\n");
+			if (newlineIndex < 0) break;
+
+			let line = buffer.slice(0, newlineIndex);
+			buffer = buffer.slice(newlineIndex + 1);
+			if (line.endsWith("\r")) line = line.slice(0, -1);
+			onLine(line);
+		}
+	};
+
+	const onEnd = () => {
+		if (!buffer) return;
+		let line = buffer;
+		buffer = "";
+		if (line.endsWith("\r")) line = line.slice(0, -1);
+		if (line) onLine(line);
+	};
+
+	stream.on("data", onData);
+	stream.on("end", onEnd);
+
+	return () => {
+		stream.off("data", onData);
+		stream.off("end", onEnd);
+	};
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -5,12 +5,12 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
-import * as readline from "node:readline";
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
+import { attachLfLineReader } from "./jsonl.js";
 import type { RpcCommand, RpcResponse, RpcSessionState, RpcSlashCommand } from "./rpc-types.js";
 
 // ============================================================================
@@ -53,7 +53,7 @@ export type RpcEventListener = (event: AgentEvent) => void;
 
 export class RpcClient {
 	private process: ChildProcess | null = null;
-	private rl: readline.Interface | null = null;
+	private stopReadingStdout: (() => void) | null = null;
 	private eventListeners: RpcEventListener[] = [];
 	private pendingRequests: Map<string, { resolve: (response: RpcResponse) => void; reject: (error: Error) => void }> =
 		new Map();
@@ -94,13 +94,9 @@ export class RpcClient {
 			this.stderr += data.toString();
 		});
 
-		// Set up line reader for stdout
-		this.rl = readline.createInterface({
-			input: this.process.stdout!,
-			terminal: false,
-		});
-
-		this.rl.on("line", (line) => {
+		// Set up LF-only line reader for stdout. Node readline also splits on U+2028/U+2029,
+		// which breaks JSONL framing when payload strings contain those characters.
+		this.stopReadingStdout = attachLfLineReader(this.process.stdout!, (line) => {
 			this.handleLine(line);
 		});
 
@@ -118,7 +114,8 @@ export class RpcClient {
 	async stop(): Promise<void> {
 		if (!this.process) return;
 
-		this.rl?.close();
+		this.stopReadingStdout?.();
+		this.stopReadingStdout = null;
 		this.process.kill("SIGTERM");
 
 		// Wait for process to exit
@@ -135,7 +132,6 @@ export class RpcClient {
 		});
 
 		this.process = null;
-		this.rl = null;
 		this.pendingRequests.clear();
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -12,7 +12,6 @@
  */
 
 import * as crypto from "node:crypto";
-import * as readline from "readline";
 import type { AgentSession } from "../../core/agent-session.js";
 import type {
 	ExtensionUIContext,
@@ -20,6 +19,7 @@ import type {
 	ExtensionWidgetOptions,
 } from "../../core/extensions/index.js";
 import { type Theme, theme } from "../interactive/theme/theme.js";
+import { attachLfLineReader, serializeRpcJsonLine } from "./jsonl.js";
 import type {
 	RpcCommand,
 	RpcExtensionUIRequest,
@@ -44,7 +44,7 @@ export type {
  */
 export async function runRpcMode(session: AgentSession): Promise<never> {
 	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
-		console.log(JSON.stringify(obj));
+		process.stdout.write(serializeRpcJsonLine(obj));
 	};
 
 	const success = <T extends RpcCommand["type"]>(
@@ -595,19 +595,12 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			await currentRunner.emit({ type: "session_shutdown" });
 		}
 
-		// Close readline interface to stop waiting for input
-		rl.close();
+		detachInput();
+		process.stdin.pause();
 		process.exit(0);
 	}
 
-	// Listen for JSON input
-	const rl = readline.createInterface({
-		input: process.stdin,
-		output: process.stdout,
-		terminal: false,
-	});
-
-	rl.on("line", async (line: string) => {
+	const handleInputLine = async (line: string) => {
 		try {
 			const parsed = JSON.parse(line);
 
@@ -632,6 +625,10 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 		} catch (e: any) {
 			output(error(undefined, "parse", `Failed to parse command: ${e.message}`));
 		}
+	};
+
+	const detachInput = attachLfLineReader(process.stdin, (line) => {
+		void handleInputLine(line);
 	});
 
 	// Keep process alive forever

--- a/packages/coding-agent/test/rpc-jsonl.test.ts
+++ b/packages/coding-agent/test/rpc-jsonl.test.ts
@@ -1,0 +1,52 @@
+import { Readable } from "node:stream";
+import { describe, expect, test } from "vitest";
+import { attachLfLineReader, serializeRpcJsonLine } from "../src/modes/rpc/jsonl.js";
+
+describe("RPC JSONL framing", () => {
+	test("escapes U+2028 and U+2029 in serialized output", () => {
+		const line = serializeRpcJsonLine({ text: "a\u2028b\u2029c" });
+
+		expect(line).toContain("\\u2028");
+		expect(line).toContain("\\u2029");
+		expect(line).not.toContain("a\u2028b");
+		expect(line.endsWith("\n")).toBe(true);
+
+		const parsed = JSON.parse(line.trim()) as { text: string };
+		expect(parsed.text).toBe("a\u2028b\u2029c");
+	});
+
+	test("splits on LF only and preserves U+2028 inside JSON payloads", async () => {
+		const lines: string[] = [];
+		const stream = Readable.from([serializeRpcJsonLine({ text: "a\u2028b" })]);
+
+		const done = new Promise<void>((resolve) => {
+			stream.on("end", resolve);
+		});
+
+		attachLfLineReader(stream, (line) => {
+			lines.push(line);
+		});
+
+		await done;
+
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0])).toEqual({ text: "a\u2028b" });
+	});
+
+	test("handles CRLF-delimited input", async () => {
+		const lines: string[] = [];
+		const stream = Readable.from([Buffer.from('{"a":1}\r\n{"b":2}\r\n')]);
+
+		const done = new Promise<void>((resolve) => {
+			stream.on("end", resolve);
+		});
+
+		attachLfLineReader(stream, (line) => {
+			lines.push(line);
+		});
+
+		await done;
+
+		expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+	});
+});


### PR DESCRIPTION
## Summary

Fix RPC JSONL framing when payload strings contain `U+2028` / `U+2029`.

## What changed

- add a shared RPC JSONL helper that escapes `U+2028` / `U+2029` on output
- switch RPC stdout parsing in `RpcClient` from `readline` to LF-only framing
- switch RPC stdin parsing in `runRpcMode()` from `readline` to LF-only framing
- add regression tests covering separator escaping, LF-only framing, and CRLF input

Fixes #1908

## Validation

- `npm run check`
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/rpc-jsonl.test.ts`
