### PR TITLE
fix(ai): don't double-count cached tokens in calculateCost

### DIFF
--- a/packages/ai/src/models.test.ts
+++ b/packages/ai/src/models.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { calculateCost } from "./models.js";
+import type { Api, Model, Usage } from "./types.js";
+
+function makeUsage(input: number, output: number, cacheRead: number, cacheWrite: number): Usage {
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: input + output,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function makeModel(costPerMillion: { input: number; output: number; cacheRead: number; cacheWrite: number }): Model<Api> {
+	return {
+		cost: costPerMillion,
+	} as Model<Api>;
+}
+
+describe("calculateCost", () => {
+	// gemini-3-flash-preview pricing: input=$0.50, output=$3.00, cacheRead=$0.05, cacheWrite=$0.05 per 1M tokens
+	const model = makeModel({ input: 0.50, output: 3.00, cacheRead: 0.05, cacheWrite: 0.05 });
+
+	it("should not double-count cached tokens in input cost", () => {
+		// Real-world example: 20212 input tokens, 16298 cached, 931 output
+		const usage = makeUsage(20212, 931, 16298, 0);
+		const cost = calculateCost(model, usage);
+
+		// Correct calculation:
+		// uncached input = 20212 - 16298 = 3914 tokens at $0.50/1M = $0.001957
+		// output = 931 tokens at $3.00/1M = $0.002793
+		// cache read = 16298 tokens at $0.05/1M = $0.000815
+		// total = $0.005565
+		const expectedTotal = (3914 * 0.50 + 931 * 3.00 + 16298 * 0.05) / 1_000_000;
+
+		expect(cost.total).toBeCloseTo(expectedTotal, 6);
+	});
+
+	it("should charge full input rate only on uncached tokens", () => {
+		const usage = makeUsage(100_000, 1_000, 80_000, 0);
+		const cost = calculateCost(model, usage);
+
+		// Only 20,000 tokens should be charged at input rate
+		const expectedInputCost = (20_000 * 0.50) / 1_000_000;
+		expect(cost.input).toBeCloseTo(expectedInputCost, 8);
+	});
+
+	it("should be correct with no caching", () => {
+		const usage = makeUsage(10_000, 1_000, 0, 0);
+		const cost = calculateCost(model, usage);
+
+		const expectedTotal = (10_000 * 0.50 + 1_000 * 3.00) / 1_000_000;
+		expect(cost.total).toBeCloseTo(expectedTotal, 8);
+	});
+
+	it("should handle cache write tokens", () => {
+		const usage = makeUsage(10_000, 1_000, 0, 5_000);
+		const cost = calculateCost(model, usage);
+
+		const expectedTotal = (10_000 * 0.50 + 1_000 * 3.00 + 5_000 * 0.05) / 1_000_000;
+		expect(cost.total).toBeCloseTo(expectedTotal, 8);
+	});
+});

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -37,7 +37,7 @@ export function getModels<TProvider extends KnownProvider>(
 }
 
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
-	usage.cost.input = (model.cost.input / 1000000) * usage.input;
+	usage.cost.input = (model.cost.input / 1000000) * Math.max(0, usage.input - usage.cacheRead);
 	usage.cost.output = (model.cost.output / 1000000) * usage.output;
 	usage.cost.cacheRead = (model.cost.cacheRead / 1000000) * usage.cacheRead;
 	usage.cost.cacheWrite = (model.cost.cacheWrite / 1000000) * usage.cacheWrite;


### PR DESCRIPTION
## Summary

- `calculateCost` charges the full input rate on **all** input tokens (including cached), then also charges the cache-read rate on cached tokens — effectively double-billing cached tokens.
- Fix: subtract `cacheRead` from `input` before applying the input rate, so only uncached tokens are charged at the full price.
- Adds a test with real-world token counts that demonstrates the bug and verifies the fix.

### Example

With `gemini-3-flash-preview` pricing (input=$0.50/1M, cacheRead=$0.05/1M):
- 20,212 input tokens, 16,298 cached, 931 output
- **Before (bug):** $0.0137 (charges $0.50/1M on all 20k input tokens + $0.05/1M on 16k cached)
- **After (fix):** $0.0056 (charges $0.50/1M on 3,914 uncached + $0.05/1M on 16k cached)

### One-line change

```diff
- usage.cost.input = (model.cost.input / 1000000) * usage.input;
+ usage.cost.input = (model.cost.input / 1000000) * Math.max(0, usage.input - usage.cacheRead);
```

## Test plan

- [x] Added `models.test.ts` — 4 tests covering cached, uncached, and cache-write scenarios
- [x] All tests pass with the fix, 2 fail without it