### PR TITLE
fix: guard model.input.includes() against undefined for custom providers

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -734,7 +734,7 @@ function convertMessages(
 						};
 					}
 				});
-				let filteredBlocks = !model?.input.includes("image") ? blocks.filter((b) => b.type !== "image") : blocks;
+				let filteredBlocks = !(model?.input?.includes("image")) ? blocks.filter((b) => b.type !== "image") : blocks;
 				filteredBlocks = filteredBlocks.filter((b) => {
 					if (b.type === "text") {
 						return b.text.trim().length > 0;

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -102,7 +102,7 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 						};
 					}
 				});
-				const filteredParts = !model.input.includes("image") ? parts.filter((p) => p.text !== undefined) : parts;
+				const filteredParts = !(model.input?.includes("image")) ? parts.filter((p) => p.text !== undefined) : parts;
 				if (filteredParts.length === 0) continue;
 				contents.push({
 					role: "user",
@@ -168,7 +168,7 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 			// Extract text and image content
 			const textContent = msg.content.filter((c): c is TextContent => c.type === "text");
 			const textResult = textContent.map((c) => c.text).join("\n");
-			const imageContent = model.input.includes("image")
+			const imageContent = model.input?.includes("image")
 				? msg.content.filter((c): c is ImageContent => c.type === "image")
 				: [];
 

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -232,7 +232,7 @@ function buildChatPayload(
 	const payload: ChatCompletionStreamRequest = {
 		model: model.id,
 		stream: true,
-		messages: toChatMessages(messages, model.input.includes("image")),
+		messages: toChatMessages(messages, model.input?.includes("image") ?? false),
 	};
 
 	if (context.tools?.length) payload.tools = toFunctionTools(context.tools);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -537,7 +537,7 @@ export function convertMessages(
 						} satisfies ChatCompletionContentPartImage;
 					}
 				});
-				const filteredContent = !model.input.includes("image")
+				const filteredContent = !(model.input?.includes("image"))
 					? content.filter((c) => c.type !== "image_url")
 					: content;
 				if (filteredContent.length === 0) continue;
@@ -652,7 +652,7 @@ export function convertMessages(
 				}
 				params.push(toolResultMsg);
 
-				if (hasImages && model.input.includes("image")) {
+				if (hasImages && model.input?.includes("image")) {
 					for (const block of toolMsg.content) {
 						if (block.type === "image") {
 							imageBlocks.push({

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -142,7 +142,7 @@ export function convertResponsesMessages<TApi extends Api>(
 						image_url: `data:${item.mimeType};base64,${item.data}`,
 					} satisfies ResponseInputImage;
 				});
-				const filteredContent = !model.input.includes("image")
+				const filteredContent = !(model.input?.includes("image"))
 					? content.filter((c) => c.type !== "input_image")
 					: content;
 				if (filteredContent.length === 0) continue;
@@ -216,7 +216,7 @@ export function convertResponsesMessages<TApi extends Api>(
 			const [callId] = msg.toolCallId.split("|");
 
 			let output: string | ResponseFunctionCallOutputItemList;
-			if (hasImages && model.input.includes("image")) {
+			if (hasImages && model.input?.includes("image")) {
 				const contentParts: ResponseFunctionCallOutputItemList = [];
 
 				if (hasText) {


### PR DESCRIPTION
## Summary

When using custom/local providers (vLLM, Ollama, etc.) via `completeSimple()`, the `model` object may lack the `input` property. The `Model` type requires `input: ("text" | "image")[]`, but runtime model objects from plugins and custom providers don't always populate it.

This causes a crash:

```
Cannot read properties of undefined (reading 'includes')
```

## Fix

Add optional chaining (`?.`) to all `model.input.includes()` calls across all provider implementations:

| File | Change |
|------|--------|
| `openai-completions.ts` | 2 call sites guarded |
| `openai-responses-shared.ts` | 2 call sites guarded |
| `anthropic.ts` | 1 call site guarded (was `model?.input.includes` — `input` itself still needed `?.`) |
| `google-shared.ts` | 2 call sites guarded |
| `mistral.ts` | 1 call site guarded (added `?? false` since the value is passed as a boolean parameter) |

When `model.input` is `undefined`, the optional chaining returns `undefined`, which is falsy — so image content is filtered out (safe default: text-only behavior).

## How to reproduce

1. Configure a custom OpenAI-compatible provider (e.g., local vLLM) in pi-ai
2. Use a plugin that calls `completeSimple()` (e.g., lossless-claw LCM context engine)
3. The model object passed to the provider lacks `input` → crash

Discovered via the lossless-claw LCM plugin (see [Martian-Engineering/lossless-claw#111](https://github.com/Martian-Engineering/lossless-claw/issues/111)).

## Test plan

- [ ] Verify existing tests still pass (`npm test` in `packages/ai`)
- [ ] Confirm custom provider calls with `model.input = undefined` no longer crash
- [ ] Confirm models with `input: ["text", "image"]` still send image content correctly
- [ ] Confirm models with `input: ["text"]` still filter out images correctly