### PR TITLE
fix(tui): clear stale scrollback on session switch

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -900,7 +900,7 @@ export class TUI extends Container {
 		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			if (clear) buffer += "\x1b[3J\x1b[2J\x1b[H"; // Clear scrollback, screen, and home
+			if (clear) buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
 				buffer += newLines[i];


### PR DESCRIPTION
Switching from one session to another via `/resume` leaves a few lines from the previous session visible when scrolling up.

https://github.com/user-attachments/assets/d2643ecc-0ba3-4f0a-97f2-4df3f6f4edd7

The TUI's `fullRender` clears the terminal with `\x1b[3J\x1b[2J\x1b[H` – clear scrollback, clear screen, move home. But `\x1b[2J` pushes on-screen content into the scrollback buffer as a side effect, repopulating the scrollback that `\x1b[3J` just emptied. Reorder to `\x1b[2J\x1b[H\x1b[3J` so the scrollback clear happens last.