### PR TITLE
fix(ai): add fetch timeout and abort signal threading to all OAuth providers

### DIFF
--- a/packages/ai/src/utils/oauth/anthropic.ts
+++ b/packages/ai/src/utils/oauth/anthropic.ts
@@ -2,6 +2,7 @@
  * Anthropic OAuth flow (Claude Pro/Max)
  */
 
+import { fetchWithTimeout } from "./fetch-utils.js";
 import { generatePKCE } from "./pkce.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
 
@@ -15,12 +16,14 @@ const SCOPES = "org:create_api_key user:profile user:inference";
 /**
  * Login with Anthropic OAuth (device code flow)
  *
- * @param onAuthUrl - Callback to handle the authorization URL (e.g., open browser)
- * @param onPromptCode - Callback to prompt user for the authorization code
+ * @param onAuthUrl     - Callback to handle the authorization URL (e.g., open browser)
+ * @param onPromptCode  - Callback to prompt user for the authorization code
+ * @param signal        - Optional AbortSignal for cancellation (e.g. from dialog cancel button)
  */
 export async function loginAnthropic(
 	onAuthUrl: (url: string) => void,
 	onPromptCode: () => Promise<string>,
+	signal?: AbortSignal,
 ): Promise<OAuthCredentials> {
 	const { verifier, challenge } = await generatePKCE();
 
@@ -47,21 +50,26 @@ export async function loginAnthropic(
 	const code = splits[0];
 	const state = splits[1];
 
-	// Exchange code for tokens
-	const tokenResponse = await fetch(TOKEN_URL, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
+	// Exchange code for tokens.
+	// Uses fetchWithTimeout so a flaky/unreachable Anthropic endpoint does not
+	// hang the UI forever; the caller's AbortSignal (cancel button) is also
+	// respected so the dialog can be dismissed at any point.
+	const tokenResponse = await fetchWithTimeout(
+		TOKEN_URL,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "authorization_code",
+				client_id: CLIENT_ID,
+				code: code,
+				state: state,
+				redirect_uri: REDIRECT_URI,
+				code_verifier: verifier,
+			}),
 		},
-		body: JSON.stringify({
-			grant_type: "authorization_code",
-			client_id: CLIENT_ID,
-			code: code,
-			state: state,
-			redirect_uri: REDIRECT_URI,
-			code_verifier: verifier,
-		}),
-	});
+		signal,
+	);
 
 	if (!tokenResponse.ok) {
 		const error = await tokenResponse.text();
@@ -77,7 +85,6 @@ export async function loginAnthropic(
 	// Calculate expiry time (current time + expires_in seconds - 5 min buffer)
 	const expiresAt = Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000;
 
-	// Save credentials
 	return {
 		refresh: tokenData.refresh_token,
 		access: tokenData.access_token,
@@ -89,7 +96,7 @@ export async function loginAnthropic(
  * Refresh Anthropic OAuth token
  */
 export async function refreshAnthropicToken(refreshToken: string): Promise<OAuthCredentials> {
-	const response = await fetch(TOKEN_URL, {
+	const response = await fetchWithTimeout(TOKEN_URL, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({
@@ -125,6 +132,7 @@ export const anthropicOAuthProvider: OAuthProviderInterface = {
 		return loginAnthropic(
 			(url) => callbacks.onAuth({ url }),
 			() => callbacks.onPrompt({ message: "Paste the authorization code:" }),
+			callbacks.signal,
 		);
 	},
 

--- a/packages/ai/src/utils/oauth/fetch-utils.ts
+++ b/packages/ai/src/utils/oauth/fetch-utils.ts
@@ -1,0 +1,54 @@
+/**
+ * Fetch utilities for OAuth providers.
+ *
+ * All network calls in OAuth flows must be cancellable and time-bounded.
+ * Without a timeout, a slow or unreachable endpoint hangs the UI forever with
+ * no way for the user to recover short of killing the process.
+ */
+
+/** Default request timeout for OAuth network calls (30 seconds). */
+export const OAUTH_FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Fetch wrapper that enforces a deadline and respects an optional caller
+ * AbortSignal.  Either the timeout or the caller signal can abort the request —
+ * whichever fires first.
+ *
+ * @param url      - Request URL
+ * @param init     - Standard RequestInit (signal field is replaced internally)
+ * @param signal   - Optional caller-supplied AbortSignal (e.g. from the login
+ *                   dialog's cancel button)
+ * @param timeoutMs - Deadline in milliseconds (default: OAUTH_FETCH_TIMEOUT_MS)
+ */
+export async function fetchWithTimeout(
+	url: string,
+	init: RequestInit,
+	signal?: AbortSignal,
+	timeoutMs: number = OAUTH_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+	const timeoutController = new AbortController();
+	const timeoutId = setTimeout(
+		() => timeoutController.abort(new Error(`Request timed out after ${timeoutMs}ms`)),
+		timeoutMs,
+	);
+
+	// Compose the deadline signal with the optional caller signal.
+	// AbortSignal.any() resolves as soon as *any* of the signals fires.
+	const composedSignal =
+		signal != null ? AbortSignal.any([timeoutController.signal, signal]) : timeoutController.signal;
+
+	try {
+		const response = await fetch(url, { ...init, signal: composedSignal });
+		return response;
+	} catch (err) {
+		// Translate timeout aborts into a friendlier error message.
+		if (timeoutController.signal.aborted && !signal?.aborted) {
+			throw new Error(
+				`OAuth request timed out after ${timeoutMs / 1000}s. Check your internet connection and try again.`,
+			);
+		}
+		throw err;
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}

--- a/packages/ai/src/utils/oauth/google-antigravity.ts
+++ b/packages/ai/src/utils/oauth/google-antigravity.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Server } from "node:http";
+import { fetchWithTimeout } from "./fetch-utils.js";
 import { generatePKCE } from "./pkce.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
 
@@ -174,7 +175,7 @@ async function discoverProject(accessToken: string, onProgress?: (message: strin
 
 	for (const endpoint of endpoints) {
 		try {
-			const loadResponse = await fetch(`${endpoint}/v1internal:loadCodeAssist`, {
+			const loadResponse = await fetchWithTimeout(`${endpoint}/v1internal:loadCodeAssist`, {
 				method: "POST",
 				headers,
 				body: JSON.stringify({
@@ -216,7 +217,7 @@ async function discoverProject(accessToken: string, onProgress?: (message: strin
  */
 async function getUserEmail(accessToken: string): Promise<string | undefined> {
 	try {
-		const response = await fetch("https://www.googleapis.com/oauth2/v1/userinfo?alt=json", {
+		const response = await fetchWithTimeout("https://www.googleapis.com/oauth2/v1/userinfo?alt=json", {
 			headers: {
 				Authorization: `Bearer ${accessToken}`,
 			},
@@ -236,7 +237,7 @@ async function getUserEmail(accessToken: string): Promise<string | undefined> {
  * Refresh Antigravity token
  */
 export async function refreshAntigravityToken(refreshToken: string, projectId: string): Promise<OAuthCredentials> {
-	const response = await fetch(TOKEN_URL, {
+	const response = await fetchWithTimeout(TOKEN_URL, {
 		method: "POST",
 		headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		body: new URLSearchParams({
@@ -278,6 +279,7 @@ export async function loginAntigravity(
 	onAuth: (info: { url: string; instructions?: string }) => void,
 	onProgress?: (message: string) => void,
 	onManualCodeInput?: () => Promise<string>,
+	signal?: AbortSignal,
 ): Promise<OAuthCredentials> {
 	const { verifier, challenge } = await generatePKCE();
 
@@ -379,20 +381,24 @@ export async function loginAntigravity(
 
 		// Exchange code for tokens
 		onProgress?.("Exchanging authorization code for tokens...");
-		const tokenResponse = await fetch(TOKEN_URL, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/x-www-form-urlencoded",
+		const tokenResponse = await fetchWithTimeout(
+			TOKEN_URL,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					client_id: CLIENT_ID,
+					client_secret: CLIENT_SECRET,
+					code,
+					grant_type: "authorization_code",
+					redirect_uri: REDIRECT_URI,
+					code_verifier: verifier,
+				}),
 			},
-			body: new URLSearchParams({
-				client_id: CLIENT_ID,
-				client_secret: CLIENT_SECRET,
-				code,
-				grant_type: "authorization_code",
-				redirect_uri: REDIRECT_URI,
-				code_verifier: verifier,
-			}),
-		});
+			signal,
+		);
 
 		if (!tokenResponse.ok) {
 			const error = await tokenResponse.text();
@@ -439,7 +445,7 @@ export const antigravityOAuthProvider: OAuthProviderInterface = {
 	usesCallbackServer: true,
 
 	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-		return loginAntigravity(callbacks.onAuth, callbacks.onProgress, callbacks.onManualCodeInput);
+		return loginAntigravity(callbacks.onAuth, callbacks.onProgress, callbacks.onManualCodeInput, callbacks.signal);
 	},
 
 	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {

--- a/packages/ai/src/utils/oauth/google-gemini-cli.ts
+++ b/packages/ai/src/utils/oauth/google-gemini-cli.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Server } from "node:http";
+import { fetchWithTimeout } from "./fetch-utils.js";
 import { generatePKCE } from "./pkce.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
 
@@ -204,7 +205,7 @@ async function pollOperation(
 			await wait(5000);
 		}
 
-		const response = await fetch(`${CODE_ASSIST_ENDPOINT}/v1internal/${operationName}`, {
+		const response = await fetchWithTimeout(`${CODE_ASSIST_ENDPOINT}/v1internal/${operationName}`, {
 			method: "GET",
 			headers,
 		});
@@ -238,7 +239,7 @@ async function discoverProject(accessToken: string, onProgress?: (message: strin
 
 	// Try to load existing project via loadCodeAssist
 	onProgress?.("Checking for existing Cloud Code Assist project...");
-	const loadResponse = await fetch(`${CODE_ASSIST_ENDPOINT}/v1internal:loadCodeAssist`, {
+	const loadResponse = await fetchWithTimeout(`${CODE_ASSIST_ENDPOINT}/v1internal:loadCodeAssist`, {
 		method: "POST",
 		headers,
 		body: JSON.stringify({
@@ -317,7 +318,7 @@ async function discoverProject(accessToken: string, onProgress?: (message: strin
 	}
 
 	// Start onboarding - this returns a long-running operation
-	const onboardResponse = await fetch(`${CODE_ASSIST_ENDPOINT}/v1internal:onboardUser`, {
+	const onboardResponse = await fetchWithTimeout(`${CODE_ASSIST_ENDPOINT}/v1internal:onboardUser`, {
 		method: "POST",
 		headers,
 		body: JSON.stringify(onboardBody),
@@ -358,7 +359,7 @@ async function discoverProject(accessToken: string, onProgress?: (message: strin
  */
 async function getUserEmail(accessToken: string): Promise<string | undefined> {
 	try {
-		const response = await fetch("https://www.googleapis.com/oauth2/v1/userinfo?alt=json", {
+		const response = await fetchWithTimeout("https://www.googleapis.com/oauth2/v1/userinfo?alt=json", {
 			headers: {
 				Authorization: `Bearer ${accessToken}`,
 			},
@@ -378,7 +379,7 @@ async function getUserEmail(accessToken: string): Promise<string | undefined> {
  * Refresh Google Cloud Code Assist token
  */
 export async function refreshGoogleCloudToken(refreshToken: string, projectId: string): Promise<OAuthCredentials> {
-	const response = await fetch(TOKEN_URL, {
+	const response = await fetchWithTimeout(TOKEN_URL, {
 		method: "POST",
 		headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		body: new URLSearchParams({
@@ -420,6 +421,7 @@ export async function loginGeminiCli(
 	onAuth: (info: { url: string; instructions?: string }) => void,
 	onProgress?: (message: string) => void,
 	onManualCodeInput?: () => Promise<string>,
+	signal?: AbortSignal,
 ): Promise<OAuthCredentials> {
 	const { verifier, challenge } = await generatePKCE();
 
@@ -521,20 +523,24 @@ export async function loginGeminiCli(
 
 		// Exchange code for tokens
 		onProgress?.("Exchanging authorization code for tokens...");
-		const tokenResponse = await fetch(TOKEN_URL, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/x-www-form-urlencoded",
+		const tokenResponse = await fetchWithTimeout(
+			TOKEN_URL,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					client_id: CLIENT_ID,
+					client_secret: CLIENT_SECRET,
+					code,
+					grant_type: "authorization_code",
+					redirect_uri: REDIRECT_URI,
+					code_verifier: verifier,
+				}),
 			},
-			body: new URLSearchParams({
-				client_id: CLIENT_ID,
-				client_secret: CLIENT_SECRET,
-				code,
-				grant_type: "authorization_code",
-				redirect_uri: REDIRECT_URI,
-				code_verifier: verifier,
-			}),
-		});
+			signal,
+		);
 
 		if (!tokenResponse.ok) {
 			const error = await tokenResponse.text();
@@ -581,7 +587,7 @@ export const geminiCliOAuthProvider: OAuthProviderInterface = {
 	usesCallbackServer: true,
 
 	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-		return loginGeminiCli(callbacks.onAuth, callbacks.onProgress, callbacks.onManualCodeInput);
+		return loginGeminiCli(callbacks.onAuth, callbacks.onProgress, callbacks.onManualCodeInput, callbacks.signal);
 	},
 
 	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -17,6 +17,7 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
 	});
 }
 
+import { fetchWithTimeout } from "./fetch-utils.js";
 import { generatePKCE } from "./pkce.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from "./types.js";
 
@@ -103,18 +104,23 @@ async function exchangeAuthorizationCode(
 	code: string,
 	verifier: string,
 	redirectUri: string = REDIRECT_URI,
+	signal?: AbortSignal,
 ): Promise<TokenResult> {
-	const response = await fetch(TOKEN_URL, {
-		method: "POST",
-		headers: { "Content-Type": "application/x-www-form-urlencoded" },
-		body: new URLSearchParams({
-			grant_type: "authorization_code",
-			client_id: CLIENT_ID,
-			code,
-			code_verifier: verifier,
-			redirect_uri: redirectUri,
-		}),
-	});
+	const response = await fetchWithTimeout(
+		TOKEN_URL,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "authorization_code",
+				client_id: CLIENT_ID,
+				code,
+				code_verifier: verifier,
+				redirect_uri: redirectUri,
+			}),
+		},
+		signal,
+	);
 
 	if (!response.ok) {
 		const text = await response.text().catch(() => "");
@@ -143,7 +149,7 @@ async function exchangeAuthorizationCode(
 
 async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
 	try {
-		const response = await fetch(TOKEN_URL, {
+		const response = await fetchWithTimeout(TOKEN_URL, {
 			method: "POST",
 			headers: { "Content-Type": "application/x-www-form-urlencoded" },
 			body: new URLSearchParams({
@@ -308,6 +314,7 @@ export async function loginOpenAICodex(options: {
 	onProgress?: (message: string) => void;
 	onManualCodeInput?: () => Promise<string>;
 	originator?: string;
+	signal?: AbortSignal;
 }): Promise<OAuthCredentials> {
 	const { verifier, state, url } = await createAuthorizationFlow(options.originator);
 	const server = await startLocalOAuthServer(state);
@@ -388,7 +395,7 @@ export async function loginOpenAICodex(options: {
 			throw new Error("Missing authorization code");
 		}
 
-		const tokenResult = await exchangeAuthorizationCode(code, verifier);
+		const tokenResult = await exchangeAuthorizationCode(code, verifier, REDIRECT_URI, options.signal);
 		if (tokenResult.type !== "success") {
 			throw new Error("Token exchange failed");
 		}
@@ -442,6 +449,7 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 			onPrompt: callbacks.onPrompt,
 			onProgress: callbacks.onProgress,
 			onManualCodeInput: callbacks.onManualCodeInput,
+			signal: callbacks.signal,
 		});
 	},
 


### PR DESCRIPTION
## Problem

All OAuth network calls had no timeout and ignored the `AbortSignal` passed via `callbacks.signal` (which comes from the login dialog's cancel button). A flaky or unreachable provider endpoint — e.g. `console.anthropic.com` during an outage — would hang the UI **indefinitely** with no user-recoverable path short of killing the process.

Affected providers: Anthropic, Google Antigravity, Google Gemini CLI, OpenAI Codex.  
GitHub Copilot already handled `signal` correctly and is unchanged.

## Changes

- **`packages/ai/src/utils/oauth/fetch-utils.ts`** (new)  
  `fetchWithTimeout(url, init, signal?, timeoutMs?)` — wraps `fetch()` with a 30 s deadline via `AbortSignal.any([deadlineSignal, callerSignal])`. Translates timeout aborts into a friendly error message.

- **`anthropic.ts`**: both `loginAnthropic` (token exchange) and `refreshAnthropicToken` now use `fetchWithTimeout`. The login function accepts an optional `signal` param threaded from `callbacks.signal`.

- **`google-antigravity.ts`**: all four `fetch()` calls replaced; `loginAntigravity` accepts `signal?` and threads it to the token-exchange call.

- **`google-gemini-cli.ts`**: all five `fetch()` calls replaced; same `signal` threading pattern.

- **`openai-codex.ts`**: `exchangeAuthorizationCode` and `refreshAccessToken` use `fetchWithTimeout`; `loginOpenAICodex` options type gains `signal?` threaded from the provider `login()` callback.

## Testing

`npx tsc -p packages/ai/tsconfig.build.json --noEmit` passes clean.

The pre-existing `cli.ts` error (`bedrockProviderModule` export) in `packages/coding-agent` is unrelated to this change and present on `main` before this branch.