### PR TITLE
fix(ai): handle unknown finish_reason values gracefully in openai-completions

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -742,10 +742,11 @@ function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"]): Sto
 			return "toolUse";
 		case "content_filter":
 			return "error";
-		default: {
-			const _exhaustive: never = reason;
-			throw new Error(`Unhandled stop reason: ${_exhaustive}`);
-		}
+		default:
+			// OpenAI-compatible providers may return non-standard finish reasons
+			// (e.g. "end"). Treat unknown reasons as "stop" since the assistant
+			// content has already been produced at this point.
+			return "stop";
 	}
 }
 


### PR DESCRIPTION
## Summary

Some OpenAI-compatible providers (e.g. Ollama, LM Studio) return non-standard `finish_reason` values like `"end"` instead of `"stop"`. Previously this threw an `Unhandled stop reason: end` error, crashing the stream.

This changes the `default` case in `mapStopReason()` to return `"stop"` instead of throwing, since the assistant content has already been produced at that point. This is safe because the function already maps `null` to `"stop"`, and unknown finish reasons semantically indicate normal completion.

## Changes

- `packages/ai/src/providers/openai-completions.ts`: Replace exhaustive-check throw in `mapStopReason()` default case with graceful `return "stop"`

## Testing

- `npm run check` passes with no errors, warnings, or infos (biome + tsgo + browser smoke + web-ui)

Fixes #2107
