### PR TITLE
fix(tui): handle OSC 133 click events in editor

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -102,7 +102,15 @@ interface LayoutLine {
 	text: string;
 	hasCursor: boolean;
 	cursorPos?: number;
+	startsLogicalLine: boolean;
+	logicalLine: number;
+	startIndex: number;
+	endIndex: number;
 }
+
+const OSC133_INPUT_START = "\x1b]133;A;click_events=1\x07\x1b]133;I\x07";
+const OSC133_CONTINUATION_INPUT = "\x1b]133;P;k=c\x07\x1b]133;I\x07";
+const OSC133_INPUT_END = "\x1b]133;D\x07";
 
 export interface EditorTheme {
 	borderColor: (str: string) => string;
@@ -168,6 +176,9 @@ export class Editor implements Component, Focusable {
 
 	// Undo support
 	private undoStack = new UndoStack<EditorState>();
+
+	private lastRenderedVisibleLines: LayoutLine[] = [];
+	private lastRenderedPaddingX = 0;
 
 	public onSubmit?: (text: string) => void;
 	public onChange?: (text: string) => void;
@@ -321,6 +332,8 @@ export class Editor implements Component, Focusable {
 
 		// Get visible lines slice
 		const visibleLines = layoutLines.slice(this.scrollOffset, this.scrollOffset + maxVisibleLines);
+		this.lastRenderedVisibleLines = visibleLines;
+		this.lastRenderedPaddingX = paddingX;
 
 		const result: string[] = [];
 		const leftPadding = " ".repeat(paddingX);
@@ -338,8 +351,9 @@ export class Editor implements Component, Focusable {
 		// Render each visible layout line
 		// Emit hardware cursor marker only when focused and not showing autocomplete
 		const emitCursorMarker = this.focused && !this.autocompleteState;
+		const emitSemanticPrompt = this.focused && !this.autocompleteState;
 
-		for (const layoutLine of visibleLines) {
+		for (const [visibleIndex, layoutLine] of visibleLines.entries()) {
 			let displayText = layoutLine.text;
 			let lineVisibleWidth = visibleWidth(layoutLine.text);
 			let cursorInPadding = false;
@@ -378,7 +392,14 @@ export class Editor implements Component, Focusable {
 			const lineRightPadding = cursorInPadding ? rightPadding.slice(1) : rightPadding;
 
 			// Render the line (no side borders, just horizontal lines above and below)
-			result.push(`${leftPadding}${displayText}${padding}${lineRightPadding}`);
+			let renderedLine = `${leftPadding}${displayText}${padding}${lineRightPadding}`;
+			if (emitSemanticPrompt) {
+				const semanticStart =
+					visibleIndex === 0 ? OSC133_INPUT_START : layoutLine.startsLogicalLine ? OSC133_CONTINUATION_INPUT : "";
+				const semanticEnd = visibleIndex === visibleLines.length - 1 ? OSC133_INPUT_END : "";
+				renderedLine = `${leftPadding}${semanticStart}${displayText}${semanticEnd}${padding}${lineRightPadding}`;
+			}
+			result.push(renderedLine);
 		}
 
 		// Render bottom border (with scroll indicator if more content below)
@@ -402,6 +423,36 @@ export class Editor implements Component, Focusable {
 		}
 
 		return result;
+	}
+
+	handleMouse(
+		event: { button: number; shift: boolean; alt: boolean; ctrl: boolean; action: "press" | "release" },
+		row: number,
+		col: number,
+	): void {
+		if (event.button !== 0 || event.shift || event.alt || event.ctrl) {
+			return;
+		}
+
+		const contentRow = row - 1;
+		if (contentRow < 0 || contentRow >= this.lastRenderedVisibleLines.length) {
+			return;
+		}
+
+		const layoutLine = this.lastRenderedVisibleLines[contentRow];
+		if (!layoutLine) {
+			return;
+		}
+
+		const targetVisualCol = Math.max(0, col - this.lastRenderedPaddingX);
+		const targetCol = this.getTextIndexForVisualColumn(
+			layoutLine.text,
+			targetVisualCol,
+			layoutLine.endIndex - layoutLine.startIndex,
+		);
+		const logicalLine = this.state.lines[layoutLine.logicalLine] || "";
+		this.state.cursorLine = layoutLine.logicalLine;
+		this.setCursorCol(Math.min(layoutLine.startIndex + targetCol, logicalLine.length));
 	}
 
 	handleInput(data: string): void {
@@ -698,6 +749,23 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
+	private getTextIndexForVisualColumn(text: string, visualCol: number, fallbackEndIndex: number): number {
+		if (visualCol <= 0 || text.length === 0) {
+			return 0;
+		}
+
+		let currentWidth = 0;
+		for (const part of segmenter.segment(text)) {
+			const partWidth = visibleWidth(part.segment);
+			if (currentWidth + partWidth > visualCol) {
+				return part.index;
+			}
+			currentWidth += partWidth;
+		}
+
+		return fallbackEndIndex;
+	}
+
 	private layoutText(contentWidth: number): LayoutLine[] {
 		const layoutLines: LayoutLine[] = [];
 
@@ -707,6 +775,10 @@ export class Editor implements Component, Focusable {
 				text: "",
 				hasCursor: true,
 				cursorPos: 0,
+				startsLogicalLine: true,
+				logicalLine: 0,
+				startIndex: 0,
+				endIndex: 0,
 			});
 			return layoutLines;
 		}
@@ -724,11 +796,19 @@ export class Editor implements Component, Focusable {
 						text: line,
 						hasCursor: true,
 						cursorPos: this.state.cursorCol,
+						startsLogicalLine: true,
+						logicalLine: i,
+						startIndex: 0,
+						endIndex: line.length,
 					});
 				} else {
 					layoutLines.push({
 						text: line,
 						hasCursor: false,
+						startsLogicalLine: true,
+						logicalLine: i,
+						startIndex: 0,
+						endIndex: line.length,
 					});
 				}
 			} else {
@@ -772,11 +852,19 @@ export class Editor implements Component, Focusable {
 							text: chunk.text,
 							hasCursor: true,
 							cursorPos: adjustedCursorPos,
+							startsLogicalLine: chunkIndex === 0,
+							logicalLine: i,
+							startIndex: chunk.startIndex,
+							endIndex: chunk.endIndex,
 						});
 					} else {
 						layoutLines.push({
 							text: chunk.text,
 							hasCursor: false,
+							startsLogicalLine: chunkIndex === 0,
+							logicalLine: i,
+							startIndex: chunk.startIndex,
+							endIndex: chunk.endIndex,
 						});
 					}
 				}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -82,6 +82,7 @@ export {
 	CURSOR_MARKER,
 	type Focusable,
 	isFocusable,
+	type MouseEvent,
 	type OverlayAnchor,
 	type OverlayHandle,
 	type OverlayMargin,

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -13,6 +13,16 @@ import { extractSegments, sliceByColumn, sliceWithWidth, visibleWidth } from "./
 /**
  * Component interface - all components must implement this
  */
+export interface MouseEvent {
+	button: number;
+	row: number;
+	col: number;
+	shift: boolean;
+	alt: boolean;
+	ctrl: boolean;
+	action: "press" | "release";
+}
+
 export interface Component {
 	/**
 	 * Render the component to lines for the given viewport width
@@ -25,6 +35,12 @@ export interface Component {
 	 * Optional handler for keyboard input when component has focus
 	 */
 	handleInput?(data: string): void;
+
+	/**
+	 * Optional handler for mouse input when component has focus.
+	 * `row` and `col` are zero-indexed and relative to the component's rendered box.
+	 */
+	handleMouse?(event: MouseEvent, row: number, col: number): void;
 
 	/**
 	 * If true, component receives key release events (Kitty protocol).
@@ -41,6 +57,28 @@ export interface Component {
 
 type InputListenerResult = { consume?: boolean; data?: string } | undefined;
 type InputListener = (data: string) => InputListenerResult;
+
+function parseSgrMouseEvent(data: string): MouseEvent | null {
+	const match = data.match(/^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/);
+	if (!match) return null;
+
+	const code = parseInt(match[1], 10);
+	const col = parseInt(match[2], 10);
+	const row = parseInt(match[3], 10);
+	if (!Number.isFinite(code) || !Number.isFinite(col) || !Number.isFinite(row)) {
+		return null;
+	}
+
+	return {
+		button: code & 0b11,
+		shift: (code & 0b100) !== 0,
+		alt: (code & 0b1000) !== 0,
+		ctrl: (code & 0b10000) !== 0,
+		action: match[4] === "M" ? "press" : "release",
+		col,
+		row,
+	};
+}
 
 /**
  * Interface for components that can receive focus and display a hardware cursor.
@@ -227,6 +265,13 @@ export class TUI extends Container {
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
 	private fullRedrawCount = 0;
 	private stopped = false;
+	private focusedComponentBounds: {
+		absoluteRow: number;
+		viewportRow: number;
+		col: number;
+		width: number;
+		height: number;
+	} | null = null;
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
@@ -409,7 +454,7 @@ export class TUI extends Container {
 	start(): void {
 		this.stopped = false;
 		this.terminal.start(
-			(data) => this.handleInput(data),
+			(data) => this.handleTerminalInput(data),
 			() => this.requestRender(),
 		);
 		this.terminal.hideCursor();
@@ -475,7 +520,70 @@ export class TUI extends Container {
 		});
 	}
 
-	private handleInput(data: string): void {
+	private findComponentBounds(
+		component: Component,
+		width: number,
+		target: Component,
+		startRow: number,
+	): { startRow: number; height: number } | null {
+		const lines = component.render(width);
+		if (component === target) {
+			return { startRow, height: lines.length };
+		}
+
+		if (component instanceof Container) {
+			let childRow = startRow;
+			for (const child of component.children) {
+				const result = this.findComponentBounds(child, width, target, childRow);
+				if (result) return result;
+				childRow += child.render(width).length;
+			}
+		}
+
+		return null;
+	}
+
+	private updateFocusedComponentBounds(width: number, height: number, contentLineCount: number): void {
+		this.focusedComponentBounds = null;
+		if (!this.focusedComponent) return;
+
+		const workingHeight = Math.max(this.maxLinesRendered, contentLineCount);
+		const viewportTop = Math.max(0, workingHeight - height);
+
+		for (const entry of this.overlayStack.filter((overlay) => this.isOverlayVisible(overlay))) {
+			const { width: overlayWidth, maxHeight } = this.resolveOverlayLayout(entry.options, 0, width, height);
+			let overlayLines = entry.component.render(overlayWidth);
+			if (maxHeight !== undefined && overlayLines.length > maxHeight) {
+				overlayLines = overlayLines.slice(0, maxHeight);
+			}
+			const { row, col } = this.resolveOverlayLayout(entry.options, overlayLines.length, width, height);
+			const overlayTarget = this.findComponentBounds(entry.component, overlayWidth, this.focusedComponent, 0);
+			if (overlayTarget) {
+				const absoluteRow = row + overlayTarget.startRow;
+				this.focusedComponentBounds = {
+					absoluteRow,
+					viewportRow: absoluteRow,
+					col,
+					width: overlayWidth,
+					height: overlayTarget.height,
+				};
+				return;
+			}
+		}
+
+		const target = this.findComponentBounds(this, width, this.focusedComponent, 0);
+		if (!target) return;
+
+		this.focusedComponentBounds = {
+			absoluteRow: target.startRow,
+			viewportRow: target.startRow - viewportTop,
+			col: 0,
+			width,
+			height: target.height,
+		};
+	}
+
+	private handleTerminalInput(data: string): void {
 		if (this.inputListeners.size > 0) {
 			let current = data;
 			for (const listener of this.inputListeners) {
@@ -499,6 +607,28 @@ export class TUI extends Container {
 			const filtered = this.parseCellSizeResponse();
 			if (filtered.length === 0) return;
 			data = filtered;
+		}
+
+		const mouseEvent = parseSgrMouseEvent(data);
+		if (mouseEvent && this.focusedComponent?.handleMouse && this.focusedComponentBounds) {
+			const zeroBasedMouseRow = mouseEvent.row - 1;
+			const relativeViewportRow = zeroBasedMouseRow - this.focusedComponentBounds.viewportRow;
+			const relativeAbsoluteRow = zeroBasedMouseRow - this.focusedComponentBounds.absoluteRow;
+			const row =
+				relativeViewportRow >= 0 && relativeViewportRow < this.focusedComponentBounds.height
+					? relativeViewportRow
+					: relativeAbsoluteRow;
+			const col = mouseEvent.col - 1 - this.focusedComponentBounds.col;
+			if (
+				row >= 0 &&
+				row < this.focusedComponentBounds.height &&
+				col >= 0 &&
+				col < this.focusedComponentBounds.width
+			) {
+				this.focusedComponent.handleMouse(mouseEvent, row, col);
+				this.requestRender();
+				return;
+			}
 		}
 
 		// Global debug key handler (Shift+Ctrl+D)
@@ -881,11 +1011,14 @@ export class TUI extends Container {
 
 		// Render all components to get new lines
 		let newLines = this.render(width);
+		const contentLineCount = newLines.length;
 
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {
 			newLines = this.compositeOverlays(newLines, width, height);
 		}
+
+		this.updateFocusedComponentBounds(width, height, contentLineCount);
 
 		// Extract cursor position before applying line resets (marker must be found first)
 		const cursorPos = this.extractCursorPosition(newLines, height);

--- a/packages/tui/test/editor-mouse.test.ts
+++ b/packages/tui/test/editor-mouse.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Editor } from "../src/components/editor.js";
+import type { Component } from "../src/tui.js";
+import { TUI } from "../src/tui.js";
+import { defaultEditorTheme } from "./test-themes.js";
+import { VirtualTerminal } from "./virtual-terminal.js";
+
+function createMountedEditor(
+	cols = 40,
+	rows = 12,
+): {
+	tui: TUI;
+	terminal: VirtualTerminal;
+	editor: Editor;
+} {
+	const terminal = new VirtualTerminal(cols, rows);
+	const tui = new TUI(terminal);
+	const editor = new Editor(tui, defaultEditorTheme);
+	tui.addChild(editor);
+	tui.setFocus(editor);
+	tui.start();
+	return { tui, terminal, editor };
+}
+
+class StaticLines implements Component {
+	constructor(private readonly lines: string[]) {}
+
+	render(): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+class MutableLines implements Component {
+	constructor(public lines: string[]) {}
+
+	render(): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+describe("Editor mouse click events", () => {
+	it("moves the cursor within a single line from click_events mouse input", async () => {
+		const { tui, terminal, editor } = createMountedEditor();
+		try {
+			editor.setText("hello");
+			tui.requestRender();
+			await terminal.flush();
+
+			terminal.sendInput("\x1b[<0;3;2M");
+			await terminal.flush();
+
+			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 2 });
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("moves the cursor to another logical line from click_events mouse input", async () => {
+		const { tui, terminal, editor } = createMountedEditor();
+		try {
+			editor.setText("hello\nworld");
+			tui.requestRender();
+			await terminal.flush();
+
+			terminal.sendInput("\x1b[<0;2;3M");
+			await terminal.flush();
+
+			assert.deepStrictEqual(editor.getCursor(), { line: 1, col: 1 });
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("accepts prompt click coordinates reported in absolute scrollback rows", async () => {
+		const terminal = new VirtualTerminal(40, 12);
+		const tui = new TUI(terminal);
+		const spacer = new StaticLines(Array.from({ length: 30 }, () => "spacer"));
+		const editor = new Editor(tui, defaultEditorTheme);
+		tui.addChild(spacer);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+		tui.start();
+		try {
+			editor.setText("hello\nworld");
+			tui.requestRender();
+			await terminal.flush();
+
+			terminal.sendInput("\x1b[<0;2;33M");
+			await terminal.flush();
+
+			assert.deepStrictEqual(editor.getCursor(), { line: 1, col: 1 });
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("uses the working-area viewport when older content keeps maxLinesRendered larger", async () => {
+		const terminal = new VirtualTerminal(40, 12);
+		const tui = new TUI(terminal);
+		const spacer = new MutableLines(Array.from({ length: 30 }, () => "spacer"));
+		const editor = new Editor(tui, defaultEditorTheme);
+		tui.addChild(spacer);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+		tui.start();
+		try {
+			editor.setText("hello\nworld");
+			tui.requestRender();
+			await terminal.flush();
+
+			spacer.lines = [];
+			tui.requestRender();
+			await terminal.flush();
+
+			terminal.sendInput("\x1b[<0;2;3M");
+			await terminal.flush();
+
+			assert.deepStrictEqual(editor.getCursor(), { line: 1, col: 1 });
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/tui/test/semantic-prompts.test.ts
+++ b/packages/tui/test/semantic-prompts.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Editor } from "../src/components/editor.js";
+import { TUI } from "../src/tui.js";
+import { visibleWidth } from "../src/utils.js";
+import { defaultEditorTheme } from "./test-themes.js";
+import { VirtualTerminal } from "./virtual-terminal.js";
+
+const OSC133_INPUT_START = "\x1b]133;A;click_events=1\x07\x1b]133;I\x07";
+const OSC133_CONTINUATION_INPUT = "\x1b]133;P;k=c\x07\x1b]133;I\x07";
+const OSC133_INPUT_END = "\x1b]133;D\x07";
+
+function createTestTUI(cols = 80, rows = 24): TUI {
+	return new TUI(new VirtualTerminal(cols, rows));
+}
+
+function _escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+describe("OSC 133 semantic prompts", () => {
+	it("marks the focused editor input area with click-enabled semantic prompt markers", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		editor.focused = true;
+		editor.setText("hello");
+
+		const lines = editor.render(20);
+		assert.match(lines[1] ?? "", /^\x1b\]133;A;click_events=1\x07\x1b\]133;I\x07/);
+		assert.match(lines[1] ?? "", /\x1b\]133;D\x07/);
+	});
+
+	it("emits continuation input markers for explicit multi-line editor input", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		editor.focused = true;
+		editor.setText("first line\nsecond line");
+
+		const lines = editor.render(20);
+		assert.match(lines[1] ?? "", /^\x1b\]133;A;click_events=1\x07\x1b\]133;I\x07/);
+		assert.match(lines[2] ?? "", new RegExp(`^${_escapeRegExp(OSC133_CONTINUATION_INPUT)}`));
+		assert.match(lines[2] ?? "", /\x1b\]133;D\x07/);
+	});
+
+	it("does not emit continuation markers for soft-wrapped lines within the same logical input line", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		editor.focused = true;
+		editor.setText("this is a long line that wraps");
+
+		const lines = editor.render(15);
+		assert.match(lines[1] ?? "", /^\x1b\]133;A;click_events=1\x07\x1b\]133;I\x07/);
+		assert.doesNotMatch(lines[2] ?? "", /^\x1b\]133;P;k=c\x07\x1b\]133;I\x07/);
+		assert.match(lines[lines.length - 2] ?? "", /\x1b\]133;D\x07/);
+	});
+
+	it("does not emit semantic prompt markers when the editor is not focused", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		editor.focused = false;
+		editor.setText("hello");
+
+		const lines = editor.render(20);
+		assert.doesNotMatch(lines[1] ?? "", /\x1b\]133;/);
+	});
+
+	it("preserves visible line width when semantic prompt markers are present", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		editor.focused = true;
+		editor.setText("hello");
+
+		const lines = editor.render(20);
+		const visibleLine = (lines[1] ?? "").replace(OSC133_INPUT_START, "").replace(OSC133_INPUT_END, "");
+		assert.strictEqual(visibleWidth(visibleLine), 20);
+	});
+});


### PR DESCRIPTION
This commit adds editor support for OSC 133 `click_events=1` prompt-click (supported by Ghostty and some others) by changing the focused TUI editor to emit click-enabled OSC 133 semantic prompt markers.

This teaches the TUI to parse and dispatch incoming mouse click events to the focused component, and teaching the editor to map those terminal click coordinates back to logical cursor positions across single-line, explicit multi-line, and wrapped inputs.

This is sloppier than I think it could be, but it took me a few attempts to make it work at all.