### PR TITLE
fix: add optional chaining for model.input in convertMessages

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -527,7 +527,7 @@ export function convertMessages(
 						} satisfies ChatCompletionContentPartImage;
 					}
 				});
-				const filteredContent = !model.input.includes("image")
+				const filteredContent = !model.input?.includes("image")
 					? content.filter((c) => c.type !== "image_url")
 					: content;
 				if (filteredContent.length === 0) continue;
@@ -642,7 +642,7 @@ export function convertMessages(
 				}
 				params.push(toolResultMsg);
 
-				if (hasImages && model.input.includes("image")) {
+				if (hasImages && model.input?.includes("image")) {
 					for (const block of toolMsg.content) {
 						if (block.type === "image") {
 							imageBlocks.push({


### PR DESCRIPTION
## Summary

Fixes crash when using custom OpenAI-compatible providers without an `input` field on the model object. `convertMessages()` was calling `model.input.includes()` without null-checking.

## Changes

Added optional chaining (`model.input?.includes()`) at two locations in `packages/ai/src/providers/openai-completions.ts`:
- Line 542: filteredContent check  
- Line 660: hasImages check

## Risk

- Low: defensive null check, no behavioral change for existing code
- Only affects code paths for custom OpenAI-compatible providers

## Testing

- `pnpm test` passes

## Rollback

Revert commit a2e37231