### PR TITLE
fix(coding-agent): match server_error and internal_error in retry regex

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2264,7 +2264,7 @@ export class AgentSession {
 
 		const err = message.errorMessage;
 		// Match: overloaded_error, rate limit, 429, 500, 502, 503, 504, service unavailable, connection errors, fetch failed, terminated, retry delay exceeded
-		return /overloaded|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server error|internal error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|terminated|retry delay/i.test(
+		return /overloaded|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|terminated|retry delay/i.test(
 			err,
 		);
 	}


### PR DESCRIPTION
## Summary

The `_isRetryableError()` regex used literal spaces (`server error`, `internal error`) but Codex SSE error events use underscores (`server_error`). The pattern never matched, so transient Codex SSE errors were not retried.

This changes the regex to use `.?` (`server.?error`, `internal.?error`) so both space, underscore, and direct concatenation variants are matched.

## Changes

- `packages/coding-agent/src/core/agent-session.ts`: Update regex in `_isRetryableError()` to use `.?` instead of literal space for `server error` and `internal error` patterns

## Testing

- `npm run check` passes with no errors, warnings, or infos (biome + tsgo + browser smoke + web-ui)

Fixes #2091
