### PR TITLE
feat(anthropic): capture rate limit headers in AssistantMessage

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -238,6 +238,18 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			const params = buildParams(model, context, isOAuthToken, options);
 			options?.onPayload?.(params);
 			const anthropicStream = client.messages.stream({ ...params, stream: true }, { signal: options?.signal });
+			// Capture rate limit headers from the HTTP response as soon as it arrives (best-effort).
+			anthropicStream.response.then((httpResponse) => {
+				const rateLimits: Record<string, string> = {};
+				for (const key of httpResponse.headers.keys()) {
+					if (key.startsWith("anthropic-ratelimit-")) {
+						rateLimits[key] = httpResponse.headers.get(key) ?? "";
+					}
+				}
+				if (Object.keys(rateLimits).length > 0) {
+					output.rateLimits = rateLimits;
+				}
+			}).catch(() => { /* best-effort, don't fail the stream */ });
 			stream.push({ type: "start", partial: output });
 
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -189,6 +189,12 @@ export interface AssistantMessage {
 	stopReason: StopReason;
 	errorMessage?: string;
 	timestamp: number; // Unix timestamp in milliseconds
+	/**
+	 * Raw rate limit headers from the LLM provider HTTP response, keyed by header name.
+	 * Currently populated for Anthropic (headers starting with `anthropic-ratelimit-`).
+	 * `undefined` for providers that do not expose response headers.
+	 */
+	rateLimits?: Record<string, string>;
 }
 
 export interface ToolResultMessage<TDetails = any> {


### PR DESCRIPTION
## Summary

Attaches Anthropic rate limit response headers (`anthropic-ratelimit-*`) to the `AssistantMessage` output object as an optional `rateLimits?: Record<string, string>` field.

## Changes

- **`packages/ai/src/types.ts`**: Added optional `rateLimits?: Record<string, string>` field to the `AssistantMessage` interface with JSDoc.
- **`packages/ai/src/providers/anthropic.ts`**: Captures headers from the Anthropic SDK's `stream.response` promise as soon as the HTTP response arrives, before streaming begins. Only `anthropic-ratelimit-*` headers are captured. Failure is silently swallowed to avoid affecting stream behaviour.

## Motivation

Downstream consumers (e.g. [OpenClaw](https://github.com/openclaw/openclaw)) need live rate limit information to implement token budget tracking and automatic model fallback. The Anthropic API exposes this via response headers:

- `anthropic-ratelimit-tokens-limit`
- `anthropic-ratelimit-tokens-remaining`
- `anthropic-ratelimit-tokens-reset`
- `anthropic-ratelimit-input-tokens-*` / `anthropic-ratelimit-output-tokens-*`

Without this, consumers must self-count tokens which is imprecise and doesn't account for cache tokens or concurrent sessions.

## Backward Compatibility

Fully backward compatible — `rateLimits` is optional and `undefined` until the field is populated. No breaking changes.