### PR TITLE
fix: add optional chaining for model.input in convertMessages

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -539,7 +539,7 @@ export function convertMessages(
 						} satisfies ChatCompletionContentPartImage;
 					}
 				});
-				const filteredContent = !model.input.includes("image")
+				const filteredContent = !model.input?.includes("image")
 					? content.filter((c) => c.type !== "image_url")
 					: content;
 				if (filteredContent.length === 0) continue;
@@ -657,7 +657,7 @@ export function convertMessages(
 				}
 				params.push(toolResultMsg);
 
-				if (hasImages && model.input.includes("image")) {
+				if (hasImages && model.input?.includes("image")) {
 					for (const block of toolMsg.content) {
 						if (block.type === "image") {
 							imageBlocks.push({


### PR DESCRIPTION
## Summary

Fixes crash when using custom OpenAI-compatible providers without an `input` field on the model object.

## Problem

`convertMessages()` calls `model.input.includes()` without null-checking, causing:
```
TypeError: Cannot read properties of undefined (reading 'includes')
```

This affects LCM compaction when using custom providers like MiniMax that don't define `model.input`.

## Fix

Added optional chaining (`model.input?.includes()`) at two locations:
- Line 542: filteredContent check
- Line 660: hasImages check

## Testing

Verified the fix compiles correctly. The change is backward-compatible since optional chaining returns `undefined` when the property doesn't exist, which evaluates to falsy in the boolean context.

## Related Issue

OpenClaw issue: https://github.com/openclaw/openclaw/issues/42068