### PR TITLE
fix(google-vertex): filter ADC sentinel from resolveApiKey

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -368,7 +368,10 @@ function createClientWithApiKey(
 }
 
 function resolveApiKey(options?: GoogleVertexOptions): string | undefined {
-	return options?.apiKey || process.env.GOOGLE_CLOUD_API_KEY;
+	const key = options?.apiKey || process.env.GOOGLE_CLOUD_API_KEY;
+	// "<authenticated>" is a sentinel returned by getEnvApiKey() when ADC is available.
+	// It must not be forwarded to the SDK as an actual API key.
+	return key === "<authenticated>" ? undefined : key;
 }
 
 function resolveProject(options?: GoogleVertexOptions): string {


### PR DESCRIPTION
## Problem

`getEnvApiKey("google-vertex")` returns the string `"<authenticated>"` as a sentinel when Application Default Credentials (ADC) are available but no explicit API key is configured. `resolveApiKey()` forwards this value directly to the Google GenAI SDK as an actual API key.

The SDK then calls the Vertex AI endpoint with `key="<authenticated>"` and receives a `401 UNAUTHENTICATED / ACCESS_TOKEN_TYPE_UNSUPPORTED` error on every request, even though ADC is perfectly valid.

## Root Cause

`env-api-keys.ts` returns `"<authenticated>"` as a sentinel to signal _"ADC is ready, no real key needed"_. But `resolveApiKey()` in `google-vertex.ts` treats this return value as a literal API key:

```ts
// Before
function resolveApiKey(options?: GoogleVertexOptions): string | undefined {
    return options?.apiKey || process.env.GOOGLE_CLOUD_API_KEY;
}
```

## Fix

Return `undefined` when the resolved key equals `"<authenticated>"`, so the caller falls through to the correct ADC path (`createClient`) instead of the API key path (`createClientWithApiKey`):

```ts
// After
function resolveApiKey(options?: GoogleVertexOptions): string | undefined {
    const key = options?.apiKey || process.env.GOOGLE_CLOUD_API_KEY;
    // "<authenticated>" is a sentinel returned by getEnvApiKey() when ADC is available.
    // It must not be forwarded to the SDK as an actual API key.
    return key === "<authenticated>" ? undefined : key;
}
```

## Reproduction

1. Configure Vertex AI with ADC only (no `GOOGLE_CLOUD_API_KEY` in env)
2. Run any request through `streamGoogleVertex`
3. Observe `401 UNAUTHENTICATED` — `ACCESS_TOKEN_TYPE_UNSUPPORTED`