### PR TITLE
mom: reply in mention threads

### DIFF
--- a/packages/mom/package.json
+++ b/packages/mom/package.json
@@ -16,6 +16,7 @@
 		"clean": "shx rm -rf dist",
 		"build": "tsgo -p tsconfig.build.json && shx chmod +x dist/main.js",
 		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
+		"test": "node --test --import tsx test/*.test.ts",
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {

--- a/packages/mom/src/main.ts
+++ b/packages/mom/src/main.ts
@@ -5,6 +5,7 @@ import { type AgentRunner, getOrCreateRunner } from "./agent.js";
 import { downloadChannel } from "./download.js";
 import { createEventsWatcher } from "./events.js";
 import * as log from "./log.js";
+import { getThreadParentTs } from "./reply-mode.js";
 import { parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
 import { type MomHandler, type SlackBot, SlackBot as SlackBotClass, type SlackEvent } from "./slack.js";
 import { ChannelStore } from "./store.js";
@@ -118,6 +119,7 @@ function createSlackContext(event: SlackEvent, slack: SlackBot, state: ChannelSt
 	let isWorking = true;
 	const workingIndicator = " ...";
 	let updatePromise = Promise.resolve();
+	const threadParentTs = getThreadParentTs(event, isEvent);
 
 	const user = slack.getUser(event.user);
 
@@ -157,7 +159,9 @@ function createSlackContext(event: SlackEvent, slack: SlackBot, state: ChannelSt
 					if (messageTs) {
 						await slack.updateMessage(event.channel, messageTs, displayText);
 					} else {
-						messageTs = await slack.postMessage(event.channel, displayText);
+						messageTs = threadParentTs
+							? await slack.postInThread(event.channel, threadParentTs, displayText)
+							: await slack.postMessage(event.channel, displayText);
 					}
 
 					if (shouldLog && messageTs) {
@@ -187,7 +191,9 @@ function createSlackContext(event: SlackEvent, slack: SlackBot, state: ChannelSt
 					if (messageTs) {
 						await slack.updateMessage(event.channel, messageTs, displayText);
 					} else {
-						messageTs = await slack.postMessage(event.channel, displayText);
+						messageTs = threadParentTs
+							? await slack.postInThread(event.channel, threadParentTs, displayText)
+							: await slack.postMessage(event.channel, displayText);
 					}
 				} catch (err) {
 					log.logWarning("Slack replaceMessage error", err instanceof Error ? err.message : String(err));
@@ -199,7 +205,8 @@ function createSlackContext(event: SlackEvent, slack: SlackBot, state: ChannelSt
 		respondInThread: async (text: string) => {
 			updatePromise = updatePromise.then(async () => {
 				try {
-					if (messageTs) {
+					const threadAnchor = threadParentTs || messageTs;
+					if (threadAnchor) {
 						// Truncate thread messages if too long (20K limit for safety)
 						const MAX_THREAD_LENGTH = 20000;
 						let threadText = text;
@@ -207,7 +214,7 @@ function createSlackContext(event: SlackEvent, slack: SlackBot, state: ChannelSt
 							threadText = `${threadText.substring(0, MAX_THREAD_LENGTH - 50)}\n\n_(truncated)_`;
 						}
 
-						const ts = await slack.postInThread(event.channel, messageTs, threadText);
+						const ts = await slack.postInThread(event.channel, threadAnchor, threadText);
 						threadMessageTs.push(ts);
 					}
 				} catch (err) {
@@ -223,7 +230,9 @@ function createSlackContext(event: SlackEvent, slack: SlackBot, state: ChannelSt
 					try {
 						if (!messageTs) {
 							accumulatedText = eventFilename ? `_Starting event: ${eventFilename}_` : "_Thinking_";
-							messageTs = await slack.postMessage(event.channel, accumulatedText + workingIndicator);
+							messageTs = threadParentTs
+								? await slack.postInThread(event.channel, threadParentTs, accumulatedText + workingIndicator)
+								: await slack.postMessage(event.channel, accumulatedText + workingIndicator);
 						}
 					} catch (err) {
 						log.logWarning("Slack setTyping error", err instanceof Error ? err.message : String(err));

--- a/packages/mom/src/reply-mode.ts
+++ b/packages/mom/src/reply-mode.ts
@@ -1,0 +1,5 @@
+import type { SlackEvent } from "./slack.js";
+
+export function getThreadParentTs(event: Pick<SlackEvent, "type" | "ts">, isEvent?: boolean): string | null {
+	return event.type === "mention" && !isEvent ? event.ts : null;
+}

--- a/packages/mom/test/reply-mode.test.ts
+++ b/packages/mom/test/reply-mode.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getThreadParentTs } from "../src/reply-mode.js";
+
+test("replies in thread for channel mentions", () => {
+	assert.equal(getThreadParentTs({ type: "mention", ts: "123.456" }), "123.456");
+});
+
+test("does not thread event-triggered runs", () => {
+	assert.equal(getThreadParentTs({ type: "mention", ts: "123.456" }, true), null);
+});
+
+test("does not thread direct messages", () => {
+	assert.equal(getThreadParentTs({ type: "dm", ts: "123.456" }), null);
+});


### PR DESCRIPTION
Closes #2246

## Summary

- reply under the original Slack mention instead of creating a new top-level bot message first
- keep DMs on the existing top-level behavior
- keep event-triggered runs on the existing top-level behavior
- add a small helper and test coverage for the reply-mode decision

## Why

`mom` currently starts channel mention responses with `postMessage(...)`, which detaches the conversation from the user's original message. This change keeps channel replies anchored to the mention thread while preserving the current behavior for DMs and events.

## Validation

- `npm test -w packages/mom`
- `npm run build`