### PR TITLE
fix(coding-agent): support PI_CODING_AGENT_DIR env var in example extensions

### DIFF
--- a/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
+++ b/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
@@ -28,10 +28,9 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { StringEnum } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { type Static, Type } from "@sinclair/typebox";
 
 const PROVIDER = "google-antigravity";
@@ -184,7 +183,8 @@ function readConfigFile(path: string): ExtensionConfig {
 }
 
 function loadConfig(cwd: string): ExtensionConfig {
-	const globalConfig = readConfigFile(join(homedir(), ".pi", "agent", "extensions", "antigravity-image-gen.json"));
+	const globalPath = join(getAgentDir(), "extensions", "antigravity-image-gen.json");
+	const globalConfig = readConfigFile(globalPath);
 	const projectConfig = readConfigFile(join(cwd, ".pi", "extensions", "antigravity-image-gen.json"));
 	return { ...globalConfig, ...projectConfig };
 }
@@ -204,7 +204,8 @@ function resolveSaveConfig(params: ToolParams, cwd: string): SaveConfig {
 	}
 
 	if (mode === "global") {
-		return { mode, outputDir: join(homedir(), ".pi", "agent", "generated-images") };
+		const outputDir = join(getAgentDir(), "generated-images");
+		return { mode, outputDir };
 	}
 
 	if (mode === "custom") {

--- a/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/test.ts
+++ b/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/test.ts
@@ -10,7 +10,7 @@
 
 import { type Api, type Context, type Model, registerApiProvider, streamSimple } from "@mariozechner/pi-ai";
 import { readFileSync } from "fs";
-import { homedir } from "os";
+import { getAgentDir } from "packages/coding-agent/src/config.js";
 import { join } from "path";
 import { MODELS, streamGitLabDuo } from "./index.js";
 
@@ -28,7 +28,7 @@ async function main() {
 	}
 
 	// Read auth
-	const authPath = join(homedir(), ".pi", "agent", "auth.json");
+	const authPath = join(getAgentDir(), "extensions", "auth.json");
 	const authData = JSON.parse(readFileSync(authPath, "utf-8"));
 	const gitlabCred = authData["gitlab-duo"];
 	if (!gitlabCred?.access) {

--- a/packages/coding-agent/examples/extensions/preset.ts
+++ b/packages/coding-agent/examples/extensions/preset.ts
@@ -39,10 +39,9 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { DynamicBorder } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { Container, Key, type SelectItem, SelectList, Text } from "@mariozechner/pi-tui";
 
 // Preset configuration
@@ -68,7 +67,7 @@ interface PresetsConfig {
  * Project-local presets override global presets with the same name.
  */
 function loadPresets(cwd: string): PresetsConfig {
-	const globalPath = join(homedir(), ".pi", "agent", "presets.json");
+	const globalPath = join(getAgentDir(), "presets.json");
 	const projectPath = join(cwd, ".pi", "presets.json");
 
 	let globalPresets: PresetsConfig = {};

--- a/packages/coding-agent/examples/extensions/sandbox/index.ts
+++ b/packages/coding-agent/examples/extensions/sandbox/index.ts
@@ -39,11 +39,10 @@
 
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { SandboxManager, type SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { type BashOperations, createBashTool } from "@mariozechner/pi-coding-agent";
+import { type BashOperations, createBashTool, getAgentDir } from "@mariozechner/pi-coding-agent";
 
 interface SandboxConfig extends SandboxRuntimeConfig {
 	enabled?: boolean;
@@ -75,7 +74,7 @@ const DEFAULT_CONFIG: SandboxConfig = {
 
 function loadConfig(cwd: string): SandboxConfig {
 	const projectConfigPath = join(cwd, ".pi", "sandbox.json");
-	const globalConfigPath = join(homedir(), ".pi", "agent", "sandbox.json");
+	const globalConfigPath = join(getAgentDir(), "extensions", "sandbox.json");
 
 	let globalConfig: Partial<SandboxConfig> = {};
 	let projectConfig: Partial<SandboxConfig> = {};

--- a/packages/coding-agent/examples/extensions/tool-override.ts
+++ b/packages/coding-agent/examples/extensions/tool-override.ts
@@ -21,14 +21,13 @@
  */
 
 import type { TextContent } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { appendFileSync, constants, readFileSync } from "fs";
 import { access, readFile } from "fs/promises";
-import { homedir } from "os";
 import { join, resolve } from "path";
 
-const LOG_FILE = join(homedir(), ".pi", "agent", "read-access.log");
+const LOG_FILE = join(getAgentDir(), "read-access.log");
 
 // Paths that are blocked from reading
 const BLOCKED_PATTERNS = [


### PR DESCRIPTION
Follows up on #1900. Updates several example extensions in `packages/coding-agent/examples/extensions/**` to make use of the `getAgentDir()` function to load the global Pi config directory set by `PI_CODING_AGENT_DIR` instead of hard-coding `~/.pi/agent`. 

Note: running `./test.sh` locally does produce one test failure in `packages/tui/test/input.test.ts`. However, that test fails for me on latest `main` of this repository without my changes, so I believe that the failure should be unrelated to my adjustments!