### PR TITLE
Relax openai-codex-responses accountId extraction for non-official Codex base URLs

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -139,7 +139,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				throw new Error(`No API key for provider: ${model.provider}`);
 			}
 
-			const accountId = extractAccountId(apiKey);
+			const accountId = extractAccountId(apiKey, model.baseUrl);
 			let body = buildRequestBody(model, context, options);
 			const nextBody = await options?.onPayload?.(body, model);
 			if (nextBody !== undefined) {
@@ -853,7 +853,17 @@ async function parseErrorResponse(response: Response): Promise<{ message: string
 // Auth & Headers
 // ============================================================================
 
-function extractAccountId(token: string): string {
+function isOfficialCodexBaseUrl(baseUrl?: string): boolean {
+	try {
+		const raw = baseUrl && baseUrl.trim().length > 0 ? baseUrl : DEFAULT_CODEX_BASE_URL;
+		const url = new URL(raw);
+		return /(^|\.)chatgpt\.com$/i.test(url.hostname);
+	} catch {
+		return true;
+	}
+}
+
+function extractAccountId(token: string, baseUrl?: string): string | undefined {
 	try {
 		const parts = token.split(".");
 		if (parts.length !== 3) throw new Error("Invalid token");
@@ -862,6 +872,7 @@ function extractAccountId(token: string): string {
 		if (!accountId) throw new Error("No account ID in token");
 		return accountId;
 	} catch {
+		if (!isOfficialCodexBaseUrl(baseUrl)) return undefined;
 		throw new Error("Failed to extract accountId from token");
 	}
 }
@@ -876,7 +887,7 @@ function createCodexRequestId(): string {
 function buildBaseCodexHeaders(
 	initHeaders: Record<string, string> | undefined,
 	additionalHeaders: Record<string, string> | undefined,
-	accountId: string,
+	accountId: string | undefined,
 	token: string,
 ): Headers {
 	const headers = new Headers(initHeaders);
@@ -884,7 +895,7 @@ function buildBaseCodexHeaders(
 		headers.set(key, value);
 	}
 	headers.set("Authorization", `Bearer ${token}`);
-	headers.set("chatgpt-account-id", accountId);
+	if (accountId) headers.set("chatgpt-account-id", accountId);
 	headers.set("originator", "pi");
 	const userAgent = _os ? `pi (${_os.platform()} ${_os.release()}; ${_os.arch()})` : "pi (browser)";
 	headers.set("User-Agent", userAgent);
@@ -894,7 +905,7 @@ function buildBaseCodexHeaders(
 function buildSSEHeaders(
 	initHeaders: Record<string, string> | undefined,
 	additionalHeaders: Record<string, string> | undefined,
-	accountId: string,
+	accountId: string | undefined,
 	token: string,
 	sessionId?: string,
 ): Headers {
@@ -913,7 +924,7 @@ function buildSSEHeaders(
 function buildWebSocketHeaders(
 	initHeaders: Record<string, string> | undefined,
 	additionalHeaders: Record<string, string> | undefined,
-	accountId: string,
+	accountId: string | undefined,
 	token: string,
 	requestId: string,
 ): Headers {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -26,6 +26,25 @@ function mockToken(): string {
 	return `aaa.${payload}.bbb`;
 }
 
+function mockOpaqueToken(): string {
+	return "opaque-bearer-token";
+}
+
+function createModel(baseUrl: string = "https://chatgpt.com/backend-api"): Model<"openai-codex-responses"> {
+	return {
+		id: "gpt-5.1-codex",
+		name: "GPT-5.1 Codex",
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+	};
+}
+
 function buildSSEPayload({
 	status,
 	includeDone = false,
@@ -183,6 +202,115 @@ describe("openai-codex streaming", () => {
 
 		expect(sawTextDelta).toBe(true);
 		expect(sawDone).toBe(true);
+	});
+
+	it("keeps official chatgpt.com auth strict for opaque bearer tokens", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(createModel(), context, { apiKey: mockOpaqueToken() }).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Failed to extract accountId from token");
+	});
+
+	it("allows opaque bearer tokens for non-official codex base URLs without chatgpt-account-id", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockOpaqueToken();
+		const encoder = new TextEncoder();
+		const sse = buildSSEPayload({ status: "completed", includeDone: true });
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "http://127.0.0.1:2455/backend-api/codex/responses") {
+				const headers = init?.headers instanceof Headers ? init.headers : undefined;
+				expect(headers?.get("Authorization")).toBe(`Bearer ${token}`);
+				expect(headers?.get("chatgpt-account-id")).toBeNull();
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(createModel("http://127.0.0.1:2455/backend-api/codex"), context, {
+			apiKey: token,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find((c) => c.type === "text")?.text).toBe("Hello");
+	});
+
+	it("still forwards chatgpt-account-id for non-official codex base URLs when the token contains one", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const encoder = new TextEncoder();
+		const sse = buildSSEPayload({ status: "completed", includeDone: true });
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "http://127.0.0.1:2455/backend-api/codex/responses") {
+				const headers = init?.headers instanceof Headers ? init.headers : undefined;
+				expect(headers?.get("Authorization")).toBe(`Bearer ${token}`);
+				expect(headers?.get("chatgpt-account-id")).toBe("acc_test");
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(createModel("http://127.0.0.1:2455/backend-api/codex"), context, {
+			apiKey: token,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find((c) => c.type === "text")?.text).toBe("Hello");
 	});
 
 	it("completes after response.completed even when the SSE body stays open", async () => {


### PR DESCRIPTION
# Relax openai-codex-responses accountId extraction for non-official Codex base URLs

## Summary

This change keeps the existing strict ChatGPT/Codex auth behavior for official `chatgpt.com` base URLs, but relaxes `chatgpt_account_id` extraction for non-official Codex-compatible proxy base URLs.

## Problem

`openai-codex-responses` currently assumes every bearer token is an official ChatGPT/Codex JWT containing `https://api.openai.com/auth.chatgpt_account_id`.

That is true for the official `chatgpt.com/backend-api` flow, but it breaks Codex-compatible proxy setups that accept opaque bearer tokens and do not require a `chatgpt-account-id` header.

In those setups, the request fails before it is even sent because `extractAccountId()` throws `Failed to extract accountId from token`.

## Approach

This PR makes the smallest possible change:

- Keep strict accountId extraction for official `chatgpt.com` Codex base URLs.
- For non-official base URLs, allow bearer-token passthrough even when the token is opaque and does not decode into a ChatGPT JWT.
- Only send `chatgpt-account-id` when an account ID was actually extracted.

## Why this shape

The incompatibility is not the Codex request/response body shape itself.
The main blocker is the auth/header assumption that every token must decode like an official ChatGPT token.

By limiting the relaxation to non-official base URLs, the official behavior stays unchanged while Codex-compatible proxy deployments can work without forking the provider.

## Tests

Added coverage for:

1. Official `chatgpt.com` base URL + opaque bearer token -> still errors.
2. Non-official Codex base URL + opaque bearer token -> request succeeds and omits `chatgpt-account-id`.
3. Non-official Codex base URL + JWT containing `chatgpt_account_id` -> still forwards `chatgpt-account-id`.

Also verified locally with:

- targeted test: `npx vitest --run test/openai-codex-stream.test.ts`
- package test suite: `npm test`
