### PR TITLE
fix(ai): handle GPT-5 empty reasoning summary causing 400 on replay

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -159,9 +159,17 @@ export function convertResponsesMessages<TApi extends Api>(
 				assistantMsg.provider === model.provider &&
 				assistantMsg.api === model.api;
 
+			// Check if any thinking blocks have empty content (reasoning was incomplete
+			// or discarded). GPT-5 models can return reasoning items with empty summary;
+			// the thinkingSignature is discarded at receive time, but the empty thinking
+			// block remains. We must strip paired fc_xxx IDs to avoid pairing validation.
+			const hasSkippedThinking = msg.content.some(
+				(block) => block.type === "thinking" && block.thinking.trim().length === 0,
+			);
+
 			for (const block of msg.content) {
 				if (block.type === "thinking") {
-					if (block.thinkingSignature) {
+					if (block.thinkingSignature && block.thinking.trim().length > 0) {
 						const reasoningItem = JSON.parse(block.thinkingSignature) as ResponseReasoningItem;
 						output.push(reasoningItem);
 					}
@@ -191,7 +199,7 @@ export function convertResponsesMessages<TApi extends Api>(
 					// For different-model messages, set id to undefined to avoid pairing validation.
 					// OpenAI tracks which fc_xxx IDs were paired with rs_xxx reasoning items.
 					// By omitting the id, we avoid triggering that validation (like cross-provider does).
-					if (isDifferentModel && itemId?.startsWith("fc_")) {
+					if ((isDifferentModel || hasSkippedThinking) && itemId?.startsWith("fc_")) {
 						itemId = undefined;
 					}
 
@@ -407,7 +415,12 @@ export async function processResponsesStream<TApi extends Api>(
 
 			if (item.type === "reasoning" && currentBlock?.type === "thinking") {
 				currentBlock.thinking = item.summary?.map((s) => s.text).join("\n\n") || "";
-				currentBlock.thinkingSignature = JSON.stringify(item);
+				// Only store thinkingSignature when summary has content. GPT-5 models
+				// intermittently return reasoning items with encrypted_content but
+				// empty summary (summary: []). Replaying these causes 400 errors.
+				if (currentBlock.thinking.trim().length > 0) {
+					currentBlock.thinkingSignature = JSON.stringify(item);
+				}
 				stream.push({
 					type: "thinking_end",
 					contentIndex: blockIndex(),

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -47,8 +47,12 @@ export function transformMessages<TApi extends Api>(
 					// For same model: keep thinking blocks with signatures (needed for replay)
 					// even if the thinking text is empty (OpenAI encrypted reasoning)
 					if (isSameModel && block.thinkingSignature) return block;
-					// Skip empty thinking blocks, convert others to plain text
-					if (!block.thinking || block.thinking.trim() === "") return [];
+					// Empty thinking: keep for same model (needed by hasSkippedThinking
+					// in convertResponsesMessages to strip paired fc_xxx IDs).
+					// Drop for cross-model since reasoning can't be replayed anyway.
+					if (!block.thinking || block.thinking.trim() === "") {
+						return isSameModel ? block : [];
+					}
 					if (isSameModel) return block;
 					return {
 						type: "text" as const,

--- a/packages/ai/test/empty-reasoning-fix.test.ts
+++ b/packages/ai/test/empty-reasoning-fix.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { convertResponsesMessages } from "../src/providers/openai-responses-shared.js";
+import { transformMessages } from "../src/providers/transform-messages.js";
+import type { AssistantMessage, Message, Model } from "../src/types.js";
+
+const mockModel: Model<"openai-responses"> = {
+	id: "gpt-5-mini",
+	name: "GPT-5 Mini",
+	provider: "openai",
+	api: "openai-responses",
+	baseUrl: "https://api.openai.com/v1",
+	contextWindow: 128000,
+	maxTokens: 16384,
+	input: ["text", "image"],
+	cost: {
+		input: 0.5,
+		output: 1.5,
+		cacheRead: 0.25,
+		cacheWrite: 0.625,
+	},
+	reasoning: true,
+	headers: {},
+};
+
+describe("Empty reasoning summary fix", () => {
+	it("should keep empty thinking blocks in transformMessages for same model", () => {
+		const assistantMsg: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "" }, // Empty thinking
+				{ type: "text", text: "Hello" },
+			],
+			provider: "openai",
+			api: "openai-responses",
+			model: "gpt-5-mini",
+			usage: {
+				input: 10,
+				output: 5,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 15,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+
+		const messages: Message[] = [assistantMsg];
+		const transformed = transformMessages(messages, mockModel);
+
+		// Should keep empty thinking block for same model
+		const assistantOut = transformed[0] as AssistantMessage;
+		expect(assistantOut.content.length).toBe(2);
+		expect(assistantOut.content[0].type).toBe("thinking");
+		expect((assistantOut.content[0] as any).thinking).toBe("");
+	});
+
+	it("should strip fc_xxx IDs when hasSkippedThinking is true", () => {
+		const assistantMsg: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "" }, // Empty thinking (skipped reasoning)
+				{
+					type: "toolCall",
+					id: "call_123|fc_456",
+					name: "test_tool",
+					arguments: {},
+				},
+			],
+			provider: "openai",
+			api: "openai-responses",
+			model: "gpt-5-mini",
+			usage: {
+				input: 10,
+				output: 5,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 15,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+
+		const context = {
+			systemPrompt: "Test",
+			messages: [assistantMsg],
+			tools: [],
+		};
+
+		const allowedProviders = new Set(["openai", "openai-codex", "opencode"]);
+		const result = convertResponsesMessages(mockModel, context, allowedProviders);
+
+		// Find the function_call in the output
+		const functionCall = result.find((item: any) => item.type === "function_call") as any;
+		expect(functionCall).toBeDefined();
+		// The fc_xxx ID should be stripped because hasSkippedThinking is true
+		expect(functionCall?.id).toBeUndefined();
+		expect(functionCall?.call_id).toBe("call_123");
+	});
+
+	it("should not strip fc_xxx IDs when thinking is not empty", () => {
+		const assistantMsg: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "Some reasoning" }, // Non-empty thinking
+				{
+					type: "toolCall",
+					id: "call_123|fc_456",
+					name: "test_tool",
+					arguments: {},
+				},
+			],
+			provider: "openai",
+			api: "openai-responses",
+			model: "gpt-5-mini",
+			usage: {
+				input: 10,
+				output: 5,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 15,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+
+		const context = {
+			systemPrompt: "Test",
+			messages: [assistantMsg],
+			tools: [],
+		};
+
+		const allowedProviders = new Set(["openai", "openai-codex", "opencode"]);
+		const result = convertResponsesMessages(mockModel, context, allowedProviders);
+
+		// Find the function_call in the output
+		const functionCall = result.find((item: any) => item.type === "function_call") as any;
+		expect(functionCall).toBeDefined();
+		// The fc_xxx ID should be kept because thinking is not empty
+		expect(functionCall?.id).toBe("fc_456");
+		expect(functionCall?.call_id).toBe("call_123");
+	});
+});


### PR DESCRIPTION
## Problem

GPT-5 models intermittently return reasoning items with `encrypted_content` but empty summary (`summary: []`). When this reasoning item is replayed in the next turn, the API returns:

```
400 Item 'fc_xxx' of type 'function_call' was provided without its required 'reasoning' item: 'rs_xxx'
```

## Root Cause

Three things interact to cause the failure:

1. `processResponsesStream` stores `thinkingSignature` even when summary is empty
2. `transformMessages` drops empty thinking blocks for same-model, hiding them from downstream detection
3. `convertResponsesMessages` only strips `fc_xxx` IDs for `isDifferentModel`, not for skipped reasoning

## Fix

- **processResponsesStream**: Only store `thinkingSignature` when summary has content
- **transformMessages**: Keep empty thinking blocks for same-model (needed by `hasSkippedThinking` detection)
- **convertResponsesMessages**: Add `hasSkippedThinking` check to strip paired `fc_xxx` IDs when reasoning is absent

## Testing

Added unit tests in `empty-reasoning-fix.test.ts` that verify:
1. Empty thinking blocks are kept for same-model detection
2. `fc_xxx` IDs are stripped when `hasSkippedThinking` is true
3. `fc_xxx` IDs are preserved when thinking is not empty

Fixes #2118