### PR TITLE
feat(config): introduce `!!` to avoid caching api keys

### DIFF
--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -89,12 +89,16 @@ Set `api` at provider level (default for all models) or model level (override pe
 
 ### Value Resolution
 
-The `apiKey` and `headers` fields support three formats:
+The `apiKey` and `headers` fields support these formats:
 
-- **Shell command:** `"!command"` executes and uses stdout
+- **Shell command (cached):** `"!command"` executes and uses stdout, cached for process lifetime
   ```json
   "apiKey": "!security find-generic-password -ws 'anthropic'"
   "apiKey": "!op read 'op://vault/item/credential'"
+  ```
+- **Shell command (fresh):** `"!!command"` executes on every request, never cached. Use this for tokens that rotate or expire (e.g., Azure tokens refreshed by an external process).
+  ```json
+  "apiKey": "!!cat /path/to/azure-token"
   ```
 - **Environment variable:** Uses the value of the named variable
   ```json

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -91,12 +91,16 @@ The file is created with `0600` permissions (user read/write only). Auth file cr
 
 ### Key Resolution
 
-The `key` field supports three formats:
+The `key` field supports these formats:
 
-- **Shell command:** `"!command"` executes and uses stdout (cached for process lifetime)
+- **Shell command (cached):** `"!command"` executes and uses stdout, cached for process lifetime
   ```json
   { "type": "api_key", "key": "!security find-generic-password -ws 'anthropic'" }
   { "type": "api_key", "key": "!op read 'op://vault/item/credential'" }
+  ```
+- **Shell command (fresh):** `"!!command"` executes on every request, never cached. Use this for tokens that rotate or expire (e.g., Azure tokens refreshed by an external process).
+  ```json
+  { "type": "api_key", "key": "!!cat /path/to/azure-token" }
   ```
 - **Environment variable:** Uses the value of the named variable
   ```json

--- a/packages/coding-agent/src/core/resolve-config-value.ts
+++ b/packages/coding-agent/src/core/resolve-config-value.ts
@@ -5,28 +5,31 @@
 
 import { execSync } from "child_process";
 
-// Cache for shell command results (persists for process lifetime)
+// Cache for shell command results (persists for process lifetime, used by "!" commands only)
 const commandResultCache = new Map<string, string | undefined>();
 
 /**
  * Resolve a config value (API key, header value, etc.) to an actual value.
+ * - If starts with "!!", executes the rest as a shell command on every call (no caching)
  * - If starts with "!", executes the rest as a shell command and uses stdout (cached)
  * - Otherwise checks environment variable first, then treats as literal (not cached)
  */
 export function resolveConfigValue(config: string): string | undefined {
+	if (config.startsWith("!!")) {
+		return executeCommand(config.slice(2), false);
+	}
 	if (config.startsWith("!")) {
-		return executeCommand(config);
+		return executeCommand(config.slice(1), true);
 	}
 	const envValue = process.env[config];
 	return envValue || config;
 }
 
-function executeCommand(commandConfig: string): string | undefined {
-	if (commandResultCache.has(commandConfig)) {
-		return commandResultCache.get(commandConfig);
+function executeCommand(command: string, cache: boolean): string | undefined {
+	if (cache && commandResultCache.has(command)) {
+		return commandResultCache.get(command);
 	}
 
-	const command = commandConfig.slice(1);
 	let result: string | undefined;
 	try {
 		const output = execSync(command, {
@@ -39,7 +42,9 @@ function executeCommand(commandConfig: string): string | undefined {
 		result = undefined;
 	}
 
-	commandResultCache.set(commandConfig, result);
+	if (cache) {
+		commandResultCache.set(command, result);
+	}
 	return result;
 }
 


### PR DESCRIPTION
# Changes

Introduces the use of `!!` as an alternative to `!<cmd>` in order to support grabbing fresh short-lived tokens from a CLI tool that provides these tokens for your model(s).