### PR TITLE
fix: detect multi-line paste without bracketed markers (tmux compat)

### DIFF
--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -280,6 +280,26 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 
 		this.buffer += str;
 
+		// Implicit paste detection: when a single data chunk contains newlines
+		// but no bracketed paste markers, treat it as a paste. This handles
+		// environments like tmux where paste-buffer doesn't emit bracketed
+		// paste markers. A single newline (\r or \n) alone is a normal Enter
+		// keypress, but multiple characters arriving together with embedded
+		// newlines indicate pasted content.
+		if (
+			!this.pasteMode &&
+			!this.buffer.includes(BRACKETED_PASTE_START) &&
+			str.length > 1 &&
+			/[\r\n]/.test(str) &&
+			str.replace(/[\r\n]+/g, "").length > 0
+		) {
+			// Normalize line endings and emit as paste
+			const content = str.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+			this.buffer = "";
+			this.emit("paste", content);
+			return;
+		}
+
 		if (this.pasteMode) {
 			this.pasteBuffer += this.buffer;
 			this.buffer = "";

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -399,6 +399,53 @@ describe("StdinBuffer", () => {
 		});
 	});
 
+	describe("Implicit paste detection (no bracketed markers)", () => {
+		let emittedPaste: string[] = [];
+
+		beforeEach(() => {
+			emittedPaste = [];
+			buffer.on("paste", (data) => {
+				emittedPaste.push(data);
+			});
+		});
+
+		it("should detect multi-line content without brackets as paste", () => {
+			// Simulates tmux paste-buffer which doesn't emit bracketed paste markers
+			processInput("line one\nline two\nline three");
+
+			assert.deepStrictEqual(emittedPaste, ["line one\nline two\nline three"]);
+			assert.deepStrictEqual(emittedSequences, []);
+		});
+
+		it("should detect content with carriage returns as paste", () => {
+			processInput("line one\r\nline two\r\nline three");
+
+			assert.deepStrictEqual(emittedPaste, ["line one\nline two\nline three"]);
+			assert.deepStrictEqual(emittedSequences, []);
+		});
+
+		it("should NOT treat a single newline as paste", () => {
+			processInput("\r");
+
+			assert.deepStrictEqual(emittedPaste, []);
+			assert.strictEqual(emittedSequences.length, 1);
+		});
+
+		it("should NOT treat a single \\n as paste", () => {
+			processInput("\n");
+
+			assert.deepStrictEqual(emittedPaste, []);
+			assert.strictEqual(emittedSequences.length, 1);
+		});
+
+		it("should still prefer bracketed paste when markers present", () => {
+			processInput("\x1b[200~line one\nline two\x1b[201~");
+
+			assert.deepStrictEqual(emittedPaste, ["line one\nline two"]);
+			assert.deepStrictEqual(emittedSequences, []);
+		});
+	});
+
 	describe("Destroy", () => {
 		it("should clear buffer on destroy", () => {
 			processInput("\x1b[<35");


### PR DESCRIPTION
## Problem

Multi-line paste does not work inside tmux (#2376). Pasting text containing newlines submits on the first newline instead of inserting the full content.

**Root cause:** tmux `paste-buffer` does not emit bracketed paste markers (`\x1b[200~`/`\x1b[201~`), so `StdinBuffer` passes raw newlines through as individual sequences. The editor then treats each `\r`/`\n` as an Enter keypress → submit.

## Fix

Adds **implicit paste detection** in `StdinBuffer.process()`: when a single data chunk contains both printable characters and newlines but no bracketed paste markers, it is emitted as a `paste` event instead of individual `data` events.

**Detection criteria:**
- Data chunk length > 1 (single `\r`/`\n` is still a normal Enter)
- Contains at least one `\r` or `\n`
- Contains at least one non-newline character
- No bracketed paste markers present (bracketed paste takes priority when available)

This matches the approach used by Claude Code and Codex, which both handle tmux paste correctly in the same environment.

## Changes

- `packages/tui/src/stdin-buffer.ts` — Added implicit paste detection before the existing bracketed paste handling
- `packages/tui/test/stdin-buffer.test.ts` — Added 5 tests covering: multi-line detection, CRLF normalization, single newline passthrough, and bracketed paste priority

## Testing

All 53 `StdinBuffer` tests pass:
```
✔ Implicit paste detection (no bracketed markers)
  ✔ should detect multi-line content without brackets as paste
  ✔ should detect content with carriage returns as paste
  ✔ should NOT treat a single newline as paste
  ✔ should NOT treat a single \n as paste
  ✔ should still prefer bracketed paste when markers present
```

**Manual verification:** Reproduced the bug on Ubuntu 24.04 + tmux 3.6a + pi 0.57.0. With this fix applied, multi-line paste via tmux `paste-buffer` is correctly treated as a paste event.

Fixes #2376