### PR TITLE
feat(tui): add ghost text / inline suggestion API for Editor

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -202,9 +202,27 @@ export interface EditorTheme {
 	selectList: SelectListTheme;
 }
 
+/**
+ * Provider for ghost text (inline suggestions).
+ * Returns a suggestion string to display as dimmed text after the cursor.
+ */
+export interface GhostTextProvider {
+	/**
+	 * Get a suggestion for the current editor content.
+	 * @param text - Full editor text
+	 * @param cursorLine - Current cursor line
+	 * @param cursorCol - Current cursor column
+	 * @param signal - Abort signal for cancellation
+	 * @returns Suggestion text to display, or null for no suggestion
+	 */
+	getSuggestion(text: string, cursorLine: number, cursorCol: number, signal: AbortSignal): Promise<string | null>;
+}
+
 export interface EditorOptions {
 	paddingX?: number;
 	autocompleteMaxVisible?: number;
+	/** Debounce delay in ms before requesting ghost text (default: 500) */
+	ghostTextDebounceMs?: number;
 }
 
 const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
@@ -241,6 +259,13 @@ export class Editor implements Component, Focusable {
 	private autocompleteState: "regular" | "force" | null = null;
 	private autocompletePrefix: string = "";
 	private autocompleteMaxVisible: number = 5;
+
+	// Ghost text (inline suggestion) support
+	private ghostTextProvider?: GhostTextProvider;
+	private ghostText: string | null = null;
+	private ghostTextAbortController: AbortController | null = null;
+	private ghostTextDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private ghostTextDebounceMs: number = 500;
 
 	// Paste tracking for large pastes
 	private pastes: Map<number, string> = new Map();
@@ -279,6 +304,8 @@ export class Editor implements Component, Focusable {
 		this.paddingX = Number.isFinite(paddingX) ? Math.max(0, Math.floor(paddingX)) : 0;
 		const maxVisible = options.autocompleteMaxVisible ?? 5;
 		this.autocompleteMaxVisible = Number.isFinite(maxVisible) ? Math.max(3, Math.min(20, Math.floor(maxVisible))) : 5;
+		const debounceMs = options.ghostTextDebounceMs ?? 500;
+		this.ghostTextDebounceMs = Number.isFinite(debounceMs) ? Math.max(0, Math.floor(debounceMs)) : 500;
 	}
 
 	/** Set of currently valid paste IDs, for marker-aware segmentation. */
@@ -317,6 +344,91 @@ export class Editor implements Component, Focusable {
 
 	setAutocompleteProvider(provider: AutocompleteProvider): void {
 		this.autocompleteProvider = provider;
+	}
+
+	/**
+	 * Set a ghost text provider for inline suggestions.
+	 * Pass undefined to disable ghost text.
+	 */
+	setGhostTextProvider(provider: GhostTextProvider | undefined): void {
+		this.ghostTextProvider = provider;
+		if (!provider) {
+			this.clearGhostText();
+		}
+	}
+
+	/** Get the current ghost text, if any. */
+	getGhostText(): string | null {
+		return this.ghostText;
+	}
+
+	private clearGhostText(): void {
+		this.ghostText = null;
+		if (this.ghostTextAbortController) {
+			this.ghostTextAbortController.abort();
+			this.ghostTextAbortController = null;
+		}
+		if (this.ghostTextDebounceTimer) {
+			clearTimeout(this.ghostTextDebounceTimer);
+			this.ghostTextDebounceTimer = null;
+		}
+	}
+
+	/** Accept the current ghost text, inserting it at the cursor. */
+	acceptGhostText(): boolean {
+		if (!this.ghostText) return false;
+		const text = this.ghostText;
+		this.ghostText = null;
+		this.pushUndoSnapshot();
+		this.lastAction = null;
+		this.insertTextAtCursorInternal(text);
+		this.scheduleGhostText();
+		return true;
+	}
+
+	private scheduleGhostText(): void {
+		// Cancel any pending request
+		if (this.ghostTextAbortController) {
+			this.ghostTextAbortController.abort();
+			this.ghostTextAbortController = null;
+		}
+		if (this.ghostTextDebounceTimer) {
+			clearTimeout(this.ghostTextDebounceTimer);
+			this.ghostTextDebounceTimer = null;
+		}
+
+		if (!this.ghostTextProvider) return;
+
+		// Don't show ghost text when autocomplete is active
+		if (this.autocompleteState) return;
+
+		this.ghostTextDebounceTimer = setTimeout(() => {
+			this.requestGhostText();
+		}, this.ghostTextDebounceMs);
+	}
+
+	private requestGhostText(): void {
+		if (!this.ghostTextProvider) return;
+
+		const controller = new AbortController();
+		this.ghostTextAbortController = controller;
+
+		const text = this.getText();
+		const { cursorLine, cursorCol } = this.state;
+
+		this.ghostTextProvider.getSuggestion(text, cursorLine, cursorCol, controller.signal).then(
+			(suggestion) => {
+				if (controller.signal.aborted) return;
+				this.ghostText = suggestion;
+				this.ghostTextAbortController = null;
+				this.tui.requestRender();
+			},
+			(_error) => {
+				// Silently ignore errors (aborted, network, etc.)
+				if (controller.signal.aborted) return;
+				this.ghostTextAbortController = null;
+			},
+		);
 	}
 
 	/**
@@ -485,6 +597,19 @@ export class Editor implements Component, Focusable {
 				}
 			}
 
+			// Add ghost text after cursor on the cursor line (single-line only, no wrapping)
+			if (layoutLine.hasCursor && this.ghostText && !this.autocompleteState) {
+				const ghostFirstLine = this.ghostText.split("\n")[0] || "";
+				if (ghostFirstLine) {
+					const availableWidth = contentWidth - lineVisibleWidth;
+					if (availableWidth > 0) {
+						const truncatedGhost = truncateToWidth(ghostFirstLine, availableWidth);
+						displayText += `\x1b[2m${truncatedGhost}\x1b[0m`;
+						lineVisibleWidth += visibleWidth(truncatedGhost);
+					}
+				}
+			}
+
 			// Calculate padding based on actual visible width
 			const padding = " ".repeat(Math.max(0, contentWidth - lineVisibleWidth));
 			const lineRightPadding = cursorInPadding ? rightPadding.slice(1) : rightPadding;
@@ -643,8 +768,12 @@ export class Editor implements Component, Focusable {
 			}
 		}
 
-		// Tab - trigger completion
+		// Tab - accept ghost text or trigger completion
 		if (kb.matches(data, "tab") && !this.autocompleteState) {
+			if (this.ghostText) {
+				this.acceptGhostText();
+				return;
+			}
 			this.handleTabCompletion();
 			return;
 		}
@@ -928,6 +1057,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	setText(text: string): void {
+		this.clearGhostText();
 		this.lastAction = null;
 		this.historyIndex = -1; // Exit history browsing mode
 		const normalized = this.normalizeText(text);
@@ -1008,8 +1138,8 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
-	// All the editor methods from before...
 	private insertCharacter(char: string, skipUndoCoalescing?: boolean): void {
+		this.clearGhostText();
 		this.historyIndex = -1; // Exit history browsing mode
 
 		// Undo coalescing (fish-style):
@@ -1068,9 +1198,15 @@ export class Editor implements Component, Focusable {
 		} else {
 			this.updateAutocomplete();
 		}
+
+		// Schedule ghost text after typing (only if no autocomplete is showing)
+		if (!this.autocompleteState) {
+			this.scheduleGhostText();
+		}
 	}
 
 	private handlePaste(pastedText: string): void {
+		this.clearGhostText();
 		this.historyIndex = -1; // Exit history browsing mode
 		this.lastAction = null;
 
@@ -1126,6 +1262,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	private addNewLine(): void {
+		this.clearGhostText();
 		this.historyIndex = -1; // Exit history browsing mode
 		this.lastAction = null;
 
@@ -1176,6 +1313,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	private handleBackspace(): void {
+		this.clearGhostText();
 		this.historyIndex = -1; // Exit history browsing mode
 		this.lastAction = null;
 
@@ -1229,6 +1367,11 @@ export class Editor implements Component, Focusable {
 			else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
 				this.tryTriggerAutocomplete();
 			}
+		}
+
+		// Schedule ghost text after deletion
+		if (!this.autocompleteState) {
+			this.scheduleGhostText();
 		}
 	}
 
@@ -1360,6 +1503,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	private deleteToStartOfLine(): void {
+		this.clearGhostText();
 		this.historyIndex = -1; // Exit history browsing mode
 
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
@@ -1395,6 +1539,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	private deleteToEndOfLine(): void {
+		this.clearGhostText();
 		this.historyIndex = -1; // Exit history browsing mode
 
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
@@ -1427,6 +1572,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	private deleteWordBackwards(): void {
+		this.clearGhostText();
 		this.historyIndex = -1; // Exit history browsing mode
 
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
@@ -1472,6 +1618,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	private deleteWordForward(): void {
+		this.clearGhostText();
 		this.historyIndex = -1; // Exit history browsing mode
 
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
@@ -1514,6 +1661,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	private handleForwardDelete(): void {
+		this.clearGhostText();
 		this.historyIndex = -1; // Exit history browsing mode
 		this.lastAction = null;
 
@@ -2046,6 +2194,8 @@ export class Editor implements Component, Focusable {
 
 	private tryTriggerAutocomplete(explicitTab: boolean = false): void {
 		if (!this.autocompleteProvider) return;
+		// Clear ghost text when autocomplete activates
+		this.clearGhostText();
 
 		// Check if we should trigger file completion on Tab
 		if (explicitTab) {

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -10,7 +10,7 @@ export {
 // Components
 export { Box } from "./components/box.js";
 export { CancellableLoader } from "./components/cancellable-loader.js";
-export { Editor, type EditorOptions, type EditorTheme } from "./components/editor.js";
+export { Editor, type EditorOptions, type EditorTheme, type GhostTextProvider } from "./components/editor.js";
 export { Image, type ImageOptions, type ImageTheme } from "./components/image.js";
 export { Input } from "./components/input.js";
 export { Loader } from "./components/loader.js";

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3437,4 +3437,281 @@ describe("Editor component", () => {
 			assert.strictEqual(submitted, pastedText);
 		});
 	});
+
+	describe("Ghost text (inline suggestions)", () => {
+		/** Create a synchronous ghost text provider for testing */
+		function createMockProvider(suggestion: string | null) {
+			return {
+				calls: [] as Array<{ text: string; cursorLine: number; cursorCol: number }>,
+				getSuggestion(text: string, cursorLine: number, cursorCol: number, _signal: AbortSignal) {
+					this.calls.push({ text, cursorLine, cursorCol });
+					return Promise.resolve(suggestion);
+				},
+			};
+		}
+
+		/** Flush pending timers and microtasks so ghost text resolves */
+		async function flushGhostText(debounceMs: number = 0) {
+			// Wait for debounce timer
+			await new Promise((resolve) => setTimeout(resolve, debounceMs + 10));
+			// Wait for promise resolution
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+
+		it("stores ghost text from provider", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const provider = createMockProvider("world");
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("h");
+			await flushGhostText();
+
+			assert.strictEqual(editor.getGhostText(), "world");
+		});
+
+		it("renders ghost text as dim text after cursor", async () => {
+			const tui = createTestTUI(40, 10);
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const provider = createMockProvider("world");
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("h");
+			editor.handleInput("e");
+			editor.handleInput("l");
+			editor.handleInput("l");
+			editor.handleInput("o");
+			await flushGhostText();
+
+			const rendered = editor.render(40);
+			// Ghost text should appear in the rendered output (dim escape: \x1b[2m)
+			const contentLine = rendered[1]; // First content line (after top border)
+			assert.ok(contentLine?.includes("\x1b[2m"), "Ghost text should be rendered with dim style");
+			assert.ok(contentLine?.includes("world"), "Ghost text content should appear");
+		});
+
+		it("clears ghost text on character input", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const provider = createMockProvider("suggestion");
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("a");
+			await flushGhostText();
+			assert.strictEqual(editor.getGhostText(), "suggestion");
+
+			// Type another character - ghost text should be cleared immediately
+			provider.getSuggestion = () => Promise.resolve(null);
+			editor.handleInput("b");
+			// Ghost text cleared synchronously before new request
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("clears ghost text on backspace", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const provider = createMockProvider("suggestion");
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("a");
+			await flushGhostText();
+			assert.strictEqual(editor.getGhostText(), "suggestion");
+
+			provider.getSuggestion = () => Promise.resolve(null);
+			editor.handleInput("\x7f"); // Backspace
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("clears ghost text on setText", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const provider = createMockProvider("suggestion");
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("a");
+			await flushGhostText();
+			assert.strictEqual(editor.getGhostText(), "suggestion");
+
+			editor.setText("replaced");
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("accepts ghost text on Tab", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const provider = createMockProvider(" world");
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("h");
+			editor.handleInput("e");
+			editor.handleInput("l");
+			editor.handleInput("l");
+			editor.handleInput("o");
+			await flushGhostText();
+			assert.strictEqual(editor.getGhostText(), " world");
+
+			// Tab should accept the ghost text
+			editor.handleInput("\t");
+			assert.strictEqual(editor.getText(), "hello world");
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("falls through to autocomplete on Tab when no ghost text", () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			// No ghost text provider - Tab should not crash
+			editor.setText("/hel");
+			editor.handleInput("\t");
+			// Should not throw, just trigger normal tab completion
+		});
+
+		it("does not show ghost text when autocomplete is active", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+
+			// Set up autocomplete provider
+			const autocompleteProvider: AutocompleteProvider = {
+				getSuggestions(_lines: string[], _cursorLine: number, _cursorCol: number) {
+					return { items: [{ value: "/help", label: "/help" }], prefix: "/" };
+				},
+				applyCompletion(
+					lines: string[],
+					cursorLine: number,
+					_cursorCol: number,
+					item: { value: string },
+					prefix: string,
+				) {
+					const line = lines[cursorLine] || "";
+					const newLine = line.slice(0, line.length - prefix.length) + item.value;
+					return { lines: [newLine], cursorLine: 0, cursorCol: newLine.length };
+				},
+			};
+			editor.setAutocompleteProvider(autocompleteProvider);
+
+			const ghostProvider = createMockProvider("ghost");
+			editor.setGhostTextProvider(ghostProvider);
+
+			// Type "/" to trigger autocomplete
+			editor.handleInput("/");
+			await flushGhostText();
+
+			// Ghost text should not appear while autocomplete is shown
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("handles null suggestion from provider", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const provider = createMockProvider(null);
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("a");
+			await flushGhostText();
+
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("aborts previous request when new input arrives", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+
+			let requestCount = 0;
+			let abortedCount = 0;
+			const provider = {
+				getSuggestion(_text: string, _cursorLine: number, _cursorCol: number, signal: AbortSignal) {
+					requestCount++;
+					return new Promise<string | null>((resolve) => {
+						signal.addEventListener("abort", () => {
+							abortedCount++;
+						});
+						// Simulate slow provider
+						setTimeout(() => {
+							if (!signal.aborted) resolve("suggestion");
+							else resolve(null);
+						}, 200);
+					});
+				},
+			};
+			editor.setGhostTextProvider(provider);
+
+			// Type first character and let the debounce fire
+			editor.handleInput("a");
+			await flushGhostText();
+			// First request is now in-flight (waiting 200ms)
+			assert.strictEqual(requestCount, 1);
+
+			// Type another character - this should abort the in-flight request
+			editor.handleInput("b");
+			assert.strictEqual(abortedCount, 1, "In-flight request should be aborted on new input");
+		});
+
+		it("clears ghost text when provider is set to undefined", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const provider = createMockProvider("suggestion");
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("a");
+			await flushGhostText();
+			assert.strictEqual(editor.getGhostText(), "suggestion");
+
+			editor.setGhostTextProvider(undefined);
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("truncates ghost text to available width", async () => {
+			const tui = createTestTUI(20, 10);
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const longSuggestion = "this is a very long suggestion that should be truncated";
+			const provider = createMockProvider(longSuggestion);
+			editor.setGhostTextProvider(provider);
+
+			editor.setText("hello");
+			editor.handleInput("!");
+			await flushGhostText();
+
+			const rendered = editor.render(20);
+			// Each rendered line should not exceed terminal width
+			for (const line of rendered) {
+				assert.ok(
+					visibleWidth(line) <= 20,
+					`Line should not exceed width 20, got ${visibleWidth(line)}: "${stripVTControlCharacters(line)}"`,
+				);
+			}
+		});
+
+		it("respects debounce delay", async () => {
+			const tui = createTestTUI();
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 100 });
+			const provider = createMockProvider("delayed");
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("a");
+
+			// Should not have ghost text immediately
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			assert.strictEqual(editor.getGhostText(), null);
+			assert.strictEqual(provider.calls.length, 0);
+
+			// Should have ghost text after debounce
+			await flushGhostText(100);
+			assert.strictEqual(editor.getGhostText(), "delayed");
+			assert.strictEqual(provider.calls.length, 1);
+		});
+
+		it("only shows first line of multi-line ghost text", async () => {
+			const tui = createTestTUI(40, 10);
+			const editor = new Editor(tui, defaultEditorTheme, { ghostTextDebounceMs: 0 });
+			const provider = createMockProvider("first line\nsecond line\nthird line");
+			editor.setGhostTextProvider(provider);
+
+			editor.handleInput("x");
+			await flushGhostText();
+
+			const rendered = editor.render(40);
+			const allContent = rendered.join("\n");
+			assert.ok(allContent.includes("first line"), "First line of ghost text should be shown");
+			assert.ok(!allContent.includes("second line"), "Subsequent lines should not be rendered inline");
+		});
+	});
 });


### PR DESCRIPTION
## What

Add a `GhostTextProvider` interface and integrate it into the TUI `Editor` component. This lets extensions provide async inline suggestions that appear as dimmed text after the cursor, accepted via Tab -- similar to how AI autocomplete works in other coding tools.

## Why

There is currently no way for extensions to provide inline text suggestions in the editor. The existing autocomplete system only handles slash commands and file paths. This feature enables AI-powered input suggestions via the extension API.

Refs #2164

## Changes

**`packages/tui/src/components/editor.ts`**
- `GhostTextProvider` interface: `getSuggestion(text, cursorLine, cursorCol, signal) => Promise<string | null>`
- `setGhostTextProvider(provider)`, `getGhostText()`, `acceptGhostText()` public methods
- Ghost text rendered as dim (`\x1b[2m`) text after cursor, truncated to available width
- Tab accepts ghost text (only when no autocomplete popup is active, so existing Tab behavior is preserved)
- Ghost text cleared on any content-modifying input (typing, backspace, delete, paste, setText, newline)
- Debounced scheduling (configurable via `ghostTextDebounceMs` option, default 500ms)
- `AbortSignal`-based cancellation of in-flight provider requests on new input
- Ghost text suppressed while autocomplete popup is shown
- Only first line of multi-line suggestions rendered inline

**`packages/tui/src/index.ts`**
- Export `GhostTextProvider`

**`packages/tui/test/editor.test.ts`**
- 14 new tests: render, accept via Tab, clear on input/backspace/setText, debounce, abort, truncation, autocomplete interaction, multi-line, null suggestion
