### PR TITLE
fix(tui): support digit keybindings

### DIFF
--- a/packages/ai/bedrock-provider.d.ts
+++ b/packages/ai/bedrock-provider.d.ts
@@ -1,1 +1,20 @@
-export * from "./dist/bedrock-provider.js";
+import type {
+	AssistantMessageEvent,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	StreamOptions,
+} from "@mariozechner/pi-ai";
+
+export declare const bedrockProviderModule: {
+	streamBedrock: (
+		model: Model<"bedrock-converse-stream">,
+		context: Context,
+		options?: StreamOptions,
+	) => AsyncIterable<AssistantMessageEvent>;
+	streamSimpleBedrock: (
+		model: Model<"bedrock-converse-stream">,
+		context: Context,
+		options?: SimpleStreamOptions,
+	) => AsyncIterable<AssistantMessageEvent>;
+};

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -469,9 +469,9 @@ function getWebSocketConstructor(): WebSocketConstructor | null {
 
 function headersToRecord(headers: Headers): Record<string, string> {
 	const out: Record<string, string> = {};
-	for (const [key, value] of headers.entries()) {
+	headers.forEach((value, key) => {
 		out[key] = value;
-	}
+	});
 	return out;
 }
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added digit keys (`0-9`) to the keybinding system, including Kitty CSI-u and legacy `modifyOtherKeys` support for bindings like `ctrl+1` ([#1905](https://github.com/badlogic/pi-mono/issues/1905))
+
 ## [0.56.3] - 2026-03-06
 
 ### Added

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -71,6 +71,8 @@ type Letter =
 	| "y"
 	| "z";
 
+type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+
 type SymbolKey =
 	| "`"
 	| "-"
@@ -136,7 +138,7 @@ type SpecialKey =
 	| "f11"
 	| "f12";
 
-type BaseKey = Letter | SymbolKey | SpecialKey;
+type BaseKey = Letter | Digit | SymbolKey | SpecialKey;
 
 /**
  * Union type of all valid key identifiers.
@@ -678,6 +680,24 @@ function rawCtrlChar(key: string): string | null {
 	return null;
 }
 
+function matchesPrintableModifyOtherKeys(data: string, expectedKeycode: number, expectedModifier: number): boolean {
+	if (expectedModifier === 0) return false;
+	return matchesModifyOtherKeys(data, expectedKeycode, expectedModifier);
+}
+
+function formatKeyNameWithModifiers(keyName: string, modifier: number): string | undefined {
+	const effectiveMod = modifier & ~LOCK_MASK;
+	const supportedModifierMask = MODIFIERS.shift | MODIFIERS.ctrl | MODIFIERS.alt;
+	if ((effectiveMod & ~supportedModifierMask) !== 0) return undefined;
+
+	const mods: string[] = [];
+	if (effectiveMod & MODIFIERS.shift) mods.push("shift");
+	if (effectiveMod & MODIFIERS.ctrl) mods.push("ctrl");
+	if (effectiveMod & MODIFIERS.alt) mods.push("alt");
+
+	return mods.length > 0 ? `${mods.join("+")}+${keyName}` : keyName;
+}
+
 function parseKeyId(keyId: string): { key: string; ctrl: boolean; shift: boolean; alt: boolean } | null {
 	const parts = keyId.toLowerCase().split("+");
 	const key = parts[parts.length - 1];
@@ -994,39 +1014,52 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 		}
 	}
 
-	// Handle single letter keys (a-z) and some symbols
-	if (key.length === 1 && ((key >= "a" && key <= "z") || SYMBOL_KEYS.has(key))) {
+	// Handle single letter/digit keys and some symbols
+	if (key.length === 1 && ((key >= "a" && key <= "z") || (key >= "0" && key <= "9") || SYMBOL_KEYS.has(key))) {
 		const codepoint = key.charCodeAt(0);
 		const rawCtrl = rawCtrlChar(key);
+		const isLetter = key >= "a" && key <= "z";
 
 		if (ctrl && alt && !shift && !_kittyProtocolActive && rawCtrl) {
 			// Legacy: ctrl+alt+key is ESC followed by the control character
 			return data === `\x1b${rawCtrl}`;
 		}
 
-		if (alt && !ctrl && !shift && !_kittyProtocolActive && key >= "a" && key <= "z") {
-			// Legacy: alt+letter is ESC followed by the letter
+		if (alt && !ctrl && !shift && !_kittyProtocolActive && (isLetter || (key >= "0" && key <= "9"))) {
+			// Legacy: alt+letter/digit is ESC followed by the key
 			if (data === `\x1b${key}`) return true;
 		}
 
 		if (ctrl && !shift && !alt) {
 			// Legacy: ctrl+key sends the control character
 			if (rawCtrl && data === rawCtrl) return true;
-			return matchesKittySequence(data, codepoint, MODIFIERS.ctrl);
+			return (
+				matchesKittySequence(data, codepoint, MODIFIERS.ctrl) ||
+				matchesPrintableModifyOtherKeys(data, codepoint, MODIFIERS.ctrl)
+			);
 		}
 
 		if (ctrl && shift && !alt) {
-			return matchesKittySequence(data, codepoint, MODIFIERS.shift + MODIFIERS.ctrl);
+			return (
+				matchesKittySequence(data, codepoint, MODIFIERS.shift + MODIFIERS.ctrl) ||
+				matchesPrintableModifyOtherKeys(data, codepoint, MODIFIERS.shift + MODIFIERS.ctrl)
+			);
 		}
 
 		if (shift && !ctrl && !alt) {
 			// Legacy: shift+letter produces uppercase
-			if (data === key.toUpperCase()) return true;
-			return matchesKittySequence(data, codepoint, MODIFIERS.shift);
+			if (isLetter && data === key.toUpperCase()) return true;
+			return (
+				matchesKittySequence(data, codepoint, MODIFIERS.shift) ||
+				matchesPrintableModifyOtherKeys(data, codepoint, MODIFIERS.shift)
+			);
 		}
 
 		if (modifier !== 0) {
-			return matchesKittySequence(data, codepoint, modifier);
+			return (
+				matchesKittySequence(data, codepoint, modifier) ||
+				matchesPrintableModifyOtherKeys(data, codepoint, modifier)
+			);
 		}
 
 		// Check both raw char and Kitty sequence (needed for release events)
@@ -1046,13 +1079,7 @@ export function parseKey(data: string): string | undefined {
 	const kitty = parseKittySequence(data);
 	if (kitty) {
 		const { codepoint, baseLayoutKey, modifier } = kitty;
-		const mods: string[] = [];
-		const effectiveMod = modifier & ~LOCK_MASK;
-		const supportedModifierMask = MODIFIERS.shift | MODIFIERS.ctrl | MODIFIERS.alt;
-		if ((effectiveMod & ~supportedModifierMask) !== 0) return undefined;
-		if (effectiveMod & MODIFIERS.shift) mods.push("shift");
-		if (effectiveMod & MODIFIERS.ctrl) mods.push("ctrl");
-		if (effectiveMod & MODIFIERS.alt) mods.push("alt");
+		const formatted = (keyName: string): string | undefined => formatKeyNameWithModifiers(keyName, modifier);
 
 		// Use base layout key only when codepoint is not a recognized Latin
 		// letter (a-z) or symbol (/, -, [, ;, etc.). For those, the codepoint
@@ -1060,8 +1087,9 @@ export function parseKey(data: string): string | undefined {
 		// remapped layouts (Dvorak, Colemak, xremap, etc.) from reporting the
 		// wrong key name based on the QWERTY physical position.
 		const isLatinLetter = codepoint >= 97 && codepoint <= 122; // a-z
+		const isDigit = codepoint >= 48 && codepoint <= 57; // 0-9
 		const isKnownSymbol = SYMBOL_KEYS.has(String.fromCharCode(codepoint));
-		const effectiveCodepoint = isLatinLetter || isKnownSymbol ? codepoint : (baseLayoutKey ?? codepoint);
+		const effectiveCodepoint = isLatinLetter || isDigit || isKnownSymbol ? codepoint : (baseLayoutKey ?? codepoint);
 
 		let keyName: string | undefined;
 		if (effectiveCodepoint === CODEPOINTS.escape) keyName = "escape";
@@ -1079,12 +1107,13 @@ export function parseKey(data: string): string | undefined {
 		else if (effectiveCodepoint === ARROW_CODEPOINTS.down) keyName = "down";
 		else if (effectiveCodepoint === ARROW_CODEPOINTS.left) keyName = "left";
 		else if (effectiveCodepoint === ARROW_CODEPOINTS.right) keyName = "right";
+		else if (effectiveCodepoint >= 48 && effectiveCodepoint <= 57) keyName = String.fromCharCode(effectiveCodepoint);
 		else if (effectiveCodepoint >= 97 && effectiveCodepoint <= 122) keyName = String.fromCharCode(effectiveCodepoint);
 		else if (SYMBOL_KEYS.has(String.fromCharCode(effectiveCodepoint)))
 			keyName = String.fromCharCode(effectiveCodepoint);
 
 		if (keyName) {
-			return mods.length > 0 ? `${mods.join("+")}+${keyName}` : keyName;
+			return formatted(keyName);
 		}
 	}
 
@@ -1098,6 +1127,16 @@ export function parseKey(data: string): string | undefined {
 
 	const legacySequenceKeyId = LEGACY_SEQUENCE_KEY_IDS[data];
 	if (legacySequenceKeyId) return legacySequenceKeyId;
+
+	const modifyOtherKeysMatch = data.match(/^\x1b\[27;(\d+);(\d+)~$/);
+	if (modifyOtherKeysMatch) {
+		const modValue = Number.parseInt(modifyOtherKeysMatch[1] ?? "", 10);
+		const keycode = Number.parseInt(modifyOtherKeysMatch[2] ?? "", 10);
+		if (!Number.isFinite(modValue) || !Number.isFinite(keycode)) return undefined;
+		if (keycode >= 32 && keycode <= 126) {
+			return formatKeyNameWithModifiers(String.fromCharCode(keycode), modValue - 1);
+		}
+	}
 
 	// Legacy sequences (used when Kitty protocol is not active, or for unambiguous sequences)
 	if (data === "\x1b") return "escape";
@@ -1124,8 +1163,8 @@ export function parseKey(data: string): string | undefined {
 		if (code >= 1 && code <= 26) {
 			return `ctrl+alt+${String.fromCharCode(code + 96)}`;
 		}
-		// Legacy alt+letter (ESC followed by letter a-z)
-		if (code >= 97 && code <= 122) {
+		// Legacy alt+letter/digit (ESC followed by the key)
+		if ((code >= 97 && code <= 122) || (code >= 48 && code <= 57)) {
 			return `alt+${String.fromCharCode(code)}`;
 		}
 	}

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -54,6 +54,15 @@ describe("matchesKey", () => {
 			setKittyProtocolActive(false);
 		});
 
+		it("should match ctrl+1 via Kitty CSI-u", () => {
+			setKittyProtocolActive(true);
+			const ctrlOne = "\x1b[49;5u";
+			assert.strictEqual(matchesKey(ctrlOne, "ctrl+1"), true);
+			assert.strictEqual(matchesKey(ctrlOne, "ctrl+2"), false);
+			assert.strictEqual(parseKey(ctrlOne), "ctrl+1");
+			setKittyProtocolActive(false);
+		});
+
 		it("should handle shifted key in format", () => {
 			setKittyProtocolActive(true);
 			// Format with shifted key: CSI codepoint:shifted:base;modifier u
@@ -202,6 +211,8 @@ describe("matchesKey", () => {
 			assert.strictEqual(parseKey("\x1bF"), "alt+right");
 			assert.strictEqual(matchesKey("\x1ba", "alt+a"), true);
 			assert.strictEqual(parseKey("\x1ba"), "alt+a");
+			assert.strictEqual(matchesKey("\x1b1", "alt+1"), true);
+			assert.strictEqual(parseKey("\x1b1"), "alt+1");
 			assert.strictEqual(matchesKey("\x1by", "alt+y"), true);
 			assert.strictEqual(parseKey("\x1by"), "alt+y");
 			assert.strictEqual(matchesKey("\x1bz", "alt+z"), true);
@@ -220,9 +231,22 @@ describe("matchesKey", () => {
 			assert.strictEqual(parseKey("\x1bF"), undefined);
 			assert.strictEqual(matchesKey("\x1ba", "alt+a"), false);
 			assert.strictEqual(parseKey("\x1ba"), undefined);
+			assert.strictEqual(matchesKey("\x1b1", "alt+1"), false);
+			assert.strictEqual(parseKey("\x1b1"), undefined);
 			assert.strictEqual(matchesKey("\x1by", "alt+y"), false);
 			assert.strictEqual(parseKey("\x1by"), undefined);
 			setKittyProtocolActive(false);
+		});
+
+		it("should match modifyOtherKeys digits", () => {
+			setKittyProtocolActive(false);
+			const ctrlOne = "\x1b[27;5;49~";
+			const shiftOne = "\x1b[27;2;49~";
+			assert.strictEqual(matchesKey(ctrlOne, "ctrl+1"), true);
+			assert.strictEqual(matchesKey(ctrlOne, "ctrl+2"), false);
+			assert.strictEqual(matchesKey(shiftOne, "shift+1"), true);
+			assert.strictEqual(parseKey(ctrlOne), "ctrl+1");
+			assert.strictEqual(parseKey(shiftOne), "shift+1");
 		});
 
 		it("should match arrow keys", () => {
@@ -292,6 +316,12 @@ describe("parseKey", () => {
 			setKittyProtocolActive(true);
 			const latinCtrlC = "\x1b[99;5u";
 			assert.strictEqual(parseKey(latinCtrlC), "ctrl+c");
+			setKittyProtocolActive(false);
+		});
+
+		it("should parse Kitty digits", () => {
+			setKittyProtocolActive(true);
+			assert.strictEqual(parseKey("\x1b[49u"), "1");
 			setKittyProtocolActive(false);
 		});
 

--- a/packages/web-ui/example/tsconfig.json
+++ b/packages/web-ui/example/tsconfig.json
@@ -1,15 +1,16 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"target": "ES2022",
 		"module": "ES2022",
 		"lib": ["ES2022", "DOM", "DOM.Iterable"],
 		"moduleResolution": "bundler",
 		"paths": {
 			"*": ["./*"],
-			"@mariozechner/pi-agent-core": ["../../agent/dist/index.d.ts"],
-			"@mariozechner/pi-ai": ["../../ai/dist/index.d.ts"],
-			"@mariozechner/pi-tui": ["../../tui/dist/index.d.ts"],
-			"@mariozechner/pi-web-ui": ["../dist/index.d.ts"]
+			"@mariozechner/pi-agent-core": ["../../agent/src/index.ts"],
+			"@mariozechner/pi-ai": ["../../ai/src/index.ts"],
+			"@mariozechner/pi-tui": ["../../tui/src/index.ts"],
+			"@mariozechner/pi-web-ui": ["../src/index.ts"]
 		},
 		"strict": true,
 		"skipLibCheck": true,

--- a/packages/web-ui/tsconfig.build.json
+++ b/packages/web-ui/tsconfig.build.json
@@ -1,20 +1,25 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "moduleResolution": "bundler",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true,
-    "useDefineForClassFields": false,
-    "rootDir": "./src",
-    "outDir": "./dist"
-  },
-  "include": ["src/**/*"]
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ES2022",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"experimentalDecorators": true,
+		"useDefineForClassFields": false,
+		"rootDir": "./src",
+		"outDir": "./dist",
+		"paths": {
+			"@mariozechner/pi-agent-core": ["../agent/src/index.ts"],
+			"@mariozechner/pi-ai": ["../ai/src/index.ts"],
+			"@mariozechner/pi-tui": ["../tui/src/index.ts"]
+		}
+	},
+	"include": ["src/**/*"]
 }

--- a/packages/web-ui/tsconfig.json
+++ b/packages/web-ui/tsconfig.json
@@ -1,7 +1,13 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["src/**/*"]
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"baseUrl": ".",
+		"noEmit": true,
+		"paths": {
+			"@mariozechner/pi-agent-core": ["../agent/src/index.ts"],
+			"@mariozechner/pi-ai": ["../ai/src/index.ts"],
+			"@mariozechner/pi-tui": ["../tui/src/index.ts"]
+		}
+	},
+	"include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- add digit keys (`0-9`) to the TUI keybinding system so bindings like `ctrl+1` are valid
- handle digit parsing/matching for Kitty CSI-u and legacy `modifyOtherKeys`, with regression coverage in `packages/tui/test/keys.test.ts`
- restore repo checks by fixing the local `bedrock-provider` declaration, a `Headers` typing issue, and source-path resolution in `packages/web-ui`

## Testing
- `cd packages/tui && node --test --import tsx test/keys.test.ts`
- `npm run check`

Fixes #1905
