### PR TITLE
Fix Anthropic OAuth manual fallback redirect URI and refresh token scope

### DIFF
--- a/packages/ai/src/utils/oauth/anthropic.ts
+++ b/packages/ai/src/utils/oauth/anthropic.ts
@@ -27,7 +27,10 @@ const decode = (s: string) => atob(s);
 const CLIENT_ID = decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl");
 const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
 const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
-const MANUAL_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback";
+// Anthropic expects the token exchange redirect_uri to match the one used in
+// the original authorization request. Even in manual copy/paste fallback flows,
+// users still paste the final localhost callback URL.
+const MANUAL_REDIRECT_URI = "http://localhost:53692/callback";
 const CALLBACK_HOST = "127.0.0.1";
 const CALLBACK_PORT = 53692;
 const CALLBACK_PATH = "/callback";
@@ -368,7 +371,6 @@ export async function refreshAnthropicToken(refreshToken: string): Promise<OAuth
 			grant_type: "refresh_token",
 			client_id: CLIENT_ID,
 			refresh_token: refreshToken,
-			scope: SCOPES,
 		});
 	} catch (error) {
 		throw new Error(`Anthropic token refresh request failed. url=${TOKEN_URL}; details=${formatErrorDetails(error)}`);


### PR DESCRIPTION
## Summary
This fixes two Anthropic OAuth issues that can break Claude authentication in Pi:

1. Manual/paste fallback used the wrong `redirect_uri` during code exchange
2. Refresh token requests incorrectly included `scope`

## Problem

### 1) Invalid redirect URI during manual login fallback
When users authenticate with Anthropic and paste back the final redirect URL, Pi exchanged the authorization code using:

- `https://platform.claude.com/oauth/code/callback`

But the authorization request was created with the localhost callback:

- `http://localhost:53692/callback`

Anthropic validates that the token exchange uses the same `redirect_uri` as the original authorization request, which caused:

- `invalid_grant`
- `Invalid 'redirect_uri' in request`

### 2) Refresh requests sent invalid scope
The refresh flow sent `scope` with `grant_type=refresh_token`. Anthropic rejected that with:

- `invalid_scope`

This prevented expired Anthropic credentials from refreshing, which surfaced in Pi as:

- `No API key for anthropic/...`
- authentication failures after a previously successful login

## Fix

- Use the localhost callback URI for manual fallback token exchange as well
- Remove `scope` from Anthropic refresh token requests

## Impact

This restores:
- Claude Pro/Max login via Anthropic OAuth
- manual fallback login flow
- refresh of expired Anthropic OAuth credentials
