### PR TITLE
fix: fully hide thinking blocks when hideThinkingBlock is true

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -48,7 +48,9 @@ export class AssistantMessageComponent extends Container {
 		this.contentContainer.clear();
 
 		const hasVisibleContent = message.content.some(
-			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
+			(c) =>
+				(c.type === "text" && c.text.trim()) ||
+				(c.type === "thinking" && c.thinking.trim() && !this.hideThinkingBlock),
 		);
 
 		if (hasVisibleContent) {
@@ -70,11 +72,7 @@ export class AssistantMessageComponent extends Container {
 					.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
 
 				if (this.hideThinkingBlock) {
-					// Show static "Thinking..." label when hidden
-					this.contentContainer.addChild(new Text(theme.italic(theme.fg("thinkingText", "Thinking...")), 1, 0));
-					if (hasVisibleContentAfter) {
-						this.contentContainer.addChild(new Spacer(1));
-					}
+					// Fully hidden: no label, no space
 				} else {
 					// Thinking traces in thinkingText color, italic
 					this.contentContainer.addChild(


### PR DESCRIPTION
Closes #1954

When `hideThinkingBlock` is true, thinking content is now skipped entirely instead of being replaced with a "Thinking..." label. Also excludes hidden thinking blocks from `hasVisibleContent` so the leading spacer is not added for thinking-only messages.