### PR TITLE
fix(coding-agent): handle GitHub releases without binary assets

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tool download when GitHub releases have no assets (e.g., fd v10.4.0). Now falls back to previous releases until finding one with available assets ([#1933](https://github.com/badlogic/pi-mono/pull/1933)) by [@aliou](https://github.com/aliou)).
+
 ## [0.57.0] - 2026-03-07
 
 ### New Features

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -98,9 +98,9 @@ export function getToolPath(tool: "fd" | "rg"): string | null {
 	return null;
 }
 
-// Fetch latest release version from GitHub
-async function getLatestVersion(repo: string): Promise<string> {
-	const response = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
+// Fetch releases from GitHub
+async function getReleases(repo: string): Promise<Array<{ tag_name: string; assets: Array<{ name: string }> }>> {
+	const response = await fetch(`https://api.github.com/repos/${repo}/releases?per_page=10`, {
 		headers: { "User-Agent": `${APP_NAME}-coding-agent` },
 		signal: AbortSignal.timeout(NETWORK_TIMEOUT_MS),
 	});
@@ -109,8 +109,39 @@ async function getLatestVersion(repo: string): Promise<string> {
 		throw new Error(`GitHub API error: ${response.status}`);
 	}
 
-	const data = (await response.json()) as { tag_name: string };
-	return data.tag_name.replace(/^v/, "");
+	return (await response.json()) as Array<{ tag_name: string; assets: Array<{ name: string }> }>;
+}
+
+// Find first release with assets matching the expected asset name
+async function getVersionWithAsset(
+	repo: string,
+	getExpectedAssetName: (version: string) => string | null,
+	skippedVersions: string[],
+): Promise<string> {
+	const releases = await getReleases(repo);
+
+	for (const release of releases) {
+		const version = release.tag_name.replace(/^v/, "");
+		const expectedAsset = getExpectedAssetName(version);
+
+		if (!expectedAsset) {
+			continue;
+		}
+
+		// Check if this release has any assets (e.g., the expected asset or similar)
+		// Some repos might use slightly different naming, so we check if assets exist at all
+		if (release.assets.length > 0) {
+			if (skippedVersions.length > 0) {
+				const skippedList = skippedVersions.join(", ");
+				skippedVersions.push(version);
+				console.log(chalk.dim(`Skipping releases without assets: ${skippedList}. Using ${release.tag_name}`));
+			}
+			return version;
+		}
+		skippedVersions.push(version);
+	}
+
+	throw new Error(`No release with assets found for ${repo}`);
 }
 
 // Download a file from URL
@@ -161,8 +192,13 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
 	const plat = platform();
 	const architecture = arch();
 
-	// Get latest version
-	const version = await getLatestVersion(config.repo);
+	// Find latest version that has assets
+	const skippedVersions: string[] = [];
+	const version = await getVersionWithAsset(
+		config.repo,
+		(ver) => config.getAssetName(ver, plat, architecture),
+		skippedVersions,
+	);
 
 	// Get asset name for this platform
 	const assetName = config.getAssetName(version, plat, architecture);


### PR DESCRIPTION
Hello!

Noticed that the `fd` download failed while testing my previous pr with an overiden `PI_CODING_AGENT_DIR`. Turns out `fd`'s [latest release workflow](https://github.com/sharkdp/fd/actions/runs/22794348628) failed and the binaries were not added to the release assets. This wasn't making pi crash, but tools using `fd` weren't working for some reason.

To fix this, this PR retrieves the last 10 release and get the most recent release with binary assets and then downloads it.

I'm sure this is a transient issue and this pr might be overkill but i feel like it might be useful for setups that don't have system binaries (e.g. sandboxes or while testing stuff).

------

<details><summary>Summary by GLM 4.7:</summary>
<p>

## Summary

Fixes tool download failures when GitHub releases exist but have no binary assets (e.g., fd v10.4.0). The release was created but binaries were never uploaded due to a workflow failure during the attestation step.

## Changes

### `packages/coding-agent/src/utils/tools-manager.ts`

**Replaced:**
- `getLatestVersion()` - single call to `/releases/latest` endpoint

**Added:**
- `getReleases()` - fetches releases with `?per_page=10` to limit data transfer
- `getVersionWithAsset()` - iterates through releases to find first with assets, logs skipped versions

**Modified `downloadTool()`:**
- Now skips releases without binary artifacts
- Logs when falling back to previous releases with assets
- Example output: `Skipping releases without assets: v10.4.0. Using v10.3.0`

### `packages/coding-agent/CHANGELOG.md`

- Added fixed entry under `### Fixed` with PR attribution

## Behavior

**Before:** Download failed with 404 when using a newly created release without assets

**After:** Automatically finds and uses the most recent release with complete binary assets

**Loop example (if multiple releases have no assets):**
```
fd not found. Downloading...
Skipping releases without assets: v10.4.0, v10.3.0, v10.2.0. Using v10.1.0
```

## Edge case

If all 10 releases have no assets, throws: `Error: No release with assets found for {repo}`

## Related

- Failed release workflow: https://github.com/sharkdp/fd/actions/runs/22794348628
- Issue: Release page created but no binaries due to attestation step failure
- Workflow crashed at "Attest artifact" → "Publish archives and packages" never ran


</p>
</details>