### PR TITLE
feat(web-ui): export CustomProviderDialog

### DIFF
--- a/packages/web-ui/src/index.ts
+++ b/packages/web-ui/src/index.ts
@@ -7,6 +7,7 @@ export { ChatPanel } from "./ChatPanel.js";
 export { AgentInterface } from "./components/AgentInterface.js";
 export { AttachmentTile } from "./components/AttachmentTile.js";
 export { ConsoleBlock } from "./components/ConsoleBlock.js";
+export { CustomProviderDialog } from "./dialogs/CustomProviderDialog.js";
 export { CustomProviderCard } from "./components/CustomProviderCard.js";
 export { ExpandableSection } from "./components/ExpandableSection.js";
 export { Input } from "./components/Input.js";


### PR DESCRIPTION
## Summary
Export `CustomProviderDialog` component from `@mariozechner/pi-web-ui` to allow sitegeist chrome extension to use it for adding local model providers.
## Context
This change is needed for the chrome extension to support local models (Ollama, LM Studio, etc.) without requiring API keys.
See related PR: https://github.com/chrisqianz/sitegeist/pull/1
## Changes
- Added export for `CustomProviderDialog` in `packages/web-ui/src/index.ts`
## Files Changed
- `packages/web-ui/src/index.ts` - Added 1 line (export CustomProviderDialog)