### PR TITLE
fix(coding-agent): skip tmux extended-keys warning when tmux is unreachable

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -626,6 +626,9 @@ export class InteractiveMode {
 			runTmuxShow("extended-keys-format"),
 		]);
 
+		// If we couldn't query tmux (timeout, sandbox, etc.), don't warn
+		if (extendedKeys === undefined) return undefined;
+
 		if (extendedKeys !== "on" && extendedKeys !== "always") {
 			return "tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.";
 		}


### PR DESCRIPTION
When running inside a sandbox (e.g., bubblewrap) that blocks access to the tmux socket, the tmux query hangs and times out, returning undefined. Previously this was treated as "extended-keys is off", showing a false warning. Now we skip the warning when the tmux server can't be reached.