### PR TITLE
feat(session-manager): allow supplying custom session ID in newSession()

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -36,6 +36,8 @@ export interface SessionHeader {
 }
 
 export interface NewSessionOptions {
+	/** Supply a custom session ID instead of auto-generating a UUID. */
+	id?: string;
 	parentSession?: string;
 }
 
@@ -721,7 +723,7 @@ export class SessionManager {
 	}
 
 	newSession(options?: NewSessionOptions): string | undefined {
-		this.sessionId = randomUUID();
+		this.sessionId = options?.id ?? randomUUID();
 		const timestamp = new Date().toISOString();
 		const header: SessionHeader = {
 			type: "session",


### PR DESCRIPTION
## Summary

Adds an optional `id` field to `NewSessionOptions` so callers of `newSession()` can supply their own session ID instead of always auto-generating a UUID.

- When `id` is provided, it is used as the session ID and appears in the JSONL header and filename
- When omitted, behavior is unchanged (`randomUUID()`)

## Motivation

Server-side integrations where an external system (control plane, orchestrator, ACP host) owns session identity need the Pi session to use the same ID. This enables:

- **Single ID system** — no mapping table between external and Pi session IDs
- **Filesystem-based session restore** — find session files by ID after process restart
- **Consistent references** — same ID in database, runtime memory, and JSONL filename

## Change

```typescript
export interface NewSessionOptions {
  id?: string;           // ← new
  parentSession?: string;
}
```

```typescript
newSession(options?: NewSessionOptions) {
  this.sessionId = options?.id ?? randomUUID();  // ← changed
  // ... rest unchanged
}
```

Fully backward compatible — no existing callers are affected.