### PR TITLE
Fix tool validation crash in restricted JS runtimes

### DIFF
--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -58,8 +58,9 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): any {
 		return toolCall.arguments;
 	}
 
-	// Compile the schema
-	const validate = ajv.compile(tool.parameters);
+	// Compile the schema — may throw in restricted runtimes (e.g. Workers)
+	let validate: any;
+	try { validate = ajv.compile(tool.parameters); } catch { return toolCall.arguments; }
 
 	// Clone arguments so AJV can safely mutate for type coercion
 	const args = structuredClone(toolCall.arguments);


### PR DESCRIPTION
Fixes #2395

## Summary
- Wrap `ajv.compile()` in a try/catch so environments that block `new Function()` (e.g. Cloudflare Workers) gracefully skip schema validation instead of crashing
- Falls back to trusting the LLM output, same as the existing browser extension path

🤖 Generated with [Claude Code](https://claude.com/claude-code)