### PR TITLE
fix: Handle Moonshot/Kimi API usage format in streaming responses

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -127,11 +127,15 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			};
 
 			for await (const chunk of openaiStream) {
-				if (chunk.usage) {
-					const cachedTokens = chunk.usage.prompt_tokens_details?.cached_tokens || 0;
-					const reasoningTokens = chunk.usage.completion_tokens_details?.reasoning_tokens || 0;
-					const input = (chunk.usage.prompt_tokens || 0) - cachedTokens;
-					const outputTokens = (chunk.usage.completion_tokens || 0) + reasoningTokens;
+				// Moonshot/Kimi models put usage in choices[0].usage instead of chunk.usage
+				const isMoonshotModel = model.id?.toLowerCase().includes("kimi") || model.id?.toLowerCase().includes("moonshot");
+				const usage = isMoonshotModel ? (chunk.choices?.[0]?.usage || chunk.usage) : chunk.usage;
+
+				if (usage) {
+					const cachedTokens = usage.prompt_tokens_details?.cached_tokens || 0;
+					const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens || 0;
+					const input = (usage.prompt_tokens || 0) - cachedTokens;
+					const outputTokens = (usage.completion_tokens || 0) + reasoningTokens;
 					output.usage = {
 						// OpenAI includes cached tokens in prompt_tokens, so subtract to get non-cached input
 						input,


### PR DESCRIPTION
## Problem

Moonshot API (Kimi K2.5 and other models) returns usage data in `chunk.choices[0].usage` instead of the standard OpenAI API format `chunk.usage`. This causes pi-ai SDK to not capture usage statistics for these models.

## Solution

Check if the model ID contains "kimi" or "moonshot", and if so, read usage data from `chunk.choices[0].usage` while maintaining backward compatibility with the standard format.

## Changes

- Modified `packages/ai/src/providers/openai-completions.ts`
- Added detection for Moonshot/Kimi models
- Usage data is now correctly captured for both standard and Moonshot API formats

## Testing

- Tested with Kimi K2.5 - usage statistics are now correctly captured
- Does not affect behavior for non-Moonshot models

## Related

This is a provider-specific compatibility fix, similar to existing provider-specific handling in the codebase.