### PR TITLE
fix(ai): add optional chaining for model.input in convertMessages

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -539,7 +539,7 @@ export function convertMessages(
 						} satisfies ChatCompletionContentPartImage;
 					}
 				});
-				const filteredContent = !model.input.includes("image")
+				const filteredContent = !model.input?.includes("image")
 					? content.filter((c) => c.type !== "image_url")
 					: content;
 				if (filteredContent.length === 0) continue;
@@ -657,7 +657,7 @@ export function convertMessages(
 				}
 				params.push(toolResultMsg);
 
-				if (hasImages && model.input.includes("image")) {
+				if (hasImages && model.input?.includes("image")) {
 					for (const block of toolMsg.content) {
 						if (block.type === "image") {
 							imageBlocks.push({


### PR DESCRIPTION
## Summary
Add optional chaining (`?.`) for `model.input` to prevent null reference errors when `model.input` is undefined.

## Changes
- `packages/ai/src/providers/openai-completions.ts`: Added optional chaining in two places where `model.input` is accessed

## Risk
- Low: Simple null-safety fix, no behavioral changes

## Testing
- Syntax check passed