### PR TITLE
fix: send assistant content as string in openai-completions provider

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -559,15 +559,12 @@ export function convertMessages(
 			// Filter out empty text blocks to avoid API validation errors
 			const nonEmptyTextBlocks = textBlocks.filter((b) => b.text && b.text.trim().length > 0);
 			if (nonEmptyTextBlocks.length > 0) {
-				// GitHub Copilot requires assistant content as a string, not an array.
-				// Sending as array causes Claude models to re-answer all previous prompts.
-				if (model.provider === "github-copilot") {
-					assistantMsg.content = nonEmptyTextBlocks.map((b) => sanitizeSurrogates(b.text)).join("");
-				} else {
-					assistantMsg.content = nonEmptyTextBlocks.map((b) => {
-						return { type: "text", text: sanitizeSurrogates(b.text) };
-					});
-				}
+				// Always send assistant content as a plain string (OpenAI Chat Completions
+				// API standard format). Sending as an array of {type:"text", text:"..."}
+				// objects is non-standard and causes some models (e.g. DeepSeek V3.2 via
+				// NVIDIA NIM) to mirror the content-block structure literally in their
+				// output, producing recursive nesting like [{'type':'text','text':'[{...}]'}].
+				assistantMsg.content = nonEmptyTextBlocks.map((b) => sanitizeSurrogates(b.text)).join("");
 			}
 
 			// Handle thinking blocks


### PR DESCRIPTION
## Summary

Fixes #2007

- Always send assistant message content as a plain string (joined text blocks) for all `openai-completions` backends
- Removes the conditional that only applied string format for `github-copilot` — now all providers get the standard format
- The OpenAI Chat Completions API specifies `assistant.content` as a string, not an array of content objects

## Problem

Some models (e.g. DeepSeek V3.2 via NVIDIA NIM) mirror the `[{type: "text", text: "..."}]` array structure they see in conversation history, producing recursive nesting that worsens each turn:

```
[{'type':'text','text':'[{\'type\':\'text\',\'text\':...}]'}]
```

## Changes

**`packages/ai/src/providers/openai-completions.ts`**
- Unified the assistant content serialization: always `join("")` text blocks into a single string
- Removed the `github-copilot`-only branch since this is now the default behavior for all providers

## Test plan

- [x] Verified fix locally with OpenClaw v2026.3.8
- [ ] Test with DeepSeek V3.2 via NVIDIA NIM — no more recursive content block nesting
- [ ] Test with GLM-5, GPT-4, Claude — no regression (these already worked with either format)
- [ ] Test with GitHub Copilot — behavior unchanged (was already using string format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)