### PR TITLE
fix(agent): emit message events for error in catch block

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -593,6 +593,15 @@ export class Agent {
 
 			this.appendMessage(errorMsg);
 			this._state.error = err?.message || String(err);
+
+			// Emit message_start + message_end so the error message is properly
+			// tracked and persisted by listeners (e.g. agent-session). Without
+			// these events, _lastAssistantMessage won't be updated, the error
+			// won't be persisted to the session file, and retry/compaction
+			// logic will operate on a stale previous message — causing the
+			// agent to silently stall after compaction.
+			this.emit({ type: "message_start", message: errorMsg });
+			this.emit({ type: "message_end", message: errorMsg });
 			this.emit({ type: "agent_end", messages: [errorMsg] });
 		} finally {
 			this._state.isStreaming = false;

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -312,6 +312,50 @@ describe("Agent", () => {
 		expect(responseCount).toBe(2);
 	});
 
+	it("should emit message_start and message_end for error messages from catch block", async () => {
+		const events: Array<{ type: string; message?: any }> = [];
+		const agent = new Agent({
+			streamFn: () => {
+				// Throw an error to trigger the catch block in _runLoop
+				throw new Error("Network failure");
+			},
+		});
+
+		agent.subscribe((event) => {
+			if (event.type === "message_start" || event.type === "message_end" || event.type === "agent_end") {
+				events.push({ type: event.type, message: "message" in event ? event.message : undefined });
+			}
+		});
+
+		await agent.prompt("hello");
+
+		// Should have: message_start (error), message_end (error), agent_end
+		const eventTypes = events.map((e) => e.type);
+		expect(eventTypes).toContain("message_start");
+		expect(eventTypes).toContain("message_end");
+		expect(eventTypes).toContain("agent_end");
+
+		// Error message_start and message_end should come before agent_end
+		const errorMsgStartIdx = events.findIndex((e) => e.type === "message_start" && e.message?.role === "assistant");
+		const errorMsgEndIdx = events.findIndex((e) => e.type === "message_end" && e.message?.role === "assistant");
+		const agentEndIdx = eventTypes.indexOf("agent_end");
+		expect(errorMsgStartIdx).toBeGreaterThanOrEqual(0);
+		expect(errorMsgEndIdx).toBeGreaterThanOrEqual(0);
+		expect(errorMsgStartIdx).toBeLessThan(agentEndIdx);
+		expect(errorMsgEndIdx).toBeLessThan(agentEndIdx);
+
+		// The error message should have stopReason "error"
+		const messageEndEvent = events.find((e) => e.type === "message_end" && e.message?.role === "assistant");
+		expect(messageEndEvent).toBeDefined();
+		expect(messageEndEvent?.message?.stopReason).toBe("error");
+		expect(messageEndEvent?.message?.errorMessage).toBe("Network failure");
+
+		// The error message should also be in agent state
+		const lastMessage = agent.state.messages[agent.state.messages.length - 1];
+		expect(lastMessage.role).toBe("assistant");
+		expect((lastMessage as any).stopReason).toBe("error");
+	});
+
 	it("forwards sessionId to streamFn options", async () => {
 		let receivedSessionId: string | undefined;
 		const agent = new Agent({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -496,17 +496,31 @@ export class AgentSession {
 		}
 
 		// Check auto-retry and auto-compaction after agent completes
-		if (event.type === "agent_end" && this._lastAssistantMessage) {
-			const msg = this._lastAssistantMessage;
+		if (event.type === "agent_end") {
+			// Prefer _lastAssistantMessage (set by message_end events during normal
+			// loop processing). Fall back to the last assistant in event.messages as
+			// a safety net — this covers edge cases where the error message was
+			// emitted only via agent_end without a preceding message_end.
+			let msg = this._lastAssistantMessage;
+			if (!msg) {
+				for (let i = event.messages.length - 1; i >= 0; i--) {
+					if (event.messages[i].role === "assistant") {
+						msg = event.messages[i] as AssistantMessage;
+						break;
+					}
+				}
+			}
 			this._lastAssistantMessage = undefined;
 
-			// Check for retryable errors first (overloaded, rate limit, server errors)
-			if (this._isRetryableError(msg)) {
-				const didRetry = await this._handleRetryableError(msg);
-				if (didRetry) return; // Retry was initiated, don't proceed to compaction
-			}
+			if (msg) {
+				// Check for retryable errors first (overloaded, rate limit, server errors)
+				if (this._isRetryableError(msg)) {
+					const didRetry = await this._handleRetryableError(msg);
+					if (didRetry) return; // Retry was initiated, don't proceed to compaction
+				}
 
-			await this._checkCompaction(msg);
+				await this._checkCompaction(msg);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

When a pi agent is working and the LLM API call throws an exception (network error, rate limit, server error, etc.), the agent silently stalls after auto-compaction. The agent shows "Working..." but produces no output and never recovers.

## Root Cause

In `Agent._runLoop()` (packages/agent), the catch block creates an error assistant message but only adds it to in-memory state via `appendMessage()` — it does **not** emit `message_start`/`message_end` events before emitting `agent_end`.

This causes a cascade of failures in `agent-session`:

1. **Error not persisted** — `sessionManager.appendMessage()` only runs in the `message_end` handler, so the error vanishes from the session file
2. **`_lastAssistantMessage` is stale** — still points to the previous *successful* LLM response (which had `stopReason: "toolUse"`)
3. **Retry mechanism bypassed** — `_isRetryableError()` checks the old non-error message → returns false
4. **Threshold compaction triggers incorrectly** — the old message's usage data shows high context → `shouldCompact()` returns true → `_runAutoCompaction("threshold", false)` with `willRetry=false`
5. **Agent state overwritten** — `replaceMessages(sessionContext.messages)` replaces everything with compacted messages that don't include the error (never persisted)
6. **Agent idles forever** — `willRetry=false` + no queued messages = no `continue()` call

## Evidence

Observed in a live session investigating this very bug. The session file showed:
- Line 80: assistant with `stopReason: toolUse` (last successful response)
- Line 81: toolResult (completed tool call)
- Line 82: **compaction entry** (no assistant message between toolResult and compaction)

The missing assistant message between lines 81-82 is the error that was never persisted — the ghost that caused the stall.

## Fix

**Primary fix** (`packages/agent/src/agent.ts`): The catch block now emits `message_start` + `message_end` for the error message before `agent_end`. This ensures the error is properly tracked, persisted, and picked up by retry/compaction logic.

**Defense in depth** (`packages/coding-agent/src/core/agent-session.ts`): The `agent_end` handler now falls back to checking `event.messages` for the last assistant message when `_lastAssistantMessage` is not set, covering any edge cases where the error message events might not flow through.

## Test

Added a test in `packages/agent/test/agent.test.ts` that verifies:
- `message_start` and `message_end` are emitted for error messages from the catch block
- These events occur before `agent_end`
- The error message has the correct `stopReason` and `errorMessage`
- The error message is present in agent state

Closes #2383