### PR TITLE
fix(ai): preserve Anthropic thinking block signatures and strip old blocks

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -688,8 +688,19 @@ function convertMessages(
 	// Transform messages for cross-provider compatibility
 	const transformedMessages = transformMessages(messages, model, normalizeToolCallId);
 
+	// Find the last assistant message index so we can preserve its thinking
+	// blocks byte-for-byte (Anthropic validates signatures on the latest one).
+	let lastAssistantIdx = -1;
+	for (let k = transformedMessages.length - 1; k >= 0; k--) {
+		if (transformedMessages[k].role === "assistant") {
+			lastAssistantIdx = k;
+			break;
+		}
+	}
+
 	for (let i = 0; i < transformedMessages.length; i++) {
 		const msg = transformedMessages[i];
+		const isLatestAssistant = i === lastAssistantIdx;
 
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
@@ -761,7 +772,12 @@ function convertMessages(
 					} else {
 						blocks.push({
 							type: "thinking",
-							thinking: sanitizeSurrogates(block.thinking),
+							// For the latest assistant message, preserve thinking text
+							// byte-for-byte — Anthropic validates the signature against
+							// the exact original content. sanitizeSurrogates() can strip
+							// lone surrogates or other characters, invalidating the
+							// cryptographic signature and causing API rejection.
+							thinking: isLatestAssistant ? block.thinking : sanitizeSurrogates(block.thinking),
 							signature: block.thinkingSignature,
 						});
 					}

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -13,8 +13,20 @@ export function transformMessages<TApi extends Api>(
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
 
-	// First pass: transform messages (thinking blocks, tool call ID normalization)
-	const transformed = messages.map((msg) => {
+	// Find the index of the last assistant message so we can preserve its
+	// thinking blocks verbatim while stripping them from earlier messages.
+	// Anthropic requires only the *latest* assistant message's thinking blocks
+	// to be unmodified; older ones can be safely removed to avoid corruption
+	// during compaction and to save context window tokens.
+	let lastAssistantIndex = -1;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (messages[i].role === "assistant") {
+			lastAssistantIndex = i;
+			break;
+		}
+	}
+
+	const transformed = messages.map((msg, msgIndex) => {
 		// User messages pass through unchanged
 		if (msg.role === "user") {
 			return msg;
@@ -37,8 +49,17 @@ export function transformMessages<TApi extends Api>(
 				assistantMsg.api === model.api &&
 				assistantMsg.model === model.id;
 
+			const isLatestAssistant = msgIndex === lastAssistantIndex;
+
 			const transformedContent = assistantMsg.content.flatMap((block) => {
 				if (block.type === "thinking") {
+					// For non-latest assistant messages: strip thinking blocks entirely.
+					// Anthropic only requires the latest assistant message's thinking
+					// blocks to be preserved verbatim. Stripping older ones avoids
+					// compaction-induced corruption and saves context tokens.
+					if (!isLatestAssistant) {
+						return [];
+					}
 					// Redacted thinking is opaque encrypted content, only valid for the same model.
 					// Drop it for cross-model to avoid API errors.
 					if (block.redacted) {


### PR DESCRIPTION
## Problem

Multi-turn conversations with Anthropic extended thinking enabled consistently fail with:
```
messages.N.content.1: thinking or redacted_thinking blocks in the latest
assistant message cannot be modified.
```

Two independent bugs combine to cause this:

### Bug 1: Thinking block accumulation (`transform-messages.ts`)

`transformMessages()` preserves **all** thinking blocks from every assistant message in the conversation. Anthropic only validates the *latest* assistant message's thinking blocks. The older ones:
- Waste context window tokens (thinking blocks are often 2-10K tokens each)
- Can be corrupted by downstream processing (compaction, truncation)
- Serve no purpose for conversation replay

### Bug 2: `sanitizeSurrogates()` invalidates thinking signatures (`anthropic.ts`)

`convertMessages()` runs `sanitizeSurrogates()` on `block.thinking` text before sending it back to the Anthropic API. This can modify the text (stripping lone surrogates, control characters), which invalidates the cryptographic signature Anthropic computed over the original content. The signature check fails and the API rejects the request.

## Fix

### `transform-messages.ts`
- Track `lastAssistantIndex` — the index of the final assistant message
- Strip thinking blocks from all prior assistant messages (return `[]`)
- Latest assistant message's thinking blocks pass through unchanged

### `anthropic.ts`
- Track `lastAssistantIdx` in `convertMessages()`
- For the latest assistant message: pass `block.thinking` through unchanged (byte-for-byte preservation)
- For older messages: fall back to `sanitizeSurrogates()` as a safety net (though these should already be stripped by the transform-messages fix)

## Impact

Without this fix, any application using `pi-ai` with Anthropic models and extended thinking will hit API rejections after several conversation turns. The failure is deterministic once thinking blocks accumulate enough for compaction or sanitization to modify any of them.

## Testing

Tested on a production deployment with `thinking=high` (Anthropic Claude Opus/Sonnet) across dozens of multi-turn sessions over 12+ hours. Before: sessions crashed within 5-10 turns. After: zero thinking block errors.