### PR TITLE
fix: start UI before extensions so session_start can use interactive prompts

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -453,14 +453,18 @@ export class InteractiveMode {
 		this.setupKeyHandlers();
 		this.setupEditorSubmitHandler();
 
-		// Initialize extensions first so resources are shown before messages
+		// Start the UI before extensions so extensions can use interactive
+		// UI methods (confirm, select, input) during session_start hooks.
+		// Previously, ui.start() came after initExtensions(), which meant
+		// the TUI input handler wasn't active yet when extensions fired.
+		this.ui.start();
+
+		// Initialize extensions — UI is now active for interactive prompts
 		await this.initExtensions();
 
 		// Render initial messages AFTER showing loaded resources
 		this.renderInitialMessages();
 
-		// Start the UI
-		this.ui.start();
 		this.isInitialized = true;
 
 		// Set terminal title


### PR DESCRIPTION
## Problem

Extensions that use `ctx.ui.confirm()`, `ctx.ui.select()`, or `ctx.ui.input()` during `session_start` hooks fail silently. The component renders but can't receive keyboard input because `ui.start()` is called **after** `initExtensions()` in `interactive-mode.ts`.

## Root Cause

In `InteractiveMode.init()`:
```
await this.initExtensions();   // extensions fire session_start here
this.renderInitialMessages();
this.ui.start();               // input handler activates HERE — too late
```

Extensions calling `ctx.ui.confirm()` during `session_start` get a rendered dialog with no keyboard handler, causing a hang.

## Fix

Move `this.ui.start()` before `await this.initExtensions()` so the TUI input handler is active when extensions fire.

## Testing

Found while building [Soma](https://github.com/meetsoma/soma-agent), a Pi extension that auto-initializes a `.soma/` directory on first run. The `ctx.ui.confirm()` call during `session_start` rendered the dialog but couldn't accept input. After this fix, interactive prompts work during `session_start`.

Workaround (current): skip interactive prompts during `session_start` and auto-init instead.