### PR TITLE
fix(ai): improve error details in response.failed handler

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -469,7 +469,14 @@ export async function processResponsesStream<TApi extends Api>(
 		} else if (event.type === "error") {
 			throw new Error(`Error Code ${event.code}: ${event.message}` || "Unknown error");
 		} else if (event.type === "response.failed") {
-			throw new Error("Unknown error");
+			const error = event.response?.error;
+			const details = event.response?.incomplete_details;
+			const msg = error
+				? `${error.code || "unknown"}: ${error.message || "no message"}`
+				: details?.reason
+					? `incomplete: ${details.reason}`
+					: "Unknown error (no error details in response)";
+			throw new Error(msg);
 		}
 	}
 }


### PR DESCRIPTION
Implements #1935

----

Adds additional error message handling to pi-ai's [OpenAPI Responses `processResponsesStream` function](https://github.com/badlogic/pi-mono/blob/b279d03d33a5c9548ebcfeb55290ac2dbd07a310/packages/ai/src/providers/openai-responses-shared.ts#L277)

When OpenAI responses return `response.failed`, a generic  "Unknown error" was provided instead of extracting the actual error details available in `event.response.error` and `event.response.incomplete_details`. This change exposes error messages that allow the user to differentiate between rate limiting, capacity issues, and implementation issues when errors are surfaced.

For reference, here's a link to OpenAPI's [Response object](https://developers.openai.com/api/reference/resources/responses#(resource)%20responses%20%3E%20(model)%20response%20%3E%20(schema)) which is included when `ResponseFailedEvent` is emitted.

## Test results

<details>
<summary>npm run check results</summary>

```text
npm run check

> pi-monorepo@0.0.3 check
> biome check --write --error-on-warnings . && tsgo --noEmit && npm run check:browser-smoke && cd packages/web-ui && npm run check

Checked 495 files in 503ms. No fixes applied.

> pi-monorepo@0.0.3 check:browser-smoke
> sh -c 'esbuild scripts/browser-smoke-entry.ts --bundle --platform=browser --format=esm --log-limit=0 --outfile=/tmp/pi-browser-smoke.js > /tmp/pi-browser-smoke-errors.log 2>&1 || { echo "Browser smoke check failed. See /tmp/pi-browser-smoke-errors.log"; exit 1; }'


> @mariozechner/pi-web-ui@0.57.1 check
> biome check --write --error-on-warnings . && tsc --noEmit && cd example && biome check --write --error-on-warnings . && tsc --noEmit

Checked 73 files in 59ms. No fixes applied.
Checked 3 files in 12ms. No fixes applied.
```

</details>

<details>
<summary>test.sh results</summary>

```
bash test.sh 2>&1 | grep -E "^( ✓| ✗| FAIL| PASS|Test Files|Tests|Duration|Start at)" 
 ✓ test/e2e.test.ts (44 tests | 42 skipped) 6ms
 ✓ test/agent-loop.test.ts (8 tests) 49ms
 ✓ test/agent.test.ts (12 tests) 41ms
 ✓ test/transform-messages-copilot-openai-to-anthropic.test.ts (2 tests) 6ms
 ✓ test/google-thinking-signature.test.ts (5 tests) 7ms
 ✓ test/google-shared-gemini3-unsigned-tool-call.test.ts (3 tests) 11ms
 ✓ test/supports-xhigh.test.ts (4 tests) 6ms
 ✓ test/github-copilot-anthropic.test.ts (2 tests) 199ms
 ✓ test/google-gemini-cli-retry-delay.test.ts (4 tests) 39ms
 ✓ test/google-gemini-cli-claude-thinking-header.test.ts (2 tests) 22ms
 ✓ test/google-tool-call-missing-args.test.ts (1 test) 42ms
 ✓ test/openai-completions-tool-result-images.test.ts (1 test) 13ms
 ✓ test/google-gemini-cli-empty-stream.test.ts (1 test) 522ms
 ✓ test/openai-completions-tool-choice.test.ts (4 tests) 12ms
 ✓ test/bedrock-models.test.ts (1 test) 9ms
 ✓ test/cache-retention.test.ts (11 tests | 4 skipped) 4088ms
 ✓ test/openai-codex-stream.test.ts (5 tests) 7060ms
 ✓ test/clipboard-image-bmp-conversion.test.ts (1 test) 171ms
 ✓ test/image-processing.test.ts (8 tests) 146ms
 ✓ test/block-images.test.ts (8 tests) 109ms
 ✓ test/skills.test.ts (27 tests) 63ms
 ✓ test/auth-storage.test.ts (23 tests) 147ms
 ✓ test/git-update.test.ts (10 tests) 1534ms
 ✓ test/model-registry.test.ts (41 tests) 223ms
 ✓ test/package-manager.test.ts (71 tests) 1558ms
 ✓ test/compaction.test.ts (21 tests | 2 skipped) 64ms
 ✓ test/tools.test.ts (42 tests) 1309ms
 ✓ test/settings-manager.test.ts (13 tests) 52ms
 ✓ test/rpc-jsonl.test.ts (4 tests) 18ms
 ✓ test/session-manager/file-operations.test.ts (17 tests) 58ms
 ✓ test/settings-manager-bug.test.ts (4 tests) 39ms
 ✓ test/prompt-templates.test.ts (73 tests) 27ms
 ✓ test/truncate-to-width.test.ts (6 tests) 42ms
 ✓ test/tree-selector.test.ts (14 tests) 30ms
 ✓ test/clipboard-image.test.ts (4 tests) 40ms
 ✓ test/frontmatter.test.ts (8 tests) 29ms
 ✓ test/sdk-skills.test.ts (3 tests) 81ms
 ✓ test/agent-session-auto-compaction-queue.test.ts (6 tests) 87ms
 ✓ test/agent-session-retry.test.ts (3 tests) 167ms
 ✓ test/agent-session-concurrent.test.ts (5 tests) 256ms
 ✓ test/extensions-input-event.test.ts (8 tests) 432ms
 ✓ test/model-resolver.test.ts (30 tests) 41ms
 ✓ test/resource-loader.test.ts (17 tests) 588ms
 ✓ test/system-prompt.test.ts (6 tests) 59ms
 ✓ test/plan-mode-utils.test.ts (33 tests) 33ms
 ✓ test/session-selector-rename.test.ts (3 tests) 38ms
 ✓ test/extensions-discovery.test.ts (27 tests) 827ms
 ✓ test/extensions-runner.test.ts (22 tests) 924ms
 ✓ test/session-manager/build-context.test.ts (14 tests) 26ms
 ✓ test/package-manager-ssh.test.ts (8 tests) 42ms
 ✓ test/agent-session-dynamic-tools.test.ts (1 test) 57ms
 ✓ test/path-utils.test.ts (10 tests) 28ms
 ✓ test/git-ssh-url.test.ts (9 tests) 19ms
 ✓ test/session-info-modified-timestamp.test.ts (1 test) 38ms
 ✓ test/session-selector-path-delete.test.ts (5 tests) 37ms
 ✓ test/session-manager/save-entry.test.ts (1 test) 11ms
 ✓ test/session-manager/labels.test.ts (8 tests) 14ms
 ✓ test/args.test.ts (46 tests) 25ms
 ✓ test/session-selector-search.test.ts (9 tests) 17ms
 ✓ test/session-manager/tree-traversal.test.ts (30 tests) 40ms
 ✓ test/package-command-paths.test.ts (5 tests) 40ms
 ✓ test/compaction-serialization.test.ts (3 tests) 21ms
 ✓ test/session-manager/migration.test.ts (2 tests) 9ms
 ✓ test/compaction-extensions-example.test.ts (2 tests) 12ms
 ✓ test/footer-width.test.ts (2 tests) 15ms
 ✓ test/tool-execution-component.test.ts (3 tests) 17ms
 ✓ test/compaction-summary-reasoning.test.ts (2 tests) 9ms
 ✓ test/agent-session-model-switch-thinking.test.ts (1 test) 30ms
 ✓ test/interactive-mode-status.test.ts (6 tests) 20ms
```

</details>