### PR TITLE
Fix tool validation crash in restricted JS runtimes

### DIFF
--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -58,8 +58,9 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): any {
 		return toolCall.arguments;
 	}
 
-	// Compile the schema
-	const validate = ajv.compile(tool.parameters);
+	// Compile the schema — may throw in restricted runtimes (e.g. Workers)
+	let validate: any;
+	try { validate = ajv.compile(tool.parameters); } catch { return toolCall.arguments; }
 
 	// Clone arguments so AJV can safely mutate for type coercion
 	const args = structuredClone(toolCall.arguments);


### PR DESCRIPTION
## Summary
- Wrap `ajv.compile()` in a try/catch so environments that block `new Function()` (e.g. Cloudflare Workers) gracefully skip schema validation instead of crashing

## Problem
`new Ajv()` succeeds at module init because the constructor doesn't use `new Function()`. But `ajv.compile()` does — it generates a validator function from a code string. In Cloudflare Workers and similar restricted runtimes, this throws `"Code generation from strings disallowed for this context"`.

The existing try/catch around `new Ajv()` (line 18) doesn't catch this because the failure point is at compile time, not construction time. So `ajv` is non-null, the `!ajv` guard passes, and `compile()` throws.

The fix falls back to trusting the LLM output without schema validation, same as the existing browser extension path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)