### PR TITLE
fix(coding-agent): use shell for external editor on windows

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
@@ -126,6 +126,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 			const [editor, ...editorArgs] = editorCmd.split(" ");
 			const result = spawnSync(editor, [...editorArgs, tmpFile], {
 				stdio: "inherit",
+				shell: process.platform === "win32",
 			});
 
 			if (result.status === 0) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2766,6 +2766,7 @@ export class InteractiveMode {
 			// Spawn editor synchronously with inherited stdio for interactive editing
 			const result = spawnSync(editor, [...editorArgs, tmpFile], {
 				stdio: "inherit",
+				shell: process.platform === "win32",
 			});
 
 			// On successful exit (status 0), replace editor content


### PR DESCRIPTION
Use shell spawning for the built-in external editor on Windows so commands like `code --wait` resolve correctly in Git Bash / MSYS environments. Fixes #1925.