### PR TITLE
fix: improve google-gemini-cli performance and compatibility

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -113,6 +113,7 @@ export function getEnvApiKey(provider: any): string | undefined {
 		openai: "OPENAI_API_KEY",
 		"azure-openai-responses": "AZURE_OPENAI_API_KEY",
 		google: "GEMINI_API_KEY",
+		"google-gemini-cli": "GEMINI_API_KEY",
 		groq: "GROQ_API_KEY",
 		cerebras: "CEREBRAS_API_KEY",
 		xai: "XAI_API_KEY",

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -67,8 +67,8 @@ const ANTIGRAVITY_ENDPOINT_FALLBACKS = [
 ] as const;
 // Headers for Gemini CLI (prod endpoint)
 const GEMINI_CLI_HEADERS = {
-	"User-Agent": "google-cloud-sdk vscode_cloudshelleditor/0.1",
-	"X-Goog-Api-Client": "gl-node/22.17.0",
+	"User-Agent": "GeminiCLI/0.33.1",
+	"X-Goog-Api-Client": "gemini-cli",
 	"Client-Metadata": JSON.stringify({
 		ideType: "IDE_UNSPECIFIED",
 		platform: "PLATFORM_UNSPECIFIED",
@@ -267,7 +267,7 @@ interface CloudCodeAssistRequest {
 	model: string;
 	request: {
 		contents: Content[];
-		sessionId?: string;
+		session_id?: string;
 		systemInstruction?: { role?: string; parts: { text: string }[] };
 		generationConfig?: {
 			maxOutputTokens?: number;
@@ -892,7 +892,7 @@ export function buildRequest(
 		contents,
 	};
 
-	request.sessionId = options.sessionId;
+	request.session_id = options.sessionId;
 
 	// System instruction must be object with parts, not plain string
 	if (context.systemPrompt) {


### PR DESCRIPTION
This PR addresses performance issues and compatibility mismatches with the Google Gemini CLI provider.

### Changes
*   **Corrected Request Schema**: Changed `sessionId` to `session_id` in the `google-gemini-cli` provider. This is critical for the Cloud Code Assist API to correctly identify sessions and enable server-side context caching.
*   **Authentic Headers**: Updated `User-Agent` and `X-Goog-Api-Client` to match the official `gemini-cli`.
*   **API Key Resolution**: Added `google-gemini-cli` to the environment API key map, allowing it to pick up `GEMINI_API_KEY` if present.

Closes #2180