### PR TITLE
feat: add agentsWalkBoundary setting for .agents/skills discovery

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -308,15 +308,15 @@ function findGitRepoRoot(startDir: string): string | null {
 	}
 }
 
-function collectAncestorAgentsSkillDirs(startDir: string): string[] {
+function collectAncestorAgentsSkillDirs(startDir: string, walkBoundary?: string): string[] {
 	const skillDirs: string[] = [];
 	const resolvedStartDir = resolve(startDir);
-	const gitRepoRoot = findGitRepoRoot(resolvedStartDir);
+	const boundary = walkBoundary ?? findGitRepoRoot(resolvedStartDir);
 
 	let dir = resolvedStartDir;
 	while (true) {
 		skillDirs.push(join(dir, ".agents", "skills"));
-		if (gitRepoRoot && dir === gitRepoRoot) {
+		if (boundary && dir === boundary) {
 			break;
 		}
 		const parent = dirname(dir);
@@ -1607,7 +1607,9 @@ export class DefaultPackageManager implements PackageManager {
 			themes: join(projectBaseDir, "themes"),
 		};
 		const userAgentsSkillsDir = join(homedir(), ".agents", "skills");
-		const projectAgentsSkillDirs = collectAncestorAgentsSkillDirs(this.cwd);
+		const agentsWalkBoundary = projectSettings.agentsWalkBoundary ?? globalSettings.agentsWalkBoundary;
+		const resolvedBoundary = agentsWalkBoundary ? this.resolvePath(agentsWalkBoundary) : undefined;
+		const projectAgentsSkillDirs = collectAncestorAgentsSkillDirs(this.cwd, resolvedBoundary);
 
 		const addResources = (
 			resourceType: ResourceType,

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -91,6 +91,7 @@ export interface Settings {
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
+	agentsWalkBoundary?: string; // Boundary dir for .agents/skills ancestor walk (default: git root, "~" for home dir)
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -190,6 +190,39 @@ Content`,
 			expect(result.skills.some((r) => r.path === aboveRepoSkill)).toBe(false);
 		});
 
+		it("should use agentsWalkBoundary as walk boundary instead of git root", async () => {
+			const workspace = join(tempDir, "workspace");
+			const repoRoot = join(workspace, "repo");
+			const nestedCwd = join(repoRoot, "packages", "feature");
+			mkdirSync(nestedCwd, { recursive: true });
+			mkdirSync(join(repoRoot, ".git"), { recursive: true });
+
+			// Skill above git root but within boundary — should be found
+			const aboveRepoSkill = join(workspace, ".agents", "skills", "above-repo", "SKILL.md");
+			mkdirSync(join(workspace, ".agents", "skills", "above-repo"), { recursive: true });
+			writeFileSync(aboveRepoSkill, "---\nname: above-repo\ndescription: above\n---\n");
+
+			// Skill above boundary — should NOT be found
+			const aboveBoundarySkill = join(tempDir, ".agents", "skills", "above-boundary", "SKILL.md");
+			mkdirSync(join(tempDir, ".agents", "skills", "above-boundary"), { recursive: true });
+			writeFileSync(aboveBoundarySkill, "---\nname: above-boundary\ndescription: above boundary\n---\n");
+
+			const repoRootSkill = join(repoRoot, ".agents", "skills", "repo-root", "SKILL.md");
+			mkdirSync(join(repoRoot, ".agents", "skills", "repo-root"), { recursive: true });
+			writeFileSync(repoRootSkill, "---\nname: repo-root\ndescription: repo\n---\n");
+
+			const pm = new DefaultPackageManager({
+				cwd: nestedCwd,
+				agentDir,
+				settingsManager: SettingsManager.inMemory({ agentsWalkBoundary: workspace }),
+			});
+
+			const result = await pm.resolve();
+			expect(result.skills.some((r) => r.path === repoRootSkill && r.enabled)).toBe(true);
+			expect(result.skills.some((r) => r.path === aboveRepoSkill && r.enabled)).toBe(true);
+			expect(result.skills.some((r) => r.path === aboveBoundarySkill)).toBe(false);
+		});
+
 		it("should scan .agents/skills up to filesystem root when not in a git repo", async () => {
 			const nonRepoRoot = join(tempDir, "non-repo");
 			const nestedCwd = join(nonRepoRoot, "a", "b");


### PR DESCRIPTION
When working in directories with multiple git repos under a shared parent, the ancestor walk for .agents/skills stops at each repo's .git boundary and never reaches the parent. This PR adds an optional agentsWalkBoundary setting that overrides the walk boundary, allowing shared .agents/skills directories above repos to be discovered.

Default: unset (preserves existing git-root boundary behavior).

Use case: Projects consisting of multiple repositories (plus worktrees) that want to share project-specific skills. Without this setting, each repo requires symlinks to a shared .agents folder. For example:
```
~/projects/
  ├── .agents/
  │   └── skills/
  │       └── company-style-guide/     ← shared across all repos
  │           └── SKILL.md
  ├── backend/
  │   ├── .git/                        ← git root stops ancestor walk here
  │   └── src/
  │       └── ...                      ← cwd when working on backend
  ├── frontend/
  │   ├── .git/
  │   └── src/
  │       └── ...
  └── infra/
      ├── .git/
      └── ...
```

With `"agentsWalkBoundary": "~/projects/my-project"` in settings, working in repo-a/ discovers both repo-a/.agents/skills/ and my-project/.agents/skills/, stopping at the boundary without walking further up.