### PR TITLE
fix(ai): treat OpenAI-compatible finish_reason "end" as stop

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -734,6 +734,7 @@ function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"]): Sto
 	if (reason === null) return "stop";
 	switch (reason) {
 		case "stop":
+		case "end":
 			return "stop";
 		case "length":
 			return "length";

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -1,10 +1,13 @@
 import { Type } from "@sinclair/typebox";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getModel } from "../src/models.js";
 import { streamSimple } from "../src/stream.js";
 import type { Tool } from "../src/types.js";
 
-const mockState = vi.hoisted(() => ({ lastParams: undefined as unknown }));
+const mockState = vi.hoisted(() => ({
+	lastParams: undefined as unknown,
+	finishReason: "stop" as "stop" | "end",
+}));
 
 vi.mock("openai", () => {
 	class FakeOpenAI {
@@ -15,7 +18,7 @@ vi.mock("openai", () => {
 					return {
 						async *[Symbol.asyncIterator]() {
 							yield {
-								choices: [{ delta: {}, finish_reason: "stop" }],
+								choices: [{ delta: {}, finish_reason: mockState.finishReason }],
 								usage: {
 									prompt_tokens: 1,
 									completion_tokens: 1,
@@ -34,6 +37,11 @@ vi.mock("openai", () => {
 });
 
 describe("openai-completions tool_choice", () => {
+	beforeEach(() => {
+		mockState.lastParams = undefined;
+		mockState.finishReason = "stop";
+	});
+
 	it("forwards toolChoice from simple options to payload", async () => {
 		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
 		const model = { ...baseModel, api: "openai-completions" } as const;
@@ -174,5 +182,29 @@ describe("openai-completions tool_choice", () => {
 
 		const params = (payload ?? mockState.lastParams) as { reasoning_effort?: string };
 		expect(params.reasoning_effort).toBe("medium");
+	});
+
+	it("maps finish_reason=end to stop", async () => {
+		mockState.finishReason = "end";
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = { ...baseModel, api: "openai-completions" } as const;
+
+		const response = await streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Hi",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test",
+			},
+		).result();
+
+		expect(response.stopReason, `Error: ${response.errorMessage}`).toBe("stop");
 	});
 });


### PR DESCRIPTION
## Summary

Some OpenAI-compatible providers return `choices[0].finish_reason = "end"` for normal completions.
In `openai-completions`, this currently triggers:

`Unhandled stop reason: end`

As a result, runs can be marked as errors even when valid assistant content is produced.

## Root cause

`mapStopReason()` in `packages/ai/src/providers/openai-completions.ts` does not handle `"end"`.

## Changes

- Map `"end"` to internal `"stop"` in `mapStopReason()`.
- Add a regression test in `packages/ai/test/openai-completions-tool-choice.test.ts` to verify that `finish_reason = "end"` resolves to `stopReason = "stop"`.

## Why this is safe

For OpenAI-compatible backends, `"end"` is semantically a normal completion terminator.
Treating it like `"stop"` prevents false error states while keeping existing behavior for other finish reasons unchanged.

## Reproduction (before this fix)

1. Use an OpenAI-compatible `/chat/completions` endpoint.
2. Send a standard chat request where the provider returns `finish_reason: "end"`.
3. Observe runtime error: `Unhandled stop reason: end`.

## Expected behavior

No error should be thrown; the response should complete with `stopReason = "stop"`.