### PR TITLE
fix(ai): handle empty OpenAI reasoning summaries in replay

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -157,12 +157,15 @@ export function convertResponsesMessages<TApi extends Api>(
 				assistantMsg.model !== model.id &&
 				assistantMsg.provider === model.provider &&
 				assistantMsg.api === model.api;
+			let hasSkippedThinking = false;
 
 			for (const block of msg.content) {
 				if (block.type === "thinking") {
 					if (block.thinkingSignature) {
 						const reasoningItem = JSON.parse(block.thinkingSignature) as ResponseReasoningItem;
 						output.push(reasoningItem);
+					} else {
+						hasSkippedThinking = true;
 					}
 				} else if (block.type === "text") {
 					const textBlock = block as TextContent;
@@ -188,9 +191,10 @@ export function convertResponsesMessages<TApi extends Api>(
 					let itemId: string | undefined = itemIdRaw;
 
 					// For different-model messages, set id to undefined to avoid pairing validation.
+					// Also drop fc_* ids if a thinking block was present but skipped (no replayable reasoning item).
 					// OpenAI tracks which fc_xxx IDs were paired with rs_xxx reasoning items.
-					// By omitting the id, we avoid triggering that validation (like cross-provider does).
-					if (isDifferentModel && itemId?.startsWith("fc_")) {
+					// By omitting the id, we avoid triggering that validation.
+					if ((isDifferentModel || hasSkippedThinking) && itemId?.startsWith("fc_")) {
 						itemId = undefined;
 					}
 
@@ -409,7 +413,9 @@ export async function processResponsesStream<TApi extends Api>(
 
 			if (item.type === "reasoning" && currentBlock?.type === "thinking") {
 				currentBlock.thinking = item.summary?.map((s) => s.text).join("\n\n") || "";
-				currentBlock.thinkingSignature = JSON.stringify(item);
+				if ((item.summary?.length || 0) > 0) {
+					currentBlock.thinkingSignature = JSON.stringify(item);
+				}
 				stream.push({
 					type: "thinking_end",
 					contentIndex: blockIndex(),

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -44,12 +44,11 @@ export function transformMessages<TApi extends Api>(
 					if (block.redacted) {
 						return isSameModel ? block : [];
 					}
-					// For same model: keep thinking blocks with signatures (needed for replay)
-					// even if the thinking text is empty (OpenAI encrypted reasoning)
-					if (isSameModel && block.thinkingSignature) return block;
-					// Skip empty thinking blocks, convert others to plain text
-					if (!block.thinking || block.thinking.trim() === "") return [];
+					// For same model: keep thinking blocks exactly as-is, including empty blocks.
+					// Empty same-model thinking blocks are used later to detect reasoning skip cases.
 					if (isSameModel) return block;
+					// Cross-model: skip empty thinking blocks, convert non-empty ones to plain text.
+					if (!block.thinking || block.thinking.trim() === "") return [];
 					return {
 						type: "text" as const,
 						text: block.thinking,

--- a/packages/ai/test/openai-responses-empty-thinking-replay.test.ts
+++ b/packages/ai/test/openai-responses-empty-thinking-replay.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.js";
+import { convertResponsesMessages } from "../src/providers/openai-responses-shared.js";
+import type { AssistantMessage, Context, Message } from "../src/types.js";
+
+describe("OpenAI Responses empty-thinking replay", () => {
+	it("drops fc_* function_call item id when thinking block has no replayable signature", () => {
+		const model = getModel("openai", "gpt-5-mini");
+
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "" },
+				{ type: "toolCall", id: "call_abc|fc_123", name: "read", arguments: { path: "README.md" } },
+			],
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5-mini",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "check file", timestamp: Date.now() - 1000 } as Message,
+				assistant,
+			],
+		};
+
+		const input = convertResponsesMessages(model, context, new Set(["openai"]));
+		const functionCall = input.find((item) => item.type === "function_call");
+
+		expect(functionCall).toBeDefined();
+		expect(functionCall?.type).toBe("function_call");
+		if (functionCall?.type === "function_call") {
+			expect(functionCall.call_id).toBe("call_abc");
+			expect(functionCall.id).toBeUndefined();
+		}
+	});
+});


### PR DESCRIPTION
## Bug
Fixes #2118.

OpenAI Responses replay can fail when a prior turn contains an empty reasoning summary. In that case, replay may include a `function_call` with an `fc_*` item id but no corresponding replayable reasoning item, which triggers pairing validation errors.

## Fix
- Keep same-model empty thinking blocks during message transformation so replay conversion can detect skipped reasoning
- In OpenAI Responses conversion, treat thinking blocks without signatures as skipped reasoning and drop `fc_*` function-call item ids for that turn
- In stream processing, only persist `thinkingSignature` when reasoning summary content exists
- Added regression test covering empty-thinking replay behavior (`function_call.id` omitted when reasoning is not replayable)

## Testing
- `npx vitest --run test/openai-responses-empty-thinking-replay.test.ts` (from `packages/ai`)

Happy to adjust if you want this split into smaller commits.

Greetings, saschabuehrle
