### PR TITLE
fix: update contextWindow to 1M for Claude 4.6 in google-antigravity

### DIFF
--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -3393,7 +3393,7 @@ export const MODELS = {
 				cacheRead: 0.5,
 				cacheWrite: 6.25,
 			},
-			contextWindow: 200000,
+			contextWindow: 1000000,
 			maxTokens: 128000,
 		} satisfies Model<"google-gemini-cli">,
 		"claude-sonnet-4-5": {
@@ -3444,7 +3444,7 @@ export const MODELS = {
 				cacheRead: 0.3,
 				cacheWrite: 3.75,
 			},
-			contextWindow: 200000,
+			contextWindow: 1000000,
 			maxTokens: 64000,
 		} satisfies Model<"google-gemini-cli">,
 		"gemini-3-flash": {


### PR DESCRIPTION
## Summary

Anthropic moved the 1M context window to GA on **2026-03-13** for Claude Opus 4.6 and Sonnet 4.6. Two google-antigravity entries in `models.generated.ts` still have `contextWindow: 200000`.

## Changes

| Model | Provider | Before | After |
|-------|----------|--------|-------|
| claude-opus-4-6-thinking | google-antigravity | 200,000 | 1,000,000 |
| claude-sonnet-4-6 | google-antigravity | 200,000 | 1,000,000 |

All other Claude 4.6 entries (anthropic, bedrock, openrouter, vercel, opencode) already have the correct 1M value.

## Reference

- Anthropic 1M GA announcement: https://claude.com/blog/1m-context-ga
- Related OpenClaw PR: https://github.com/openclaw/openclaw/pull/46761