### PR TITLE
fix(extensions): improve VS Code launch reliability on Windows in /diff and /files

### DIFF
--- a/.pi/extensions/diff.ts
+++ b/.pi/extensions/diff.ts
@@ -66,12 +66,26 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
+			const openWithCode = async (file: string) => {
+				if (process.platform === "win32") {
+					return pi.exec("cmd", ["/d", "/s", "/c", "code", "-g", file], { cwd: ctx.cwd });
+				}
+				return pi.exec("code", ["-g", file], { cwd: ctx.cwd });
+			};
+
 			const openSelected = async (fileInfo: FileInfo): Promise<void> => {
 				try {
 					// Open in VS Code diff view.
 					// For untracked files, git difftool won't work, so fall back to just opening the file.
 					if (fileInfo.status === "?") {
-						await pi.exec("code", ["-g", fileInfo.file], { cwd: ctx.cwd });
+						const openResult = await openWithCode(fileInfo.file);
+						if (openResult.code !== 0) {
+							const openStderr = openResult.stderr.trim();
+							ctx.ui.notify(
+								`Failed to open ${fileInfo.file} (exit ${openResult.code})${openStderr ? `: ${openStderr}` : ""}`,
+								"error",
+							);
+						}
 						return;
 					}
 
@@ -79,7 +93,24 @@ export default function (pi: ExtensionAPI) {
 						cwd: ctx.cwd,
 					});
 					if (diffResult.code !== 0) {
-						await pi.exec("code", ["-g", fileInfo.file], { cwd: ctx.cwd });
+						const diffStderr = diffResult.stderr.trim();
+						ctx.ui.notify(
+							`Failed to show diff with vscode for ${fileInfo.file} (exit ${diffResult.code})${diffStderr ? `: ${diffStderr}` : ""}`,
+							"error",
+						);
+						ctx.ui.notify(
+							"Troubleshooting: check git difftool config (e.g. `git config --get difftool.vscode.cmd`).",
+							"info",
+						);
+
+						const openResult = await openWithCode(fileInfo.file);
+						if (openResult.code !== 0) {
+							const openStderr = openResult.stderr.trim();
+							ctx.ui.notify(
+								`Failed to open ${fileInfo.file} (exit ${openResult.code})${openStderr ? `: ${openStderr}` : ""}`,
+								"error",
+							);
+						}
 					}
 				} catch (error) {
 					const message = error instanceof Error ? error.message : String(error);

--- a/.pi/extensions/files.ts
+++ b/.pi/extensions/files.ts
@@ -89,9 +89,23 @@ export default function (pi: ExtensionAPI) {
 			// Sort by most recent first
 			const files = Array.from(fileMap.values()).sort((a, b) => b.lastTimestamp - a.lastTimestamp);
 
+			const openWithCode = async (path: string) => {
+				if (process.platform === "win32") {
+					return pi.exec("cmd", ["/d", "/s", "/c", "code", "-g", path], { cwd: ctx.cwd });
+				}
+				return pi.exec("code", ["-g", path], { cwd: ctx.cwd });
+			};
+
 			const openSelected = async (file: FileEntry): Promise<void> => {
 				try {
-					await pi.exec("code", ["-g", file.path], { cwd: ctx.cwd });
+					const openResult = await openWithCode(file.path);
+					if (openResult.code !== 0) {
+						const openStderr = openResult.stderr.trim();
+						ctx.ui.notify(
+							`Failed to open ${file.path} (exit ${openResult.code})${openStderr ? `: ${openStderr}` : ""}`,
+							"error",
+						);
+					}
 				} catch (error) {
 					const message = error instanceof Error ? error.message : String(error);
 					ctx.ui.notify(`Failed to open ${file.path}: ${message}`, "error");


### PR DESCRIPTION
This is a follow-up on #2186.

Supersedes #2212, which was auto-closed by OSS weekend automation.

This PR adds a minimal reliability fix for opening files in VS Code from:

- `.pi/extensions/diff.ts`
- `.pi/extensions/files.ts`

### Problem

- On Windows, direct `pi.exec("code", ["-g", ...])` can fail, and when it fails no error info is shown to the user in `/diff` and `/files`.
- In `/diff`, when `git difftool --tool=vscode` fails (for example, missing difftool config), the failure reason is not shown to the user.

### Changes

- Add local `openWithCode()` in both files:
  - Windows: `cmd /d /s /c code -g <file>`
  - Non-Windows: `code -g <file>`
- Replace direct `pi.exec("code", ...)` calls with `openWithCode(...)`.
- Add explicit open-failure notification (exit code + stderr) for `/diff` and `/files`.
- In `/diff`, when `git difftool` fails:
  - show error with exit code + stderr
  - show troubleshooting hint:
    `git config --get difftool.vscode.cmd`
  - keep existing fallback behavior unchanged.
