### PR TITLE
fix(coding-agent): recover from 413 request too large

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `isRequestTooLarge()` to detect HTTP 413 / request payload size errors, separate from token-based context overflow detection
+
 ## [0.57.0] - 2026-03-07
 
 ### Added

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -115,6 +115,43 @@ export function isContextOverflow(message: AssistantMessage, contextWindow?: num
 }
 
 /**
+ * Check if an assistant message indicates the HTTP request body was too large.
+ *
+ * This is separate from context overflow (token limits). Request size limits
+ * are about the raw HTTP payload bytes, not model context windows. This typically
+ * happens when sessions accumulate many images — each image is cheap in tokens
+ * but large in bytes (~1-2MB base64 each).
+ *
+ * Detection: checks for HTTP 413 status or known "request too large" error patterns.
+ * Note: Cerebras 413 with no body is already handled by isContextOverflow() as a
+ * context overflow, so callers should check isContextOverflow() first.
+ *
+ * Known error formats:
+ * - Anthropic SDK: '413 {"type":"error","error":{"type":"request_too_large","message":"..."}}'
+ * - Generic HTTP: "413", "request entity too large", "payload too large"
+ *
+ * @param message - The assistant message to check
+ * @returns true if the error indicates a request payload size issue
+ */
+export function isRequestTooLarge(message: AssistantMessage): boolean {
+	if (message.stopReason !== "error" || !message.errorMessage) return false;
+	const err = message.errorMessage;
+
+	// Exclude "no body" variants — those are context overflow (Cerebras), not payload size
+	if (/\(no body\)/i.test(err)) return false;
+
+	// Check for HTTP 413 status
+	if (/^413\b/.test(err)) return true;
+
+	// Check for known request-too-large error patterns
+	if (/request_too_large|request.*exceeds.*maximum.*size|request entity too large|payload too large/i.test(err)) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Get the overflow patterns for testing purposes.
  */
 export function getOverflowPatterns(): RegExp[] {

--- a/packages/ai/test/request-too-large.test.ts
+++ b/packages/ai/test/request-too-large.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Test isRequestTooLarge detection for HTTP 413 / payload size errors.
+ *
+ * This is separate from context overflow (token limits). Request size limits
+ * are about raw HTTP payload bytes, typically caused by accumulated image data.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage } from "../src/types.js";
+import { isContextOverflow, isRequestTooLarge } from "../src/utils/overflow.js";
+
+function makeErrorMessage(errorMessage: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "error",
+		errorMessage,
+		timestamp: Date.now(),
+	};
+}
+
+function makeSuccessMessage(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "Hello" }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4",
+		usage: {
+			input: 1000,
+			output: 50,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 1050,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("isRequestTooLarge", () => {
+	it("should detect Anthropic SDK 413 with request_too_large", () => {
+		const msg = makeErrorMessage(
+			'413 {"type":"error","error":{"type":"request_too_large","message":"Request exceeds the maximum size"}}',
+		);
+		expect(isRequestTooLarge(msg)).toBe(true);
+	});
+
+	it("should detect plain 413 status", () => {
+		const msg = makeErrorMessage("413 Request Entity Too Large");
+		expect(isRequestTooLarge(msg)).toBe(true);
+	});
+
+	it("should detect request_too_large error type", () => {
+		const msg = makeErrorMessage("request_too_large: Request exceeds the maximum size");
+		expect(isRequestTooLarge(msg)).toBe(true);
+	});
+
+	it("should detect generic payload too large", () => {
+		const msg = makeErrorMessage("Payload too large");
+		expect(isRequestTooLarge(msg)).toBe(true);
+	});
+
+	it("should detect request entity too large", () => {
+		const msg = makeErrorMessage("Request entity too large");
+		expect(isRequestTooLarge(msg)).toBe(true);
+	});
+
+	it("should NOT detect Cerebras 413 with no body (that is context overflow)", () => {
+		const msg = makeErrorMessage("413 (no body)");
+		expect(isRequestTooLarge(msg)).toBe(false);
+		// Verify it IS detected as context overflow instead
+		expect(isContextOverflow(msg)).toBe(true);
+	});
+
+	it("should NOT detect Cerebras 413 status code (no body)", () => {
+		const msg = makeErrorMessage("413 status code (no body)");
+		expect(isRequestTooLarge(msg)).toBe(false);
+		expect(isContextOverflow(msg)).toBe(true);
+	});
+
+	it("should NOT detect 413 with no body even if it matches generic patterns", () => {
+		const msg = makeErrorMessage("413 Request Entity Too Large (no body)");
+		expect(isRequestTooLarge(msg)).toBe(false);
+	});
+
+	it("should NOT detect context overflow errors", () => {
+		const msg = makeErrorMessage("prompt is too long: 213462 tokens > 200000 maximum");
+		expect(isRequestTooLarge(msg)).toBe(false);
+	});
+
+	it("should NOT detect rate limit errors", () => {
+		const msg = makeErrorMessage("429 Too Many Requests");
+		expect(isRequestTooLarge(msg)).toBe(false);
+	});
+
+	it("should NOT detect successful messages", () => {
+		const msg = makeSuccessMessage();
+		expect(isRequestTooLarge(msg)).toBe(false);
+	});
+
+	it("should NOT detect non-error messages with stopReason stop", () => {
+		const msg = makeSuccessMessage();
+		msg.stopReason = "stop";
+		expect(isRequestTooLarge(msg)).toBe(false);
+	});
+
+	it("should NOT detect error messages without errorMessage", () => {
+		const msg = makeSuccessMessage();
+		msg.stopReason = "error";
+		msg.errorMessage = undefined;
+		expect(isRequestTooLarge(msg)).toBe(false);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Fixed HTTP 413 "request too large" errors when sessions accumulate many images. Images are cheap in tokens but large in bytes (~1-2MB each); after ~20 image reads the request payload exceeds provider limits while context usage shows only ~30%. On 413, the oldest half of images are now automatically stripped and the request is retried (up to 3 attempts).
 - Fixed custom tool collapsed/expanded rendering in HTML exports. Custom tools that define different collapsed vs expanded displays now render correctly in exported HTML, with expandable sections when both states differ and direct display when only expanded exists ([#1934](https://github.com/badlogic/pi-mono/pull/1934) by [@aliou](https://github.com/aliou))
 
 ## [0.57.0] - 2026-03-07

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -24,7 +24,13 @@ import type {
 	ThinkingLevel,
 } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@mariozechner/pi-ai";
-import { isContextOverflow, modelsAreEqual, resetApiProviders, supportsXhigh } from "@mariozechner/pi-ai";
+import {
+	isContextOverflow,
+	isRequestTooLarge,
+	modelsAreEqual,
+	resetApiProviders,
+	supportsXhigh,
+} from "@mariozechner/pi-ai";
 import { getDocsPath } from "../config.js";
 import { theme } from "../modes/interactive/theme/theme.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
@@ -72,6 +78,7 @@ import {
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
+import { countImages, stripOldestImages } from "./request-size.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.js";
 import { getLatestCompactionEntry } from "./session-manager.js";
@@ -233,6 +240,8 @@ export class AgentSession {
 	private _compactionAbortController: AbortController | undefined = undefined;
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
 	private _overflowRecoveryAttempted = false;
+	private _requestTooLargeRecoveryAttempts = 0;
+	private static readonly MAX_REQUEST_TOO_LARGE_RETRIES = 3;
 
 	// Branch summarization state
 	private _branchSummaryAbortController: AbortController | undefined = undefined;
@@ -370,6 +379,7 @@ export class AgentSession {
 		// This ensures the UI sees the updated queue state
 		if (event.type === "message_start" && event.message.role === "user") {
 			this._overflowRecoveryAttempted = false;
+			this._requestTooLargeRecoveryAttempts = 0;
 			const messageText = this._getUserMessageText(event.message);
 			if (messageText) {
 				// Check steering queue first
@@ -420,6 +430,7 @@ export class AgentSession {
 				const assistantMsg = event.message as AssistantMessage;
 				if (assistantMsg.stopReason !== "error") {
 					this._overflowRecoveryAttempted = false;
+					this._requestTooLargeRecoveryAttempts = 0;
 				}
 
 				// Reset retry counter immediately on successful assistant response
@@ -1681,9 +1692,6 @@ export class AgentSession {
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
 	 */
 	private async _checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<void> {
-		const settings = this.settingsManager.getCompactionSettings();
-		if (!settings.enabled) return;
-
 		// Skip if message was aborted (user cancelled) - unless skipAbortedCheck is false
 		if (skipAbortedCheck && assistantMessage.stopReason === "aborted") return;
 
@@ -1705,6 +1713,69 @@ export class AgentSession {
 		if (assistantIsFromBeforeCompaction) {
 			return;
 		}
+
+		// Case 0: Request too large - HTTP payload exceeded provider's size limit.
+		// This is distinct from token overflow. Typically caused by accumulated image data
+		// (images are cheap in tokens but large in bytes). Strip oldest images and retry.
+		if (sameModel && isRequestTooLarge(assistantMessage)) {
+			if (this._requestTooLargeRecoveryAttempts >= AgentSession.MAX_REQUEST_TOO_LARGE_RETRIES) {
+				this._emit({
+					type: "auto_compaction_end",
+					result: undefined,
+					aborted: false,
+					willRetry: false,
+					errorMessage:
+						"Request payload too large. Tried stripping images but request is still too large. Try starting a new session or using /compact.",
+				});
+				return;
+			}
+
+			// Remove the error message from agent state
+			const messages = this.agent.state.messages;
+			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
+				this.agent.replaceMessages(messages.slice(0, -1));
+			}
+
+			// Strip oldest half of images from the in-memory messages.
+			const currentMessages = this.agent.state.messages;
+			const imageCount = countImages(currentMessages);
+			if (imageCount === 0) {
+				this._emit({
+					type: "auto_compaction_end",
+					result: undefined,
+					aborted: false,
+					willRetry: false,
+					errorMessage:
+						"Request payload too large but no images to strip. Try starting a new session or using /compact.",
+				});
+				return;
+			}
+
+			// Strip images from the raw agent messages (user and toolResult roles)
+			const { messages: strippedMessages, strippedCount } = stripOldestImages(currentMessages);
+			this.agent.replaceMessages(strippedMessages);
+			this._requestTooLargeRecoveryAttempts++;
+
+			this._emit({
+				type: "auto_compaction_start",
+				reason: "overflow",
+			});
+			this._emit({
+				type: "auto_compaction_end",
+				result: undefined,
+				aborted: false,
+				willRetry: true,
+				errorMessage: `Request too large: stripped ${strippedCount} old image(s), retrying (attempt ${this._requestTooLargeRecoveryAttempts}/${AgentSession.MAX_REQUEST_TOO_LARGE_RETRIES})`,
+			});
+
+			setTimeout(() => {
+				this.agent.continue().catch(() => {});
+			}, 100);
+			return;
+		}
+
+		const settings = this.settingsManager.getCompactionSettings();
+		if (!settings.enabled) return;
 
 		// Case 1: Overflow - LLM returned context overflow error
 		if (sameModel && isContextOverflow(assistantMessage, contextWindow)) {
@@ -2261,6 +2332,9 @@ export class AgentSession {
 		// Context overflow is handled by compaction, not retry
 		const contextWindow = this.model?.contextWindow ?? 0;
 		if (isContextOverflow(message, contextWindow)) return false;
+
+		// Request too large is handled by image pruning, not retry
+		if (isRequestTooLarge(message)) return false;
 
 		const err = message.errorMessage;
 		// Match: overloaded_error, rate limit, 429, 500, 502, 503, 504, service unavailable, connection errors, fetch failed, terminated, retry delay exceeded

--- a/packages/coding-agent/src/core/request-size.ts
+++ b/packages/coding-agent/src/core/request-size.ts
@@ -1,0 +1,99 @@
+/**
+ * Request size management for LLM API calls.
+ *
+ * Providers have HTTP request body size limits (e.g., Anthropic ~25MB)
+ * that are separate from token-based context window limits. When sessions
+ * accumulate many images, the base64 data can exceed these limits even
+ * though token usage is low (images are cheap in tokens but large in bytes).
+ *
+ * This module provides utilities to strip old images from outbound messages
+ * to bring the request size under the provider's limit.
+ */
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
+
+const IMAGE_PLACEHOLDER = "[image omitted from request — payload too large]";
+
+/**
+ * Check if a message has array content that could contain image blocks.
+ * Handles user, toolResult, and custom message roles.
+ */
+function hasArrayContent(msg: AgentMessage): msg is AgentMessage & { content: (TextContent | ImageContent)[] } {
+	if (msg.role === "user" || msg.role === "toolResult" || msg.role === "custom") {
+		return Array.isArray(msg.content);
+	}
+	return false;
+}
+
+/**
+ * Count the total number of image content blocks across all messages.
+ * Checks user, toolResult, and custom messages (all roles that can carry images).
+ */
+export function countImages(messages: AgentMessage[]): number {
+	let count = 0;
+	for (const msg of messages) {
+		if (hasArrayContent(msg)) {
+			for (const block of msg.content) {
+				if ((block as ImageContent).type === "image") {
+					count++;
+				}
+			}
+		}
+	}
+	return count;
+}
+
+export interface StripImagesResult {
+	messages: AgentMessage[];
+	strippedCount: number;
+}
+
+/**
+ * Strip the oldest half of image content blocks from messages, replacing
+ * them with text placeholders. Preserves message structure and all non-image
+ * content. Returns a new array — does not mutate the input.
+ *
+ * Images are removed oldest-first (from the start of the messages array),
+ * keeping the most recent images which are more likely to be relevant.
+ * Handles user, toolResult, and custom message roles.
+ *
+ * @param messages - The agent messages to process
+ * @returns New messages array with old images replaced, plus count of stripped images
+ */
+export function stripOldestImages(messages: AgentMessage[]): StripImagesResult {
+	const totalImages = countImages(messages);
+	if (totalImages === 0) {
+		return { messages, strippedCount: 0 };
+	}
+
+	const stripCount = Math.ceil(totalImages / 2);
+	let stripped = 0;
+
+	const result: AgentMessage[] = messages.map((msg) => {
+		if (stripped >= stripCount) return msg;
+
+		if (hasArrayContent(msg)) {
+			let hasStrippableImage = false;
+			for (const block of msg.content) {
+				if ((block as ImageContent).type === "image" && stripped < stripCount) {
+					hasStrippableImage = true;
+					break;
+				}
+			}
+			if (hasStrippableImage) {
+				const newContent = msg.content.map((block) => {
+					if ((block as ImageContent).type === "image" && stripped < stripCount) {
+						stripped++;
+						return { type: "text" as const, text: IMAGE_PLACEHOLDER };
+					}
+					return block;
+				});
+				return { ...msg, content: newContent } as AgentMessage;
+			}
+		}
+		return msg;
+	});
+
+	return { messages: result, strippedCount: stripped };
+}

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -30,7 +30,7 @@ function createAssistantMessage(text: string, overrides?: Partial<AssistantMessa
 		content: [{ type: "text", text }],
 		api: "anthropic-messages",
 		provider: "anthropic",
-		model: "mock",
+		model: "claude-sonnet-4-5",
 		usage: {
 			input: 0,
 			output: 0,
@@ -67,10 +67,18 @@ describe("AgentSession retry", () => {
 		}
 	});
 
-	function createSession(options?: { failCount?: number; maxRetries?: number; delayAssistantMessageEndMs?: number }) {
+	function createSession(options?: {
+		failCount?: number;
+		maxRetries?: number;
+		delayAssistantMessageEndMs?: number;
+		errorMessage?: string;
+		compactionEnabled?: boolean;
+	}) {
 		const failCount = options?.failCount ?? 1;
 		const maxRetries = options?.maxRetries ?? 3;
 		const delayAssistantMessageEndMs = options?.delayAssistantMessageEndMs ?? 0;
+		const errorMessage = options?.errorMessage ?? "overloaded_error";
+		const compactionEnabled = options?.compactionEnabled ?? true;
 		let callCount = 0;
 
 		const model = getModel("anthropic", "claude-sonnet-4-5")!;
@@ -84,7 +92,7 @@ describe("AgentSession retry", () => {
 					if (callCount <= failCount) {
 						const msg = createAssistantMessage("", {
 							stopReason: "error",
-							errorMessage: "overloaded_error",
+							errorMessage,
 						});
 						stream.push({ type: "start", partial: msg });
 						stream.push({ type: "error", reason: "error", error: msg });
@@ -103,7 +111,10 @@ describe("AgentSession retry", () => {
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
 		const modelRegistry = new ModelRegistry(authStorage, tempDir);
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
-		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries, baseDelayMs: 1 } });
+		settingsManager.applyOverrides({
+			retry: { enabled: true, maxRetries, baseDelayMs: 1 },
+			compaction: { enabled: compactionEnabled },
+		});
 
 		session = new AgentSession({
 			agent,
@@ -167,5 +178,55 @@ describe("AgentSession retry", () => {
 
 		expect(created.getCallCount()).toBe(2);
 		expect(created.session.isRetrying).toBe(false);
+	});
+
+	it("recovers from request-too-large even when auto-compaction is disabled", async () => {
+		const created = createSession({
+			failCount: 1,
+			errorMessage: '413 {"error":{"type":"request_too_large","message":"Request exceeds the maximum size"}}',
+			compactionEnabled: false,
+		});
+
+		created.session.agent.appendMessage({
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read",
+			content: [
+				{ type: "text", text: "Read image-1.png [image/png]" },
+				{ type: "image", data: "image-1", mimeType: "image/png" },
+			],
+			isError: false,
+			timestamp: Date.now(),
+		});
+		created.session.agent.appendMessage({
+			role: "toolResult",
+			toolCallId: "call-2",
+			toolName: "read",
+			content: [
+				{ type: "text", text: "Read image-2.png [image/png]" },
+				{ type: "image", data: "image-2", mimeType: "image/png" },
+			],
+			isError: false,
+			timestamp: Date.now(),
+		});
+
+		await created.session.prompt("yoo");
+		await created.session.agent.waitForIdle();
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		await created.session.agent.waitForIdle();
+
+		expect(created.getCallCount()).toBe(2);
+
+		const toolResults = created.session.agent.state.messages.filter((m) => m.role === "toolResult");
+		expect(toolResults).toHaveLength(2);
+		const first = toolResults[0];
+		if (first.role !== "toolResult") throw new Error("expected toolResult");
+		expect(first.content[1].type).toBe("text");
+		if (first.content[1].type !== "text") throw new Error("expected text placeholder");
+		expect(first.content[1].text).toContain("image omitted");
+
+		const second = toolResults[1];
+		if (second.role !== "toolResult") throw new Error("expected toolResult");
+		expect(second.content[1].type).toBe("image");
 	});
 });

--- a/packages/coding-agent/test/request-size.test.ts
+++ b/packages/coding-agent/test/request-size.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Tests for request size management utilities.
+ *
+ * Tests countImages() and stripOldestImages() which handle the case where
+ * accumulated image data in a session exceeds provider HTTP request size limits.
+ */
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, ImageContent, TextContent, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { countImages, stripOldestImages } from "../src/core/request-size.js";
+
+// Helper to create a user message with text
+function userText(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: Date.now() };
+}
+
+// Helper to create a user message with image content
+function userWithImage(text: string, imageData = "base64data"): UserMessage {
+	return {
+		role: "user",
+		content: [
+			{ type: "text", text },
+			{ type: "image", data: imageData, mimeType: "image/png" },
+		],
+		timestamp: Date.now(),
+	};
+}
+
+// Helper to create a tool result with image content
+function toolResultWithImage(imageData = "base64data"): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "call_1",
+		toolName: "read",
+		content: [
+			{ type: "text", text: "Read image.png [image/png]" },
+			{ type: "image", data: imageData, mimeType: "image/png" },
+		],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+// Helper to create a tool result with only text
+function toolResultText(text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "call_1",
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+// Helper to create an assistant message
+function assistantMsg(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4",
+		usage: {
+			input: 100,
+			output: 50,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 150,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("countImages", () => {
+	it("should return 0 for empty messages", () => {
+		expect(countImages([])).toBe(0);
+	});
+
+	it("should return 0 for text-only messages", () => {
+		const messages: AgentMessage[] = [userText("hello"), assistantMsg("hi"), toolResultText("file content")];
+		expect(countImages(messages)).toBe(0);
+	});
+
+	it("should count images in user messages", () => {
+		const messages: AgentMessage[] = [userWithImage("look at this"), userWithImage("and this")];
+		expect(countImages(messages)).toBe(2);
+	});
+
+	it("should count images in tool results", () => {
+		const messages: AgentMessage[] = [toolResultWithImage(), toolResultWithImage(), toolResultWithImage()];
+		expect(countImages(messages)).toBe(3);
+	});
+
+	it("should count images across mixed message types", () => {
+		const messages: AgentMessage[] = [
+			userWithImage("img 1"),
+			assistantMsg("I see the image"),
+			toolResultWithImage(),
+			assistantMsg("And this one"),
+			toolResultText("just text"),
+			userWithImage("img 3"),
+		];
+		expect(countImages(messages)).toBe(3);
+	});
+
+	it("should not count images in assistant messages", () => {
+		const messages: AgentMessage[] = [assistantMsg("no images here")];
+		expect(countImages(messages)).toBe(0);
+	});
+
+	it("should handle user messages with string content", () => {
+		const messages: AgentMessage[] = [userText("just a string")];
+		expect(countImages(messages)).toBe(0);
+	});
+});
+
+describe("stripOldestImages", () => {
+	it("should return original messages when no images", () => {
+		const messages: AgentMessage[] = [userText("hello"), assistantMsg("hi")];
+		const result = stripOldestImages(messages);
+		expect(result.strippedCount).toBe(0);
+		expect(result.messages).toBe(messages); // Same reference
+	});
+
+	it("should strip half of images (rounded up) from oldest first", () => {
+		const messages: AgentMessage[] = [
+			toolResultWithImage("img1"), // oldest - should be stripped
+			assistantMsg("response 1"),
+			toolResultWithImage("img2"), // should be stripped
+			assistantMsg("response 2"),
+			toolResultWithImage("img3"), // should be kept
+			assistantMsg("response 3"),
+			toolResultWithImage("img4"), // should be kept
+		];
+
+		const result = stripOldestImages(messages);
+		expect(result.strippedCount).toBe(2); // ceil(4/2) = 2
+
+		// First two tool results should have images replaced
+		const first = result.messages[0] as ToolResultMessage;
+		expect(first.content).toHaveLength(2);
+		expect(first.content[0].type).toBe("text");
+		expect((first.content[0] as TextContent).text).toBe("Read image.png [image/png]");
+		expect(first.content[1].type).toBe("text"); // was image, now text placeholder
+		expect((first.content[1] as TextContent).text).toContain("image omitted");
+
+		const third = result.messages[2] as ToolResultMessage;
+		expect(third.content[1].type).toBe("text"); // also stripped
+		expect((third.content[1] as TextContent).text).toContain("image omitted");
+
+		// Last two should still have images
+		const fifth = result.messages[4] as ToolResultMessage;
+		expect(fifth.content[1].type).toBe("image");
+		expect((fifth.content[1] as ImageContent).data).toBe("img3");
+
+		const seventh = result.messages[6] as ToolResultMessage;
+		expect(seventh.content[1].type).toBe("image");
+		expect((seventh.content[1] as ImageContent).data).toBe("img4");
+	});
+
+	it("should strip 1 image when there are only 1 (ceil(1/2) = 1)", () => {
+		const messages: AgentMessage[] = [toolResultWithImage("only_img")];
+
+		const result = stripOldestImages(messages);
+		expect(result.strippedCount).toBe(1);
+
+		const msg = result.messages[0] as ToolResultMessage;
+		expect(msg.content[1].type).toBe("text");
+		expect((msg.content[1] as TextContent).text).toContain("image omitted");
+	});
+
+	it("should strip 2 images when there are 3 (ceil(3/2) = 2)", () => {
+		const messages: AgentMessage[] = [
+			toolResultWithImage("img1"),
+			toolResultWithImage("img2"),
+			toolResultWithImage("img3"),
+		];
+
+		const result = stripOldestImages(messages);
+		expect(result.strippedCount).toBe(2);
+
+		// First two stripped
+		expect(((result.messages[0] as ToolResultMessage).content[1] as TextContent).text).toContain("image omitted");
+		expect(((result.messages[1] as ToolResultMessage).content[1] as TextContent).text).toContain("image omitted");
+
+		// Third kept
+		expect((result.messages[2] as ToolResultMessage).content[1].type).toBe("image");
+	});
+
+	it("should not mutate original messages array", () => {
+		const original: AgentMessage[] = [toolResultWithImage("img1"), toolResultWithImage("img2")];
+		const originalContent = (original[0] as ToolResultMessage).content;
+
+		stripOldestImages(original);
+
+		// Original should be unchanged
+		expect((original[0] as ToolResultMessage).content).toBe(originalContent);
+		expect((original[0] as ToolResultMessage).content[1].type).toBe("image");
+	});
+
+	it("should preserve text content alongside stripped images", () => {
+		const messages: AgentMessage[] = [
+			{
+				role: "toolResult",
+				toolCallId: "call_1",
+				toolName: "read",
+				content: [
+					{ type: "text", text: "Read screenshot.png [image/png]" },
+					{ type: "text", text: "[Image: original 1920x1080, displayed at 1000x562]" },
+					{ type: "image", data: "big_image_data", mimeType: "image/png" },
+				],
+				isError: false,
+				timestamp: Date.now(),
+			} satisfies ToolResultMessage,
+		];
+
+		const result = stripOldestImages(messages);
+		expect(result.strippedCount).toBe(1);
+
+		const msg = result.messages[0] as ToolResultMessage;
+		expect(msg.content).toHaveLength(3);
+		expect((msg.content[0] as TextContent).text).toBe("Read screenshot.png [image/png]");
+		expect((msg.content[1] as TextContent).text).toBe("[Image: original 1920x1080, displayed at 1000x562]");
+		expect(msg.content[2].type).toBe("text"); // replaced image
+		expect((msg.content[2] as TextContent).text).toContain("image omitted");
+	});
+
+	it("should handle mixed user and tool result images", () => {
+		const messages: AgentMessage[] = [
+			userWithImage("user img 1"), // stripped (oldest)
+			assistantMsg("ok"),
+			toolResultWithImage("tool img"), // stripped
+			assistantMsg("I see"),
+			userWithImage("user img 2"), // kept (newest)
+		];
+
+		const result = stripOldestImages(messages);
+		expect(result.strippedCount).toBe(2); // ceil(3/2) = 2
+
+		// User image 1 stripped
+		const first = result.messages[0] as UserMessage;
+		expect((first.content as (TextContent | ImageContent)[])[1].type).toBe("text");
+
+		// Tool result image stripped
+		const third = result.messages[2] as ToolResultMessage;
+		expect(third.content[1].type).toBe("text");
+
+		// User image 2 kept
+		const fifth = result.messages[4] as UserMessage;
+		expect((fifth.content as (TextContent | ImageContent)[])[1].type).toBe("image");
+	});
+
+	it("should handle iterative stripping (simulating retry loop)", () => {
+		const messages: AgentMessage[] = [
+			toolResultWithImage("img1"),
+			toolResultWithImage("img2"),
+			toolResultWithImage("img3"),
+			toolResultWithImage("img4"),
+			toolResultWithImage("img5"),
+			toolResultWithImage("img6"),
+		];
+
+		// First strip: 3 of 6
+		const first = stripOldestImages(messages);
+		expect(first.strippedCount).toBe(3);
+		expect(countImages(first.messages)).toBe(3);
+
+		// Second strip: 2 of 3
+		const second = stripOldestImages(first.messages);
+		expect(second.strippedCount).toBe(2);
+		expect(countImages(second.messages)).toBe(1);
+
+		// Third strip: 1 of 1
+		const third = stripOldestImages(second.messages);
+		expect(third.strippedCount).toBe(1);
+		expect(countImages(third.messages)).toBe(0);
+
+		// Fourth strip: nothing left
+		const fourth = stripOldestImages(third.messages);
+		expect(fourth.strippedCount).toBe(0);
+	});
+
+	it("should count and strip images in custom messages", () => {
+		const customWithImage: AgentMessage = {
+			role: "custom",
+			customType: "artifact",
+			content: [
+				{ type: "text", text: "Generated image:" },
+				{ type: "image", data: "custom_img_data", mimeType: "image/png" },
+			],
+			display: true,
+			timestamp: Date.now(),
+		};
+
+		const messages: AgentMessage[] = [customWithImage, toolResultWithImage("tool_img")];
+
+		expect(countImages(messages)).toBe(2);
+
+		const result = stripOldestImages(messages);
+		expect(result.strippedCount).toBe(1); // ceil(2/2) = 1, strips oldest (custom)
+
+		// Custom message image should be stripped
+		const custom = result.messages[0] as { role: "custom"; content: (TextContent | ImageContent)[] };
+		expect(custom.content[0].type).toBe("text");
+		expect((custom.content[0] as TextContent).text).toBe("Generated image:");
+		expect(custom.content[1].type).toBe("text"); // replaced
+		expect((custom.content[1] as TextContent).text).toContain("image omitted");
+
+		// Tool result image should be kept
+		const tool = result.messages[1] as ToolResultMessage;
+		expect(tool.content[1].type).toBe("image");
+	});
+
+	it("should handle custom messages with string content (no images)", () => {
+		const messages: AgentMessage[] = [
+			{
+				role: "custom",
+				customType: "note",
+				content: "just a string, no images",
+				display: true,
+				timestamp: Date.now(),
+			},
+		];
+
+		expect(countImages(messages)).toBe(0);
+		const result = stripOldestImages(messages);
+		expect(result.strippedCount).toBe(0);
+	});
+});


### PR DESCRIPTION
Anthropic returns HTTP 413 `request_too_large` when the request payload exceeds 32 MB. I could reproduce this consistently in image-heavy sessions where context token usage was still relatively low (~30%), but the request body had grown too large because conversation history contained many base64-encoded images.

I couldn’t reproduce the same failure on OpenAI models, likely because their effective payload limits are higher, but 413 is a standard HTTP error for this class of problem.

## Root cause

Compaction currently tracks token usage, not HTTP request size.

That works for normal text-heavy sessions, but images are a bad mismatch for token-only accounting:

- images are relatively cheap in tokens
- images are expensive in bytes once embedded as base64 in message history

So a session can stay far below the context window while still exceeding the provider’s request size limit.

## Fix

When a request fails with HTTP 413 / `request_too_large`:

- detect it separately from token-based context overflow
- remove the failed assistant error from in-memory state
- strip the oldest half of image blocks from context
- replace stripped images with a text placeholder
- retry the request
- repeat up to 3 attempts

This recovery now works even when auto-compaction is disabled.

The stripping logic handles images in:

- `user` messages
- `toolResult` messages
- `custom` messages

Session history on disk is left untouched. Only the in-memory request context is modified for recovery.

## Tests

Added tests for:

- `isRequestTooLarge()` detection
- image counting and oldest-first stripping
- repeated stripping across retries
- custom messages with images
- recovery from 413 even when auto-compaction is disabled
