### PR TITLE
fix(tui): restore shift+tab in xterm modifyOtherKeys mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed interactive input fields backed by the TUI `Input` component to scroll by visual column width for wide Unicode text (CJK, fullwidth characters), preventing rendered line overflow and TUI crashes in places like search and filter inputs ([#1982](https://github.com/badlogic/pi-mono/issues/1982))
+- Fixed `shift+tab` and other modified Tab bindings in tmux when `extended-keys-format` is left at the default `xterm`
 
 ## [0.57.1] - 2026-03-07
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `Input` horizontal scrolling for wide Unicode text (CJK, fullwidth characters) to use visual column width and strict slice boundaries, preventing rendered line overflow and TUI crashes ([#1982](https://github.com/badlogic/pi-mono/issues/1982))
+- Fixed xterm `modifyOtherKeys` handling for `Tab` in `matchesKey()`, restoring `shift+tab` and other modified Tab bindings in tmux when `extended-keys-format` is left at the default `xterm`
 
 ## [0.57.1] - 2026-03-07
 

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -769,12 +769,19 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 
 		case "tab":
 			if (shift && !ctrl && !alt) {
-				return data === "\x1b[Z" || matchesKittySequence(data, CODEPOINTS.tab, MODIFIERS.shift);
+				return (
+					data === "\x1b[Z" ||
+					matchesKittySequence(data, CODEPOINTS.tab, MODIFIERS.shift) ||
+					matchesModifyOtherKeys(data, CODEPOINTS.tab, MODIFIERS.shift)
+				);
 			}
 			if (modifier === 0) {
 				return data === "\t" || matchesKittySequence(data, CODEPOINTS.tab, 0);
 			}
-			return matchesKittySequence(data, CODEPOINTS.tab, modifier);
+			return (
+				matchesKittySequence(data, CODEPOINTS.tab, modifier) ||
+				matchesModifyOtherKeys(data, CODEPOINTS.tab, modifier)
+			);
 
 		case "enter":
 		case "return":

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -157,6 +157,16 @@ describe("matchesKey", () => {
 			assert.strictEqual(parseKey("\x1b[27;3;13~"), "alt+enter");
 		});
 
+		it("should match xterm modifyOtherKeys Tab variants", () => {
+			setKittyProtocolActive(false);
+			assert.strictEqual(matchesKey("\x1b[27;2;9~", "shift+tab"), true);
+			assert.strictEqual(matchesKey("\x1b[27;5;9~", "ctrl+tab"), true);
+			assert.strictEqual(matchesKey("\x1b[27;3;9~", "alt+tab"), true);
+			assert.strictEqual(parseKey("\x1b[27;2;9~"), "shift+tab");
+			assert.strictEqual(parseKey("\x1b[27;5;9~"), "ctrl+tab");
+			assert.strictEqual(parseKey("\x1b[27;3;9~"), "alt+tab");
+		});
+
 		it("should match xterm modifyOtherKeys symbol combos", () => {
 			setKittyProtocolActive(false);
 			assert.strictEqual(matchesKey("\x1b[27;5;47~", "ctrl+/"), true);


### PR DESCRIPTION
## Summary

This fixes `Shift+Tab` not triggering keybindings when the terminal sends Tab through xterm `modifyOtherKeys` sequences.

In my case, this is reproducible in WezTerm. `Ctrl+<letter>` bindings were also broken starting with `0.56.0`, but those were fixed by `0.57.0`. `Shift+Tab` remained broken after that.

## What was happening

`parseKey()` already recognized xterm `modifyOtherKeys` Tab sequences correctly, for example:

- `\x1b[27;2;9~` -> `shift+tab`

But `matchesKey()` did not match those same sequences for `tab`-based bindings.

That meant the key could be parsed correctly, but the actual keybinding action would never fire.

## Fix

Add xterm `modifyOtherKeys` matching for Tab in `matchesKey()` so these bindings work again:

- `shift+tab`
- `ctrl+tab`
- `alt+tab`

## Regression coverage

Added tests for:

- `\x1b[27;2;9~` -> `shift+tab`
- `\x1b[27;5;9~` -> `ctrl+tab`
- `\x1b[27;3;9~` -> `alt+tab`

## Repro context

Observed in:

- WezTerm

Started happening in:

- `0.56.0`