### PR TITLE
fix(pods): stop leaking setup credentials

### DIFF
--- a/packages/pods/scripts/pod_setup.sh
+++ b/packages/pods/scripts/pod_setup.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 # Parse arguments passed from pi CLI
 MOUNT_COMMAND=""
 MODELS_PATH=""
-HF_TOKEN=""
-PI_API_KEY=""
 VLLM_VERSION="release"  # Default to release
 
 while [[ $# -gt 0 ]]; do
@@ -17,14 +15,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --models-path)
             MODELS_PATH="$2"
-            shift 2
-            ;;
-        --hf-token)
-            HF_TOKEN="$2"
-            shift 2
-            ;;
-        --vllm-api-key)
-            PI_API_KEY="$2"
             shift 2
             ;;
         --vllm)
@@ -39,16 +29,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Validate required parameters
-if [ -z "$HF_TOKEN" ]; then
-    echo "ERROR: HF_TOKEN is required" >&2
-    exit 1
-fi
-
-if [ -z "$PI_API_KEY" ]; then
-    echo "ERROR: PI_API_KEY is required" >&2
-    exit 1
-fi
-
 if [ -z "$MODELS_PATH" ]; then
     echo "ERROR: MODELS_PATH is required" >&2
     exit 1
@@ -305,9 +285,6 @@ cat >> ~/.bashrc << EOF
 [ -d "\$HOME/venv" ] && source "\$HOME/venv/bin/activate"
 export PATH="/usr/local/cuda-${DRIVER_CUDA_VERSION}/bin:\$HOME/.local/bin:\$PATH"
 export LD_LIBRARY_PATH="/usr/local/cuda-${DRIVER_CUDA_VERSION}/lib64:\${LD_LIBRARY_PATH:-}"
-export HF_TOKEN="${HF_TOKEN}"
-export PI_API_KEY="${PI_API_KEY}"
-export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
 export HF_HUB_ENABLE_HF_TRANSFER=1
 export VLLM_NO_USAGE_STATS=1
 export VLLM_DO_NOT_TRACK=1

--- a/packages/pods/src/commands/pods.ts
+++ b/packages/pods/src/commands/pods.ts
@@ -46,23 +46,6 @@ export const setupPod = async (
 	sshCmd: string,
 	options: { mount?: string; modelsPath?: string; vllm?: "release" | "nightly" | "gpt-oss" },
 ) => {
-	// Validate environment variables
-	const hfToken = process.env.HF_TOKEN;
-	const vllmApiKey = process.env.PI_API_KEY;
-
-	if (!hfToken) {
-		console.error(chalk.red("ERROR: HF_TOKEN environment variable is required"));
-		console.error("Get a token from: https://huggingface.co/settings/tokens");
-		console.error("Then run: export HF_TOKEN=your_token_here");
-		process.exit(1);
-	}
-
-	if (!vllmApiKey) {
-		console.error(chalk.red("ERROR: PI_API_KEY environment variable is required"));
-		console.error("Set an API key: export PI_API_KEY=your_api_key_here");
-		process.exit(1);
-	}
-
 	// Determine models path
 	let modelsPath = options.modelsPath;
 	if (!modelsPath && options.mount) {
@@ -109,7 +92,7 @@ export const setupPod = async (
 	console.log(chalk.green("✓ Setup script copied"));
 
 	// Build setup command
-	let setupCmd = `bash /tmp/pod_setup.sh --models-path '${modelsPath}' --hf-token '${hfToken}' --vllm-api-key '${vllmApiKey}'`;
+	let setupCmd = `bash /tmp/pod_setup.sh --models-path '${modelsPath}'`;
 	if (options.mount) {
 		setupCmd += ` --mount '${options.mount}'`;
 	}
@@ -166,6 +149,11 @@ export const setupPod = async (
 	addPod(name, pod);
 	console.log("");
 	console.log(chalk.green(`✓ Pod '${name}' setup complete and set as active pod`));
+	console.log("");
+	console.log("Before starting a model, set credentials in your local shell:");
+	console.log(chalk.cyan("  export HF_TOKEN=your_huggingface_token"));
+	console.log(chalk.cyan("  export PI_API_KEY=your_api_key"));
+	console.log(chalk.gray("  These credentials are sent at model start time and are not persisted on the pod."));
 	console.log("");
 	console.log("You can now deploy models with:");
 	console.log(chalk.cyan(`  pi start <model> --name <name>`));


### PR DESCRIPTION
## Summary

- stop passing setup credentials to `pi pods setup`
- stop persisting pod credentials to the remote shell profile

## Verification

- `npm run check`
- `./test.sh`
