### PR TITLE
fix(openai-responses): pass systemPrompt as instructions field

### DIFF
--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -195,6 +195,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
 		prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
 		store: false,
+		instructions: context.systemPrompt || undefined,
 	};
 
 	if (options?.maxTokens) {


### PR DESCRIPTION
## Problem

The `openai-responses` provider does not map `context.systemPrompt` to the Responses API `instructions` field. This causes **400 'Instructions are required'** errors when used with custom providers / proxies that enforce the `instructions` field.

## Root Cause

In `packages/ai/src/providers/openai-responses.ts`, the `buildParams()` function constructs the request body without an `instructions` field. The `openai-codex-responses` provider already does this correctly at line 301:

```ts
instructions: context.systemPrompt,
```

## Fix

One-line addition to `openai-responses.ts` `buildParams()`:

```ts
instructions: context.systemPrompt || undefined,
```

This aligns `openai-responses` with `openai-codex-responses` behavior.

## Reproduction

1. Configure a custom provider with `api: "openai-responses"` and a `baseUrl` pointing to an OpenAI-compatible proxy
2. Send a message → upstream returns `400 Instructions are required`
3. With this fix, `instructions` is populated from the system prompt and the request succeeds

## Related

- openclaw/openclaw#38706 (GPT-5.4 via openai-codex OAuth uses wrong API)