### PR TITLE
fix(ai): merge consecutive same-role turns in Gemini Content output

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -223,7 +223,29 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 		}
 	}
 
-	return contents;
+	return mergeConsecutiveRoles(contents);
+}
+
+/**
+ * Merge consecutive turns with the same role into a single turn.
+ *
+ * The Gemini API requires strictly alternating user/model roles.
+ * After filtering empty blocks (e.g. empty thinking without signatures),
+ * assistant turns can produce zero parts and get skipped, leaving
+ * consecutive same-role turns (e.g. user → [skipped] → user).
+ */
+function mergeConsecutiveRoles(contents: Content[]): Content[] {
+	const merged: Content[] = [];
+	for (const entry of contents) {
+		const last = merged[merged.length - 1];
+		if (last && last.role === entry.role) {
+			last.parts = last.parts ?? [];
+			if (entry.parts) last.parts.push(...entry.parts);
+		} else {
+			merged.push(entry);
+		}
+	}
+	return merged;
 }
 
 /**

--- a/packages/ai/test/google-shared-merge-consecutive-roles.test.ts
+++ b/packages/ai/test/google-shared-merge-consecutive-roles.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages } from "../src/providers/google-shared.js";
+import type { Context, Model } from "../src/types.js";
+
+function makeGeminiModel(id = "gemini-3-pro-preview"): Model<"google-generative-ai"> {
+	return {
+		id,
+		name: "Gemini 3 Pro Preview",
+		api: "google-generative-ai",
+		provider: "google",
+		baseUrl: "https://generativelanguage.googleapis.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	};
+}
+
+describe("google-shared convertMessages — merge consecutive roles", () => {
+	it("merges consecutive user turns when assistant turn is skipped (empty thinking)", () => {
+		const now = Date.now();
+		const model = makeGeminiModel();
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Hello", timestamp: now },
+				{
+					role: "assistant",
+					content: [{ type: "thinking", thinking: "", thinkingSignature: undefined }],
+					api: "google-generative-ai",
+					provider: "google-vertex",
+					model: "gemini-3-pro-preview",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: now,
+				},
+				{ role: "user", content: "Follow up", timestamp: now },
+			],
+		};
+
+		const contents = convertMessages(model, context);
+
+		// No consecutive same-role turns
+		for (let i = 1; i < contents.length; i++) {
+			expect(contents[i].role).not.toBe(contents[i - 1].role);
+		}
+		// Both user texts should be merged into a single user turn
+		const userTurns = contents.filter((c) => c.role === "user");
+		expect(userTurns).toHaveLength(1);
+		expect(userTurns[0].parts).toHaveLength(2);
+	});
+
+	it("merges consecutive model turns when user turn is skipped (empty image-only for non-image model)", () => {
+		const now = Date.now();
+		const model = makeGeminiModel();
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Start", timestamp: now },
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "First response" }],
+					api: "google-generative-ai",
+					provider: "google",
+					model: "gemini-3-pro-preview",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: now,
+				},
+				{
+					role: "user",
+					content: [{ type: "image", mimeType: "image/png", data: "abc" }],
+					timestamp: now,
+				},
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "Second response" }],
+					api: "google-generative-ai",
+					provider: "google",
+					model: "gemini-3-pro-preview",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: now,
+				},
+			],
+		};
+
+		const contents = convertMessages(model, context);
+
+		for (let i = 1; i < contents.length; i++) {
+			expect(contents[i].role).not.toBe(contents[i - 1].role);
+		}
+	});
+
+	it("does not merge when roles already alternate correctly", () => {
+		const now = Date.now();
+		const model = makeGeminiModel();
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Hello", timestamp: now },
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "Hi there" }],
+					api: "google-generative-ai",
+					provider: "google",
+					model: "gemini-3-pro-preview",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: now,
+				},
+				{ role: "user", content: "Thanks", timestamp: now },
+			],
+		};
+
+		const contents = convertMessages(model, context);
+
+		expect(contents).toHaveLength(3);
+		expect(contents[0].role).toBe("user");
+		expect(contents[1].role).toBe("model");
+		expect(contents[2].role).toBe("user");
+	});
+});


### PR DESCRIPTION
Fixes #2294

## Problem

When replaying multi-turn conversations through the Gemini API, certain assistant turns produce zero `Part` objects after filtering (e.g. empty `thinking` block without `thoughtSignature`). These turns get skipped via `continue` in `convertMessages()`, leaving consecutive turns with the same role in the `Content[]` output.

The Gemini API requires strictly alternating `user`/`model` roles and returns **400 INVALID_ARGUMENT** when violated.

## Solution

Added `mergeConsecutiveRoles()` as a post-processing step at the end of `convertMessages()`. It concatenates `parts` from adjacent turns sharing the same role into a single turn, restoring the alternating-role invariant.

- ~10 lines, O(n), no changes to existing filtering/conversion logic
- Only affects the output array

## Test plan

3 test cases added:
- [x] Merges consecutive user turns when assistant turn is skipped (empty thinking block)
- [x] Merges consecutive user turns when image-only assistant is skipped for non-image model
- [x] No-op for already-alternating conversations (no merge needed)