### PR TITLE
fix: fall back to input_tokens/output_tokens for OpenAI-compatible servers

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -719,6 +719,9 @@ function parseChunkUsage(
 	rawUsage: {
 		prompt_tokens?: number;
 		completion_tokens?: number;
+		// Some OpenAI-compatible servers (mlx-vlm, vLLM) use input_tokens/output_tokens instead
+		input_tokens?: number;
+		output_tokens?: number;
 		prompt_tokens_details?: { cached_tokens?: number };
 		completion_tokens_details?: { reasoning_tokens?: number };
 	},
@@ -727,10 +730,11 @@ function parseChunkUsage(
 	const cachedTokens = rawUsage.prompt_tokens_details?.cached_tokens || 0;
 	const reasoningTokens = rawUsage.completion_tokens_details?.reasoning_tokens || 0;
 	// OpenAI includes cached tokens in prompt_tokens, so subtract to get non-cached input
-	const input = (rawUsage.prompt_tokens || 0) - cachedTokens;
+	// Fall back to input_tokens/output_tokens for compatible servers (mlx-vlm, vLLM)
+	const input = (rawUsage.prompt_tokens ?? rawUsage.input_tokens ?? 0) - cachedTokens;
 	// Compute totalTokens ourselves since we add reasoning_tokens to output
 	// and some providers (e.g., Groq) don't include them in total_tokens
-	const outputTokens = (rawUsage.completion_tokens || 0) + reasoningTokens;
+	const outputTokens = (rawUsage.completion_tokens ?? rawUsage.output_tokens ?? 0) + reasoningTokens;
 	const usage: AssistantMessage["usage"] = {
 		input,
 		output: outputTokens,


### PR DESCRIPTION
## Problem

Some OpenAI-compatible servers (mlx-vlm, vLLM) return usage fields with different names than the OpenAI standard:

| Field | OpenAI Standard | mlx-vlm / vLLM |
|---|---|---|
| Input tokens | `prompt_tokens` | `input_tokens` |
| Output tokens | `completion_tokens` | `output_tokens` |

`parseChunkUsage()` in `openai-completions.ts` only reads `prompt_tokens`/`completion_tokens`, so when these fields are absent, both input and output are reported as 0 — causing context usage to always show `0%`.

## Fix

Use nullish coalescing (`??`) to fall back to `input_tokens`/`output_tokens` when the standard fields are not present:

```ts
const input = (rawUsage.prompt_tokens ?? rawUsage.input_tokens ?? 0) - cachedTokens;
const outputTokens = (rawUsage.completion_tokens ?? rawUsage.output_tokens ?? 0) + reasoningTokens;
```

Using `??` instead of `||` ensures that an explicit `0` value for `prompt_tokens` is respected and doesn't trigger the fallback.

## Related

Fixes openclaw/openclaw#49316