### PR TITLE
fix(coding-agent): prevent OAuth URL shell injection

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -1,9 +1,9 @@
 import { getOAuthProviders } from "@mariozechner/pi-ai/oauth";
 import { Container, type Focusable, getEditorKeybindings, Input, Spacer, Text, type TUI } from "@mariozechner/pi-tui";
-import { exec } from "child_process";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
+import { openExternalUrl } from "./open-url.js";
 
 /**
  * Login dialog component - replaces editor during OAuth login flow
@@ -96,8 +96,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		}
 
 		// Try to open browser
-		const openCmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-		exec(`${openCmd} "${url}"`);
+		openExternalUrl(url);
 
 		this.tui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/interactive/components/open-url.ts
+++ b/packages/coding-agent/src/modes/interactive/components/open-url.ts
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+
+export interface OpenUrlCommand {
+	command: string;
+	args: string[];
+}
+
+type Platform = NodeJS.Platform;
+type SpawnFn = typeof spawn;
+
+export function getOpenUrlCommand(url: string, platform: Platform = process.platform): OpenUrlCommand {
+	if (platform === "darwin") {
+		return { command: "open", args: [url] };
+	}
+
+	if (platform === "win32") {
+		// Use rundll32 directly to avoid shell parsing on Windows.
+		return { command: "rundll32", args: ["url.dll,FileProtocolHandler", url] };
+	}
+
+	return { command: "xdg-open", args: [url] };
+}
+
+export function openExternalUrl(url: string, platform: Platform = process.platform, spawnFn: SpawnFn = spawn): void {
+	const { command, args } = getOpenUrlCommand(url, platform);
+
+	const child = spawnFn(command, args, {
+		shell: false,
+		detached: true,
+		stdio: "ignore",
+		windowsHide: true,
+	});
+
+	// Best-effort browser launch: surface URL in UI regardless of opener availability.
+	child.on("error", () => {});
+	child.unref();
+}

--- a/packages/coding-agent/test/open-url.test.ts
+++ b/packages/coding-agent/test/open-url.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test, vi } from "vitest";
+import { getOpenUrlCommand, openExternalUrl } from "../src/modes/interactive/components/open-url.js";
+
+describe("getOpenUrlCommand", () => {
+	test("returns macOS open command", () => {
+		expect(getOpenUrlCommand("https://example.com", "darwin")).toEqual({
+			command: "open",
+			args: ["https://example.com"],
+		});
+	});
+
+	test("returns Windows rundll32 command", () => {
+		expect(getOpenUrlCommand("https://example.com", "win32")).toEqual({
+			command: "rundll32",
+			args: ["url.dll,FileProtocolHandler", "https://example.com"],
+		});
+	});
+
+	test("returns xdg-open command for Linux", () => {
+		expect(getOpenUrlCommand("https://example.com", "linux")).toEqual({
+			command: "xdg-open",
+			args: ["https://example.com"],
+		});
+	});
+});
+
+describe("openExternalUrl", () => {
+	test("spawns detached process without shell parsing", () => {
+		const child = {
+			on: vi.fn().mockReturnThis(),
+			unref: vi.fn(),
+		};
+		const spawnFn = vi.fn().mockReturnValue(child) as NonNullable<Parameters<typeof openExternalUrl>[2]>;
+
+		openExternalUrl("https://example.com", "linux", spawnFn);
+
+		expect(spawnFn).toHaveBeenCalledTimes(1);
+		expect(spawnFn).toHaveBeenCalledWith("xdg-open", ["https://example.com"], {
+			shell: false,
+			detached: true,
+			stdio: "ignore",
+			windowsHide: true,
+		});
+		expect(child.on).toHaveBeenCalledWith("error", expect.any(Function));
+		expect(child.unref).toHaveBeenCalledTimes(1);
+	});
+
+	test("keeps malicious payload as a single argument", () => {
+		const child = {
+			on: vi.fn().mockReturnThis(),
+			unref: vi.fn(),
+		};
+		const spawnFn = vi.fn().mockReturnValue(child) as NonNullable<Parameters<typeof openExternalUrl>[2]>;
+		const maliciousUrl = 'https://example.com/callback?next=";touch /tmp/pwned;echo "';
+
+		openExternalUrl(maliciousUrl, "linux", spawnFn);
+
+		expect(spawnFn).toHaveBeenCalledTimes(1);
+		expect(spawnFn).toHaveBeenCalledWith("xdg-open", [maliciousUrl], expect.any(Object));
+	});
+});


### PR DESCRIPTION
## What this fixes

This patch removes shell-string execution from the OAuth browser-open path in `coding-agent`.

Previously, login dialog used:

- `exec(`${openCmd} "${url}"`)`

That treats URL content as part of a shell command string, which creates command-injection risk if a URL contains shell metacharacters.

## Changes

- Added a dedicated opener helper:
  - `packages/coding-agent/src/modes/interactive/components/open-url.ts`
- Switched login dialog to use the helper:
  - `packages/coding-agent/src/modes/interactive/components/login-dialog.ts`
- Added regression tests:
  - `packages/coding-agent/test/open-url.test.ts`

Implementation details:

- Uses `spawn(command, args, { shell: false, detached: true, stdio: "ignore" })`
- Platform mapping:
  - macOS: `open`
  - Linux: `xdg-open`
  - Windows: `rundll32 url.dll,FileProtocolHandler`

## Why this is safe

- URL is passed as a single argument, not concatenated into shell source
- Keeps existing UX behavior (URL remains visible in terminal for manual copy)

## Tests

Ran:

```bash
npx vitest --run test/open-url.test.ts
```

Result:

- `1 passed`
- `5 tests passed`

Covers:

1. command mapping by OS
2. `shell: false` enforcement
3. malicious payload stays a single argument

## Related

- Closes #2227
