### PR TITLE
fix(web-ui): use tsc instead of tsgo for build

### DIFF
--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -11,7 +11,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf dist",
-		"build": "tsgo -p tsconfig.build.json && tailwindcss -i ./src/app.css -o ./dist/app.css --minify",
+		"build": "tsc -p tsconfig.build.json && tailwindcss -i ./src/app.css -o ./dist/app.css --minify",
 		"dev": "concurrently --names \"build,example\" --prefix-colors \"cyan,green\" \"tsc -p tsconfig.build.json --watch --preserveWatchOutput\" \"tailwindcss -i ./src/app.css -o ./dist/app.css --watch\" \"npm run dev --prefix example\"",
 		"dev:tsc": "concurrently --names \"build\" --prefix-colors \"cyan\" \"tsc -p tsconfig.build.json --watch --preserveWatchOutput\" \"tailwindcss -i ./src/app.css -o ./dist/app.css --watch\"",
 		"check": "biome check --write --error-on-warnings . && tsc --noEmit && cd example && biome check --write --error-on-warnings . && tsc --noEmit"


### PR DESCRIPTION
## Summary
- Changes the build script in `packages/web-ui/package.json` from using `tsgo` to `tsc` directly
- `tsgo` was stripping `@state()` decorators from Lit components, causing updates to not trigger properly
- This broke the ChatPanel and other components from rendering in the browser