### PR TITLE
feat(tui,coding-agent): terminal focus awareness with caret dimming and extension API

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -278,6 +278,9 @@ user sends another prompt ◄─────────────────
 /model or Ctrl+P (model selection/cycling)
   └─► model_select
 
+terminal focus changes (interactive mode)
+  └─► terminal_focus
+
 exit (Ctrl+C, Ctrl+D)
   └─► session_shutdown
 ```
@@ -548,6 +551,33 @@ pi.on("model_select", async (event, ctx) => {
 ```
 
 Use this to update UI elements (status bars, footers) or perform model-specific initialization when the active model changes.
+
+### Terminal Focus Events
+
+#### terminal_focus
+
+Fired in interactive mode when the terminal window gains or loses focus.
+
+```typescript
+pi.on("terminal_focus", async (event, ctx) => {
+  // event.focused - current focus state
+  // event.previousFocused - previous focus state
+
+  const state = event.focused ? "focused" : "blurred";
+  ctx.ui.setStatus("focus", `Terminal: ${state}`);
+
+  // You can also read current state at any time
+  const current = ctx.ui.isTerminalFocused();
+  if (!current) {
+    // pause animations, timers, etc.
+  }
+});
+```
+
+Notes:
+- Emitted only in interactive mode.
+- Not emitted in print/json mode.
+- In RPC mode, `ctx.ui.isTerminalFocused()` currently returns `false`.
 
 ### Tool Events
 
@@ -1740,6 +1770,9 @@ ctx.ui.setTitle("pi - my-project");
 // Editor text
 ctx.ui.setEditorText("Prefill text");
 const current = ctx.ui.getEditorText();
+
+// Terminal focus state (interactive mode)
+const focused = ctx.ui.isTerminalFocused();
 
 // Paste into editor (triggers paste handling, including collapse for large content)
 ctx.ui.pasteToEditor("pasted content");

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -128,6 +128,7 @@ export type {
 	SetLabelHandler,
 	SetModelHandler,
 	SetThinkingLevelHandler,
+	TerminalFocusEvent,
 	TerminalInputHandler,
 	// Events - Tool
 	ToolCallEvent,

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -173,6 +173,7 @@ const noOpUIContext: ExtensionUIContext = {
 	input: async () => undefined,
 	notify: () => {},
 	onTerminalInput: () => () => {},
+	isTerminalFocused: () => false,
 	setStatus: () => {},
 	setWorkingMessage: () => {},
 	setWidget: () => {},

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -120,6 +120,9 @@ export interface ExtensionUIContext {
 	/** Listen to raw terminal input (interactive mode only). Returns an unsubscribe function. */
 	onTerminalInput(handler: TerminalInputHandler): () => void;
 
+	/** Whether the terminal window currently has focus. */
+	isTerminalFocused(): boolean;
+
 	/** Set status text in the footer/status bar. Pass undefined to clear. */
 	setStatus(key: string, text: string | undefined): void;
 
@@ -600,6 +603,17 @@ export interface ModelSelectEvent {
 }
 
 // ============================================================================
+// Terminal Focus Events
+// ============================================================================
+
+/** Fired when terminal window focus changes in interactive mode. */
+export interface TerminalFocusEvent {
+	type: "terminal_focus";
+	focused: boolean;
+	previousFocused: boolean;
+}
+
+// ============================================================================
 // User Bash Events
 // ============================================================================
 
@@ -833,6 +847,7 @@ export type ExtensionEvent =
 	| ToolExecutionUpdateEvent
 	| ToolExecutionEndEvent
 	| ModelSelectEvent
+	| TerminalFocusEvent
 	| UserBashEvent
 	| InputEvent
 	| ToolCallEvent
@@ -987,6 +1002,7 @@ export interface ExtensionAPI {
 	on(event: "tool_execution_update", handler: ExtensionHandler<ToolExecutionUpdateEvent>): void;
 	on(event: "tool_execution_end", handler: ExtensionHandler<ToolExecutionEndEvent>): void;
 	on(event: "model_select", handler: ExtensionHandler<ModelSelectEvent>): void;
+	on(event: "terminal_focus", handler: ExtensionHandler<TerminalFocusEvent>): void;
 	on(event: "tool_call", handler: ExtensionHandler<ToolCallEvent, ToolCallEventResult>): void;
 	on(event: "tool_result", handler: ExtensionHandler<ToolResultEvent, ToolResultEventResult>): void;
 	on(event: "user_bash", handler: ExtensionHandler<UserBashEvent, UserBashEventResult>): void;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -110,6 +110,7 @@ export type {
 	SlashCommandInfo,
 	SlashCommandLocation,
 	SlashCommandSource,
+	TerminalFocusEvent,
 	TerminalInputHandler,
 	ToolCallEvent,
 	ToolDefinition,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -215,6 +215,7 @@ export class InteractiveMode {
 	private extensionInput: ExtensionInputComponent | undefined = undefined;
 	private extensionEditor: ExtensionEditorComponent | undefined = undefined;
 	private extensionTerminalInputUnsubscribers = new Set<() => void>();
+	private terminalFocusListenerUnsubscribe: (() => void) | undefined = undefined;
 
 	// Extension widgets (components rendered above/below the editor)
 	private extensionWidgetsAbove = new Map<string, Component & { dispose?(): void }>();
@@ -455,6 +456,7 @@ export class InteractiveMode {
 
 		// Initialize extensions first so resources are shown before messages
 		await this.initExtensions();
+		this.setupTerminalFocusTracking();
 
 		// Render initial messages AFTER showing loaded resources
 		this.renderInitialMessages();
@@ -1435,6 +1437,7 @@ export class InteractiveMode {
 			input: (title, placeholder, opts) => this.showExtensionInput(title, placeholder, opts),
 			notify: (message, type) => this.showExtensionNotify(message, type),
 			onTerminalInput: (handler) => this.addExtensionTerminalInputListener(handler),
+			isTerminalFocused: () => this.ui.isTerminalFocused(),
 			setStatus: (key, text) => this.setExtensionStatus(key, text),
 			setWorkingMessage: (message) => {
 				if (this.loadingAnimation) {
@@ -1483,6 +1486,21 @@ export class InteractiveMode {
 			getToolsExpanded: () => this.toolOutputExpanded,
 			setToolsExpanded: (expanded) => this.setToolsExpanded(expanded),
 		};
+	}
+
+	private setupTerminalFocusTracking(): void {
+		this.terminalFocusListenerUnsubscribe?.();
+		this.terminalFocusListenerUnsubscribe = this.ui.onTerminalFocusChange((focused, previousFocused) => {
+			const extensionRunner = this.session.extensionRunner;
+			if (!extensionRunner?.hasHandlers("terminal_focus")) {
+				return;
+			}
+			void extensionRunner.emit({
+				type: "terminal_focus",
+				focused,
+				previousFocused,
+			});
+		});
 	}
 
 	/**
@@ -4451,6 +4469,8 @@ export class InteractiveMode {
 			this.loadingAnimation = undefined;
 		}
 		this.clearExtensionTerminalInputListeners();
+		this.terminalFocusListenerUnsubscribe?.();
+		this.terminalFocusListenerUnsubscribe = undefined;
 		this.footer.dispose();
 		this.footerDataProvider.dispose();
 		if (this.unsubscribe) {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -149,6 +149,11 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			return () => {};
 		},
 
+		isTerminalFocused(): boolean {
+			// Terminal focus state not available in RPC mode
+			return false;
+		},
+
 		setStatus(key: string, text: string | undefined): void {
 			// Fire and forget - no response needed
 			output({

--- a/packages/coding-agent/test/extensions-terminal-focus.test.ts
+++ b/packages/coding-agent/test/extensions-terminal-focus.test.ts
@@ -1,0 +1,102 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { discoverAndLoadExtensions } from "../src/core/extensions/loader.js";
+import { ExtensionRunner } from "../src/core/extensions/runner.js";
+import type { ExtensionUIContext } from "../src/core/extensions/types.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import type { Theme } from "../src/modes/interactive/theme/theme.js";
+
+describe("Terminal Focus Extension Event", () => {
+	let tempDir: string;
+	let extensionsDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-terminal-focus-test-"));
+		extensionsDir = path.join(tempDir, "extensions");
+		fs.mkdirSync(extensionsDir);
+		delete (globalThis as { testVar?: unknown }).testVar;
+	});
+
+	afterEach(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+	async function createRunner(...extensions: string[]) {
+		fs.rmSync(extensionsDir, { recursive: true, force: true });
+		fs.mkdirSync(extensionsDir);
+		for (let i = 0; i < extensions.length; i++) {
+			fs.writeFileSync(path.join(extensionsDir, `e${i}.ts`), extensions[i]);
+		}
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const sm = SessionManager.inMemory();
+		const mr = new ModelRegistry(AuthStorage.create(path.join(tempDir, "auth.json")));
+		return new ExtensionRunner(result.extensions, result.runtime, tempDir, sm, mr);
+	}
+
+	it("exposes terminal focus state through ctx.ui and terminal_focus event", async () => {
+		const runner = await createRunner(`
+export default function (pi) {
+	pi.on("terminal_focus", (event, ctx) => {
+		globalThis.testVar = {
+			focused: event.focused,
+			previousFocused: event.previousFocused,
+			uiFocused: ctx.ui.isTerminalFocused(),
+		};
+	});
+}
+`);
+
+		const uiContext = {
+			select: async () => undefined,
+			confirm: async () => false,
+			input: async () => undefined,
+			notify: () => {},
+			onTerminalInput: () => () => {},
+			isTerminalFocused: () => false,
+			setStatus: () => {},
+			setWorkingMessage: () => {},
+			setWidget: () => {},
+			setFooter: () => {},
+			setHeader: () => {},
+			setTitle: () => {},
+			custom: async () => undefined as never,
+			pasteToEditor: () => {},
+			setEditorText: () => {},
+			getEditorText: () => "",
+			editor: async () => undefined,
+			setEditorComponent: () => {},
+			get theme() {
+				return {} as Theme;
+			},
+			getAllThemes: () => [],
+			getTheme: () => undefined,
+			setTheme: () => ({ success: false, error: "not used" }),
+			getToolsExpanded: () => false,
+			setToolsExpanded: () => {},
+		} satisfies ExtensionUIContext;
+
+		runner.setUIContext(uiContext);
+		await runner.emit({ type: "terminal_focus", focused: false, previousFocused: true });
+
+		expect((globalThis as { testVar?: unknown }).testVar).toEqual({
+			focused: false,
+			previousFocused: true,
+			uiFocused: false,
+		});
+	});
+
+	it("no-op UI context reports terminal unfocused", async () => {
+		const runner = await createRunner(`
+export default function (pi) {
+	pi.on("terminal_focus", (_event, ctx) => {
+		globalThis.testVar = ctx.ui.isTerminalFocused();
+	});
+}
+`);
+
+		await runner.emit({ type: "terminal_focus", focused: true, previousFocused: false });
+		expect((globalThis as { testVar?: unknown }).testVar).toBe(false);
+	});
+});

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -216,6 +216,8 @@ export class Editor implements Component, Focusable {
 
 	/** Focusable interface - set by TUI when focus changes */
 	focused: boolean = false;
+	/** Terminal window focus state for caret styling. */
+	terminalFocused: boolean = true;
 
 	protected tui: TUI;
 	private theme: EditorTheme;
@@ -443,8 +445,9 @@ export class Editor implements Component, Focusable {
 		}
 
 		// Render each visible layout line
-		// Emit hardware cursor marker only when focused and not showing autocomplete
-		const emitCursorMarker = this.focused && !this.autocompleteState;
+		// Emit hardware cursor marker only when terminal is focused and autocomplete is hidden
+		const emitCursorMarker = this.focused && this.terminalFocused && !this.autocompleteState;
+		const useBlurredCaret = this.focused && !this.terminalFocused;
 
 		for (const layoutLine of visibleLines) {
 			let displayText = layoutLine.text;
@@ -465,12 +468,18 @@ export class Editor implements Component, Focusable {
 					const afterGraphemes = [...this.segment(after)];
 					const firstGrapheme = afterGraphemes[0]?.segment || "";
 					const restAfter = after.slice(firstGrapheme.length);
-					const cursor = `\x1b[7m${firstGrapheme}\x1b[0m`;
-					displayText = before + marker + cursor + restAfter;
-					// lineVisibleWidth stays the same - we're replacing, not adding
+					if (useBlurredCaret) {
+						const cursor = `\x1b[2m\x1b[4m${firstGrapheme}\x1b[0m`;
+						displayText = before + marker + cursor + restAfter;
+						// lineVisibleWidth stays the same - we're replacing, not adding
+					} else {
+						const cursor = `\x1b[7m${firstGrapheme}\x1b[0m`;
+						displayText = before + marker + cursor + restAfter;
+						// lineVisibleWidth stays the same - we're replacing, not adding
+					}
 				} else {
 					// Cursor is at the end - add highlighted space
-					const cursor = "\x1b[7m \x1b[0m";
+					const cursor = useBlurredCaret ? "\x1b[2m\x1b[4m \x1b[0m" : "\x1b[7m \x1b[0m";
 					displayText = before + marker + cursor;
 					lineVisibleWidth = lineVisibleWidth + 1;
 					// If cursor overflows content width into the padding, flag it

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -23,6 +23,8 @@ export class Input implements Component, Focusable {
 
 	/** Focusable interface - set by TUI when focus changes */
 	focused: boolean = false;
+	/** Terminal window focus state for caret styling. */
+	terminalFocused: boolean = true;
 
 	// Bracketed paste mode buffering
 	private pasteBuffer: string = "";
@@ -487,10 +489,11 @@ export class Input implements Component, Focusable {
 		const afterCursor = visibleText.slice(cursorDisplay + atCursor.length);
 
 		// Hardware cursor marker (zero-width, emitted before fake cursor for IME positioning)
-		const marker = this.focused ? CURSOR_MARKER : "";
+		const marker = this.focused && this.terminalFocused ? CURSOR_MARKER : "";
 
-		// Use inverse video to show cursor
-		const cursorChar = `\x1b[7m${atCursor}\x1b[27m`; // ESC[7m = reverse video, ESC[27m = normal
+		// Use subdued underlined caret when terminal is blurred
+		const cursorChar =
+			this.focused && !this.terminalFocused ? `\x1b[2m\x1b[4m${atCursor}\x1b[0m` : `\x1b[7m${atCursor}\x1b[27m`; // ESC[7m = reverse video, ESC[27m = normal
 		const textWithCursor = beforeCursor + marker + cursorChar + afterCursor;
 
 		// Calculate visual width

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -32,6 +32,10 @@ export interface Terminal {
 
 	// Whether Kitty keyboard protocol is active
 	get kittyProtocolActive(): boolean;
+	// Whether the terminal window currently has focus
+	get focused(): boolean;
+	// Subscribe to terminal focus changes
+	onFocusChange(listener: (focused: boolean) => void): () => void;
 
 	// Cursor positioning (relative to current position)
 	moveBy(lines: number): void; // Move cursor up (negative) or down (positive) by N lines
@@ -61,9 +65,30 @@ export class ProcessTerminal implements Terminal {
 	private stdinBuffer?: StdinBuffer;
 	private stdinDataHandler?: (data: string) => void;
 	private writeLogPath = process.env.PI_TUI_WRITE_LOG || "";
+	private _focused = true;
+	private focusListeners = new Set<(focused: boolean) => void>();
 
 	get kittyProtocolActive(): boolean {
 		return this._kittyProtocolActive;
+	}
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	onFocusChange(listener: (focused: boolean) => void): () => void {
+		this.focusListeners.add(listener);
+		return () => {
+			this.focusListeners.delete(listener);
+		};
+	}
+
+	private setFocused(focused: boolean): void {
+		if (this._focused === focused) return;
+		this._focused = focused;
+		for (const listener of this.focusListeners) {
+			listener(focused);
+		}
 	}
 
 	start(onInput: (data: string) => void, onResize: () => void): void {
@@ -80,6 +105,9 @@ export class ProcessTerminal implements Terminal {
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		process.stdout.write("\x1b[?2004h");
+		// Enable focus in/out reporting - terminal emits \x1b[I and \x1b[O
+		process.stdout.write("\x1b[?1004h");
+		this._focused = true;
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.resizeHandler);
@@ -118,6 +146,15 @@ export class ProcessTerminal implements Terminal {
 
 		// Forward individual sequences to the input handler
 		this.stdinBuffer.on("data", (sequence) => {
+			if (sequence === "\x1b[I") {
+				this.setFocused(true);
+				return;
+			}
+			if (sequence === "\x1b[O") {
+				this.setFocused(false);
+				return;
+			}
+
 			// Check for Kitty protocol response (only if not already enabled)
 			if (!this._kittyProtocolActive) {
 				const match = sequence.match(kittyResponsePattern);
@@ -249,6 +286,9 @@ export class ProcessTerminal implements Terminal {
 	stop(): void {
 		// Disable bracketed paste mode
 		process.stdout.write("\x1b[?2004l");
+		// Disable focus reporting mode
+		process.stdout.write("\x1b[?1004l");
+		this._focused = true;
 
 		// Disable Kitty keyboard protocol if not already done by drainInput()
 		if (this._kittyProtocolActive) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -41,6 +41,7 @@ export interface Component {
 
 type InputListenerResult = { consume?: boolean; data?: string } | undefined;
 type InputListener = (data: string) => InputListenerResult;
+type TerminalFocusListener = (focused: boolean, previousFocused: boolean) => void;
 
 /**
  * Interface for components that can receive focus and display a hardware cursor.
@@ -51,6 +52,8 @@ type InputListener = (data: string) => InputListenerResult;
 export interface Focusable {
 	/** Set by TUI when focus changes. Component should emit CURSOR_MARKER when true. */
 	focused: boolean;
+	/** Optional terminal focus signal for caret styling when window focus changes. */
+	terminalFocused?: boolean;
 }
 
 /** Type guard to check if a component implements Focusable */
@@ -213,6 +216,9 @@ export class TUI extends Container {
 	private previousHeight = 0;
 	private focusedComponent: Component | null = null;
 	private inputListeners = new Set<InputListener>();
+	private terminalFocused = true;
+	private terminalFocusListeners = new Set<TerminalFocusListener>();
+	private terminalFocusUnsubscribe?: () => void;
 
 	/** Global callback for debug key (Shift+Ctrl+D). Called before input is forwarded to focused component. */
 	public onDebug?: () => void;
@@ -241,6 +247,7 @@ export class TUI extends Container {
 	constructor(terminal: Terminal, showHardwareCursor?: boolean) {
 		super();
 		this.terminal = terminal;
+		this.terminalFocused = terminal.focused;
 		if (showHardwareCursor !== undefined) {
 			this.showHardwareCursor = showHardwareCursor;
 		}
@@ -276,18 +283,35 @@ export class TUI extends Container {
 		this.clearOnShrink = enabled;
 	}
 
+	isTerminalFocused(): boolean {
+		return this.terminalFocused;
+	}
+
+	onTerminalFocusChange(listener: TerminalFocusListener): () => void {
+		this.terminalFocusListeners.add(listener);
+		return () => {
+			this.terminalFocusListeners.delete(listener);
+		};
+	}
+
+	private notifyTerminalFocusChange(focused: boolean, previousFocused: boolean): void {
+		for (const listener of this.terminalFocusListeners) {
+			listener(focused, previousFocused);
+		}
+	}
+
+	private setFocusableState(component: Component | null, focused: boolean): void {
+		if (!isFocusable(component)) return;
+		component.focused = focused;
+		if ("terminalFocused" in component) {
+			component.terminalFocused = this.terminalFocused;
+		}
+	}
+
 	setFocus(component: Component | null): void {
-		// Clear focused flag on old component
-		if (isFocusable(this.focusedComponent)) {
-			this.focusedComponent.focused = false;
-		}
-
+		this.setFocusableState(this.focusedComponent, false);
 		this.focusedComponent = component;
-
-		// Set focused flag on new component
-		if (isFocusable(component)) {
-			component.focused = true;
-		}
+		this.setFocusableState(component, true);
 	}
 
 	/**
@@ -412,6 +436,19 @@ export class TUI extends Container {
 			(data) => this.handleInput(data),
 			() => this.requestRender(),
 		);
+		this.terminalFocused = this.terminal.focused;
+		this.terminalFocusUnsubscribe?.();
+		this.terminalFocusUnsubscribe = this.terminal.onFocusChange((focused) => {
+			const previousFocused = this.terminalFocused;
+			if (previousFocused === focused) return;
+			this.terminalFocused = focused;
+			this.setFocusableState(this.focusedComponent, this.focusedComponent !== null);
+			if (!focused) {
+				this.terminal.hideCursor();
+			}
+			this.notifyTerminalFocusChange(focused, previousFocused);
+			this.requestRender();
+		});
 		this.terminal.hideCursor();
 		this.queryCellSize();
 		this.requestRender();
@@ -441,6 +478,8 @@ export class TUI extends Container {
 
 	stop(): void {
 		this.stopped = true;
+		this.terminalFocusUnsubscribe?.();
+		this.terminalFocusUnsubscribe = undefined;
 		// Move cursor to the end of the content to prevent overwriting/artifacts on exit
 		if (this.previousLines.length > 0) {
 			const targetRow = this.previousLines.length; // Line after the last content
@@ -1203,7 +1242,7 @@ export class TUI extends Container {
 		}
 
 		this.hardwareCursorRow = targetRow;
-		if (this.showHardwareCursor) {
+		if (this.showHardwareCursor && this.terminalFocused) {
 			this.terminal.showCursor();
 		} else {
 			this.terminal.hideCursor();

--- a/packages/tui/test/terminal-focus.test.ts
+++ b/packages/tui/test/terminal-focus.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Editor } from "../src/components/editor.js";
+import { TUI } from "../src/tui.js";
+import { VirtualTerminal } from "./virtual-terminal.js";
+
+const TEST_THEME = {
+	borderColor: (str: string) => str,
+	selectList: {
+		selectedPrefix: (text: string) => text,
+		selectedText: (text: string) => text,
+		description: (text: string) => text,
+		scrollInfo: (text: string) => text,
+		noMatch: (text: string) => text,
+	},
+};
+
+describe("terminal focus handling", () => {
+	it("updates editor caret rendering when terminal focus changes", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal, true);
+		const editor = new Editor(tui, TEST_THEME);
+		editor.setText("hello");
+		tui.addChild(editor);
+		tui.setFocus(editor);
+		tui.start();
+		await terminal.flush();
+
+		const focusedRender = editor.render(20).join("\n");
+		assert.match(focusedRender, /\x1b_pi:c\x07/, "focused editor should emit hardware cursor marker");
+		assert.match(focusedRender, /\x1b\[7m/, "focused editor should render inverse caret");
+
+		terminal.setFocused(false);
+		await terminal.flush();
+
+		const blurredRender = editor.render(20).join("\n");
+		assert.ok(!blurredRender.includes("\x1b_pi:c\x07"), "blurred editor must not emit hardware cursor marker");
+		assert.match(blurredRender, /\x1b\[2m\x1b\[4m/, "blurred editor should render subdued underlined caret");
+		assert.strictEqual(tui.isTerminalFocused(), false);
+
+		terminal.setFocused(true);
+		await terminal.flush();
+		assert.strictEqual(tui.isTerminalFocused(), true);
+		assert.match(editor.render(20).join("\n"), /\x1b_pi:c\x07/, "caret marker should return after focus");
+
+		tui.stop();
+	});
+
+	it("emits terminal focus change notifications with previous state", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const changes: Array<{ focused: boolean; previousFocused: boolean }> = [];
+		const unsubscribe = tui.onTerminalFocusChange((focused, previousFocused) => {
+			changes.push({ focused, previousFocused });
+		});
+
+		tui.start();
+		await terminal.flush();
+
+		terminal.setFocused(false);
+		terminal.setFocused(true);
+		await terminal.flush();
+
+		assert.deepStrictEqual(changes, [
+			{ focused: false, previousFocused: true },
+			{ focused: true, previousFocused: false },
+		]);
+
+		unsubscribe();
+		tui.stop();
+	});
+});

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -14,6 +14,8 @@ export class VirtualTerminal implements Terminal {
 	private resizeHandler?: () => void;
 	private _columns: number;
 	private _rows: number;
+	private _focused = true;
+	private focusListeners = new Set<(focused: boolean) => void>();
 
 	constructor(columns = 80, rows = 24) {
 		this._columns = columns;
@@ -32,6 +34,7 @@ export class VirtualTerminal implements Terminal {
 	start(onInput: (data: string) => void, onResize: () => void): void {
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
+		this._focused = true;
 		// Enable bracketed paste mode for consistency with ProcessTerminal
 		this.xterm.write("\x1b[?2004h");
 	}
@@ -43,6 +46,7 @@ export class VirtualTerminal implements Terminal {
 	stop(): void {
 		// Disable bracketed paste mode
 		this.xterm.write("\x1b[?2004l");
+		this._focused = true;
 		this.inputHandler = undefined;
 		this.resizeHandler = undefined;
 	}
@@ -62,6 +66,17 @@ export class VirtualTerminal implements Terminal {
 	get kittyProtocolActive(): boolean {
 		// Virtual terminal always reports Kitty protocol as active for testing
 		return true;
+	}
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	onFocusChange(listener: (focused: boolean) => void): () => void {
+		this.focusListeners.add(listener);
+		return () => {
+			this.focusListeners.delete(listener);
+		};
 	}
 
 	moveBy(lines: number): void {
@@ -120,6 +135,14 @@ export class VirtualTerminal implements Terminal {
 		this.xterm.resize(columns, rows);
 		if (this.resizeHandler) {
 			this.resizeHandler();
+		}
+	}
+
+	setFocused(focused: boolean): void {
+		if (this._focused === focused) return;
+		this._focused = focused;
+		for (const listener of this.focusListeners) {
+			listener(focused);
 		}
 	}
 


### PR DESCRIPTION
Add terminal focus awareness to the TUI and expose it to extensions.

## Changes

### TUI (`packages/tui`)

- **ProcessTerminal**: Enable DECSET 1004 focus reporting on start, disable on stop. Consume `\x1b[I` / `\x1b[O` sequences and track focus state.
- **TUI**: Sync terminal focus state, hide hardware cursor when blurred, re-render on focus change. Expose `isTerminalFocused()` and `onTerminalFocusChange()`.
- **Editor / Input**: Render dim underline caret (`\x1b[2m\x1b[4m`) when terminal is unfocused instead of inverse video. Suppress `CURSOR_MARKER` emission when blurred.
- **VirtualTerminal**: Add `setFocused()` for test support.

### Coding Agent (`packages/coding-agent`)

- **Extension types**: Add `TerminalFocusEvent` (`type: "terminal_focus"`, `focused`, `previousFocused`) and `ctx.ui.isTerminalFocused()` getter.
- **Interactive mode**: Wire TUI focus changes to extension runner via `emit()`.
- **RPC / no-op contexts**: `isTerminalFocused()` returns `false`.
- **Exports**: `TerminalFocusEvent` exported from package index.
- **Docs**: Updated `extensions.md` with lifecycle entry, dedicated section, and usage examples.

### Tests

- `packages/tui/test/terminal-focus.test.ts` — caret rendering and focus notification tests.
- `packages/coding-agent/test/extensions-terminal-focus.test.ts` — extension event wiring tests.

## Notes

- No new user-facing settings. Behavior is opinionated: focused = inverse caret, unfocused = dim underline.
- Focus reporting requires terminal support for DECSET 1004 (most modern terminals).
