### PR TITLE
fix(ai): handle GPT-5 empty reasoning summary to prevent 400 on replay

### DIFF
--- a/packages/ai/scripts/repro-empty-reasoning-summary.ts
+++ b/packages/ai/scripts/repro-empty-reasoning-summary.ts
@@ -1,0 +1,116 @@
+/**
+ * Reproduction script: GPT-5 models intermittently return reasoning items
+ * with encrypted_content but empty summary (summary: []).
+ *
+ * When replayed, these cause:
+ *   400 "function_call was provided without its required reasoning item"
+ *   400 "reasoning was provided without its required following item"
+ *
+ * Usage:
+ *   AZURE_OPENAI_API_KEY=xxx AZURE_OPENAI_BASE_URL=https://xxx.openai.azure.com/openai/v1 \
+ *     npx tsx packages/ai/scripts/repro-empty-reasoning-summary.ts
+ *
+ * Or with OpenAI directly:
+ *   OPENAI_API_KEY=xxx npx tsx packages/ai/scripts/repro-empty-reasoning-summary.ts --openai
+ */
+import OpenAI, { AzureOpenAI } from "openai";
+
+const useOpenAI = process.argv.includes("--openai");
+
+function createClient() {
+	if (useOpenAI) {
+		return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+	}
+	return new AzureOpenAI({
+		apiKey: process.env.AZURE_OPENAI_API_KEY,
+		apiVersion: "v1",
+		baseURL: process.env.AZURE_OPENAI_BASE_URL,
+	});
+}
+
+const client = createClient();
+const MODEL = "gpt-5.3-codex";
+const TOOLS: OpenAI.Responses.Tool[] = [
+	{
+		type: "function",
+		name: "read",
+		description: "Read a file",
+		parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+		strict: false,
+	},
+];
+
+async function streamAndCollectItems(input: OpenAI.Responses.ResponseInput) {
+	const stream = await client.responses.create({
+		model: MODEL,
+		input,
+		stream: true,
+		tools: TOOLS,
+		reasoning: { effort: "medium", summary: "auto" },
+		include: ["reasoning.encrypted_content"],
+	});
+	const items: OpenAI.Responses.ResponseOutputItem[] = [];
+	for await (const event of stream) {
+		if (event.type === "response.output_item.done") {
+			items.push(event.item);
+		}
+	}
+	return items;
+}
+
+async function main() {
+	const MAX_ATTEMPTS = 10;
+	console.log(`Attempting to reproduce empty reasoning summary (up to ${MAX_ATTEMPTS} tries)...\n`);
+
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		const items = await streamAndCollectItems([
+			{ role: "developer", content: "You are a coding assistant. Use the read tool." },
+			{ role: "user", content: [{ type: "input_text", text: "hi, tell me about this project" }] },
+		]);
+
+		const emptyReasoning = items.filter(
+			(i) => i.type === "reasoning" && (!i.summary || i.summary.length === 0),
+		);
+		const validReasoning = items.filter(
+			(i) => i.type === "reasoning" && i.summary && i.summary.length > 0,
+		);
+		const funcCalls = items.filter((i) => i.type === "function_call");
+
+		const status = emptyReasoning.length > 0 ? "EMPTY SUMMARY" : "ok";
+		console.log(
+			`  [${attempt}/${MAX_ATTEMPTS}] ${status} — ` +
+				`${validReasoning.length} valid reasoning, ${emptyReasoning.length} empty reasoning, ${funcCalls.length} function_calls`,
+		);
+
+		if (emptyReasoning.length === 0) continue;
+
+		// Found empty reasoning — now demonstrate the replay failure
+		console.log("\n=== Reproducing replay failure ===\n");
+
+		const fc = funcCalls[0] as OpenAI.Responses.ResponseFunctionToolCall;
+		const replayInput: OpenAI.Responses.ResponseInput = [
+			{ role: "developer", content: "You are a coding assistant." },
+			{ role: "user", content: [{ type: "input_text", text: "hi" }] },
+			...items, // replay all items including empty reasoning
+			{ type: "function_call_output", call_id: fc.call_id, output: "file content here" },
+		];
+
+		try {
+			await streamAndCollectItems(replayInput);
+			console.log("  Replay succeeded (unexpected)");
+		} catch (err: any) {
+			console.log(`  Replay failed: ${err.message}`);
+			if (err.message.includes("400")) {
+				console.log("\n  CONFIRMED: Empty reasoning summary causes 400 on replay.");
+				console.log(`  Empty reasoning item: id=${emptyReasoning[0].id}`);
+				console.log(`  summary: ${JSON.stringify((emptyReasoning[0] as any).summary)}`);
+				console.log(`  has encrypted_content: ${!!(emptyReasoning[0] as any).encrypted_content}`);
+			}
+		}
+		return;
+	}
+
+	console.log(`\nDid not reproduce in ${MAX_ATTEMPTS} attempts (intermittent ~40% rate on Azure).`);
+}
+
+main().catch(console.error);

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -158,9 +158,17 @@ export function convertResponsesMessages<TApi extends Api>(
 				assistantMsg.provider === model.provider &&
 				assistantMsg.api === model.api;
 
+			// Check if any thinking blocks have empty content (reasoning was incomplete
+			// or discarded). GPT-5 models can return reasoning items with empty summary;
+			// the thinkingSignature is discarded at receive time, but the empty thinking
+			// block remains. We must strip paired fc_xxx IDs to avoid pairing validation.
+			const hasSkippedThinking = msg.content.some(
+				(block) => block.type === "thinking" && block.thinking.trim().length === 0,
+			);
+
 			for (const block of msg.content) {
 				if (block.type === "thinking") {
-					if (block.thinkingSignature) {
+					if (block.thinkingSignature && block.thinking.trim().length > 0) {
 						const reasoningItem = JSON.parse(block.thinkingSignature) as ResponseReasoningItem;
 						output.push(reasoningItem);
 					}
@@ -190,7 +198,7 @@ export function convertResponsesMessages<TApi extends Api>(
 					// For different-model messages, set id to undefined to avoid pairing validation.
 					// OpenAI tracks which fc_xxx IDs were paired with rs_xxx reasoning items.
 					// By omitting the id, we avoid triggering that validation (like cross-provider does).
-					if (isDifferentModel && itemId?.startsWith("fc_")) {
+					if ((isDifferentModel || hasSkippedThinking) && itemId?.startsWith("fc_")) {
 						itemId = undefined;
 					}
 
@@ -409,7 +417,12 @@ export async function processResponsesStream<TApi extends Api>(
 
 			if (item.type === "reasoning" && currentBlock?.type === "thinking") {
 				currentBlock.thinking = item.summary?.map((s) => s.text).join("\n\n") || "";
-				currentBlock.thinkingSignature = JSON.stringify(item);
+				// Only store thinkingSignature when summary has content. GPT-5 models
+				// intermittently return reasoning items with encrypted_content but
+				// empty summary (summary: []). Replaying these causes 400 errors.
+				if (currentBlock.thinking.trim().length > 0) {
+					currentBlock.thinkingSignature = JSON.stringify(item);
+				}
 				stream.push({
 					type: "thinking_end",
 					contentIndex: blockIndex(),

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -47,8 +47,12 @@ export function transformMessages<TApi extends Api>(
 					// For same model: keep thinking blocks with signatures (needed for replay)
 					// even if the thinking text is empty (OpenAI encrypted reasoning)
 					if (isSameModel && block.thinkingSignature) return block;
-					// Skip empty thinking blocks, convert others to plain text
-					if (!block.thinking || block.thinking.trim() === "") return [];
+					// Empty thinking: keep for same model (needed by hasSkippedThinking
+					// in convertResponsesMessages to strip paired fc_xxx IDs).
+					// Drop for cross-model since reasoning can't be replayed anyway.
+					if (!block.thinking || block.thinking.trim() === "") {
+						return isSameModel ? block : [];
+					}
 					if (isSameModel) return block;
 					return {
 						type: "text" as const,


### PR DESCRIPTION
GPT-5 models (e.g., gpt-5.3-codex) intermittently return reasoning items with encrypted_content but empty summary (summary: []). When these items are replayed in subsequent turns, the API returns 400:

  "function_call was provided without its required reasoning item"
  "reasoning was provided without its required following item"

Root cause: three interacting issues in the replay pipeline:

1. processResponsesStream stored thinkingSignature unconditionally, even when summary was empty — creating an invalid reasoning item in the session that cannot be replayed.

2. transformMessages' first-pass flatMap dropped empty thinking blocks for same-model messages (return []), removing the evidence needed by hasSkippedThinking to detect incomplete reasoning downstream.

3. convertResponsesMessages only stripped fc_xxx IDs for cross-model messages (isDifferentModel), not when reasoning was skipped due to empty summary — leaving paired fc_xxx IDs that reference missing rs_xxx reasoning items.

Fix:
- processResponsesStream: only store thinkingSignature when summary is non-empty
- transformMessages: keep empty thinking blocks for same-model (so hasSkippedThinking can detect them)
- convertResponsesMessages: add hasSkippedThinking check that detects empty thinking regardless of thinkingSignature; skip empty reasoning items and strip paired fc_xxx IDs

Includes reproduction script (packages/ai/scripts/) that demonstrates the issue with ~40% reproduction rate on Azure OpenAI.

Tested with Azure OpenAI gpt-5.3-codex. Direct API testing confirms Azure does support reasoning summaries normally — empty summary is an intermittent API behavior, not a provider limitation.