### PR TITLE
fix(ai,coding-agent): show provider-specific thinking levels for Anthropic adaptive thinking

### DIFF
--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -215,9 +215,10 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 
 /**
  * Thinking/reasoning level for models that support it.
- * Note: "xhigh" is only supported by OpenAI gpt-5.1-codex-max, gpt-5.2, gpt-5.2-codex, gpt-5.3, and gpt-5.3-codex models.
+ * Note: "xhigh" is only supported by select OpenAI models.
+ * Note: "max" and "auto" are Anthropic adaptive thinking levels (Opus 4.6, Sonnet 4.6).
  */
-export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "auto";
 
 /**
  * Extensible interface for custom app messages.

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -65,6 +65,33 @@ export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
 }
 
 /**
+ * Check if a model uses Anthropic's adaptive thinking API.
+ * These models use effort levels (low/medium/high/max) instead of token budgets.
+ *
+ * Supported today:
+ * - Opus 4.6 (supports all levels including "max")
+ * - Sonnet 4.6 (supports low/medium/high, not "max")
+ */
+export function supportsAdaptiveThinking<TApi extends Api>(model: Model<TApi>): boolean {
+	if (model.api !== "anthropic-messages") return false;
+	return (
+		model.id.includes("opus-4-6") ||
+		model.id.includes("opus-4.6") ||
+		model.id.includes("sonnet-4-6") ||
+		model.id.includes("sonnet-4.6")
+	);
+}
+
+/**
+ * Check if a model supports the "max" effort level (Anthropic adaptive thinking).
+ * Currently only Opus 4.6 supports "max".
+ */
+export function supportsMaxEffort<TApi extends Api>(model: Model<TApi>): boolean {
+	if (model.api !== "anthropic-messages") return false;
+	return model.id.includes("opus-4-6") || model.id.includes("opus-4.6");
+}
+
+/**
  * Check if two models are equal by comparing both their id and provider.
  * Returns false if either model is null or undefined.
  */

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -397,8 +397,10 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 function mapThinkingLevelToEffort(
 	level: SimpleStreamOptions["reasoning"],
 	modelId: string,
-): "low" | "medium" | "high" | "max" {
+): "low" | "medium" | "high" | "max" | undefined {
 	switch (level) {
+		case "auto":
+			return undefined;
 		case "minimal":
 		case "low":
 			return "low";
@@ -406,6 +408,8 @@ function mapThinkingLevelToEffort(
 			return "medium";
 		case "high":
 			return "high";
+		case "max":
+			return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
 		case "xhigh":
 			return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
 		default:
@@ -704,23 +708,33 @@ function buildAdditionalModelRequestFields(
 	}
 
 	if (model.id.includes("anthropic.claude") || model.id.includes("anthropic/claude")) {
+		const effort = mapThinkingLevelToEffort(options.reasoning, model.id);
 		const result: Record<string, any> = supportsAdaptiveThinking(model.id)
 			? {
 					thinking: { type: "adaptive" },
-					output_config: { effort: mapThinkingLevelToEffort(options.reasoning, model.id) },
+					...(effort ? { output_config: { effort } } : {}),
 				}
 			: (() => {
-					const defaultBudgets: Record<ThinkingLevel, number> = {
+					const defaultBudgets: Record<string, number> = {
 						minimal: 1024,
 						low: 2048,
 						medium: 8192,
 						high: 16384,
-						xhigh: 16384, // Claude doesn't support xhigh, clamp to high
+						xhigh: 16384,
+						max: 16384,
+						auto: 8192,
 					};
 
-					// Custom budgets override defaults (xhigh not in ThinkingBudgets, use high)
-					const level = options.reasoning === "xhigh" ? "high" : options.reasoning;
-					const budget = options.thinkingBudgets?.[level] ?? defaultBudgets[options.reasoning];
+					// Custom budgets override defaults (xhigh/max/auto not in ThinkingBudgets, use closest)
+					const budgetLevel =
+						options.reasoning === "xhigh" || options.reasoning === "max"
+							? "high"
+							: options.reasoning === "auto"
+								? "high"
+								: options.reasoning;
+					const budget =
+						options.thinkingBudgets?.[budgetLevel as keyof typeof options.thinkingBudgets] ??
+						defaultBudgets[options.reasoning];
 
 					return {
 						thinking: {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -455,10 +455,18 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 
 /**
  * Map ThinkingLevel to Anthropic effort levels for adaptive thinking.
+ * Anthropic-native levels (low/medium/high/max) pass through directly.
+ * Legacy pi-ai levels (minimal/xhigh) are mapped to their closest equivalent.
+ * "auto" returns undefined (omit effort parameter, let model decide).
  * Note: effort "max" is only valid on Opus 4.6.
  */
-function mapThinkingLevelToEffort(level: SimpleStreamOptions["reasoning"], modelId: string): AnthropicEffort {
+function mapThinkingLevelToEffort(
+	level: SimpleStreamOptions["reasoning"],
+	modelId: string,
+): AnthropicEffort | undefined {
 	switch (level) {
+		case "auto":
+			return undefined;
 		case "minimal":
 			return "low";
 		case "low":
@@ -467,6 +475,8 @@ function mapThinkingLevelToEffort(level: SimpleStreamOptions["reasoning"], model
 			return "medium";
 		case "high":
 			return "high";
+		case "max":
+			return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
 		case "xhigh":
 			return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
 		default:

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -13,7 +13,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
-import { buildBaseOptions, clampReasoning } from "./simple-options.js";
+import { buildBaseOptions, clampReasoningForOpenAI } from "./simple-options.js";
 
 const DEFAULT_AZURE_API_VERSION = "v1";
 const AZURE_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode", "azure-openai-responses"]);
@@ -131,7 +131,7 @@ export const streamSimpleAzureOpenAIResponses: StreamFunction<"azure-openai-resp
 	}
 
 	const base = buildBaseOptions(model, options, apiKey);
-	const reasoningEffort = supportsXhigh(model) ? options?.reasoning : clampReasoning(options?.reasoning);
+	const reasoningEffort = clampReasoningForOpenAI(options?.reasoning, supportsXhigh(model));
 
 	return streamAzureOpenAIResponses(model, context, {
 		...base,

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -944,7 +944,7 @@ export function buildRequest(
 	};
 }
 
-type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh">;
+type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh" | "max" | "auto">;
 
 function getGeminiCliThinkingLevel(effort: ClampedThinkingLevel, modelId: string): GoogleThinkingLevel {
 	if (isGemini3ProModel(modelId)) {

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -454,7 +454,7 @@ function buildParams(
 	return params;
 }
 
-type ClampedThinkingLevel = Exclude<PiThinkingLevel, "xhigh">;
+type ClampedThinkingLevel = Exclude<PiThinkingLevel, "xhigh" | "max" | "auto">;
 
 function isGemini3ProModel(model: Model<"google-generative-ai">): boolean {
 	return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -389,7 +389,7 @@ function buildParams(
 	return params;
 }
 
-type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh">;
+type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh" | "max" | "auto">;
 
 function isGemini3ProModel(model: Model<"google-generative-ai">): boolean {
 	return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -28,7 +28,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
-import { buildBaseOptions, clampReasoning } from "./simple-options.js";
+import { buildBaseOptions, clampReasoningForOpenAI } from "./simple-options.js";
 
 // ============================================================================
 // Configuration
@@ -281,7 +281,7 @@ export const streamSimpleOpenAICodexResponses: StreamFunction<"openai-codex-resp
 	}
 
 	const base = buildBaseOptions(model, options, apiKey);
-	const reasoningEffort = supportsXhigh(model) ? options?.reasoning : clampReasoning(options?.reasoning);
+	const reasoningEffort = clampReasoningForOpenAI(options?.reasoning, supportsXhigh(model));
 
 	return streamOpenAICodexResponses(model, context, {
 		...base,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -30,7 +30,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
-import { buildBaseOptions, clampReasoning } from "./simple-options.js";
+import { buildBaseOptions, clampReasoningForOpenAI } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**
@@ -312,7 +312,7 @@ export const streamSimpleOpenAICompletions: StreamFunction<"openai-completions",
 	}
 
 	const base = buildBaseOptions(model, options, apiKey);
-	const reasoningEffort = supportsXhigh(model) ? options?.reasoning : clampReasoning(options?.reasoning);
+	const reasoningEffort = clampReasoningForOpenAI(options?.reasoning, supportsXhigh(model));
 	const toolChoice = (options as OpenAICompletionsOptions | undefined)?.toolChoice;
 
 	return streamOpenAICompletions(model, context, {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -16,7 +16,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
-import { buildBaseOptions, clampReasoning } from "./simple-options.js";
+import { buildBaseOptions, clampReasoningForOpenAI } from "./simple-options.js";
 
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
 
@@ -138,7 +138,7 @@ export const streamSimpleOpenAIResponses: StreamFunction<"openai-responses", Sim
 	}
 
 	const base = buildBaseOptions(model, options, apiKey);
-	const reasoningEffort = supportsXhigh(model) ? options?.reasoning : clampReasoning(options?.reasoning);
+	const reasoningEffort = clampReasoningForOpenAI(options?.reasoning, supportsXhigh(model));
 
 	return streamOpenAIResponses(model, context, {
 		...base,

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -15,8 +15,31 @@ export function buildBaseOptions(model: Model<Api>, options?: SimpleStreamOption
 	};
 }
 
-export function clampReasoning(effort: ThinkingLevel | undefined): Exclude<ThinkingLevel, "xhigh"> | undefined {
-	return effort === "xhigh" ? "high" : effort;
+/**
+ * Clamp ThinkingLevel to levels supported by most providers (excludes xhigh, max, auto).
+ * Used by Google, Bedrock, and other providers that only support minimal/low/medium/high.
+ */
+export function clampReasoning(
+	effort: ThinkingLevel | undefined,
+): Exclude<ThinkingLevel, "xhigh" | "max" | "auto"> | undefined {
+	if (effort === "xhigh" || effort === "max") return "high";
+	if (effort === "auto") return "high";
+	return effort;
+}
+
+/**
+ * Clamp ThinkingLevel for OpenAI providers (supports xhigh but not max/auto).
+ * For models supporting xhigh, passes minimal/low/medium/high/xhigh through.
+ * Anthropic-specific levels (max, auto) are mapped to their closest equivalents.
+ */
+export function clampReasoningForOpenAI(
+	effort: ThinkingLevel | undefined,
+	modelSupportsXhigh: boolean,
+): Exclude<ThinkingLevel, "max" | "auto"> | undefined {
+	if (effort === "max") return modelSupportsXhigh ? "xhigh" : "high";
+	if (effort === "auto") return "high";
+	if (effort === "xhigh" && !modelSupportsXhigh) return "high";
+	return effort;
 }
 
 export function adjustMaxTokensForThinking(

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -42,7 +42,7 @@ export type KnownProvider =
 	| "kimi-coding";
 export type Provider = KnownProvider | string;
 
-export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh";
+export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "auto";
 
 /** Token budgets for each thinking level (token-based providers only) */
 export interface ThinkingBudgets {

--- a/packages/coding-agent/examples/extensions/preset.ts
+++ b/packages/coding-agent/examples/extensions/preset.ts
@@ -51,7 +51,7 @@ interface Preset {
 	/** Model ID (e.g., "claude-sonnet-4-5") */
 	model?: string;
 	/** Thinking level */
-	thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "auto";
 	/** Tools to enable (replaces default set) */
 	tools?: string[];
 	/** Instructions to append to system prompt */

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -47,7 +47,7 @@ export interface Args {
 	unknownFlags: Map<string, boolean | string>;
 }
 
-const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max", "auto"] as const;
 
 export function isValidThinkingLevel(level: string): level is ThinkingLevel {
 	return VALID_THINKING_LEVELS.includes(level as ThinkingLevel);
@@ -213,7 +213,7 @@ ${chalk.bold("Options:")}
   --no-tools                     Disable all built-in tools
   --tools <tools>                Comma-separated list of tools to enable (default: read,bash,edit,write)
                                  Available: read, bash, edit, write, grep, find, ls
-  --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh
+  --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh, max, auto
   --extension, -e <path>         Load an extension file (can be used multiple times)
   --no-extensions, -ne           Disable extension discovery (explicit -e paths still work)
   --skill <path>                 Load a skill file or directory (can be used multiple times)

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -24,7 +24,14 @@ import type {
 	ThinkingLevel,
 } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@mariozechner/pi-ai";
-import { isContextOverflow, modelsAreEqual, resetApiProviders, supportsXhigh } from "@mariozechner/pi-ai";
+import {
+	isContextOverflow,
+	modelsAreEqual,
+	resetApiProviders,
+	supportsAdaptiveThinking,
+	supportsMaxEffort,
+	supportsXhigh,
+} from "@mariozechner/pi-ai";
 import { getDocsPath } from "../config.js";
 import { theme } from "../modes/interactive/theme/theme.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
@@ -199,11 +206,17 @@ export interface SessionStats {
 // Constants
 // ============================================================================
 
-/** Standard thinking levels */
+/** Standard thinking levels (OpenAI-style) */
 const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high"];
 
-/** Thinking levels including xhigh (for supported models) */
+/** Thinking levels including xhigh (for supported OpenAI models) */
 const THINKING_LEVELS_WITH_XHIGH: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
+
+/** Anthropic adaptive thinking levels (Sonnet 4.6) */
+const ANTHROPIC_ADAPTIVE_LEVELS: ThinkingLevel[] = ["off", "auto", "low", "medium", "high"];
+
+/** Anthropic adaptive thinking levels including max (Opus 4.6) */
+const ANTHROPIC_ADAPTIVE_LEVELS_WITH_MAX: ThinkingLevel[] = ["off", "auto", "low", "medium", "high", "max"];
 
 // ============================================================================
 // AgentSession Class
@@ -1524,10 +1537,17 @@ export class AgentSession {
 
 	/**
 	 * Get available thinking levels for current model.
-	 * The provider will clamp to what the specific model supports internally.
+	 * Returns provider-appropriate levels:
+	 * - Anthropic adaptive thinking (Opus 4.6): off/auto/low/medium/high/max
+	 * - Anthropic adaptive thinking (Sonnet 4.6): off/auto/low/medium/high
+	 * - OpenAI with xhigh support: off/minimal/low/medium/high/xhigh
+	 * - Standard: off/minimal/low/medium/high
 	 */
 	getAvailableThinkingLevels(): ThinkingLevel[] {
 		if (!this.supportsThinking()) return ["off"];
+		if (this.model && supportsAdaptiveThinking(this.model)) {
+			return supportsMaxEffort(this.model) ? ANTHROPIC_ADAPTIVE_LEVELS_WITH_MAX : ANTHROPIC_ADAPTIVE_LEVELS;
+		}
 		return this.supportsXhighThinking() ? THINKING_LEVELS_WITH_XHIGH : THINKING_LEVELS;
 	}
 
@@ -1556,20 +1576,35 @@ export class AgentSession {
 	}
 
 	private _clampThinkingLevel(level: ThinkingLevel, availableLevels: ThinkingLevel[]): ThinkingLevel {
-		const ordered = THINKING_LEVELS_WITH_XHIGH;
 		const available = new Set(availableLevels);
-		const requestedIndex = ordered.indexOf(level);
-		if (requestedIndex === -1) {
-			return availableLevels[0] ?? "off";
+
+		// Direct match — level is available
+		if (available.has(level)) return level;
+
+		// Cross-provider mapping: translate between equivalent levels
+		const equivalents: Record<string, ThinkingLevel[]> = {
+			xhigh: ["max", "high"],
+			max: ["xhigh", "high"],
+			minimal: ["low"],
+			auto: ["high"],
+		};
+		for (const equiv of equivalents[level] ?? []) {
+			if (available.has(equiv)) return equiv;
 		}
-		for (let i = requestedIndex; i < ordered.length; i++) {
-			const candidate = ordered[i];
-			if (available.has(candidate)) return candidate;
+
+		// Fall back to the ordered available list: find closest by intensity
+		const intensityOrder: ThinkingLevel[] = ["off", "auto", "minimal", "low", "medium", "high", "xhigh", "max"];
+		const requestedIndex = intensityOrder.indexOf(level);
+		if (requestedIndex !== -1) {
+			// Search forward then backward for nearest available
+			for (let i = requestedIndex; i < intensityOrder.length; i++) {
+				if (available.has(intensityOrder[i])) return intensityOrder[i];
+			}
+			for (let i = requestedIndex - 1; i >= 0; i--) {
+				if (available.has(intensityOrder[i])) return intensityOrder[i];
+			}
 		}
-		for (let i = requestedIndex - 1; i >= 0; i--) {
-			const candidate = ordered[i];
-			if (available.has(candidate)) return candidate;
-		}
+
 		return availableLevels[0] ?? "off";
 	}
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -64,7 +64,7 @@ export interface Settings {
 	lastChangelogVersion?: string;
 	defaultProvider?: string;
 	defaultModel?: string;
-	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "auto";
 	transport?: TransportSetting; // default: "sse"
 	steeringMode?: "all" | "one-at-a-time";
 	followUpMode?: "all" | "one-at-a-time";
@@ -588,11 +588,11 @@ export class SettingsManager {
 		this.save();
 	}
 
-	getDefaultThinkingLevel(): "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined {
+	getDefaultThinkingLevel(): "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "auto" | undefined {
 		return this.settings.defaultThinkingLevel;
 	}
 
-	setDefaultThinkingLevel(level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh"): void {
+	setDefaultThinkingLevel(level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "auto"): void {
 		this.globalSettings.defaultThinkingLevel = level;
 		this.markModified("defaultThinkingLevel");
 		this.save();

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -5,7 +5,7 @@
  * createAgentSession() options. The SDK does the heavy lifting.
  */
 
-import { type ImageContent, modelsAreEqual, supportsXhigh } from "@mariozechner/pi-ai";
+import { type ImageContent, modelsAreEqual } from "@mariozechner/pi-ai";
 import chalk from "chalk";
 import { createInterface } from "readline";
 import { type Args, parseArgs, printHelp } from "./cli/args.js";
@@ -823,8 +823,21 @@ export async function main(args: string[]) {
 		let effectiveThinking = session.thinkingLevel;
 		if (!session.model.reasoning) {
 			effectiveThinking = "off";
-		} else if (effectiveThinking === "xhigh" && !supportsXhigh(session.model)) {
-			effectiveThinking = "high";
+		} else {
+			// Clamp to available levels for the current model
+			const available = session.getAvailableThinkingLevels();
+			if (!available.includes(effectiveThinking)) {
+				// Cross-provider: xhigh → max, max → xhigh, etc.
+				if (effectiveThinking === "xhigh" && available.includes("max")) {
+					effectiveThinking = "max";
+				} else if (effectiveThinking === "max" && available.includes("xhigh")) {
+					effectiveThinking = "xhigh";
+				} else if (effectiveThinking === "xhigh" || effectiveThinking === "max") {
+					effectiveThinking = "high";
+				} else {
+					effectiveThinking = "high";
+				}
+			}
 		}
 		if (effectiveThinking !== session.thinkingLevel) {
 			session.setThinkingLevel(effectiveThinking);

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -26,6 +26,8 @@ const THINKING_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	medium: "Moderate reasoning (~8k tokens)",
 	high: "Deep reasoning (~16k tokens)",
 	xhigh: "Maximum reasoning (~32k tokens)",
+	max: "Always thinks with no constraints",
+	auto: "Model decides when and how much to think",
 };
 
 export interface SettingsConfig {

--- a/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
@@ -15,6 +15,8 @@ const LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	medium: "Moderate reasoning (~8k tokens)",
 	high: "Deep reasoning (~16k tokens)",
 	xhigh: "Maximum reasoning (~32k tokens)",
+	max: "Always thinks with no constraints",
+	auto: "Model decides when and how much to think",
 };
 
 /**

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -72,13 +72,15 @@ const ThemeJsonSchema = Type.Object({
 		syntaxType: ColorValueSchema,
 		syntaxOperator: ColorValueSchema,
 		syntaxPunctuation: ColorValueSchema,
-		// Thinking Level Borders (6 colors)
+		// Thinking Level Borders (8 colors)
 		thinkingOff: ColorValueSchema,
 		thinkingMinimal: ColorValueSchema,
 		thinkingLow: ColorValueSchema,
 		thinkingMedium: ColorValueSchema,
 		thinkingHigh: ColorValueSchema,
 		thinkingXhigh: ColorValueSchema,
+		thinkingMax: Type.Optional(ColorValueSchema),
+		thinkingAuto: Type.Optional(ColorValueSchema),
 		// Bash Mode (1 color)
 		bashMode: ColorValueSchema,
 	}),
@@ -140,6 +142,8 @@ export type ThemeColor =
 	| "thinkingMedium"
 	| "thinkingHigh"
 	| "thinkingXhigh"
+	| "thinkingMax"
+	| "thinkingAuto"
 	| "bashMode";
 
 export type ThemeBg =
@@ -412,7 +416,9 @@ export class Theme {
 		return this.mode;
 	}
 
-	getThinkingBorderColor(level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh"): (str: string) => string {
+	getThinkingBorderColor(
+		level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "auto",
+	): (str: string) => string {
 		// Map thinking levels to dedicated theme colors
 		switch (level) {
 			case "off":
@@ -427,6 +433,10 @@ export class Theme {
 				return (str: string) => this.fg("thinkingHigh", str);
 			case "xhigh":
 				return (str: string) => this.fg("thinkingXhigh", str);
+			case "max":
+				return (str: string) => this.fg("thinkingMax", str);
+			case "auto":
+				return (str: string) => this.fg("thinkingAuto", str);
 			default:
 				return (str: string) => this.fg("thinkingOff", str);
 		}
@@ -594,6 +604,11 @@ function createTheme(themeJson: ThemeJson, mode?: ColorMode, sourcePath?: string
 			fgColors[key as ThemeColor] = value;
 		}
 	}
+
+	// Fallback for new thinking level colors: reuse existing colors when not defined
+	if (!fgColors.thinkingMax) fgColors.thinkingMax = fgColors.thinkingXhigh;
+	if (!fgColors.thinkingAuto) fgColors.thinkingAuto = fgColors.thinkingHigh;
+
 	return new Theme(fgColors, bgColors, colorMode, {
 		name: themeJson.name,
 		sourcePath,

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -105,7 +105,7 @@ describe("parseModelPattern", () => {
 		});
 
 		test("all valid thinking levels work", () => {
-			for (const level of ["off", "minimal", "low", "medium", "high", "xhigh"]) {
+			for (const level of ["off", "minimal", "low", "medium", "high", "xhigh", "max", "auto"]) {
 				const result = parseModelPattern(`sonnet:${level}`, allModels);
 				expect(result.model?.id).toBe("claude-sonnet-4-5");
 				expect(result.thinkingLevel).toBe(level);

--- a/packages/web-ui/src/components/AgentInterface.ts
+++ b/packages/web-ui/src/components/AgentInterface.ts
@@ -8,7 +8,7 @@ import "./MessageList.js";
 import "./Messages.js"; // Import for side effects to register the custom elements
 import { getAppStorage } from "../storage/app-storage.js";
 import "./StreamingMessageContainer.js";
-import type { Agent, AgentEvent } from "@mariozechner/pi-agent-core";
+import type { Agent, AgentEvent, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { Attachment } from "../utils/attachment-utils.js";
 import { formatUsage } from "../utils/format.js";
 import { i18n } from "../utils/i18n.js";
@@ -381,7 +381,7 @@ export class AgentInterface extends LitElement {
 							}}
 							.onThinkingChange=${
 								this.enableThinkingSelector
-									? (level: "off" | "minimal" | "low" | "medium" | "high") => {
+									? (level: ThinkingLevel) => {
 											session.setThinkingLevel(level);
 										}
 									: undefined

--- a/packages/web-ui/src/components/MessageEditor.ts
+++ b/packages/web-ui/src/components/MessageEditor.ts
@@ -30,6 +30,7 @@ export class MessageEditor extends LitElement {
 	@property() isStreaming = false;
 	@property() currentModel?: Model<any>;
 	@property() thinkingLevel: ThinkingLevel = "off";
+	@property() availableThinkingLevels: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high"];
 	@property() showAttachmentButton = true;
 	@property() showModelSelector = true;
 	@property() showThinkingSelector = true;
@@ -37,7 +38,7 @@ export class MessageEditor extends LitElement {
 	@property() onSend?: (input: string, attachments: Attachment[]) => void;
 	@property() onAbort?: () => void;
 	@property() onModelSelect?: () => void;
-	@property() onThinkingChange?: (level: "off" | "minimal" | "low" | "medium" | "high") => void;
+	@property() onThinkingChange?: (level: ThinkingLevel) => void;
 	@property() onFilesChange?: (files: Attachment[]) => void;
 	@property() attachments: Attachment[] = [];
 	@property() maxFiles = 10;
@@ -325,15 +326,13 @@ export class MessageEditor extends LitElement {
 									${Select({
 										value: this.thinkingLevel,
 										placeholder: i18n("Off"),
-										options: [
-											{ value: "off", label: i18n("Off"), icon: icon(Brain, "sm") },
-											{ value: "minimal", label: i18n("Minimal"), icon: icon(Brain, "sm") },
-											{ value: "low", label: i18n("Low"), icon: icon(Brain, "sm") },
-											{ value: "medium", label: i18n("Medium"), icon: icon(Brain, "sm") },
-											{ value: "high", label: i18n("High"), icon: icon(Brain, "sm") },
-										] as SelectOption[],
+										options: this.availableThinkingLevels.map((level) => ({
+											value: level,
+											label: i18n(level.charAt(0).toUpperCase() + level.slice(1)),
+											icon: icon(Brain, "sm"),
+										})) as SelectOption[],
 										onChange: (value: string) => {
-											const level = value as "off" | "minimal" | "low" | "medium" | "high";
+											const level = value as ThinkingLevel;
 											this.thinkingLevel = level;
 											this.onThinkingChange?.(level);
 										},


### PR DESCRIPTION
## Summary

Anthropic models using adaptive thinking (Opus 4.6, Sonnet 4.6) now show their native effort levels instead of the OpenAI-centric levels.

**Before:** All reasoning models show `off / minimal / low / medium / high` (or `xhigh` for select models)
**After:** Anthropic adaptive thinking models show `off / auto / low / medium / high / max`

## Problem

The thinking level UI was OpenAI-centric:
- `minimal` and `low` both mapped to Anthropic's `low` (duplicate)
- `xhigh` shown instead of `max` (Anthropic's terminology)
- No way to use "auto" mode (let model decide when/how much to think)
- Sonnet 4.6 excluded from `supportsXhigh()` despite supporting adaptive thinking
- Token budget descriptions (`~1k tokens`) don't apply to adaptive thinking

See #2397 for full details.

## Changes

**packages/ai:**
- Add `"max"` and `"auto"` to `ThinkingLevel` type
- Add `supportsAdaptiveThinking()` and `supportsMaxEffort()` to `models.ts`
- Handle `"max"` and `"auto"` directly in Anthropic and Bedrock `mapThinkingLevelToEffort()`
- `"auto"` returns `undefined` (omits effort param, model decides)
- Add `clampReasoningForOpenAI()` — OpenAI providers clamp `max`→`xhigh`, `auto`→`high`
- Update `clampReasoning()` to exclude `max`/`auto` for Google/Bedrock providers
- Update `ClampedThinkingLevel` in Google/Vertex providers

**packages/coding-agent:**
- Add `ANTHROPIC_ADAPTIVE_LEVELS` and `ANTHROPIC_ADAPTIVE_LEVELS_WITH_MAX` constants
- Make `getAvailableThinkingLevels()` provider-aware
- Rewrite `_clampThinkingLevel()` for cross-provider model switching (e.g. `xhigh`↔`max`)
- Update CLI `--thinking` to accept `max` and `auto`
- Update settings persistence, theme colors, descriptions

**packages/agent:** Update `ThinkingLevel` type

**packages/web-ui:** Use `availableThinkingLevels` property instead of hardcoded options

Fixes #2397
