### PR TITLE
feat(ai): add MiniMax-M2.7 fallback model entries

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added fallback `MiniMax-M2.7` model entries for `minimax` and `minimax-cn` providers so the new model can be selected before upstream model catalogs include it.
+
 ## [0.60.0] - 2026-03-18
 
 ### Fixed

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -12,6 +12,44 @@ for (const [provider, models] of Object.entries(MODELS)) {
 	modelRegistry.set(provider, providerModels);
 }
 
+interface ModelFallbackAlias {
+	provider: "minimax" | "minimax-cn";
+	id: string;
+	name: string;
+}
+
+const MINIMAX_FALLBACK_SOURCE_IDS = ["MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"] as const;
+
+const MINIMAX_FALLBACK_ALIASES: readonly ModelFallbackAlias[] = [
+	{ provider: "minimax", id: "MiniMax-M2.7", name: "MiniMax-M2.7" },
+	{ provider: "minimax-cn", id: "MiniMax-M2.7", name: "MiniMax-M2.7" },
+];
+
+function registerModelFallbackAliases(): void {
+	for (const alias of MINIMAX_FALLBACK_ALIASES) {
+		const providerModels = modelRegistry.get(alias.provider);
+		if (!providerModels || providerModels.has(alias.id)) {
+			continue;
+		}
+
+		const sourceModel = MINIMAX_FALLBACK_SOURCE_IDS
+			.map((modelId) => providerModels.get(modelId))
+			.find((model): model is Model<Api> => model !== undefined);
+
+		if (!sourceModel) {
+			continue;
+		}
+
+		providerModels.set(alias.id, {
+			...sourceModel,
+			id: alias.id,
+			name: alias.name,
+		});
+	}
+}
+
+registerModelFallbackAliases();
+
 type ModelApi<
 	TProvider extends KnownProvider,
 	TModelId extends keyof (typeof MODELS)[TProvider],


### PR DESCRIPTION
## Summary
- Add runtime fallback model aliases for MiniMax-M2.7 under minimax and minimax-cn.
- Reuse existing MiniMax M2.x metadata (preferring M2.5, then M2.1, then M2) so the new model can be selected before upstream catalogs are updated.
- Update packages/ai/CHANGELOG.md under [Unreleased].

## Validation
- Attempted: pnpm run check
- Result: failed in this environment because dependencies are not installed (missing node_modules / biome).
