### PR TITLE
fix: add optional chaining for model.input in convertMessages

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -539,7 +539,7 @@ export function convertMessages(
 						} satisfies ChatCompletionContentPartImage;
 					}
 				});
-				const filteredContent = !model.input.includes("image")
+				const filteredContent = !model.input?.includes("image")
 					? content.filter((c) => c.type !== "image_url")
 					: content;
 				if (filteredContent.length === 0) continue;
@@ -657,7 +657,7 @@ export function convertMessages(
 				}
 				params.push(toolResultMsg);
 
-				if (hasImages && model.input.includes("image")) {
+				if (hasImages && model.input?.includes("image")) {
 					for (const block of toolMsg.content) {
 						if (block.type === "image") {
 							imageBlocks.push({


### PR DESCRIPTION
## Description

Some OpenAI-compatible providers don't include the `input` field in the model object, causing runtime errors when calling `model.input.includes()`.

## Changes

- `packages/ai/src/providers/openai-completions.ts`: Added optional chaining (`model.input?.includes()`) at lines 542 and 660 to safely handle undefined `model.input`.

## Testing

Defensive null check - no behavior change. Existing tests should pass.

## Risk

Low - only adds optional chaining, no breaking changes.

## Rollback

Simply revert this commit.