### PR TITLE
Adds OSC133_ZONE_FINAL character to resolve ⌘K bug in iterm2

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/user-message.ts
@@ -3,6 +3,7 @@ import { getMarkdownTheme, theme } from "../theme/theme.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
+const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
 /**
  * Component that renders a user message
@@ -26,7 +27,7 @@ export class UserMessageComponent extends Container {
 		}
 
 		lines[0] = OSC133_ZONE_START + lines[0];
-		lines[lines.length - 1] = lines[lines.length - 1] + OSC133_ZONE_END;
+		lines[lines.length - 1] = lines[lines.length - 1] + OSC133_ZONE_END + OSC133_ZONE_FINAL;
 		return lines;
 	}
 }


### PR DESCRIPTION
To reproduce my bug, run `pi` in iterm2 (3.3.6 or beta). type any prompt, then immediately cancel and exit. Then press ⌘K

Expected: Terminal session clears entirely.
Actual: Only part of the terminal session is reset.

I submitted a bug report to iTerm2, but I already strongly suspected that it was pi related. George helped me verify that `OSC 133; C ST` was missing. I found the other `OSC 133` sequences, and added this one - and voila, problem solved. https://gitlab.com/gnachman/iterm2/-/work_items/12764

```
./tests.sh

ℹ tests 488
ℹ suites 94
ℹ pass 488
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1055.662
```

```
npm run check
Checked 500 files in 515ms. No fixes applied.
Checked 73 files in 48ms. No fixes applied.
Checked 3 files in 7ms. No fixes applied.
```

HTH! 