### PR TITLE
fix: move (latest) tag from Claude Opus 4.5 to 4.6

### DIFF
--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -1675,7 +1675,7 @@ export const MODELS = {
 		} satisfies Model<"anthropic-messages">,
 		"claude-opus-4-5": {
 			id: "claude-opus-4-5",
-			name: "Claude Opus 4.5 (latest)",
+			name: "Claude Opus 4.5",
 			api: "anthropic-messages",
 			provider: "anthropic",
 			baseUrl: "https://api.anthropic.com",
@@ -1709,7 +1709,7 @@ export const MODELS = {
 		} satisfies Model<"anthropic-messages">,
 		"claude-opus-4-6": {
 			id: "claude-opus-4-6",
-			name: "Claude Opus 4.6",
+			name: "Claude Opus 4.6 (latest)",
 			api: "anthropic-messages",
 			provider: "anthropic",
 			baseUrl: "https://api.anthropic.com",


### PR DESCRIPTION
Claude Opus 4.6 is now the latest Opus model. The model catalog in `models.generated.ts` still has `(latest)` on the Opus 4.5 entry for the Anthropic provider.

This PR:
- Removes `(latest)` from `claude-opus-4-5` name
- Adds `(latest)` to `claude-opus-4-6` name

Only affects the Anthropic provider entries (other providers like opencode don't use the `(latest)` suffix).