### PR TITLE
fix(coding-agent): custom tool collapsed/expanded rendering in HTML export

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fixed custom tool collapsed/expanded rendering in HTML exports. Custom tools that define different collapsed vs expanded displays now render correctly in exported HTML, with expandable sections when both states differ and direct display when only expanded exists ([#1934](https://github.com/badlogic/pi-mono/pull/1934) by [@aliou](https://github.com/aliou))
+
 ## [0.57.0] - 2026-03-07
 
 ### New Features

--- a/packages/coding-agent/src/core/export-html/index.ts
+++ b/packages/coding-agent/src/core/export-html/index.ts
@@ -14,19 +14,20 @@ import { SessionManager } from "../session-manager.js";
 export interface ToolHtmlRenderer {
 	/** Render a tool call to HTML. Returns undefined if tool has no custom renderer. */
 	renderCall(toolName: string, args: unknown): string | undefined;
-	/** Render a tool result to HTML. Returns undefined if tool has no custom renderer. */
+	/** Render a tool result to HTML. Returns collapsed/expanded or undefined if tool has no custom renderer. */
 	renderResult(
 		toolName: string,
 		result: Array<{ type: string; text?: string; data?: string; mimeType?: string }>,
 		details: unknown,
 		isError: boolean,
-	): string | undefined;
+	): { collapsed?: string; expanded?: string } | undefined;
 }
 
 /** Pre-rendered HTML for a custom tool call and result */
 interface RenderedToolHtml {
 	callHtml?: string;
-	resultHtml?: string;
+	resultHtmlCollapsed?: string;
+	resultHtmlExpanded?: string;
 }
 
 export interface ExportOptions {
@@ -204,11 +205,12 @@ function preRenderCustomTools(
 			// Only render if we have a pre-rendered call OR it's not a built-in tool
 			const existing = renderedTools[msg.toolCallId];
 			if (existing || !BUILTIN_TOOLS.has(toolName)) {
-				const resultHtml = toolRenderer.renderResult(toolName, msg.content, msg.details, msg.isError || false);
-				if (resultHtml) {
+				const rendered = toolRenderer.renderResult(toolName, msg.content, msg.details, msg.isError || false);
+				if (rendered) {
 					renderedTools[msg.toolCallId] = {
 						...existing,
-						resultHtml,
+						resultHtmlCollapsed: rendered.collapsed,
+						resultHtmlExpanded: rendered.expanded,
 					};
 				}
 			}

--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -966,7 +966,7 @@
           default: {
             // Check for pre-rendered custom tool HTML
             const rendered = renderedTools?.[call.id];
-            if (rendered?.callHtml || rendered?.resultHtml) {
+            if (rendered?.callHtml || rendered?.resultHtmlCollapsed || rendered?.resultHtmlExpanded) {
               // Custom tool with pre-rendered HTML from TUI renderer
               if (rendered.callHtml) {
                 html += `<div class="tool-header ansi-rendered">${rendered.callHtml}</div>`;
@@ -974,20 +974,17 @@
                 html += `<div class="tool-header"><span class="tool-name">${escapeHtml(name)}</span></div>`;
               }
               
-              if (rendered.resultHtml) {
-                // Apply same truncation as built-in tools (10 lines)
-                const lines = rendered.resultHtml.split('\n');
-                if (lines.length > 10) {
-                  const preview = lines.slice(0, 10).join('\n');
-                  html += `<div class="tool-output expandable ansi-rendered" onclick="this.classList.toggle('expanded')">
-                    <div class="output-preview">${preview}<div class="expand-hint">... (${lines.length - 10} more lines)</div></div>
-                    <div class="output-full">${rendered.resultHtml}</div>
-                  </div>`;
-                } else {
-                  html += `<div class="tool-output ansi-rendered">${rendered.resultHtml}</div>`;
-                }
+              if (rendered.resultHtmlCollapsed && rendered.resultHtmlExpanded && rendered.resultHtmlCollapsed !== rendered.resultHtmlExpanded) {
+                // Both collapsed and expanded differ - render expandable section
+                html += `<div class="tool-output expandable ansi-rendered" onclick="this.classList.toggle('expanded')">
+                  <div class="output-preview">${rendered.resultHtmlCollapsed}</div>
+                  <div class="output-full">${rendered.resultHtmlExpanded}</div>
+                </div>`;
+              } else if (rendered.resultHtmlExpanded) {
+                // Only expanded exists (or collapsed is identical) - show directly
+                html += `<div class="tool-output ansi-rendered">${rendered.resultHtmlExpanded}</div>`;
               } else if (result) {
-                // Fallback to JSON for result if no pre-rendered HTML
+                // No pre-rendered result HTML - fallback to JSON
                 const output = getResultText();
                 if (output) html += formatExpandableOutput(output, 10);
               }

--- a/packages/coding-agent/src/core/export-html/tool-renderer.ts
+++ b/packages/coding-agent/src/core/export-html/tool-renderer.ts
@@ -22,13 +22,13 @@ export interface ToolHtmlRendererDeps {
 export interface ToolHtmlRenderer {
 	/** Render a tool call to HTML. Returns undefined if tool has no custom renderer. */
 	renderCall(toolName: string, args: unknown): string | undefined;
-	/** Render a tool result to HTML. Returns undefined if tool has no custom renderer. */
+	/** Render a tool result to collapsed/expanded HTML. Returns undefined if tool has no custom renderer. */
 	renderResult(
 		toolName: string,
 		result: Array<{ type: string; text?: string; data?: string; mimeType?: string }>,
 		details: unknown,
 		isError: boolean,
-	): string | undefined;
+	): { collapsed?: string; expanded?: string } | undefined;
 }
 
 /**
@@ -65,7 +65,7 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 			result: Array<{ type: string; text?: string; data?: string; mimeType?: string }>,
 			details: unknown,
 			isError: boolean,
-		): string | undefined {
+		): { collapsed?: string; expanded?: string } | undefined {
 			try {
 				const toolDef = getToolDefinition(toolName);
 				if (!toolDef?.renderResult) {
@@ -80,13 +80,31 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 					isError,
 				};
 
-				// Always render expanded, client-side will apply truncation
-				const component = toolDef.renderResult(agentToolResult, { expanded: true, isPartial: false }, theme);
-				if (!component) {
+				// Render collapsed
+				const collapsedComponent = toolDef.renderResult(
+					agentToolResult,
+					{ expanded: false, isPartial: false },
+					theme,
+				);
+				const collapsed = collapsedComponent ? ansiLinesToHtml(collapsedComponent.render(width)) : undefined;
+
+				// Render expanded
+				const expandedComponent = toolDef.renderResult(
+					agentToolResult,
+					{ expanded: true, isPartial: false },
+					theme,
+				);
+				const expanded = expandedComponent ? ansiLinesToHtml(expandedComponent.render(width)) : undefined;
+
+				// Return collapsed only if it exists and differs from expanded
+				if (!expanded) {
 					return undefined;
 				}
-				const lines = component.render(width);
-				return ansiLinesToHtml(lines);
+
+				return {
+					...(collapsed && collapsed !== expanded ? { collapsed } : {}),
+					expanded,
+				};
 			} catch {
 				// On error, return undefined to trigger JSON fallback
 				return undefined;


### PR DESCRIPTION
Hello! (Apologies for all of the PRs, cleaning out my backlog from the past few weeks 😅)

This is a follow up of https://github.com/badlogic/pi-mono/pull/702. Now, for custom tools, instead of collapsing after collpasing after 10 lines, we match their collapsed and expanded design from when running in the TUI


Before: https://pi.dev/session/#583ce81607841d249e9d03456d73cf24
After: https://pi.dev/session/#d6f258babdd4502d9a684dc9949083b9

------

<details><summary>Summary by GLM 4.7:</summary>
<p>

Custom tools can define different displays when collapsed vs expanded via `renderResult(result, { expanded, isPartial }, theme)`. Previously, HTML exports ignored this and applied naive 10-line HTML truncation in `template.js`, breaking HTML tags mid-element and discarding the tool's collapsed view logic.

## Changes

### `packages/coding-agent/src/core/export-html/index.ts`
- Updated `RenderedToolHtml` interface to use `resultHtmlCollapsed` / `resultHtmlExpanded` fields
- Updated `ToolHtmlRenderer.renderResult` return type to `{ collapsed?: string; expanded?: string } | undefined`
- Updated `preRenderCustomTools` to map renderer output keys correctly to `resultHtmlCollapsed` / `resultHtmlExpanded`

### `packages/coding-agent/src/core/export-html/tool-renderer.ts`
- Updated `ToolHtmlRenderer` interface to return collapsed/expanded object
- Implemented dual rendering: calls `toolDef.renderResult` twice with `{ expanded: false }` and `{ expanded: true }`
- Returns `collapsed` only if it exists and differs from `expanded`; returns `undefined` when neither render exists

### `packages/coding-agent/src/core/export-html/template.js`
- Replaced naive 10-line HTML truncation with proper collapsible rendering
- Added conditional logic:
  - Expandable section when both collapsed and expanded exist and differ
  - Direct expanded render when only expanded exists or collapsed is identical
  - Fallback to existing JSON display when no pre-rendered result HTML is present

## Testing

Created `.pi/extensions/demo-collapsed-expanded.ts` with a `wordCount` tool that demonstrates collapsed (summary with match count) vs expanded (full results list) rendering. Use `wordCount` tool to verify HTML export behavior.

</p>
</details>