### PR TITLE
fix(coding-agent): harden --session path handling on Windows/Git Bash

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Fixed interactive input fields backed by the TUI `Input` component to scroll by visual column width for wide Unicode text (CJK, fullwidth characters), preventing rendered line overflow and TUI crashes in places like search and filter inputs ([#1982](https://github.com/badlogic/pi-mono/issues/1982))
+- Fixed `--session` path handling to error when a path-like argument does not exist instead of silently creating a new session file.
+- Added a targeted Git Bash/MSYS hint for `--session` when unquoted Windows backslashes are likely stripped by shell escaping (`C:Users...jsonl`).
 
 ## [0.57.1] - 2026-03-07
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -204,7 +204,11 @@ Sessions auto-save to `~/.pi/agent/sessions/` organized by working directory.
 pi -c                  # Continue most recent session
 pi -r                  # Browse and select from past sessions
 pi --no-session        # Ephemeral mode (don't save)
-pi --session <path>    # Use specific session file or ID
+pi --session <path>    # Use specific session file or ID prefix
+
+# Git Bash/MSYS on Windows: quote backslash paths or use forward slashes
+pi --session 'C:\Users\Admin\.pi\agent\sessions\...jsonl'
+pi --session C:/Users/Admin/.pi/agent/sessions/...jsonl
 ```
 
 ### Branching
@@ -466,7 +470,7 @@ pi config                   # Enable/disable package resources
 |--------|-------------|
 | `-c`, `--continue` | Continue most recent session |
 | `-r`, `--resume` | Browse and select session |
-| `--session <path>` | Use specific session file or partial UUID |
+| `--session <path>` | Use specific session file or partial UUID (quote Windows backslash paths in Git Bash/MSYS) |
 | `--session-dir <dir>` | Custom session storage directory |
 | `--no-session` | Ephemeral mode (don't save) |
 

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -15,3 +15,16 @@ For most users, [Git for Windows](https://git-scm.com/download/win) is sufficien
   "shellPath": "C:\\cygwin64\\bin\\bash.exe"
 }
 ```
+
+## Session Paths in Git Bash / MSYS
+
+When using `--session` with a Windows path in Git Bash/MSYS, quote backslash paths or use forward slashes.
+
+```bash
+# Good
+pi --session 'C:\Users\Admin\.pi\agent\sessions\...jsonl'
+pi --session C:/Users/Admin/.pi/agent/sessions/...jsonl
+
+# Bad (unquoted backslashes get eaten by bash)
+pi --session C:\Users\Admin\.pi\agent\sessions\...jsonl
+```

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -200,7 +200,7 @@ ${chalk.bold("Options:")}
   --print, -p                    Non-interactive mode: process prompt and exit
   --continue, -c                 Continue previous session
   --resume, -r                   Select a session to resume
-  --session <path>               Use specific session file
+  --session <path>               Use specific session file or partial UUID
   --session-dir <dir>            Directory for session storage and lookup
   --no-session                   Don't save session (ephemeral)
   --models <patterns>            Comma-separated model patterns for Ctrl+P cycling
@@ -244,6 +244,13 @@ ${chalk.bold("Examples:")}
 
   # Continue previous session
   ${APP_NAME} --continue "What did we discuss?"
+
+  # Resume specific session by ID prefix
+  ${APP_NAME} --session 94a31582
+
+  # Git Bash/MSYS on Windows: quote backslash paths or use forward slashes
+  ${APP_NAME} --session 'C:\\Users\\Admin\\.pi\\agent\\sessions\\...jsonl'
+  ${APP_NAME} --session C:/Users/Admin/.pi/agent/sessions/...jsonl
 
   # Use different model
   ${APP_NAME} --provider openai --model gpt-4o-mini "Help me refactor this code"

--- a/packages/coding-agent/src/cli/session-path.ts
+++ b/packages/coding-agent/src/cli/session-path.ts
@@ -1,0 +1,89 @@
+/**
+ * Session argument resolution helpers.
+ */
+
+import { existsSync, statSync } from "fs";
+import { APP_NAME } from "../config.js";
+import { SessionManager } from "../core/session-manager.js";
+
+/** Result from resolving a session argument */
+export type ResolvedSession =
+	| { type: "path"; path: string } // Direct file path
+	| { type: "local"; path: string } // Found in current project
+	| { type: "global"; path: string; cwd: string } // Found in different project
+	| { type: "not_found"; arg: string; pathLike: boolean; hint?: string }; // Not found anywhere
+
+const LIKELY_ESCAPED_WINDOWS_PATH = /^[a-zA-Z]:[^\\/].*\.jsonl$/;
+
+export function isPathLikeSessionArg(sessionArg: string): boolean {
+	return sessionArg.includes("/") || sessionArg.includes("\\") || sessionArg.endsWith(".jsonl");
+}
+
+function isExistingFile(filePath: string): boolean {
+	if (!existsSync(filePath)) {
+		return false;
+	}
+
+	try {
+		return statSync(filePath).isFile();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Detect likely Git Bash/MSYS escaping of unquoted Windows paths.
+ * Example broken input: C:UsersAdmin.piagentsessions--C--...jsonl
+ */
+export function getSessionPathNotFoundHint(sessionArg: string): string | undefined {
+	if (!LIKELY_ESCAPED_WINDOWS_PATH.test(sessionArg)) {
+		return undefined;
+	}
+
+	return [
+		"Hint: this looks like an unquoted Windows path parsed by bash.",
+		"If you're using Git Bash/MSYS, quote the path or use forward slashes:",
+		`  ${APP_NAME} --session 'C:\\Users\\Admin\\.pi\\agent\\sessions\\...jsonl'`,
+		`  ${APP_NAME} --session C:/Users/Admin/.pi/agent/sessions/...jsonl`,
+	].join("\n");
+}
+
+/**
+ * Resolve a session argument to a file path.
+ * If it looks like a path, it must point to an existing file.
+ * Otherwise, treat it as a session ID prefix.
+ */
+export async function resolveSessionPath(
+	sessionArg: string,
+	cwd: string,
+	sessionDir?: string,
+): Promise<ResolvedSession> {
+	const pathLike = isPathLikeSessionArg(sessionArg);
+
+	if (pathLike) {
+		if (isExistingFile(sessionArg)) {
+			return { type: "path", path: sessionArg };
+		}
+		return {
+			type: "not_found",
+			arg: sessionArg,
+			pathLike: true,
+			hint: getSessionPathNotFoundHint(sessionArg),
+		};
+	}
+
+	const localSessions = await SessionManager.list(cwd, sessionDir);
+	const localMatches = localSessions.filter((s) => s.id.startsWith(sessionArg));
+	if (localMatches.length >= 1) {
+		return { type: "local", path: localMatches[0].path };
+	}
+
+	const allSessions = await SessionManager.listAll();
+	const globalMatches = allSessions.filter((s) => s.id.startsWith(sessionArg));
+	if (globalMatches.length >= 1) {
+		const match = globalMatches[0];
+		return { type: "global", path: match.path, cwd: match.cwd };
+	}
+
+	return { type: "not_found", arg: sessionArg, pathLike: false };
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -12,6 +12,7 @@ import { type Args, parseArgs, printHelp } from "./cli/args.js";
 import { selectConfig } from "./cli/config-selector.js";
 import { processFileArguments } from "./cli/file-processor.js";
 import { listModels } from "./cli/list-models.js";
+import { resolveSessionPath } from "./cli/session-path.js";
 import { selectSession } from "./cli/session-picker.js";
 import { APP_NAME, getAgentDir, getModelsPath, VERSION } from "./config.js";
 import { AuthStorage } from "./core/auth-storage.js";
@@ -327,44 +328,6 @@ async function prepareInitialMessage(
 	};
 }
 
-/** Result from resolving a session argument */
-type ResolvedSession =
-	| { type: "path"; path: string } // Direct file path
-	| { type: "local"; path: string } // Found in current project
-	| { type: "global"; path: string; cwd: string } // Found in different project
-	| { type: "not_found"; arg: string }; // Not found anywhere
-
-/**
- * Resolve a session argument to a file path.
- * If it looks like a path, use as-is. Otherwise try to match as session ID prefix.
- */
-async function resolveSessionPath(sessionArg: string, cwd: string, sessionDir?: string): Promise<ResolvedSession> {
-	// If it looks like a file path, use as-is
-	if (sessionArg.includes("/") || sessionArg.includes("\\") || sessionArg.endsWith(".jsonl")) {
-		return { type: "path", path: sessionArg };
-	}
-
-	// Try to match as session ID in current project first
-	const localSessions = await SessionManager.list(cwd, sessionDir);
-	const localMatches = localSessions.filter((s) => s.id.startsWith(sessionArg));
-
-	if (localMatches.length >= 1) {
-		return { type: "local", path: localMatches[0].path };
-	}
-
-	// Try global search across all projects
-	const allSessions = await SessionManager.listAll();
-	const globalMatches = allSessions.filter((s) => s.id.startsWith(sessionArg));
-
-	if (globalMatches.length >= 1) {
-		const match = globalMatches[0];
-		return { type: "global", path: match.path, cwd: match.cwd };
-	}
-
-	// Not found anywhere
-	return { type: "not_found", arg: sessionArg };
-}
-
 /** Prompt user for yes/no confirmation */
 async function promptConfirm(message: string): Promise<boolean> {
 	return new Promise((resolve) => {
@@ -440,7 +403,14 @@ async function createSessionManager(
 			}
 
 			case "not_found":
-				console.error(chalk.red(`No session found matching '${resolved.arg}'`));
+				if (resolved.pathLike) {
+					console.error(chalk.red(`Session file not found: ${resolved.arg}`));
+					if (resolved.hint) {
+						console.error(chalk.yellow(resolved.hint));
+					}
+				} else {
+					console.error(chalk.red(`No session found matching '${resolved.arg}'`));
+				}
 				process.exit(1);
 		}
 	}

--- a/packages/coding-agent/test/session-path.test.ts
+++ b/packages/coding-agent/test/session-path.test.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getSessionPathNotFoundHint, isPathLikeSessionArg, resolveSessionPath } from "../src/cli/session-path.js";
+
+describe("session path resolution", () => {
+	const tempDirs: string[] = [];
+
+	const createTempDir = (): string => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-session-path-"));
+		tempDirs.push(dir);
+		return dir;
+	};
+
+	afterEach(() => {
+		for (const dir of tempDirs) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+		tempDirs.length = 0;
+	});
+
+	it("detects path-like session args", () => {
+		expect(isPathLikeSessionArg("C:\\Users\\Admin\\session.jsonl")).toBe(true);
+		expect(isPathLikeSessionArg("C:/Users/Admin/session.jsonl")).toBe(true);
+		expect(isPathLikeSessionArg("/tmp/session.jsonl")).toBe(true);
+		expect(isPathLikeSessionArg("94a31582")).toBe(false);
+	});
+
+	it("detects likely Git Bash/MSYS escaped Windows paths", () => {
+		const escapedPath = "C:UsersAdmin.piagentsessions--C--Users-Admin--2026-03-02.jsonl";
+		const hint = getSessionPathNotFoundHint(escapedPath);
+		expect(hint).toContain("unquoted Windows path");
+		expect(hint).toContain("quote the path");
+		expect(getSessionPathNotFoundHint("C:/Users/Admin/.pi/agent/sessions/session.jsonl")).toBeUndefined();
+	});
+
+	it("resolves existing explicit session paths", async () => {
+		const cwd = createTempDir();
+		const file = join(cwd, "session.jsonl");
+		writeFileSync(
+			file,
+			`${JSON.stringify({ type: "session", version: 3, id: "abc", timestamp: "2026-01-01T00:00:00.000Z", cwd })}\n`,
+		);
+
+		const resolved = await resolveSessionPath(file, cwd);
+		expect(resolved).toEqual({ type: "path", path: file });
+	});
+
+	it("treats existing directories as missing session files", async () => {
+		const cwd = createTempDir();
+		const sessionDir = join(cwd, "session.jsonl");
+		mkdirSync(sessionDir, { recursive: true });
+
+		const resolved = await resolveSessionPath(sessionDir, cwd);
+		expect(resolved.type).toBe("not_found");
+		if (resolved.type !== "not_found") {
+			throw new Error("Expected not_found result");
+		}
+		expect(resolved.pathLike).toBe(true);
+	});
+
+	it("returns not_found for missing path-like args and includes escaped-path hint", async () => {
+		const cwd = createTempDir();
+		const escapedPath = "C:UsersAdmin.piagentsessions--C--Users-Admin--2026-03-02.jsonl";
+
+		const resolved = await resolveSessionPath(escapedPath, cwd);
+		expect(resolved.type).toBe("not_found");
+		if (resolved.type !== "not_found") {
+			throw new Error("Expected not_found result");
+		}
+		expect(resolved.pathLike).toBe(true);
+		expect(resolved.hint).toContain("Git Bash/MSYS");
+	});
+
+	it("resolves local session ID prefixes", async () => {
+		const cwd = createTempDir();
+		const sessionDir = join(cwd, "sessions");
+		mkdirSync(sessionDir, { recursive: true });
+
+		const sessionId = "94a31582-6d60-4d01-a5ae-0e17bc89a312";
+		const file = join(sessionDir, `2026-03-02T21-23-51-158Z_${sessionId}.jsonl`);
+		writeFileSync(
+			file,
+			`${JSON.stringify({ type: "session", version: 3, id: sessionId, timestamp: "2026-03-02T21:23:51.158Z", cwd })}\n`,
+		);
+
+		const resolved = await resolveSessionPath("94a31582", cwd, sessionDir);
+		expect(resolved.type).toBe("local");
+		if (resolved.type !== "local") {
+			throw new Error("Expected local result");
+		}
+		expect(resolved.path).toBe(file);
+	});
+
+	it("returns not_found for unknown ID prefixes", async () => {
+		const cwd = createTempDir();
+		const sessionDir = join(cwd, "sessions");
+		mkdirSync(sessionDir, { recursive: true });
+
+		const resolved = await resolveSessionPath("unknown-session-id", cwd, sessionDir);
+		expect(resolved).toEqual({
+			type: "not_found",
+			arg: "unknown-session-id",
+			pathLike: false,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fix `pi --session` handling for Windows/Git Bash-style invocation.

When a Windows backslash path is passed unquoted in Git Bash/MSYS, the shell strips backslashes before Node sees the argument. Pi previously treated that mangled value as a session path and could fall through into behavior that looked like the argument was ignored / a new session was started.

This change makes `--session` resolution stricter and more explicit:
- path-like values must point to an existing session file
- missing path-like values now error immediately
- likely Git Bash/MSYS-mangled Windows paths get a targeted hint
- partial UUID lookup still works as before

## Changes

- extracted session argument resolution into `src/cli/session-path.ts`
- preserved current `main` session-directory hook flow
- distinguish:
  - missing path-like args → `Session file not found: ...`
  - missing ID/prefix args → `No session found matching '...'`
- added Git Bash/MSYS guidance for mangled inputs like `C:Users...jsonl`
- require an existing file, not just existence
- documented quoting / forward-slash usage for Windows Git Bash/MSYS

## Validation

### Automated
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/session-path.test.ts`
- `npm run check`

### Manual
Verified from Git Bash on Windows:
- quoted Windows session path works
- unquoted Windows backslash path fails with targeted hint
- partial UUID resolution works with `--session-dir`

## Non-goals

This PR does **not** address broader Windows shell-command behavior in config/auth/model-registry tests. That should be handled separately.
