### PR TITLE
feat(ai): capture responseId from provider API responses

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -248,6 +248,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 
 			for await (const event of anthropicStream) {
 				if (event.type === "message_start") {
+					output.responseId = event.message.id;
 					// Capture initial token usage from message_start event
 					// This ensures we have input token counts even if the stream is aborted early
 					output.usage.input = event.message.usage.input_tokens || 0;

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -704,6 +704,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 									},
 								};
 								calculateCost(model, output.usage);
+								if (responseData.responseId) output.responseId = responseData.responseId;
 							}
 						}
 					}

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -285,6 +285,7 @@ async function consumeChatStream(
 
 	for await (const event of mistralStream) {
 		const chunk = event.data;
+		if (!output.responseId && chunk.id) output.responseId = chunk.id;
 
 		if (chunk.usage) {
 			output.usage.input = chunk.usage.promptTokens || 0;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -127,6 +127,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			};
 
 			for await (const chunk of openaiStream) {
+				if (!output.responseId && chunk.id) output.responseId = chunk.id;
 				if (chunk.usage) {
 					output.usage = parseChunkUsage(chunk.usage, model);
 				}

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -442,6 +442,7 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.completed") {
 			const response = event.response;
+			if (response?.id) output.responseId = response.id;
 			if (response?.usage) {
 				const cachedTokens = response.usage.input_tokens_details?.cached_tokens || 0;
 				output.usage = {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -193,6 +193,7 @@ export interface AssistantMessage {
 	api: Api;
 	provider: Provider;
 	model: string;
+	responseId?: string;
 	usage: Usage;
 	stopReason: StopReason;
 	errorMessage?: string;


### PR DESCRIPTION
## Summary
- Adds optional `responseId` field to `AssistantMessage` interface
- Populates it from each provider's native response ID:
  - **Anthropic**: `event.message.id` from `message_start`
  - **OpenAI Responses**: `response.id` from `response.completed`
  - **OpenAI Completions**: `chunk.id` from first stream chunk
  - **Mistral**: `chunk.id` from first stream chunk
  - **Google Gemini CLI**: `responseData.responseId`
- Enables downstream consumers (e.g. OTel instrumentation) to set `gen_ai.response.id` span attributes for trace correlation

## Test plan
- [ ] Verify Anthropic streaming populates `responseId` on `AssistantMessage`
- [ ] Verify OpenAI Responses streaming populates `responseId`
- [ ] Verify OpenAI Completions streaming populates `responseId`
- [ ] Confirm no regression on providers without response IDs (Bedrock, Google Vertex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)