### PR TITLE
fix(edit-diff): add NFKC normalization for Chinese text matching

### DIFF
--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -34,6 +34,7 @@ export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string 
 export function normalizeForFuzzyMatch(text: string): string {
 	return (
 		text
+			.normalize("NFKC")
 			// Strip trailing whitespace per line
 			.split("\n")
 			.map((line) => line.trimEnd())


### PR DESCRIPTION
## Summary

- Add Unicode NFKC normalization at the start of `normalizeForFuzzyMatch`
- This ensures Chinese characters with different encodings can match correctly
- Fixes issue #2044

## Changes

- Added `.normalize("NFKC")` call in `packages/coding-agent/src/core/tools/edit-diff.ts`

## Testing

- The fix adds NFKC normalization which is a standard Unicode normalization form
- This should not affect existing functionality for ASCII text

Co-authored-by: OpenClaw <openclaw@sparklab.ai>