### PR TITLE
Fixed md formatting

### DIFF
--- a/packages/mom/README.md
+++ b/packages/mom/README.md
@@ -237,7 +237,7 @@ description: Read, search, and send Gmail via IMAP/SMTP
 
 When mom responds, she's given the names, descriptions, and file locations of all `SKILL.md` files in `/workspace/skills/` and `/workspace/<channel>/skills/`, so she knows what's available to handle your request. When mom decides to use a skill, she reads the `SKILL.md` in full, after which she's able to use the skill by invoking its scripts and programs.
 
-You can find a set of basic skills at <https://github.com/badlogic/pi-skills|github.com/badlogic/pi-skills>. Just tell mom to clone this repository into `/workspace/skills/pi-skills` and she'll help you set up the rest.
+You can find a set of basic skills at [github.com/badlogic/pi-skills](https://github.com/badlogic/pi-skills). Just tell mom to clone this repository into `/workspace/skills/pi-skills` and she'll help you set up the rest.
 
 #### Creating a Skill
 


### PR DESCRIPTION
This just fixes the readme which currently renders incorrectly:

<img width="1004" height="111" alt="image" src="https://github.com/user-attachments/assets/b82c55ea-d400-4170-b5c2-4923ba286a53" />

And doesn't open on click:

<img width="811" height="541" alt="image" src="https://github.com/user-attachments/assets/b274b139-2f9d-4955-9528-e855973e44ab" />
