### PR TITLE
feat: add setCwd() API to ExtensionContext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6382,6 +6382,7 @@
 			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
 			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@lit/reactive-element": "^2.1.0",
 				"lit-element": "^4.2.0",
@@ -7767,6 +7768,7 @@
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
 			"integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -7795,7 +7797,8 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
 			"integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -7913,6 +7916,7 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -8009,6 +8013,7 @@
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -8097,6 +8102,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -8211,6 +8217,7 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -8504,6 +8511,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2092,6 +2092,15 @@ export class AgentSession {
 				shutdown: () => {
 					this._extensionShutdownHandler?.();
 				},
+				setCwd: (newCwd: string) => {
+					this._cwd = newCwd;
+					process.chdir(newCwd);
+					this._buildRuntime({
+						activeToolNames: this.getActiveToolNames(),
+						includeAllExtensionTools: true,
+					});
+					this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+				},
 				getContextUsage: () => this.getContextUsage(),
 				compact: (options) => {
 					void (async () => {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -217,6 +217,7 @@ export class ExtensionRunner {
 	private switchSessionHandler: SwitchSessionHandler = async () => ({ cancelled: false });
 	private reloadHandler: ReloadHandler = async () => {};
 	private shutdownHandler: ShutdownHandler = () => {};
+	private setCwdFn: (newCwd: string) => void = () => {};
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
 
@@ -258,6 +259,7 @@ export class ExtensionRunner {
 		this.abortFn = contextActions.abort;
 		this.hasPendingMessagesFn = contextActions.hasPendingMessages;
 		this.shutdownHandler = contextActions.shutdown;
+		this.setCwdFn = contextActions.setCwd;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
@@ -517,6 +519,10 @@ export class ExtensionRunner {
 			abort: () => this.abortFn(),
 			hasPendingMessages: () => this.hasPendingMessagesFn(),
 			shutdown: () => this.shutdownHandler(),
+			setCwd: (newCwd: string) => {
+				this.cwd = newCwd;
+				this.setCwdFn(newCwd);
+			},
 			getContextUsage: () => this.getContextUsageFn(),
 			compact: (options) => this.compactFn(options),
 			getSystemPrompt: () => this.getSystemPromptFn(),

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -279,6 +279,16 @@ export interface ExtensionContext {
 	hasPendingMessages(): boolean;
 	/** Gracefully shutdown pi and exit. Available in all contexts. */
 	shutdown(): void;
+	/**
+	 * Change the working directory and rebuild all tools.
+	 * Tools (bash, read, edit, write) are bound to cwd at creation time via closure.
+	 * This method updates the cwd and recreates the tool runtime so that all
+	 * subsequent tool invocations use the new directory.
+	 *
+	 * Typical use case: worktree extensions that create a new directory and need
+	 * the agent to operate there without restarting pi.
+	 */
+	setCwd(newCwd: string): void;
 	/** Get current context usage for the active model. */
 	getContextUsage(): ContextUsage | undefined;
 	/** Trigger compaction without awaiting completion. */
@@ -1349,6 +1359,7 @@ export interface ExtensionContextActions {
 	abort: () => void;
 	hasPendingMessages: () => boolean;
 	shutdown: () => void;
+	setCwd: (newCwd: string) => void;
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
 	getSystemPrompt: () => string;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1175,6 +1175,10 @@ export class InteractiveMode {
 			shutdown: () => {
 				this.shutdownRequested = true;
 			},
+			setCwd: () => {
+				// setCwd is handled by the session's extension runner; this context
+				// is only used for keyboard shortcuts and doesn't need its own impl.
+			},
 			getContextUsage: () => this.session.getContextUsage(),
 			compact: (options) => {
 				void (async () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -73,6 +73,7 @@ describe("ExtensionRunner", () => {
 		abort: () => {},
 		hasPendingMessages: () => false,
 		shutdown: () => {},
+		setCwd: () => {},
 		getContextUsage: () => undefined,
 		compact: () => {},
 		getSystemPrompt: () => "",


### PR DESCRIPTION
## What

Add `ctx.setCwd(newCwd)` method to `ExtensionContext`, allowing extensions to change the working directory at runtime.

## Why

Extensions like [pi-worktree](https://github.com/nicepkg/pi-worktree) need to create a directory (e.g., a git worktree) and then have the agent operate there. Currently, all tools (`bash`, `read`, `edit`, `write`) are bound to `cwd` via closure at startup in `createAllTools()`, and `session_start` fires _after_ tool creation. There is no API to change `cwd` afterward.

The only workaround is to shut down pi and relaunch it in the new directory via terminal injection (`cmux send` / `tmux send-keys`), which:
- Only works in cmux/tmux environments (bare terminal users are out of luck)
- Is inherently racy (relies on a `sleep 0.3` delay)
- Causes a visible session restart

See the current workaround: https://github.com/nicepkg/pi-worktree/blob/main/extensions/worktree.ts#L349-L390

## How

1. **`ExtensionContext.setCwd(newCwd: string)`** — new method on the extension context
2. **`ExtensionContextActions.setCwd`** — wired through the runner
3. **`AgentSession`** — implementation:
   - Updates `this._cwd`
   - Calls `process.chdir(newCwd)`
   - Calls `this._buildRuntime()` to recreate all tools with the new cwd
   - Rebuilds the system prompt (which includes the cwd)
4. **`ExtensionRunner`** — also updates its own `cwd` field so subsequent `createContext()` calls reflect the change

## Usage example

```typescript
pi.on("session_start", async (_event, ctx) => {
  const worktreePath = await createWorktree(...);
  ctx.setCwd(worktreePath);
  // All tools now operate in worktreePath — no restart needed
});
```

## Files changed

- `core/extensions/types.ts` — added `setCwd` to `ExtensionContext` and `ExtensionContextActions`
- `core/extensions/runner.ts` — wired `setCwdFn` through runner, exposed in `createContext()`
- `core/agent-session.ts` — implementation that rebuilds runtime + system prompt
- `modes/interactive/interactive-mode.ts` — stub for shortcut context (shortcuts use runner context)
- `test/extensions-runner.test.ts` — added `setCwd` to test mock