### PR TITLE
feat(coding-agent): add --max-turns and --max-tokens flags to --print…

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -39,6 +39,8 @@ export interface Args {
 	noThemes?: boolean;
 	listModels?: string | true;
 	verbose?: boolean;
+	maxTurns?: number;
+	maxTokens?: number;
 	messages: string[];
 	fileArgs: string[];
 	/** Unknown flags (potentially extension flags) - map of flag name to value */
@@ -151,6 +153,12 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			}
 		} else if (arg === "--verbose") {
 			result.verbose = true;
+		} else if (arg === "--max-turns" && i + 1 < args.length) {
+			const n = parseInt(args[++i], 10);
+			if (!isNaN(n) && n > 0) result.maxTurns = n;
+		} else if (arg === "--max-tokens" && i + 1 < args.length) {
+			const n = parseInt(args[++i], 10);
+			if (!isNaN(n) && n > 0) result.maxTokens = n;
 		} else if (arg.startsWith("@")) {
 			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
 		} else if (arg.startsWith("--") && extensionFlags) {
@@ -216,6 +224,8 @@ ${chalk.bold("Options:")}
   --no-themes                    Disable theme discovery and loading
   --export <file>                Export session file to HTML and exit
   --list-models [search]         List available models (with optional fuzzy search)
+  --max-turns <n>                Stop agent loop after N turns in --print mode
+  --max-tokens <n>               Stop if cumulative output tokens exceed N in --print mode
   --verbose                      Force verbose startup (overrides quietStartup setting)
   --help, -h                     Show this help
   --version, -v                  Show version number

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -760,6 +760,8 @@ export async function main(args: string[]) {
 			messages: parsed.messages,
 			initialMessage,
 			initialImages,
+			maxTurns: parsed.maxTurns,
+			maxTokens: parsed.maxTokens,
 		});
 		stopThemeWatcher();
 		if (process.stdout.writableLength > 0) {

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -21,6 +21,10 @@ export interface PrintModeOptions {
 	initialMessage?: string;
 	/** Images to attach to the initial message */
 	initialImages?: ImageContent[];
+	/** Stop the agent loop after N turns (--max-turns) */
+	maxTurns?: number;
+	/** Stop if cumulative output tokens exceed N (--max-tokens) */
+	maxTokens?: number;
 }
 
 /**
@@ -28,7 +32,7 @@ export interface PrintModeOptions {
  * Sends prompts to the agent and outputs the result.
  */
 export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
-	const { mode, messages = [], initialMessage, initialImages } = options;
+	const { mode, messages = [], initialMessage, initialImages, maxTurns, maxTokens } = options;
 	if (mode === "json") {
 		const header = session.sessionManager.getHeader();
 		if (header) {
@@ -72,11 +76,34 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 		},
 	});
 
+	// Track turns and tokens for --max-turns / --max-tokens enforcement
+	let turnCount = 0;
+	let totalOutputTokens = 0;
+
 	// Always subscribe to enable session persistence via _handleAgentEvent
 	session.subscribe((event) => {
 		// In JSON mode, output all events
 		if (mode === "json") {
 			console.log(JSON.stringify(event));
+		}
+
+		// Enforce --max-turns limit
+		if (maxTurns !== undefined && event.type === "turn_end") {
+			turnCount++;
+			if (turnCount >= maxTurns) {
+				session.abort();
+			}
+		}
+
+		// Enforce --max-tokens limit
+		if (maxTokens !== undefined && event.type === "message_end" && event.message.role === "assistant") {
+			const assistantMsg = event.message as AssistantMessage;
+			if (assistantMsg.usage) {
+				totalOutputTokens += assistantMsg.usage.output;
+				if (totalOutputTokens >= maxTokens) {
+					session.abort();
+				}
+			}
 		}
 	});
 


### PR DESCRIPTION
… mode

Closes #1898

Add two optional CLI flags for pi --print (non-interactive mode):

  --max-turns <n>   Stop the agent loop after N turns
  --max-tokens <n>  Stop if cumulative output tokens exceed N

When a limit is hit the agent is aborted cleanly and whatever output was produced up to that point is returned — no error exit.

Changes:
- Args interface: maxTurns / maxTokens fields + parsing in parseArgs()
- Help text updated with descriptions for both flags
- PrintModeOptions: maxTurns / maxTokens fields
- runPrintMode: subscribes to turn_end / message_end events and calls session.abort() when the respective limit is reached
- main.ts: forwards parsed.maxTurns / parsed.maxTokens to runPrintMode