### PR TITLE
Fix context token usage tracking

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -361,9 +361,7 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 		stream: true,
 	};
 
-	if (compat.supportsUsageInStreaming !== false) {
-		(params as any).stream_options = { include_usage: true };
-	}
+	(params as any).stream_options = { include_usage: true };
 
 	if (compat.supportsStore) {
 		params.store = false;


### PR DESCRIPTION
Fix context token usage tracking by always requesting usage stats

## Problem

The conditional check for `supportsUsageInStreaming` was preventing usage statistics from being requested in some scenarios, causing the context display to show 0 tokens even when tokens were being used.

## Solution

Removed the conditional check and always set `stream_options.include_usage = true` for streaming requests. This ensures token usage statistics are consistently requested from the model provider.

## Changes

- `packages/ai/src/providers/openai-completions.ts`: Always set `include_usage: true` for streaming

## Testing

Before fix:
```
Context: 0/262k (0%)
```

After fix:
```
Context: 88k/262k (34%)
```

## Related

Fixes the issue reported in openclaw/openclaw#45358
