### PR TITLE
fix(tui): normalize tab characters in Input paste to spaces

### DIFF
--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -420,7 +420,7 @@ export class Input implements Component, Focusable {
 		this.pushUndo();
 
 		// Clean the pasted text - remove newlines and carriage returns
-		const cleanText = pastedText.replace(/\r\n/g, "").replace(/\r/g, "").replace(/\n/g, "");
+		const cleanText = pastedText.replace(/\r\n/g, "").replace(/\r/g, "").replace(/\n/g, "").replace(/\t/g, "    ");
 
 		// Insert at cursor position
 		this.value = this.value.slice(0, this.cursor) + cleanText + this.value.slice(this.cursor);


### PR DESCRIPTION
Tabs in pasted text were not being handled by the Input component, causing rendering issues.

This PR fixes this by converting tabs to 4 spaces during paste, consistent with how the Editor component already handles this.