### PR TITLE
docs: document xfce4-terminal and terminator keyboard protocol limitations

### DIFF
--- a/packages/coding-agent/docs/terminal-setup.md
+++ b/packages/coding-agent/docs/terminal-setup.md
@@ -86,6 +86,17 @@ Add to `settings.json` (Ctrl+Shift+, or Settings → Open JSON file) to forward 
 
 If you already have an `actions` array, add the objects to it. If the old fullscreen behavior persists, fully close and reopen Windows Terminal.
 
+## xfce4-terminal, terminator
+
+These terminals have limited escape sequence support. Modified Enter keys like `Ctrl+Enter` and `Shift+Enter` cannot be distinguished from plain `Enter`, preventing custom keybindings such as `submit: ["ctrl+enter"]` from working.
+
+For the best experience, use a terminal that supports the Kitty keyboard protocol:
+- [Kitty](https://sw.kovidgoyal.net/kitty/)
+- [Ghostty](https://ghostty.org/)
+- [WezTerm](https://wezfurlong.org/wezterm/)
+- [iTerm2](https://iterm2.com/)
+- [Alacritty](https://github.com/alacritty/alacritty) (requires compilation with Kitty protocol support)
+
 ## IntelliJ IDEA (Integrated Terminal)
 
 The built-in terminal has limited escape sequence support. Shift+Enter cannot be distinguished from Enter in IntelliJ's terminal.


### PR DESCRIPTION
## Problem

Ctrl+Enter and Shift+Enter keybindings don't work in xfce4-terminal and terminator. Users report that keybindings like `submit: ["ctrl+enter"]` are ignored, and the action falls through as if plain Enter was pressed.

Fixes #2132

## Root Cause

xfce4-terminal and terminator lack support for the Kitty keyboard protocol and xterm modifyOtherKeys mode. These protocols are required to distinguish modified Enter keys from plain Enter. When these terminals send keyboard input, they only send `\r` for all Enter variants, making it impossible for pi to detect Ctrl+Enter or Shift+Enter.

The key detection code in `packages/tui/src/keys.ts` correctly handles modified keys when terminals support these protocols, but these terminals simply don't send the necessary escape sequences.

## Change

This PR adds documentation to `packages/coding-agent/docs/terminal-setup.md` explaining:

1. The limitation: modified Enter keys cannot be distinguished from plain Enter in xfce4-terminal and terminator
2. The impact: keybindings like `submit: ["ctrl+enter"]` won't work
3. The solution: recommends using terminals that support the Kitty keyboard protocol (Kitty, Ghostty, WezTerm, iTerm2, Alacritty with Kitty protocol support)

## Verification

- `git diff --check` passes ✓
- Documentation is well-formatted and placed in the appropriate section
- No code changes required - this is a terminal limitation, not a pi bug

## Risk

No risk - documentation-only change. Users will now have clear guidance when they encounter this issue, reducing confusion and support burden.