### PR TITLE
fix(tui): stop wide input slice overflow

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `Input` horizontal scrolling for wide Unicode text (CJK, fullwidth characters) to use visual column width instead of string length, preventing rendered line overflow and TUI crashes ([#1982](https://github.com/badlogic/pi-mono/issues/1982))
+- Fixed `Input` horizontal scrolling for wide Unicode text (CJK, fullwidth characters) to use visual column width and strict slice boundaries, preventing rendered line overflow and TUI crashes ([#1982](https://github.com/badlogic/pi-mono/issues/1982))
 
 ## [0.57.1] - 2026-03-07
 

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -468,8 +468,8 @@ export class Input implements Component, Focusable {
 					startCol = Math.max(0, cursorCol - halfWidth);
 				}
 
-				visibleText = sliceByColumn(this.value, startCol, scrollWidth);
-				const beforeCursor = sliceByColumn(this.value, startCol, Math.max(0, cursorCol - startCol));
+				visibleText = sliceByColumn(this.value, startCol, scrollWidth, true);
+				const beforeCursor = sliceByColumn(this.value, startCol, Math.max(0, cursorCol - startCol), true);
 				cursorDisplay = beforeCursor.length;
 			} else {
 				visibleText = "";

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -43,15 +43,28 @@ describe("Input component", () => {
 				"这是一段测试文本，用于验证中文字符在终端中的显示宽度是否被正确计算，如果不正确就会导致用户界面崩溃的问题",
 				"ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ０１２３４５６７８９ａｂｃｄｅｆｇｈｉｊｋｌｍ",
 			];
+			const cursorPositions = [
+				{ label: "start", move: (_input: Input) => {} },
+				{
+					label: "middle",
+					move: (input: Input) => {
+						for (let i = 0; i < 10; i++) input.handleInput("\x1b[C");
+					},
+				},
+				{ label: "end", move: (input: Input) => input.handleInput("\x05") },
+			];
 
 			for (const text of cases) {
-				const input = new Input();
-				input.setValue(text);
-				input.focused = true;
+				for (const { label, move } of cursorPositions) {
+					const input = new Input();
+					input.setValue(text);
+					input.focused = true;
+					move(input);
 
-				const [line] = input.render(width);
-				assert.ok(line);
-				assert.ok(visibleWidth(line) <= width, `rendered line overflowed for ${text}`);
+					const [line] = input.render(width);
+					assert.ok(line);
+					assert.ok(visibleWidth(line) <= width, `rendered line overflowed for ${text} at ${label}`);
+				}
 			}
 		});
 


### PR DESCRIPTION
## Summary

- fix `Input` horizontal scrolling for wide CJK/fullwidth text by using strict column slicing at viewport boundaries
- add regression coverage for wide text with the cursor at the start, middle, and end
- update the TUI changelog entry for the fix

## Why CI was failing

`build-check-test` was failing in `packages/tui/test/input.test.ts` on `main`.

The previous `#1982` fix switched scrolling to visual column width, but it still used non-strict `sliceByColumn()`. That can include a wide grapheme that crosses the right edge of the viewport, so the rendered line ends up one column too wide and trips the overflow assertion.

## Validation

- `cd packages/tui && node --test --import tsx test/input.test.ts`
- `npm run check`

Closes #1982
