### PR TITLE
fix(tui): remove raw markdown heading markers for h3-h6

### DIFF
--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -271,7 +271,6 @@ export class Markdown implements Component {
 		switch (token.type) {
 			case "heading": {
 				const headingLevel = token.depth;
-				const headingPrefix = `${"#".repeat(headingLevel)} `;
 				const headingText = this.renderInlineTokens(token.tokens || [], styleContext);
 				let styledHeading: string;
 				if (headingLevel === 1) {
@@ -279,7 +278,7 @@ export class Markdown implements Component {
 				} else if (headingLevel === 2) {
 					styledHeading = this.theme.heading(this.theme.bold(headingText));
 				} else {
-					styledHeading = this.theme.heading(this.theme.bold(headingPrefix + headingText));
+					styledHeading = this.theme.heading(this.theme.bold(headingText));
 				}
 				lines.push(styledHeading);
 				if (nextTokenType !== "space") {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -480,6 +480,37 @@ describe("Markdown component", () => {
 		});
 	});
 
+	describe("Heading rendering", () => {
+		it("should not render raw markdown heading markers for h3 to h6", () => {
+			const markdown = new Markdown(
+				`### Third level
+#### Fourth level
+##### Fifth level
+###### Sixth level`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80);
+			const plainLines = lines
+				.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trim())
+				.filter((line) => line.length > 0);
+
+			assert.ok(plainLines.includes("Third level"));
+			assert.ok(plainLines.includes("Fourth level"));
+			assert.ok(plainLines.includes("Fifth level"));
+			assert.ok(plainLines.includes("Sixth level"));
+
+			for (const line of plainLines) {
+				assert.ok(!line.startsWith("### "), `Expected no raw heading prefix, got: "${line}"`);
+				assert.ok(!line.startsWith("#### "), `Expected no raw heading prefix, got: "${line}"`);
+				assert.ok(!line.startsWith("##### "), `Expected no raw heading prefix, got: "${line}"`);
+				assert.ok(!line.startsWith("###### "), `Expected no raw heading prefix, got: "${line}"`);
+			}
+		});
+	});
+
 	describe("Pre-styled text (thinking traces)", () => {
 		it("should preserve gray italic styling after inline code", () => {
 			// This replicates how thinking content is rendered in assistant-message.ts


### PR DESCRIPTION
## Summary
- remove raw markdown heading marker prefixes (`###`, `####`, `#####`, `######`) from terminal rendering for h3-h6
- keep existing heading styling behavior
- add a regression test for h3-h6 heading rendering

## Why
Fixes #1949: h3-h6 headings were rendered with visible raw markdown markers in terminal output.

## Changes
- `packages/tui/src/components/markdown.ts`
  - heading rendering no longer prepends raw `#` markers for h3-h6
- `packages/tui/test/markdown.test.ts`
  - new test: `should not render raw markdown heading markers for h3 to h6`

## Validation
- `cd packages/tui && node --test --import tsx test/markdown.test.ts`
- `cd packages/tui && npm test`
