### PR TITLE
fix(coding-agent): handle reftable footer branch detection

### DIFF
--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -77,23 +77,8 @@ export class FooterDataProvider {
 
 	/** Current git branch, null if not in repo, "detached" if detached HEAD */
 	getGitBranch(): string | null {
-		if (this.cachedBranch !== undefined) return this.cachedBranch;
-
-		try {
-			if (!this.gitPaths) {
-				this.cachedBranch = null;
-				return null;
-			}
-			const content = readFileSync(this.gitPaths.headPath, "utf8").trim();
-			if (content.startsWith("ref: refs/heads/")) {
-				const branch = content.slice(16);
-				this.cachedBranch =
-					branch === ".invalid" ? (resolveBranchWithGit(this.gitPaths.repoDir) ?? "detached") : branch;
-			} else {
-				this.cachedBranch = "detached";
-			}
-		} catch {
-			this.cachedBranch = null;
+		if (this.cachedBranch === undefined) {
+			this.cachedBranch = this.resolveGitBranch();
 		}
 		return this.cachedBranch;
 	}
@@ -146,9 +131,32 @@ export class FooterDataProvider {
 		this.branchChangeCallbacks.clear();
 	}
 
-	private invalidateGitBranch(): void {
-		this.cachedBranch = undefined;
+	private notifyBranchChange(): void {
 		for (const cb of this.branchChangeCallbacks) cb();
+	}
+
+	private refreshGitBranch(): void {
+		const nextBranch = this.resolveGitBranch();
+		if (this.cachedBranch !== undefined && this.cachedBranch !== nextBranch) {
+			this.cachedBranch = nextBranch;
+			this.notifyBranchChange();
+			return;
+		}
+		this.cachedBranch = nextBranch;
+	}
+
+	private resolveGitBranch(): string | null {
+		try {
+			if (!this.gitPaths) return null;
+			const content = readFileSync(this.gitPaths.headPath, "utf8").trim();
+			if (content.startsWith("ref: refs/heads/")) {
+				const branch = content.slice(16);
+				return branch === ".invalid" ? (resolveBranchWithGit(this.gitPaths.repoDir) ?? "detached") : branch;
+			}
+			return "detached";
+		} catch {
+			return null;
+		}
 	}
 
 	private setupGitWatcher(): void {
@@ -160,7 +168,7 @@ export class FooterDataProvider {
 		try {
 			this.headWatcher = watch(dirname(this.gitPaths.headPath), (_eventType, filename) => {
 				if (!filename || filename.toString() === "HEAD") {
-					this.invalidateGitBranch();
+					this.refreshGitBranch();
 				}
 			});
 		} catch {
@@ -173,7 +181,7 @@ export class FooterDataProvider {
 		if (existsSync(reftableDir)) {
 			try {
 				this.reftableWatcher = watch(reftableDir, () => {
-					this.invalidateGitBranch();
+					this.refreshGitBranch();
 				});
 			} catch {
 				// Silently fail if we can't watch

--- a/packages/coding-agent/test/footer-data-provider.test.ts
+++ b/packages/coding-agent/test/footer-data-provider.test.ts
@@ -29,6 +29,13 @@ function createPlainReftableRepo(tempDir: string): string {
 	return repoDir;
 }
 
+function createPlainRepo(tempDir: string): string {
+	const repoDir = join(tempDir, "repo");
+	mkdirSync(join(repoDir, ".git"), { recursive: true });
+	writeFileSync(join(repoDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+	return repoDir;
+}
+
 function createReftableWorktree(tempDir: string): WorktreeFixture {
 	const repoDir = join(tempDir, "repo");
 	const commonGitDir = join(repoDir, ".git");
@@ -48,6 +55,16 @@ function createReftableWorktree(tempDir: string): WorktreeFixture {
 	return { worktreeDir, reftableDir };
 }
 
+async function waitFor(condition: () => boolean, timeoutMs = 2000): Promise<void> {
+	const startedAt = Date.now();
+	while (!condition()) {
+		if (Date.now() - startedAt > timeoutMs) {
+			throw new Error("Timed out waiting for condition");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
 describe("FooterDataProvider reftable branch detection", () => {
 	let originalCwd: string;
 	let tempDir: string;
@@ -63,6 +80,21 @@ describe("FooterDataProvider reftable branch detection", () => {
 		process.chdir(originalCwd);
 		if (tempDir && existsSync(tempDir)) {
 			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("uses HEAD directly in a regular repo from a nested directory", () => {
+		const repoDir = createPlainRepo(tempDir);
+		const nestedDir = join(repoDir, "src", "nested");
+		mkdirSync(nestedDir, { recursive: true });
+		process.chdir(nestedDir);
+
+		const provider = new FooterDataProvider();
+		try {
+			expect(provider.getGitBranch()).toBe("main");
+			expect(vi.mocked(spawnSync)).not.toHaveBeenCalled();
+		} finally {
+			provider.dispose();
 		}
 	});
 
@@ -107,6 +139,27 @@ describe("FooterDataProvider reftable branch detection", () => {
 		const provider = new FooterDataProvider();
 		try {
 			expect(provider.getGitBranch()).toBe("detached");
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	it("does not notify listeners when reftable updates keep the same branch", async () => {
+		const { worktreeDir, reftableDir } = createReftableWorktree(tempDir);
+		process.chdir(worktreeDir);
+
+		const provider = new FooterDataProvider();
+		try {
+			expect(provider.getGitBranch()).toBe("main");
+			vi.mocked(spawnSync).mockClear();
+			const onBranchChange = vi.fn();
+			provider.onBranchChange(onBranchChange);
+
+			writeFileSync(join(reftableDir, "tables.list"), "1\n");
+			await waitFor(() => vi.mocked(spawnSync).mock.calls.length > 0);
+
+			expect(provider.getGitBranch()).toBe("main");
+			expect(onBranchChange).not.toHaveBeenCalled();
 		} finally {
 			provider.dispose();
 		}


### PR DESCRIPTION
## Problem

Git repositories using the reftable backend write `ref: refs/heads/.invalid` to the worktree HEAD file instead of the actual branch name. The footer's branch detection read HEAD directly, so it displayed `.invalid` instead of the real branch. Additionally, reftable repos store ref updates in a `reftable/` directory rather than updating HEAD, so branch switches were never picked up by the file watcher.

## Changes

**`packages/coding-agent/src/core/footer-data-provider.ts`**

- `findGitPaths()` now returns `repoDir`, `commonGitDir`, and `headPath` (was just `headPath`). Reads the `commondir` file in worktrees to locate the shared git directory.
- When HEAD contains `ref: refs/heads/.invalid`, falls back to `git symbolic-ref` to resolve the actual branch.
- Watches the `reftable/` directory in `commonGitDir` for ref updates.
- Watcher events re-resolve the branch and only notify listeners when the branch string actually changed, avoiding unnecessary rerenders from background fetches or unrelated ref updates.

**`packages/coding-agent/test/footer-data-provider.test.ts`** (new file)

- Plain reftable repo: `.invalid` HEAD resolved via mocked `git symbolic-ref`
- Reftable-backed worktree: branch resolved through `.git` file -> `gitdir` -> `commondir` chain
- Unresolved `.invalid`: treated as detached
- Reftable directory watch: branch change callback fires on actual change
- Reftable churn suppression: no callback when resolved branch is unchanged
- Regular repo from nested directory: fast path reads HEAD directly, no `git` spawn

## Verification

`npm run check` passes (biome, tsgo, browser smoke, web-ui tsc).
