### PR TITLE
fix(ai): support prompt caching for Bedrock application inference profiles

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -430,10 +430,22 @@ function resolveCacheRetention(cacheRetention?: CacheRetention): CacheRetention 
 /**
  * Check if the model supports prompt caching.
  * Supported: Claude 3.5 Haiku, Claude 3.7 Sonnet, Claude 4.x models
+ *
+ * For base models and system-defined inference profiles the model ID / ARN
+ * contains the model name, so we can decide locally.
+ *
+ * For application inference profiles (whose ARNs don't contain the model name),
+ * set AWS_BEDROCK_FORCE_CACHE=1 to enable cache points.  Amazon Nova models
+ * have automatic caching and don't need explicit cache points.
  */
 function supportsPromptCaching(model: Model<"bedrock-converse-stream">): boolean {
 	const id = model.id.toLowerCase();
-	if (!id.includes("claude")) return false;
+	if (!id.includes("claude")) {
+		// Application inference profiles don't contain the model name in the ARN.
+		// Allow users to force cache points via environment variable.
+		if (typeof process !== "undefined" && process.env.AWS_BEDROCK_FORCE_CACHE === "1") return true;
+		return false;
+	}
 	// Claude 4.x models (opus-4, sonnet-4, haiku-4)
 	if (id.includes("-4-") || id.includes("-4.")) return true;
 	// Claude 3.7 Sonnet

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -147,6 +147,13 @@ Also supports ECS task roles (`AWS_CONTAINER_CREDENTIALS_*`) and IRSA (`AWS_WEB_
 pi --provider amazon-bedrock --model us.anthropic.claude-sonnet-4-20250514-v1:0
 ```
 
+Prompt caching is enabled automatically for Claude models whose ID contains a recognizable model name (base models and system-defined inference profiles). For application inference profiles (whose ARNs don't contain the model name), set `AWS_BEDROCK_FORCE_CACHE=1` to enable cache points:
+
+```bash
+export AWS_BEDROCK_FORCE_CACHE=1
+pi --provider amazon-bedrock --model arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123
+```
+
 If you are connecting to a Bedrock API proxy, the following environment variables can be used:
 
 ```bash


### PR DESCRIPTION
Commit `1a4d153` fixed #2053 by limiting Bedrock prompt caching to model IDs containing "claude". This works for base models and system-defined inference profiles (their IDs/ARNs contain the model name), but breaks prompt caching for application inference profiles — their ARNs look like `arn:aws:bedrock:<region>:<account-id>:application-inference-profile/<id>`, which don't contain "claude". This partially reverted the fix from #1326.

Amazon Nova should support explicit cache points according to [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html#prompt-caching-models), so the cachePoint rejection in #2053 may be related to message type or API compatibility rather than a fundamental limitation.

However, since Nova supports automatic caching, limiting explicit cache points to Claude models is a reasonable default.

This PR adds `AWS_BEDROCK_FORCE_CACHE=1` environment variable support. When the model ID doesn't contain a recognizable Claude model name, users can set this variable to force cache point injection. This follows the existing pattern of `AWS_BEDROCK_SKIP_AUTH` and `AWS_BEDROCK_FORCE_HTTP1`.