### PR TITLE
fix(ai): normalize tool schema required array to prevent OpenAI 400 errors

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -686,6 +686,20 @@ export function convertMessages(
 	return params;
 }
 
+/**
+ * Normalize tool parameters so that `type: "object"` schemas always include a
+ * `required` array.  Some schema generators (e.g. TypeBox) omit `required`
+ * when every property is optional, but the OpenAI API rejects schemas without
+ * it, returning a 400 "required is a required property" error.
+ */
+function normalizeToolParams(params: unknown): Record<string, unknown> {
+	const p = (params ?? {}) as Record<string, unknown>;
+	if (p.type === "object" && !Array.isArray(p.required)) {
+		return { ...p, required: p.required ?? [] };
+	}
+	return p as Record<string, unknown>;
+}
+
 function convertTools(
 	tools: Tool[],
 	compat: Required<OpenAICompletionsCompat>,
@@ -695,7 +709,7 @@ function convertTools(
 		function: {
 			name: tool.name,
 			description: tool.description,
-			parameters: tool.parameters as any, // TypeBox already generates JSON Schema
+			parameters: normalizeToolParams(tool.parameters),
 			// Only include strict if provider supports it. Some reject unknown fields.
 			...(compat.supportsStrictMode !== false && { strict: false }),
 		},

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -259,13 +259,27 @@ export function convertResponsesMessages<TApi extends Api>(
 // Tool conversion
 // =============================================================================
 
+/**
+ * Normalize tool parameters so that `type: "object"` schemas always include a
+ * `required` array.  Some schema generators (e.g. TypeBox) omit `required`
+ * when every property is optional, but the OpenAI API rejects schemas without
+ * it, returning a 400 "required is a required property" error.
+ */
+function normalizeToolParams(params: unknown): Record<string, unknown> {
+	const p = (params ?? {}) as Record<string, unknown>;
+	if (p.type === "object" && !Array.isArray(p.required)) {
+		return { ...p, required: p.required ?? [] };
+	}
+	return p as Record<string, unknown>;
+}
+
 export function convertResponsesTools(tools: Tool[], options?: ConvertResponsesToolsOptions): OpenAITool[] {
 	const strict = options?.strict === undefined ? false : options.strict;
 	return tools.map((tool) => ({
 		type: "function",
 		name: tool.name,
 		description: tool.description,
-		parameters: tool.parameters as any, // TypeBox already generates JSON Schema
+		parameters: normalizeToolParams(tool.parameters),
 		strict,
 	}));
 }


### PR DESCRIPTION
## Summary

When tools have all-optional parameters, TypeBox generates JSON Schema without a `required` field. The OpenAI API rejects these schemas with a 400 error: `"required" is a required property`.

This adds a `normalizeToolParams()` helper that ensures `type: "object"` schemas always include a `required` array (defaulting to `[]`). Applied in both `openai-completions` and `openai-responses-shared` tool converters.

## Changes

- `packages/ai/src/providers/openai-completions.ts`: Add `normalizeToolParams()`, use it in `convertTools()`
- `packages/ai/src/providers/openai-responses-shared.ts`: Add `normalizeToolParams()`, use it in `convertResponsesTools()`

## Testing

- `npm run check` passes with no errors, warnings, or infos (biome + tsgo + browser smoke + web-ui)

Fixes #2100
