### PR TITLE
feat(anthropic): SSE stream compatibility for proxies omitting event field

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -569,10 +569,84 @@ function createClient(
 	}
 
 	// API key auth
+
+	// Some third-party Anthropic-compatible proxies return valid SSE `data:` lines
+	// but omit the preceding `event:` lines. The @anthropic-ai/sdk SSE parser only
+	// dispatches events when `sse.event` matches known types, so without `event:`
+	// lines all events are silently dropped, causing "request ended without sending
+	// any chunks". We wrap fetch to inject `event: <type>` lines inferred from
+	// `data.type` when they are missing.
+	// See: https://github.com/badlogic/pi-mono/issues/1983
+	const customFetch: typeof fetch = async (url, init) => {
+		const response = await fetch(url, init);
+		if (!response.body) return response;
+
+		const reader = response.body.getReader();
+		const encoder = new TextEncoder();
+		const decoder = new TextDecoder();
+
+		const stream = new ReadableStream<Uint8Array>({
+			async start(controller) {
+				let buffer = "";
+				let lastEventType: string | null = null;
+				try {
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) {
+							if (buffer) controller.enqueue(encoder.encode(buffer));
+							controller.close();
+							break;
+						}
+						buffer += decoder.decode(value, { stream: true });
+						const lines = buffer.split("\n");
+						buffer = lines.pop() ?? "";
+						for (const line of lines) {
+							if (line.startsWith("event:")) {
+								lastEventType = line.slice(6).trim();
+								controller.enqueue(encoder.encode(line + "\n"));
+							} else if (line.startsWith("data:")) {
+								const dataStr = line.slice(5).trim();
+								if (dataStr && !lastEventType) {
+									try {
+										const parsed = JSON.parse(dataStr) as { type?: string };
+										if (parsed.type) {
+											lastEventType = parsed.type;
+											controller.enqueue(encoder.encode(`event: ${parsed.type}\n`));
+										}
+									} catch {
+										// Not JSON — pass through as-is
+									}
+								}
+								controller.enqueue(encoder.encode(line + "\n"));
+							} else if (line === "") {
+								lastEventType = null;
+								controller.enqueue(encoder.encode("\n"));
+							} else {
+								controller.enqueue(encoder.encode(line + "\n"));
+							}
+						}
+					}
+				} catch (e) {
+					controller.error(e);
+				}
+			},
+			cancel() {
+				reader.cancel();
+			},
+		});
+
+		return new Response(stream, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
+	};
+
 	const client = new Anthropic({
 		apiKey,
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
+		fetch: customFetch,
 		defaultHeaders: mergeHeaders(
 			{
 				accept: "application/json",


### PR DESCRIPTION
## Summary

This PR adds a compatibility layer for third-party Anthropic-compatible proxies that return valid SSE `data:` lines but omit the preceding `event:` field lines.

The `@anthropic-ai/sdk` SSE parser only dispatches events when `sse.event` matches known types (`message_start`, `content_block_start`, etc.). When proxies omit `event:` lines, all events are silently dropped, causing the unhelpful error:

```
Error: request ended without sending any chunks
```

## The Issue

Standard Anthropic SSE format:
```
event: message_start
data: {"type":"message_start","message":{...}}
```

Some proxies return:
```
data: {"type":"message_start","message":{...}}
```

The `type` field is already present in the JSON payload — the `event:` line is technically redundant but required by the SDK parser.

## The Fix

A `customFetch` wrapper that:
1. Passes through conformant streams unchanged (zero overhead for correct implementations)
2. Detects `data:` lines containing valid JSON with a `type` field
3. Injects the corresponding `event: <type>` line when no `event:` line precedes it

## Discussion Points

I'd like to discuss whether this kind of "defensive compatibility" is appropriate for pi-mono:

**Arguments for:**
- Real-world proxies exist that are "Anthropic-compatible" at the API level but not strictly SSE-conformant
- The fix is transparent to compliant implementations (no performance/behavior impact)
- Improves user experience: instead of a cryptic "no chunks" error, things just work
- The `type` field is already in the JSON — we're just surface-transporting what's already there

**Arguments against:**
- Encourages non-compliant implementations
- Adds maintenance burden for a non-standard case
- The "correct" solution is for proxies to fix their SSE format

**Alternative approaches:**
- Add a provider-level option like `strictSSE: false` to opt-in to this behavior
- Document the requirement for `event:` lines more prominently instead

Would love to hear thoughts on whether this belongs in core or should be handled at the custom-provider level.

## Test Plan

- [ ] Verified with conformant SSE stream (passes through unchanged)
- [ ] Verified with proxy omitting `event:` lines (events now dispatched correctly)
- [ ] No regression in error handling for malformed data

---

Related: #1983