### PR TITLE
docs: fix grammar typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm run check        # Lint, format, and type check
 ./pi-test.sh         # Run pi from sources (must be run from repo root)
 ```
 
-> **Note:** `npm run check` requires `npm run build` to be run first. The web-ui package uses `tsc` which needs compiled `.d.ts` files from dependencies.
+> **Note:** `npm run check` requires `npm run build` to be run first. The web-ui package uses `tsc` which needs to compile `.d.ts` files from dependencies.
 
 ## License
 


### PR DESCRIPTION
Fixes a grammatical error in the Development section: 'needs compiled' → 'needs to compile'.