### PR TITLE
fix(tui): stale content after tree navigation

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1026,11 +1026,9 @@ export class TUI extends Container {
 		}
 
 		// Check if firstChanged is above what was previously visible
-		// Use previousLines.length (not maxLinesRendered) to avoid false positives after content shrinks
-		const previousContentViewportTop = Math.max(0, this.previousLines.length - height);
-		if (firstChanged < previousContentViewportTop) {
+		if (firstChanged < prevViewportTop) {
 			// First change is above previous viewport - need full re-render
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${previousContentViewportTop})`);
+			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
 			fullRender(true);
 			return;
 		}

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -326,4 +326,64 @@ describe("TUI differential rendering", () => {
 
 		tui.stop();
 	});
+
+	it("clears stale content when maxLinesRendered inflated by transient component", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const chat = new TestComponent();
+		const editor = new TestComponent();
+		tui.addChild(chat);
+		tui.addChild(editor);
+
+		const longChat = Array.from({ length: 15 }, (_, i) => `Chat ${i}`);
+		const shortChat = Array.from({ length: 12 }, (_, i) => `Chat ${i}`);
+		const editorLines = ["Editor 0", "Editor 1", "Editor 2"];
+		const selectorLines = Array.from({ length: 8 }, (_, i) => `Selector ${i}`);
+
+		// Render 1: long chat (15) + editor (3) = 18 lines
+		chat.lines = longChat;
+		editor.lines = editorLines;
+		tui.start();
+		await terminal.flush();
+
+		// Render 2: replace editor with taller selector -> 23 lines, maxLinesRendered=23
+		editor.lines = selectorLines;
+		tui.requestRender();
+		await terminal.flush();
+
+		// Render 3: restore editor -> 18 lines, maxLinesRendered stays 23
+		editor.lines = editorLines;
+		tui.requestRender();
+		await terminal.flush();
+
+		// Render 4: switch to shorter chat -> 15 lines
+		// firstChanged=12 (where short diverges from long)
+		// Bug: previousContentViewportTop = 18-10 = 8, so 12>=8 -> differential path
+		// But actual viewportTop = 23-10 = 13, and 12<13 -> should be fullRender
+		chat.lines = shortChat;
+		tui.requestRender();
+		await terminal.flush();
+
+		const viewport = terminal.getViewport();
+
+		// Stale lines from the long chat must not appear
+		for (let i = 0; i < 10; i++) {
+			const line = viewport[i] ?? "";
+			assert.ok(!line.includes("Chat 12"), `Stale "Chat 12" at viewport row ${i}`);
+			assert.ok(!line.includes("Chat 13"), `Stale "Chat 13" at viewport row ${i}`);
+			assert.ok(!line.includes("Chat 14"), `Stale "Chat 14" at viewport row ${i}`);
+		}
+
+		// Correct content visible: last 10 of the 15 lines (Chat 5..11, Editor 0..2)
+		assert.ok(
+			viewport.some((l) => l.includes("Chat 11")),
+			"Last short-chat line visible",
+		);
+		assert.ok(
+			viewport.some((l) => l.includes("Editor 0")),
+			"Editor visible",
+		);
+
+		tui.stop();
+	});
 });


### PR DESCRIPTION
## Problem

When navigating the session tree with "No summary", stale messages from the old branch remain on screen and duplicate on repeated navigation.

Here's a repro case that the clanker has crafted:

[repro-stale-tree-nav.zip](https://github.com/user-attachments/files/25978549/repro-stale-tree-nav.zip)

And here's the recording of the bug in that session and the fix:

https://github.com/user-attachments/assets/cc3749eb-0942-43cc-a689-a43b65570dc5

## Root cause

The differential renderer decides whether to fall back to `fullRender` by checking if `firstChanged` is above the viewport:

```typescript
const previousContentViewportTop = Math.max(0, this.previousLines.length - height);
if (firstChanged < previousContentViewportTop) {
    fullRender(true);
```

This uses `previousLines.length` to estimate the viewport position. But `maxLinesRendered`, which determines the actual viewport, can be larger than `previousLines.length` when transient UI components (tree selector, extension selector) inflated it during the same interaction. The tree selector adds ~40 extra lines, then closes, but `maxLinesRendered` doesn't shrink.

This was done in 0925fafe which changed the check from `firstChanged < viewportTop` (using `maxLinesRendered`) to `firstChanged < previousContentViewportTop` (using `previousLines.length`) to avoid false positive redraws when appending lines after content shrunk. However, the differential renderer genuinely can't address lines above `maxLinesRendered - height`.

## Fix

Use `prevViewportTop` (derived from `maxLinesRendered`) for the check, restoring the original correct behavior:

```typescript
if (firstChanged < prevViewportTop) {
    fullRender(true);
```

This may trigger a few more `fullRender` calls when `maxLinesRendered` is inflated, but those redraws are necessary for correctness.