### PR TITLE
fix(coding-agent): drain extension event queue before checking follow-ups

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -221,6 +221,8 @@ export class AgentSession {
 	private _unsubscribeAgent?: () => void;
 	private _eventListeners: AgentSessionEventListener[] = [];
 	private _agentEventQueue: Promise<void> = Promise.resolve();
+	/** True when inside the prompt drain loop, so sendCustomMessage can use followUp */
+	private _isInPromptDrainLoop = false;
 
 	/** Tracks pending steering messages for UI display. Removed when delivered. */
 	private _steeringMessages: string[] = [];
@@ -940,7 +942,35 @@ export class AgentSession {
 			}
 		}
 
-		await this.agent.prompt(messages);
+		// Set drain flag BEFORE agent.prompt() so extension handlers that fire
+		// during the turn (via _agentEventQueue microtasks) use followUp() instead of
+		// starting fire-and-forget prompt() calls. Must be set here (after command
+		// handling) because command handlers need _isInPromptDrainLoop=false.
+		this._isInPromptDrainLoop = true;
+		try {
+			await this.agent.prompt(messages);
+			// Drain extension event handlers queued via _agentEventQueue.
+			await this._agentEventQueue;
+			// If handlers enqueued follow-up messages, continue the agent loop.
+			// Cap iterations to prevent infinite loops from extensions that
+			// unconditionally re-enqueue on every agent_end.
+			let drainCount = 0;
+			while (this.agent.hasQueuedMessages() && drainCount++ < 50) {
+				// Respect abort: don't start a new turn if the user cancelled.
+				const lastMsg = this.agent.state.messages[this.agent.state.messages.length - 1];
+				if (
+					lastMsg?.role === "assistant" &&
+					((lastMsg as AssistantMessage).stopReason === "aborted" ||
+						(lastMsg as AssistantMessage).stopReason === "error")
+				) {
+					break;
+				}
+				await this.agent.continue();
+				await this._agentEventQueue;
+			}
+		} finally {
+			this._isInPromptDrainLoop = false;
+		}
 		await this.waitForRetry();
 	}
 
@@ -1128,7 +1158,35 @@ export class AgentSession {
 				this.agent.steer(appMessage);
 			}
 		} else if (options?.triggerTurn) {
-			await this.agent.prompt(appMessage);
+			if (this._isInPromptDrainLoop) {
+				// Inside the prompt drain loop — queue as follow-up.
+				// The drain loop will pick it up via agent.continue().
+				this.agent.followUp(appMessage);
+			} else {
+				// Outside a turn (e.g., from a command handler or cold start).
+				// Start a new turn with its own drain loop.
+				this._isInPromptDrainLoop = true;
+				try {
+					await this.agent.prompt(appMessage);
+					await this._agentEventQueue;
+					let drainCount = 0;
+					while (this.agent.hasQueuedMessages() && drainCount++ < 50) {
+						const lastMsg = this.agent.state.messages[this.agent.state.messages.length - 1];
+						if (
+							lastMsg?.role === "assistant" &&
+							((lastMsg as AssistantMessage).stopReason === "aborted" ||
+								(lastMsg as AssistantMessage).stopReason === "error")
+						) {
+							break;
+						}
+						await this.agent.continue();
+						await this._agentEventQueue;
+					}
+				} finally {
+					this._isInPromptDrainLoop = false;
+				}
+				await this.waitForRetry();
+			}
 		} else {
 			this.agent.appendMessage(appMessage);
 			this.sessionManager.appendCustomMessageEntry(


### PR DESCRIPTION
## Bug

Extension handlers that queue follow-up messages (via `sendCustomMessage` with `deliverAs:'followUp'`, `triggerTurn:true`) during `turn_end`/`agent_end` fire asynchronously in `_agentEventQueue`. But `runLoop()` in `agent-loop.ts` calls `getFollowUpMessages()` **before** those handlers complete — finding nothing queued. The follow-up message is silently lost.

## Root Cause

`_agentEventQueue` is a Promise chain (`this._agentEventQueue = this._agentEventQueue.then(...)`). Extension handlers are enqueued as microtasks. The drain loop in `prompt()` awaits `agent.prompt()` which resolves when agentLoop's EventStream ends — but the extension handlers enqueued via `_handleAgentEvent` haven't fired yet because they're downstream microtasks.

## Fix

Add a `_isInPromptDrainLoop` flag that distinguishes between in-turn extension handlers (which should use `agent.followUp()` so the drain loop picks them up) and cold-start/command handlers (which need their own `agent.prompt()` + drain loop). The flag is set **before** `agent.prompt()` (because microtasks resolve during the await) but **after** command handling (because `/loop` etc. need the cold-start path).

**Dual-path `triggerTurn` logic:**
- When `_isInPromptDrainLoop` is `true`: `sendCustomMessage` uses `agent.followUp()` — the running drain loop picks it up via `getFollowUpMessages()`.
- When `false` (cold start/command): starts its own `agent.prompt()` + drain loop.

**Safety guard:** iteration cap (50) prevents infinite loops from extensions that unconditionally re-enqueue on every `agent_end`.

## Testing

- 7 regression test assertions pass in print mode
- Counting-test-loop end-to-end verified: loop 1→10, follow-up 'add all numbers' queued → drained → model returned 55

See commit 615d9893 for full implementation details.