### PR TITLE
fix(ai): sanitize tool schemas for OpenAPI when using Cloud Code Assist with Claude

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -233,6 +233,9 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
  * anyOf, oneOf, const, etc.). Set `useParameters` to true to use the legacy `parameters`
  * field instead (OpenAPI 3.03 Schema). This is needed for Cloud Code Assist with Claude
  * models, where the API translates `parameters` into Anthropic's `input_schema`.
+ *
+ * When `useParameters` is true, schemas are sanitized to remove JSON Schema features
+ * unsupported by OpenAPI 3.03 (const, patternProperties, anyOf with const values).
  */
 export function convertTools(
 	tools: Tool[],
@@ -244,10 +247,67 @@ export function convertTools(
 			functionDeclarations: tools.map((tool) => ({
 				name: tool.name,
 				description: tool.description,
-				...(useParameters ? { parameters: tool.parameters } : { parametersJsonSchema: tool.parameters }),
+				...(useParameters
+					? { parameters: sanitizeSchemaForOpenApi(tool.parameters) }
+					: { parametersJsonSchema: tool.parameters }),
 			})),
 		},
 	];
+}
+
+/**
+ * Recursively sanitize a JSON Schema object for OpenAPI 3.03 compatibility.
+ *
+ * Converts JSON Schema constructs that are unsupported by Google's Cloud Code Assist
+ * `parameters` field:
+ * - `anyOf` / `oneOf` with `{const: value}` entries → `enum` array
+ * - standalone `const` → `enum` with single value
+ * - `patternProperties` → stripped (no OpenAPI equivalent)
+ */
+function sanitizeSchemaForOpenApi(schema: unknown): unknown {
+	if (schema === null || schema === undefined || typeof schema !== "object") {
+		return schema;
+	}
+
+	if (Array.isArray(schema)) {
+		return schema.map(sanitizeSchemaForOpenApi);
+	}
+
+	const obj = schema as Record<string, unknown>;
+	const result: Record<string, unknown> = {};
+
+	for (const [key, value] of Object.entries(obj)) {
+		// Strip patternProperties — no OpenAPI equivalent
+		if (key === "patternProperties") {
+			continue;
+		}
+
+		// Convert anyOf/oneOf with const entries to enum
+		if ((key === "anyOf" || key === "oneOf") && Array.isArray(value)) {
+			const constValues = value
+				.filter(
+					(item): item is Record<string, unknown> => typeof item === "object" && item !== null && "const" in item,
+				)
+				.map((item) => item.const);
+
+			if (constValues.length === value.length && constValues.length > 0) {
+				// biome-ignore lint/complexity/useLiteralKeys: "enum" is a reserved word
+				result["enum"] = constValues;
+				continue;
+			}
+		}
+
+		// Convert standalone const to single-value enum
+		if (key === "const") {
+			// biome-ignore lint/complexity/useLiteralKeys: "enum" is a reserved word
+			result["enum"] = [value];
+			continue;
+		}
+
+		result[key] = sanitizeSchemaForOpenApi(value);
+	}
+
+	return result;
 }
 
 /**

--- a/packages/ai/test/google-shared-sanitize-schema.test.ts
+++ b/packages/ai/test/google-shared-sanitize-schema.test.ts
@@ -1,0 +1,119 @@
+import { Type } from "@sinclair/typebox";
+import { describe, expect, it } from "vitest";
+import { convertTools } from "../src/providers/google-shared.js";
+import type { Tool } from "../src/types.js";
+
+describe("convertTools schema sanitization for OpenAPI (useParameters=true)", () => {
+	it("converts anyOf with const entries to enum", () => {
+		const tool = {
+			name: "test_tool",
+			description: "A test tool",
+			parameters: Type.Object({
+				mode: Type.Union([Type.Literal("fast"), Type.Literal("slow"), Type.Literal("auto")]),
+			}),
+		};
+
+		const result = convertTools([tool], true);
+		const params = result![0].functionDeclarations[0].parameters as Record<string, unknown>;
+		const properties = params.properties as Record<string, unknown>;
+		const mode = properties.mode as Record<string, unknown>;
+
+		expect(mode.enum).toEqual(["fast", "slow", "auto"]);
+		expect(mode.anyOf).toBeUndefined();
+		expect(mode.const).toBeUndefined();
+	});
+
+	it("strips patternProperties", () => {
+		const tool = {
+			name: "test_tool",
+			description: "A test tool",
+			parameters: {
+				type: "object",
+				properties: {
+					metadata: {
+						type: "object",
+						patternProperties: {
+							"^x-": { type: "string" },
+						},
+					},
+				},
+			},
+		} as unknown as Tool;
+
+		const result = convertTools([tool], true);
+		const params = result![0].functionDeclarations[0].parameters as Record<string, unknown>;
+		const properties = params.properties as Record<string, unknown>;
+		const metadata = properties.metadata as Record<string, unknown>;
+
+		expect(metadata.patternProperties).toBeUndefined();
+		expect(metadata.type).toBe("object");
+	});
+
+	it("converts standalone const to single-value enum", () => {
+		const tool = {
+			name: "test_tool",
+			description: "A test tool",
+			parameters: {
+				type: "object",
+				properties: {
+					version: { const: "v2" },
+				},
+			},
+		} as unknown as Tool;
+
+		const result = convertTools([tool], true);
+		const params = result![0].functionDeclarations[0].parameters as Record<string, unknown>;
+		const properties = params.properties as Record<string, unknown>;
+		const version = properties.version as Record<string, unknown>;
+
+		expect(version.enum).toEqual(["v2"]);
+		expect(version.const).toBeUndefined();
+	});
+
+	it("does not sanitize when useParameters is false", () => {
+		const tool = {
+			name: "test_tool",
+			description: "A test tool",
+			parameters: Type.Object({
+				mode: Type.Union([Type.Literal("fast"), Type.Literal("slow")]),
+			}),
+		};
+
+		const result = convertTools([tool], false);
+		const decl = result![0].functionDeclarations[0];
+
+		// Should use parametersJsonSchema, not parameters
+		expect(decl.parametersJsonSchema).toBeDefined();
+		expect(decl.parameters).toBeUndefined();
+	});
+
+	it("handles nested schemas recursively", () => {
+		const tool = {
+			name: "test_tool",
+			description: "A test tool",
+			parameters: {
+				type: "object",
+				properties: {
+					config: {
+						type: "object",
+						properties: {
+							level: {
+								anyOf: [{ const: "low" }, { const: "high" }],
+							},
+						},
+					},
+				},
+			},
+		} as unknown as Tool;
+
+		const result = convertTools([tool], true);
+		const params = result![0].functionDeclarations[0].parameters as Record<string, unknown>;
+		const properties = params.properties as Record<string, unknown>;
+		const config = properties.config as Record<string, unknown>;
+		const configProps = config.properties as Record<string, unknown>;
+		const level = configProps.level as Record<string, unknown>;
+
+		expect(level.enum).toEqual(["low", "high"]);
+		expect(level.anyOf).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Claude models via Antigravity/Cloud Code Assist fail with 400 errors on every request because tool parameter schemas contain JSON Schema features unsupported by the OpenAPI 3.03 `parameters` field:

```
Error: Cloud Code Assist API error (400): Invalid JSON payload received.
Unknown name "const" at 'request.tools[0].function_declarations[18].parameters.properties[0].value.any_of[0]'
Unknown name "patternProperties" at 'request.tools[0].function_declarations[21].parameters.properties[3].value'
```

TypeBox generates `anyOf` with `{const: value}` entries for union/literal types and `patternProperties` for record types. The `parametersJsonSchema` field handles these fine, but the legacy `parameters` field (used when `useParameters=true` for Claude models) does not.

## Changes

**`packages/ai/src/providers/google-shared.ts`**
- Added `sanitizeSchemaForOpenApi()` — recursively transforms schemas for OpenAPI compatibility
- `anyOf`/`oneOf` with `{const: value}` entries → `enum` arrays
- Standalone `const` → single-value `enum`
- `patternProperties` → stripped (no OpenAPI equivalent)
- Applied only when `useParameters=true` in `convertTools()`, leaving the `parametersJsonSchema` path untouched

**`packages/ai/test/google-shared-sanitize-schema.test.ts`**
- 5 tests covering: anyOf→enum conversion, patternProperties stripping, standalone const, nested schemas, and verifying non-sanitization when `useParameters=false`

## Testing

- Verified locally: patched installed `google-shared.js`, restarted pi, confirmed Antigravity + Claude Opus 4.6 sends messages successfully (previously 400'd on every request)
- All new tests pass, existing google-shared tests unaffected