### PR TITLE
fix: fail gracefully when fd release asset is missing

### DIFF
--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -11,6 +11,30 @@ import { APP_NAME, getBinDir } from "../config.js";
 const TOOLS_DIR = getBinDir();
 const NETWORK_TIMEOUT_MS = 10000;
 
+type ToolManagerOps = {
+	spawnSync: typeof spawnSync;
+	fetch: typeof fetch;
+	createWriteStream: typeof createWriteStream;
+	existsSync: typeof existsSync;
+	mkdirSync: typeof mkdirSync;
+	readdirSync: typeof readdirSync;
+	renameSync: typeof renameSync;
+	rmSync: typeof rmSync;
+	chmodSync: typeof chmodSync;
+};
+
+const defaultOps: ToolManagerOps = {
+	spawnSync,
+	fetch,
+	createWriteStream,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	renameSync,
+	rmSync,
+	chmodSync,
+};
+
 function isOfflineModeEnabled(): boolean {
 	const value = process.env.PI_OFFLINE;
 	if (!value) return false;
@@ -23,6 +47,7 @@ interface ToolConfig {
 	binaryName: string; // Name of the binary inside the archive
 	tagPrefix: string; // Prefix for tags (e.g., "v" for v1.0.0, "" for 1.0.0)
 	getAssetName: (version: string, plat: string, architecture: string) => string | null;
+	installHint?: string;
 }
 
 const TOOLS: Record<string, ToolConfig> = {
@@ -31,6 +56,14 @@ const TOOLS: Record<string, ToolConfig> = {
 		repo: "sharkdp/fd",
 		binaryName: "fd",
 		tagPrefix: "v",
+		installHint:
+			platform() === "darwin"
+				? "Install via Homebrew: brew install fd"
+				: platform() === "linux"
+					? "Install via your package manager, e.g. apt install fd-find or dnf install fd-find"
+					: platform() === "win32"
+						? "Install via winget install sharkdp.fd or choco install fd"
+						: undefined,
 		getAssetName: (version, plat, architecture) => {
 			if (plat === "darwin") {
 				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
@@ -69,9 +102,9 @@ const TOOLS: Record<string, ToolConfig> = {
 };
 
 // Check if a command exists in PATH by trying to run it
-function commandExists(cmd: string): boolean {
+function commandExists(cmd: string, ops: ToolManagerOps = defaultOps): boolean {
 	try {
-		const result = spawnSync(cmd, ["--version"], { stdio: "pipe" });
+		const result = ops.spawnSync(cmd, ["--version"], { stdio: "pipe" });
 		// Check for ENOENT error (command not found)
 		return result.error === undefined || result.error === null;
 	} catch {
@@ -80,18 +113,18 @@ function commandExists(cmd: string): boolean {
 }
 
 // Get the path to a tool (system-wide or in our tools dir)
-export function getToolPath(tool: "fd" | "rg"): string | null {
+export function getToolPath(tool: "fd" | "rg", ops: ToolManagerOps = defaultOps): string | null {
 	const config = TOOLS[tool];
 	if (!config) return null;
 
 	// Check our tools directory first
 	const localPath = join(TOOLS_DIR, config.binaryName + (platform() === "win32" ? ".exe" : ""));
-	if (existsSync(localPath)) {
+	if (ops.existsSync(localPath)) {
 		return localPath;
 	}
 
 	// Check system PATH - if found, just return the command name (it's in PATH)
-	if (commandExists(config.binaryName)) {
+	if (commandExists(config.binaryName, ops)) {
 		return config.binaryName;
 	}
 
@@ -99,8 +132,8 @@ export function getToolPath(tool: "fd" | "rg"): string | null {
 }
 
 // Fetch latest release version from GitHub
-async function getLatestVersion(repo: string): Promise<string> {
-	const response = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
+async function getLatestVersion(repo: string, ops: ToolManagerOps = defaultOps): Promise<string> {
+	const response = await ops.fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
 		headers: { "User-Agent": `${APP_NAME}-coding-agent` },
 		signal: AbortSignal.timeout(NETWORK_TIMEOUT_MS),
 	});
@@ -109,13 +142,32 @@ async function getLatestVersion(repo: string): Promise<string> {
 		throw new Error(`GitHub API error: ${response.status}`);
 	}
 
-	const data = (await response.json()) as { tag_name: string };
+	const data = (await response.json()) as { tag_name: string; assets?: { name: string }[] };
 	return data.tag_name.replace(/^v/, "");
 }
 
+async function hasReleaseAsset(
+	repo: string,
+	tag: string,
+	assetName: string,
+	ops: ToolManagerOps = defaultOps,
+): Promise<boolean> {
+	const response = await ops.fetch(`https://api.github.com/repos/${repo}/releases/tags/${tag}`, {
+		headers: { "User-Agent": `${APP_NAME}-coding-agent` },
+		signal: AbortSignal.timeout(NETWORK_TIMEOUT_MS),
+	});
+
+	if (!response.ok) {
+		throw new Error(`GitHub API error: ${response.status}`);
+	}
+
+	const data = (await response.json()) as { assets?: { name: string }[] };
+	return (data.assets ?? []).some((asset) => asset.name === assetName);
+}
+
 // Download a file from URL
-async function downloadFile(url: string, dest: string): Promise<void> {
-	const response = await fetch(url, {
+async function downloadFile(url: string, dest: string, ops: ToolManagerOps = defaultOps): Promise<void> {
+	const response = await ops.fetch(url, {
 		signal: AbortSignal.timeout(NETWORK_TIMEOUT_MS),
 	});
 
@@ -127,18 +179,22 @@ async function downloadFile(url: string, dest: string): Promise<void> {
 		throw new Error("No response body");
 	}
 
-	const fileStream = createWriteStream(dest);
+	const fileStream = ops.createWriteStream(dest);
 	await finished(Readable.fromWeb(response.body as any).pipe(fileStream));
 }
 
-function findBinaryRecursively(rootDir: string, binaryFileName: string): string | null {
+function findBinaryRecursively(
+	rootDir: string,
+	binaryFileName: string,
+	ops: ToolManagerOps = defaultOps,
+): string | null {
 	const stack: string[] = [rootDir];
 
 	while (stack.length > 0) {
 		const currentDir = stack.pop();
 		if (!currentDir) continue;
 
-		const entries = readdirSync(currentDir, { withFileTypes: true });
+		const entries = ops.readdirSync(currentDir, { withFileTypes: true });
 		for (const entry of entries) {
 			const fullPath = join(currentDir, entry.name);
 			if (entry.isFile() && entry.name === binaryFileName) {
@@ -154,7 +210,7 @@ function findBinaryRecursively(rootDir: string, binaryFileName: string): string 
 }
 
 // Download and install a tool
-async function downloadTool(tool: "fd" | "rg"): Promise<string> {
+async function downloadTool(tool: "fd" | "rg", ops: ToolManagerOps = defaultOps): Promise<string> {
 	const config = TOOLS[tool];
 	if (!config) throw new Error(`Unknown tool: ${tool}`);
 
@@ -162,7 +218,7 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
 	const architecture = arch();
 
 	// Get latest version
-	const version = await getLatestVersion(config.repo);
+	const version = await getLatestVersion(config.repo, ops);
 
 	// Get asset name for this platform
 	const assetName = config.getAssetName(version, plat, architecture);
@@ -170,16 +226,22 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
 		throw new Error(`Unsupported platform: ${plat}/${architecture}`);
 	}
 
-	// Create tools directory
-	mkdirSync(TOOLS_DIR, { recursive: true });
+	const tag = `${config.tagPrefix}${version}`;
+	const assetExists = await hasReleaseAsset(config.repo, tag, assetName, ops);
+	if (!assetExists) {
+		throw new Error(`Release asset not found for ${config.repo}@${tag}: ${assetName}`);
+	}
 
-	const downloadUrl = `https://github.com/${config.repo}/releases/download/${config.tagPrefix}${version}/${assetName}`;
+	// Create tools directory
+	ops.mkdirSync(TOOLS_DIR, { recursive: true });
+
+	const downloadUrl = `https://github.com/${config.repo}/releases/download/${tag}/${assetName}`;
 	const archivePath = join(TOOLS_DIR, assetName);
 	const binaryExt = plat === "win32" ? ".exe" : "";
 	const binaryPath = join(TOOLS_DIR, config.binaryName + binaryExt);
 
 	// Download
-	await downloadFile(downloadUrl, archivePath);
+	await downloadFile(downloadUrl, archivePath, ops);
 
 	// Extract into a unique temp directory. fd and rg downloads can run concurrently
 	// during startup, so sharing a fixed directory causes races.
@@ -187,11 +249,11 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
 		TOOLS_DIR,
 		`extract_tmp_${config.binaryName}_${process.pid}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
 	);
-	mkdirSync(extractDir, { recursive: true });
+	ops.mkdirSync(extractDir, { recursive: true });
 
 	try {
 		if (assetName.endsWith(".tar.gz")) {
-			const extractResult = spawnSync("tar", ["xzf", archivePath, "-C", extractDir], { stdio: "pipe" });
+			const extractResult = ops.spawnSync("tar", ["xzf", archivePath, "-C", extractDir], { stdio: "pipe" });
 			if (extractResult.error || extractResult.status !== 0) {
 				const errMsg = extractResult.error?.message ?? extractResult.stderr?.toString().trim() ?? "unknown error";
 				throw new Error(`Failed to extract ${assetName}: ${errMsg}`);
@@ -207,26 +269,26 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
 		const binaryFileName = config.binaryName + binaryExt;
 		const extractedDir = join(extractDir, assetName.replace(/\.(tar\.gz|zip)$/, ""));
 		const extractedBinaryCandidates = [join(extractedDir, binaryFileName), join(extractDir, binaryFileName)];
-		let extractedBinary = extractedBinaryCandidates.find((candidate) => existsSync(candidate));
+		let extractedBinary = extractedBinaryCandidates.find((candidate) => ops.existsSync(candidate));
 
 		if (!extractedBinary) {
-			extractedBinary = findBinaryRecursively(extractDir, binaryFileName) ?? undefined;
+			extractedBinary = findBinaryRecursively(extractDir, binaryFileName, ops) ?? undefined;
 		}
 
 		if (extractedBinary) {
-			renameSync(extractedBinary, binaryPath);
+			ops.renameSync(extractedBinary, binaryPath);
 		} else {
 			throw new Error(`Binary not found in archive: expected ${binaryFileName} under ${extractDir}`);
 		}
 
 		// Make executable (Unix only)
 		if (plat !== "win32") {
-			chmodSync(binaryPath, 0o755);
+			ops.chmodSync(binaryPath, 0o755);
 		}
 	} finally {
 		// Cleanup
-		rmSync(archivePath, { force: true });
-		rmSync(extractDir, { recursive: true, force: true });
+		ops.rmSync(archivePath, { force: true });
+		ops.rmSync(extractDir, { recursive: true, force: true });
 	}
 
 	return binaryPath;
@@ -240,8 +302,12 @@ const TERMUX_PACKAGES: Record<string, string> = {
 
 // Ensure a tool is available, downloading if necessary
 // Returns the path to the tool, or null if unavailable
-export async function ensureTool(tool: "fd" | "rg", silent: boolean = false): Promise<string | undefined> {
-	const existingPath = getToolPath(tool);
+export async function ensureTool(
+	tool: "fd" | "rg",
+	silent: boolean = false,
+	ops: ToolManagerOps = defaultOps,
+): Promise<string | undefined> {
+	const existingPath = getToolPath(tool, ops);
 	if (existingPath) {
 		return existingPath;
 	}
@@ -272,14 +338,18 @@ export async function ensureTool(tool: "fd" | "rg", silent: boolean = false): Pr
 	}
 
 	try {
-		const path = await downloadTool(tool);
+		const path = await downloadTool(tool, ops);
 		if (!silent) {
 			console.log(chalk.dim(`${config.name} installed to ${path}`));
 		}
 		return path;
 	} catch (e) {
 		if (!silent) {
-			console.log(chalk.yellow(`Failed to download ${config.name}: ${e instanceof Error ? e.message : e}`));
+			const message = e instanceof Error ? e.message : String(e);
+			console.log(chalk.yellow(`Failed to download ${config.name}: ${message}`));
+			if (config.installHint) {
+				console.log(chalk.dim(config.installHint));
+			}
 		}
 		return undefined;
 	}

--- a/packages/coding-agent/test/tools-manager.test.ts
+++ b/packages/coding-agent/test/tools-manager.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+async function loadModule() {
+	vi.resetModules();
+	return import("../src/utils/tools-manager.js");
+}
+
+describe("tools-manager", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	it("returns existing PATH tool without fetching releases", async () => {
+		const fetchSpy = vi.fn();
+		const { ensureTool } = await loadModule();
+		const result = await ensureTool("fd", true, {
+			spawnSync: vi.fn().mockReturnValue({ status: 0, error: undefined }),
+			fetch: fetchSpy as any,
+			createWriteStream: vi.fn() as any,
+			existsSync: vi.fn().mockReturnValue(false),
+			mkdirSync: vi.fn() as any,
+			readdirSync: vi.fn() as any,
+			renameSync: vi.fn() as any,
+			rmSync: vi.fn() as any,
+			chmodSync: vi.fn() as any,
+		});
+
+		expect(result).toBe("fd");
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("reports missing release asset with install hint instead of attempting blind download", async () => {
+		const logs: string[] = [];
+		vi.spyOn(console, "log").mockImplementation((...args) => {
+			logs.push(args.join(" "));
+		});
+
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = String(input);
+			if (url.includes("/repos/sharkdp/fd/releases/latest")) {
+				return new Response(JSON.stringify({ tag_name: "v10.4.0", assets: [] }), { status: 200 });
+			}
+			if (url.includes("/repos/sharkdp/fd/releases/tags/v10.4.0")) {
+				return new Response(JSON.stringify({ assets: [] }), { status: 200 });
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+
+		const createWriteStreamMock = vi.fn();
+		const { ensureTool } = await loadModule();
+		const result = await ensureTool("fd", false, {
+			spawnSync: vi.fn().mockReturnValue({ status: null, error: { message: "spawn fd ENOENT" } }),
+			fetch: fetchMock as any,
+			createWriteStream: createWriteStreamMock as any,
+			existsSync: vi.fn().mockReturnValue(false),
+			mkdirSync: vi.fn() as any,
+			readdirSync: vi.fn().mockReturnValue([]) as any,
+			renameSync: vi.fn() as any,
+			rmSync: vi.fn() as any,
+			chmodSync: vi.fn() as any,
+		});
+
+		expect(result).toBeUndefined();
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(createWriteStreamMock).not.toHaveBeenCalled();
+		expect(logs.some((line) => line.includes("fd not found. Downloading..."))).toBe(true);
+		expect(
+			logs.some((line) =>
+				line.includes("Release asset not found for sharkdp/fd@v10.4.0: fd-v10.4.0-aarch64-apple-darwin.tar.gz"),
+			),
+		).toBe(true);
+		expect(logs.some((line) => line.includes("brew install fd"))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1927.

This change makes `pi`'s tool bootstrap logic more robust when GitHub releases exist but the expected platform binary asset does not.

## Problem

When `fd` is missing from PATH, `pi` attempts to auto-download the latest release asset from `sharkdp/fd`. The existing implementation assumes that:

1. `releases/latest` returns a valid tag
2. a matching platform asset exists for that tag

That assumption is currently false for at least one real-world case: the latest `sharkdp/fd` release returns a tag, but no matching binary asset, causing the constructed download URL to 404.

This produces startup output like:

```text
fd not found. Downloading...
Failed to download fd: Failed to download: 404
```

## What this PR changes

### 1. Verifies the asset exists before download

The downloader now queries the tagged GitHub release and checks whether the computed asset name is actually present in the release metadata before constructing the download URL.

If the asset is missing, it now fails with a precise error:

```text
Release asset not found for sharkdp/fd@v10.4.0: fd-v10.4.0-aarch64-apple-darwin.tar.gz
```

### 2. Adds platform-specific install hints

When download fails, `pi` now prints a manual installation hint instead of leaving the user with a bare 404.

Examples:

- macOS: `brew install fd`
- Linux: `apt install fd-find` / `dnf install fd-find`
- Windows: `winget install sharkdp.fd` / `choco install fd`

### 3. Makes the downloader testable

This patch also introduces dependency injection for the low-level process/network/fs operations used by `tools-manager.ts`. That keeps runtime behavior unchanged while allowing focused tests to verify edge cases like missing GitHub release assets without mutating ESM module bindings.

## Why this approach

This is intentionally a minimal, low-risk fix.

It does **not** try to redesign package installation logic or add package-manager integration. Instead, it improves the existing flow by:

- detecting the real failure mode early
- avoiding a blind 404 download attempt
- giving the user a concrete next step
- adding regression coverage for the exact failure case

## Validation

### Runtime verification of upstream state

Validated manually against the current upstream release metadata:

- `https://api.github.com/repos/sharkdp/fd/releases/latest` returns tag `v10.4.0`
- `https://api.github.com/repos/sharkdp/fd/releases/tags/v10.4.0` currently reports `assets: []`
- expected macOS arm64 asset:
  `fd-v10.4.0-aarch64-apple-darwin.tar.gz`
- asset presence check returns `false`

So the old code path would inevitably attempt a broken download URL and produce a `404`, while this patch turns that into a specific missing-asset error plus a manual install hint.

### Automated test coverage

Added targeted tests in:

- `packages/coding-agent/test/tools-manager.test.ts`

Covered cases:

1. `ensureTool("fd")` returns the PATH binary immediately without fetching release metadata when `fd` is already available.
2. When `fd` is missing and the tagged GitHub release lacks the expected asset:
   - `ensureTool("fd")` returns `undefined`
   - only release metadata endpoints are queried
   - no archive download is attempted
   - the log includes the precise missing-asset message
   - the log includes the manual install hint (`brew install fd` on macOS)

Test command run successfully:

```bash
npm --prefix packages/coding-agent test -- tools-manager.test.ts
```

## Files changed

- `packages/coding-agent/src/utils/tools-manager.ts`
- `packages/coding-agent/test/tools-manager.test.ts`
