### PR TITLE
feat(coding-agent): add terminal command timeout

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -252,6 +252,36 @@ Use `/settings` to modify common options, or edit JSON files directly:
 
 See [docs/settings.md](docs/settings.md) for all options.
 
+### Terminal Command Timeout
+
+Configure timeout for bash commands to prevent hanging indefinitely:
+
+```json
+{
+  "terminal": {
+    "timeout": {
+      "default": 60,
+      "patterns": {
+        "npm install": 300,
+        "pip install": 300,
+        "git.*push": 600,
+        "cargo.*build": 600
+      }
+    }
+  }
+}
+```
+
+- `default`: Default timeout in seconds for all commands (0 = no timeout)
+- `patterns`: Per-regex-pattern timeout in seconds. Pattern matching happens before default, so order matters.
+
+Example patterns:
+- `"npm install"` - matches commands containing "npm install"
+- `"git.*push"` - matches "git push", "git push origin", etc.
+- `"cargo.*build"` - matches "cargo build", "cargo build --release", etc.
+
+Configure via `/settings` → "Terminal timeout" for the default timeout, or edit the JSON files directly for pattern-based timeouts.
+
 ---
 
 ## Context Files

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -108,8 +108,38 @@ When a provider requests a retry delay longer than `maxDelayMs` (e.g., Google's 
 |---------|------|---------|-------------|
 | `terminal.showImages` | boolean | `true` | Show images in terminal (if supported) |
 | `terminal.clearOnShrink` | boolean | `false` | Clear empty rows when content shrinks (can cause flicker) |
+| `terminal.timeout.default` | number | `0` | Default timeout in seconds for bash commands (0 = no timeout) |
+| `terminal.timeout.patterns` | object | `{}` | Per-regex-pattern timeout in seconds |
 | `images.autoResize` | boolean | `true` | Resize images to 2000x2000 max |
 | `images.blockImages` | boolean | `false` | Block all images from being sent to LLM |
+
+#### terminal.timeout
+
+Configure timeout for bash commands to prevent hanging indefinitely:
+
+```json
+{
+  "terminal": {
+    "timeout": {
+      "default": 60,
+      "patterns": {
+        "npm install": 300,
+        "pip install": 300,
+        "git.*push": 600,
+        "cargo.*build": 600
+      }
+    }
+  }
+}
+```
+
+- `default`: Default timeout in seconds for all commands (0 = no timeout). Configure via `/settings` → "Terminal timeout".
+- `patterns`: Per-regex-pattern timeout in seconds. Pattern matching happens before default, so order matters. Edit JSON files directly for pattern-based timeouts.
+
+Example patterns:
+- `"npm install"` - matches commands containing "npm install"
+- `"git.*push"` - matches "git push", "git push origin", etc.
+- `"cargo.*build"` - matches "cargo build", "cargo build --release", etc.
 
 ### Shell
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2231,11 +2231,17 @@ export class AgentSession {
 	}): void {
 		const autoResizeImages = this.settingsManager.getImageAutoResize();
 		const shellCommandPrefix = this.settingsManager.getShellCommandPrefix();
+		const defaultTimeout = this.settingsManager.getTerminalTimeoutDefault();
+		const patternTimeouts = this.settingsManager.getTerminalTimeoutPatterns();
 		const baseTools = this._baseToolsOverride
 			? this._baseToolsOverride
 			: createAllTools(this._cwd, {
 					read: { autoResizeImages },
-					bash: { commandPrefix: shellCommandPrefix },
+					bash: {
+						commandPrefix: shellCommandPrefix,
+						defaultTimeout,
+						patternTimeouts,
+					},
 				});
 
 		this._baseToolRegistry = new Map(Object.entries(baseTools).map(([name, tool]) => [name, tool as AgentTool]));

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -22,9 +22,15 @@ export interface RetrySettings {
 	maxDelayMs?: number; // default: 60000 (max server-requested delay before failing)
 }
 
+export interface TerminalTimeoutSettings {
+	default?: number; // Default timeout in seconds for all terminal commands (0 = no timeout)
+	patterns?: Record<string, number>; // Per-regex-pattern timeout in seconds (e.g., {"npm install": 300, "git push": 600})
+}
+
 export interface TerminalSettings {
 	showImages?: boolean; // default: true (only relevant if terminal supports images)
 	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
+	timeout?: TerminalTimeoutSettings; // Timeout configuration for terminal commands
 }
 
 export interface ImageSettings {
@@ -949,5 +955,85 @@ export class SettingsManager {
 
 	getCodeBlockIndent(): string {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
+	}
+
+	getTerminalTimeoutDefault(): number {
+		// Environment variable takes precedence over settings, which takes precedence over default 0
+		const envTimeout = process.env.PI_TERMINAL_TIMEOUT_DEFAULT;
+		if (envTimeout !== undefined && envTimeout !== "") {
+			const parsed = parseInt(envTimeout, 10);
+			if (!isNaN(parsed)) {
+				return parsed;
+			}
+		}
+		return this.settings.terminal?.timeout?.default ?? 0; // 0 = no timeout
+	}
+
+	getTerminalTimeoutPatterns(): Record<string, number> {
+		return this.settings.terminal?.timeout?.patterns ?? {};
+	}
+
+	getTerminalTimeoutForCommand(command: string): number {
+		const defaultTimeout = this.getTerminalTimeoutDefault();
+		const patterns = this.getTerminalTimeoutPatterns();
+
+		// Check pattern-based timeouts first
+		for (const [pattern, timeout] of Object.entries(patterns)) {
+			const regex = new RegExp(pattern);
+			if (regex.test(command)) {
+				return timeout;
+			}
+		}
+
+		// Fall back to default timeout
+		return defaultTimeout;
+	}
+
+	setTerminalTimeoutDefault(timeout: number): void {
+		if (!this.globalSettings.terminal) {
+			this.globalSettings.terminal = {};
+		}
+		if (!this.globalSettings.terminal.timeout) {
+			this.globalSettings.terminal.timeout = {};
+		}
+		this.globalSettings.terminal.timeout.default = timeout;
+		this.markModified("terminal", "timeout.default");
+		this.save();
+	}
+
+	setTerminalTimeoutPatterns(patterns: Record<string, number>): void {
+		if (!this.globalSettings.terminal) {
+			this.globalSettings.terminal = {};
+		}
+		if (!this.globalSettings.terminal.timeout) {
+			this.globalSettings.terminal.timeout = {};
+		}
+		this.globalSettings.terminal.timeout.patterns = { ...patterns };
+		this.markModified("terminal", "timeout.patterns");
+		this.save();
+	}
+
+	addTerminalTimeoutPattern(pattern: string, timeout: number): void {
+		if (!this.globalSettings.terminal) {
+			this.globalSettings.terminal = {};
+		}
+		if (!this.globalSettings.terminal.timeout) {
+			this.globalSettings.terminal.timeout = {};
+		}
+		if (!this.globalSettings.terminal.timeout.patterns) {
+			this.globalSettings.terminal.timeout.patterns = {};
+		}
+		this.globalSettings.terminal.timeout.patterns[pattern] = timeout;
+		this.markModified("terminal", "timeout.patterns");
+		this.save();
+	}
+
+	removeTerminalTimeoutPattern(pattern: string): void {
+		if (!this.globalSettings.terminal?.timeout?.patterns) {
+			return;
+		}
+		delete this.globalSettings.terminal.timeout.patterns[pattern];
+		this.markModified("terminal", "timeout.patterns");
+		this.save();
 	}
 }

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -161,12 +161,18 @@ export interface BashToolOptions {
 	commandPrefix?: string;
 	/** Hook to adjust command, cwd, or env before execution */
 	spawnHook?: BashSpawnHook;
+	/** Default timeout in seconds (0 = no timeout) */
+	defaultTimeout?: number;
+	/** Per-pattern timeout configuration (regex pattern -> timeout in seconds) */
+	patternTimeouts?: Record<string, number>;
 }
 
 export function createBashTool(cwd: string, options?: BashToolOptions): AgentTool<typeof bashSchema> {
 	const ops = options?.operations ?? defaultBashOperations;
 	const commandPrefix = options?.commandPrefix;
 	const spawnHook = options?.spawnHook;
+	const defaultTimeout = options?.defaultTimeout ?? 0;
+	const patternTimeouts = options?.patternTimeouts ?? {};
 
 	return {
 		name: "bash",
@@ -182,6 +188,27 @@ export function createBashTool(cwd: string, options?: BashToolOptions): AgentToo
 			// Apply command prefix if configured (e.g., "shopt -s expand_aliases" for alias support)
 			const resolvedCommand = commandPrefix ? `${commandPrefix}\n${command}` : command;
 			const spawnContext = resolveSpawnContext(resolvedCommand, cwd, spawnHook);
+
+			// Determine effective timeout: explicit > pattern-based > default
+			let effectiveTimeout: number | undefined;
+			if (timeout !== undefined && timeout > 0) {
+				// Explicit timeout from tool call takes precedence
+				effectiveTimeout = timeout;
+			} else if (defaultTimeout > 0 || Object.keys(patternTimeouts).length > 0) {
+				// Apply configured timeouts
+				// Check pattern-based timeouts first
+				for (const [pattern, patternTimeout] of Object.entries(patternTimeouts)) {
+					const regex = new RegExp(pattern);
+					if (regex.test(resolvedCommand)) {
+						effectiveTimeout = patternTimeout;
+						break;
+					}
+				}
+				// Fall back to default timeout if no pattern matched
+				if (effectiveTimeout === undefined && defaultTimeout > 0) {
+					effectiveTimeout = defaultTimeout;
+				}
+			}
 
 			return new Promise((resolve, reject) => {
 				// We'll stream to a temp file if output gets large
@@ -241,7 +268,7 @@ export function createBashTool(cwd: string, options?: BashToolOptions): AgentToo
 				ops.exec(spawnContext.command, spawnContext.cwd, {
 					onData: handleData,
 					signal,
-					timeout,
+					timeout: effectiveTimeout,
 					env: spawnContext.env,
 				})
 					.then(({ exitCode }) => {

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -50,6 +50,8 @@ export interface SettingsConfig {
 	autocompleteMaxVisible: number;
 	quietStartup: boolean;
 	clearOnShrink: boolean;
+	terminalTimeoutDefault: number;
+	terminalTimeoutPatterns: Record<string, number>;
 }
 
 export interface SettingsCallbacks {
@@ -73,6 +75,8 @@ export interface SettingsCallbacks {
 	onAutocompleteMaxVisibleChange: (maxVisible: number) => void;
 	onQuietStartupChange: (enabled: boolean) => void;
 	onClearOnShrinkChange: (enabled: boolean) => void;
+	onTerminalTimeoutDefaultChange: (timeout: number) => void;
+	onTerminalTimeoutPatternsChange: (patterns: Record<string, number>) => void;
 	onCancel: () => void;
 }
 
@@ -354,6 +358,53 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
+		// Terminal timeout settings (insert after clear-on-shrink)
+		const clearOnShrinkIndex = items.findIndex((item) => item.id === "clear-on-shrink");
+		items.splice(clearOnShrinkIndex + 1, 0, {
+			id: "terminal-timeout",
+			label: "Terminal timeout",
+			description: "Configure timeout for bash commands",
+			currentValue: String(config.terminalTimeoutDefault) + "s",
+			submenu: (currentValue, done) =>
+				new SelectSubmenu(
+					"Terminal Timeout",
+					"Set default timeout in seconds (0 = no timeout). Pattern-based timeouts are configured separately.",
+					[
+						{
+							value: "0",
+							label: "No timeout",
+							description: "Commands run indefinitely",
+						},
+						{
+							value: "30",
+							label: "30 seconds",
+							description: "Short timeout for quick commands",
+						},
+						{
+							value: "60",
+							label: "60 seconds",
+							description: "Standard timeout",
+						},
+						{
+							value: "120",
+							label: "120 seconds",
+							description: "Long timeout",
+						},
+						{
+							value: "300",
+							label: "300 seconds",
+							description: "Very long timeout",
+						},
+					],
+					currentValue,
+					(value) => {
+						callbacks.onTerminalTimeoutDefaultChange(parseInt(value, 10));
+						done(value);
+					},
+					() => done(),
+				),
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -415,6 +466,10 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "clear-on-shrink":
 						callbacks.onClearOnShrinkChange(newValue === "true");
+						break;
+					case "terminal-timeout":
+						// Handle timeout value selection (e.g., "0", "30", "60")
+						callbacks.onTerminalTimeoutDefaultChange(parseInt(newValue, 10));
 						break;
 				}
 			},

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3111,6 +3111,8 @@ export class InteractiveMode {
 					autocompleteMaxVisible: this.settingsManager.getAutocompleteMaxVisible(),
 					quietStartup: this.settingsManager.getQuietStartup(),
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
+					terminalTimeoutDefault: this.settingsManager.getTerminalTimeoutDefault(),
+					terminalTimeoutPatterns: this.settingsManager.getTerminalTimeoutPatterns(),
 				},
 				{
 					onAutoCompactChange: (enabled) => {
@@ -3209,6 +3211,12 @@ export class InteractiveMode {
 					onClearOnShrinkChange: (enabled) => {
 						this.settingsManager.setClearOnShrink(enabled);
 						this.ui.setClearOnShrink(enabled);
+					},
+					onTerminalTimeoutDefaultChange: (timeout) => {
+						this.settingsManager.setTerminalTimeoutDefault(timeout);
+					},
+					onTerminalTimeoutPatternsChange: (patterns) => {
+						this.settingsManager.setTerminalTimeoutPatterns(patterns);
 					},
 					onCancel: () => {
 						done();


### PR DESCRIPTION
Adds a configurable timeout for terminal commands, so that Pi can handle execution failure cases.

Assistant-contribution: 100%.  
Assistant-model: Qwen3.5-35B-A3B