### PR TITLE
Add OpenRouter API key login to /login command

### DIFF
--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -25,6 +25,8 @@ export { antigravityOAuthProvider, loginAntigravity, refreshAntigravityToken } f
 export { geminiCliOAuthProvider, loginGeminiCli, refreshGoogleCloudToken } from "./google-gemini-cli.js";
 // OpenAI Codex (ChatGPT OAuth)
 export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.js";
+// OpenRouter (API Key)
+export { openrouterOAuthProvider } from "./openrouter.js";
 
 export * from "./types.js";
 
@@ -37,6 +39,7 @@ import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { antigravityOAuthProvider } from "./google-antigravity.js";
 import { geminiCliOAuthProvider } from "./google-gemini-cli.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
+import { openrouterOAuthProvider } from "./openrouter.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
@@ -45,6 +48,7 @@ const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	geminiCliOAuthProvider,
 	antigravityOAuthProvider,
 	openaiCodexOAuthProvider,
+	openrouterOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(

--- a/packages/ai/src/utils/oauth/openrouter.ts
+++ b/packages/ai/src/utils/oauth/openrouter.ts
@@ -1,0 +1,69 @@
+/**
+ * OpenRouter API key login flow with model discovery validation.
+ */
+
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+
+const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+
+// Far-future expiry — API keys don't expire
+const TEN_YEARS_MS = 10 * 365 * 24 * 60 * 60 * 1000;
+
+/**
+ * Validate an OpenRouter API key by fetching available models.
+ * Returns the number of available models on success, throws on failure.
+ */
+async function validateApiKey(apiKey: string, signal?: AbortSignal): Promise<number> {
+	const response = await fetch(OPENROUTER_MODELS_URL, {
+		headers: { Authorization: `Bearer ${apiKey}` },
+		signal,
+	});
+
+	if (!response.ok) {
+		if (response.status === 401 || response.status === 403) {
+			throw new Error("Invalid API key");
+		}
+		throw new Error(`OpenRouter API error: ${response.status} ${response.statusText}`);
+	}
+
+	const data = (await response.json()) as { data?: unknown[] };
+	return data.data?.length ?? 0;
+}
+
+export const openrouterOAuthProvider: OAuthProviderInterface = {
+	id: "openrouter",
+	name: "OpenRouter (API Key)",
+
+	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+		const apiKey = await callbacks.onPrompt({
+			message: "Enter your OpenRouter API key:",
+			placeholder: "sk-or-v1-...",
+		});
+
+		if (!apiKey || !apiKey.trim()) {
+			throw new Error("API key is required");
+		}
+
+		const trimmedKey = apiKey.trim();
+
+		// Validate by discovering models
+		callbacks.onProgress?.("Validating API key...");
+		const modelCount = await validateApiKey(trimmedKey, callbacks.signal);
+		callbacks.onProgress?.(`Validated — ${modelCount} models available`);
+
+		return {
+			refresh: "",
+			access: trimmedKey,
+			expires: Date.now() + TEN_YEARS_MS,
+		};
+	},
+
+	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+		// API keys don't expire — return as-is
+		return credentials;
+	},
+
+	getApiKey(credentials: OAuthCredentials): string {
+		return credentials.access;
+	},
+};


### PR DESCRIPTION
## Summary
- Adds **OpenRouter** as a provider in the `/login` interactive selector
- Users can authenticate with their OpenRouter API key directly from the TUI, instead of requiring the `OPENROUTER_API_KEY` environment variable
- The API key is validated against the OpenRouter models API (`/api/v1/models`) before saving to `auth.json`

## Changes
- **New**: `packages/ai/src/utils/oauth/openrouter.ts` — OpenRouter provider implementing `OAuthProviderInterface` with API key prompt, validation via model discovery, and far-future expiry (API keys don't expire)
- **Modified**: `packages/ai/src/utils/oauth/index.ts` — Import and register the OpenRouter provider in the built-in provider list

## Test plan
- [ ] Run `pi`, type `/login`, verify "OpenRouter (API Key)" appears in the provider list
- [ ] Select it, enter a valid API key, verify it validates and saves
- [ ] Enter an invalid key, verify it shows an error
- [ ] After login, verify OpenRouter models are available for use
- [ ] Type `/logout`, verify OpenRouter can be logged out