### PR TITLE
fix(coding-agent): sendUserMessage skips slash command dispatch

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -867,7 +867,9 @@ export class AgentSession {
 
 		// Handle extension commands first (execute immediately, even during streaming)
 		// Extension commands manage their own LLM interaction via pi.sendMessage()
-		if (expandPromptTemplates && text.startsWith("/")) {
+		// Note: This check runs regardless of expandPromptTemplates so that sendUserMessage()
+		// can properly dispatch slash commands to registered extension handlers.
+		if (text.startsWith("/")) {
 			const handled = await this._tryExecuteExtensionCommand(text);
 			if (handled) {
 				// Extension command executed, no prompt to send


### PR DESCRIPTION
Fixes #2023

The shipped `reload-runtime` extension example was broken because `sendUserMessage` skips slash command dispatch.

## Root Cause

The `sendUserMessage` function passes `expandPromptTemplates: false` to `prompt()`, which caused the extension command check to be skipped because it was gated behind the `expandPromptTemplates` flag:

```typescript
if (expandPromptTemplates && text.startsWith("/")) {
    const handled = await this._tryExecuteExtensionCommand(text);
    ...
}
```

This prevented the reload-runtime extension (and any other extensions using `sendUserMessage` with slash commands) from properly dispatching to registered extension handlers.

## Fix

Remove the `expandPromptTemplates` check from the extension command dispatch condition, allowing slash commands sent via `sendUserMessage` to be properly routed to registered extension handlers. The template/skill expansion is still controlled by `expandPromptTemplates` downstream.

## Testing

- All 476 existing tests pass
- The reload-runtime extension example now works correctly when the tool queues a `/reload-runtime` follow-up command
