### PR TITLE
fix: update contextWindow to 1M for Claude 4.6 in google-antigravity and github-copilot

### DIFF
--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -2580,7 +2580,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 1000000,
 			maxTokens: 64000,
 		} satisfies Model<"anthropic-messages">,
 		"claude-sonnet-4": {
@@ -2634,7 +2634,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 1000000,
 			maxTokens: 32000,
 		} satisfies Model<"anthropic-messages">,
 		"gemini-2.5-pro": {
@@ -3393,7 +3393,7 @@ export const MODELS = {
 				cacheRead: 0.5,
 				cacheWrite: 6.25,
 			},
-			contextWindow: 200000,
+			contextWindow: 1000000,
 			maxTokens: 128000,
 		} satisfies Model<"google-gemini-cli">,
 		"claude-sonnet-4-5": {
@@ -3444,7 +3444,7 @@ export const MODELS = {
 				cacheRead: 0.3,
 				cacheWrite: 3.75,
 			},
-			contextWindow: 200000,
+			contextWindow: 1000000,
 			maxTokens: 64000,
 		} satisfies Model<"google-gemini-cli">,
 		"gemini-3-flash": {


### PR DESCRIPTION
## Summary

Update `contextWindow` from incorrect values to `1000000` (1M) for Claude 4.6 models in two providers.

## Changes

| Provider | Model | Before | After |
|---|---|---|---|
| google-antigravity | claude-opus-4-6-thinking | 200,000 | 1,000,000 |
| google-antigravity | claude-sonnet-4-6 | 200,000 | 1,000,000 |
| github-copilot | claude-opus-4.6 | 128,000 | 1,000,000 |
| github-copilot | claude-sonnet-4.6 | 128,000 | 1,000,000 |

## Context

Claude Opus 4.6 and Sonnet 4.6 support 1M context window (GA since 2026-03-13). Other providers (amazon-bedrock, anthropic, opencode) already have the correct 1M value.

Fixes #2268
Related: #2209