### PR TITLE
feat(keybindings): scope built-in keybindings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed built-in keybinding conflict detection to use keybinding scopes so extension shortcut conflicts are checked only against built-in shortcuts active in global and editor contexts ([#2403](https://github.com/badlogic/pi-mono/pull/2403) by [@aliou](https://github.com/aliou))
+
 ### Fixed
 
 - Tests for session-selector-rename and tree-selector are now keybinding-agnostic, resetting editor keybindings to defaults before each test so user `keybindings.json` cannot cause failures ([#2360](https://github.com/badlogic/pi-mono/issues/2360))

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -4,10 +4,15 @@
 
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent, Model } from "@mariozechner/pi-ai";
-import type { KeyId } from "@mariozechner/pi-tui";
+import { DEFAULT_EDITOR_KEYBINDING_METADATA, type KeybindingScope, type KeyId } from "@mariozechner/pi-tui";
 import { type Theme, theme } from "../../modes/interactive/theme/theme.js";
 import type { ResourceDiagnostic } from "../diagnostics.js";
-import type { KeyAction, KeybindingsConfig } from "../keybindings.js";
+import {
+	type AppAction,
+	DEFAULT_APP_KEYBINDING_METADATA,
+	type KeyAction,
+	type KeybindingsConfig,
+} from "../keybindings.js";
 import type { ModelRegistry } from "../model-registry.js";
 import type { SessionManager } from "../session-manager.js";
 import type {
@@ -72,19 +77,44 @@ const RESERVED_ACTIONS_FOR_EXTENSION_CONFLICTS: ReadonlyArray<KeyAction> = [
 	"deleteToLineEnd",
 ];
 
-type BuiltInKeyBindings = Partial<Record<KeyId, { action: KeyAction; restrictOverride: boolean }>>;
+const EXTENSION_CONFLICT_SCOPES: ReadonlySet<KeybindingScope> = new Set(["global", "editor"]);
+
+type BuiltInKeyBinding = { action: KeyAction; restrictOverride: boolean; scope: KeybindingScope };
+
+type BuiltInKeyBindings = Partial<Record<KeyId, BuiltInKeyBinding>>;
+
+const shouldCheckExtensionConflictForScope = (scope: KeybindingScope): boolean => EXTENSION_CONFLICT_SCOPES.has(scope);
 
 const buildBuiltinKeybindings = (effectiveKeybindings: Required<KeybindingsConfig>): BuiltInKeyBindings => {
 	const builtinKeybindings = {} as BuiltInKeyBindings;
-	for (const [action, keys] of Object.entries(effectiveKeybindings)) {
+	for (const [action, metadata] of Object.entries(DEFAULT_EDITOR_KEYBINDING_METADATA)) {
+		if (!shouldCheckExtensionConflictForScope(metadata.scope)) continue;
 		const keyAction = action as KeyAction;
-		const keyList = Array.isArray(keys) ? keys : [keys];
+		const configuredKeys = effectiveKeybindings[keyAction];
+		const keyList = Array.isArray(configuredKeys) ? configuredKeys : [configuredKeys];
 		const restrictOverride = RESERVED_ACTIONS_FOR_EXTENSION_CONFLICTS.includes(keyAction);
 		for (const key of keyList) {
 			const normalizedKey = key.toLowerCase() as KeyId;
 			builtinKeybindings[normalizedKey] = {
 				action: keyAction,
-				restrictOverride: restrictOverride,
+				restrictOverride,
+				scope: metadata.scope,
+			};
+		}
+	}
+
+	for (const [action, metadata] of Object.entries(DEFAULT_APP_KEYBINDING_METADATA)) {
+		if (!shouldCheckExtensionConflictForScope(metadata.scope)) continue;
+		const appAction = action as AppAction;
+		const configuredKeys = effectiveKeybindings[appAction];
+		const keyList = Array.isArray(configuredKeys) ? configuredKeys : [configuredKeys];
+		const restrictOverride = RESERVED_ACTIONS_FOR_EXTENSION_CONFLICTS.includes(appAction);
+		for (const key of keyList) {
+			const normalizedKey = key.toLowerCase() as KeyId;
+			builtinKeybindings[normalizedKey] = {
+				action: appAction,
+				restrictOverride,
+				scope: metadata.scope,
 			};
 		}
 	}
@@ -404,7 +434,7 @@ export class ExtensionRunner {
 
 				if (builtInKeybinding?.restrictOverride === false) {
 					addDiagnostic(
-						`Extension shortcut conflict: '${key}' is built-in shortcut for ${builtInKeybinding.action} and ${shortcut.extensionPath}. Using ${shortcut.extensionPath}.`,
+						`Extension shortcut conflict: '${key}' is built-in shortcut for ${builtInKeybinding.action} in ${builtInKeybinding.scope} scope. Using ${shortcut.extensionPath}.`,
 						shortcut.extensionPath,
 					);
 				}

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -3,6 +3,7 @@ import {
 	type EditorAction,
 	type EditorKeybindingsConfig,
 	EditorKeybindingsManager,
+	type KeybindingScope,
 	type KeyId,
 	matchesKey,
 	setEditorKeybindings,
@@ -48,29 +49,41 @@ export type KeybindingsConfig = {
 };
 
 /**
+ * Default application keybinding metadata.
+ */
+export const DEFAULT_APP_KEYBINDING_METADATA: Record<AppAction, AppKeybindingMetadata> = {
+	interrupt: { keys: "escape", scope: "global" },
+	clear: { keys: "ctrl+c", scope: "editor" },
+	exit: { keys: "ctrl+d", scope: "editor" },
+	suspend: { keys: "ctrl+z", scope: "global" },
+	cycleThinkingLevel: { keys: "shift+tab", scope: "global" },
+	cycleModelForward: { keys: "ctrl+p", scope: "editor" },
+	cycleModelBackward: { keys: "shift+ctrl+p", scope: "editor" },
+	selectModel: { keys: "ctrl+l", scope: "editor" },
+	expandTools: { keys: "ctrl+o", scope: "editor" },
+	toggleThinking: { keys: "ctrl+t", scope: "global" },
+	toggleSessionNamedFilter: { keys: "ctrl+n", scope: "sessionPicker" },
+	externalEditor: { keys: "ctrl+g", scope: "editor" },
+	followUp: { keys: "alt+enter", scope: "editor" },
+	dequeue: { keys: "alt+up", scope: "editor" },
+	pasteImage: { keys: process.platform === "win32" ? "alt+v" : "ctrl+v", scope: "editor" },
+	newSession: { keys: [], scope: "global" },
+	tree: { keys: [], scope: "global" },
+	fork: { keys: [], scope: "global" },
+	resume: { keys: [], scope: "global" },
+};
+
+/**
  * Default application keybindings.
  */
-export const DEFAULT_APP_KEYBINDINGS: Record<AppAction, KeyId | KeyId[]> = {
-	interrupt: "escape",
-	clear: "ctrl+c",
-	exit: "ctrl+d",
-	suspend: "ctrl+z",
-	cycleThinkingLevel: "shift+tab",
-	cycleModelForward: "ctrl+p",
-	cycleModelBackward: "shift+ctrl+p",
-	selectModel: "ctrl+l",
-	expandTools: "ctrl+o",
-	toggleThinking: "ctrl+t",
-	toggleSessionNamedFilter: "ctrl+n",
-	externalEditor: "ctrl+g",
-	followUp: "alt+enter",
-	dequeue: "alt+up",
-	pasteImage: process.platform === "win32" ? "alt+v" : "ctrl+v",
-	newSession: [],
-	tree: [],
-	fork: [],
-	resume: [],
-};
+export const DEFAULT_APP_KEYBINDINGS: Record<AppAction, KeyId | KeyId[]> = Object.fromEntries(
+	Object.entries(DEFAULT_APP_KEYBINDING_METADATA).map(([action, metadata]) => [action, metadata.keys]),
+) as Record<AppAction, KeyId | KeyId[]>;
+
+export interface AppKeybindingMetadata {
+	keys: KeyId | KeyId[];
+	scope: KeybindingScope;
+}
 
 /**
  * All default keybindings (app + editor).
@@ -160,8 +173,8 @@ export class KeybindingsManager {
 		this.appActionToKeys.clear();
 
 		// Set defaults for app actions
-		for (const [action, keys] of Object.entries(DEFAULT_APP_KEYBINDINGS)) {
-			const keyArray = Array.isArray(keys) ? keys : [keys];
+		for (const [action, metadata] of Object.entries(DEFAULT_APP_KEYBINDING_METADATA)) {
+			const keyArray = Array.isArray(metadata.keys) ? metadata.keys : [metadata.keys];
 			this.appActionToKeys.set(action as AppAction, [...keyArray]);
 		}
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added built-in keybinding scope metadata and exports to distinguish editor, selection, session picker, tree picker, and global shortcut contexts ([#2403](https://github.com/badlogic/pi-mono/pull/2403) by [@aliou](https://github.com/aliou))
+
 ## [0.60.0] - 2026-03-18
 
 ### Fixed

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -32,11 +32,14 @@ export type { EditorComponent } from "./editor-component.js";
 export { type FuzzyMatch, fuzzyFilter, fuzzyMatch } from "./fuzzy.js";
 // Keybindings
 export {
+	DEFAULT_EDITOR_KEYBINDING_METADATA,
 	DEFAULT_EDITOR_KEYBINDINGS,
 	type EditorAction,
+	type EditorKeybindingMetadata,
 	type EditorKeybindingsConfig,
 	EditorKeybindingsManager,
 	getEditorKeybindings,
+	type KeybindingScope,
 	setEditorKeybindings,
 } from "./keybindings.js";
 // Keyboard input handling

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -1,5 +1,7 @@
 import { type KeyId, matchesKey } from "./keys.js";
 
+export type KeybindingScope = "global" | "editor" | "selection" | "sessionPicker" | "treePicker";
+
 /**
  * Editor actions that can be bound to keys.
  */
@@ -64,60 +66,72 @@ export type EditorKeybindingsConfig = {
 	[K in EditorAction]?: KeyId | KeyId[];
 };
 
+export interface EditorKeybindingMetadata {
+	keys: KeyId | KeyId[];
+	scope: KeybindingScope;
+}
+
+/**
+ * Default editor keybinding metadata.
+ */
+export const DEFAULT_EDITOR_KEYBINDING_METADATA: Record<EditorAction, EditorKeybindingMetadata> = {
+	// Cursor movement
+	cursorUp: { keys: "up", scope: "editor" },
+	cursorDown: { keys: "down", scope: "editor" },
+	cursorLeft: { keys: ["left", "ctrl+b"], scope: "editor" },
+	cursorRight: { keys: ["right", "ctrl+f"], scope: "editor" },
+	cursorWordLeft: { keys: ["alt+left", "ctrl+left", "alt+b"], scope: "editor" },
+	cursorWordRight: { keys: ["alt+right", "ctrl+right", "alt+f"], scope: "editor" },
+	cursorLineStart: { keys: ["home", "ctrl+a"], scope: "editor" },
+	cursorLineEnd: { keys: ["end", "ctrl+e"], scope: "editor" },
+	jumpForward: { keys: "ctrl+]", scope: "editor" },
+	jumpBackward: { keys: "ctrl+alt+]", scope: "editor" },
+	pageUp: { keys: "pageUp", scope: "editor" },
+	pageDown: { keys: "pageDown", scope: "editor" },
+	// Deletion
+	deleteCharBackward: { keys: "backspace", scope: "editor" },
+	deleteCharForward: { keys: ["delete", "ctrl+d"], scope: "editor" },
+	deleteWordBackward: { keys: ["ctrl+w", "alt+backspace"], scope: "editor" },
+	deleteWordForward: { keys: ["alt+d", "alt+delete"], scope: "editor" },
+	deleteToLineStart: { keys: "ctrl+u", scope: "editor" },
+	deleteToLineEnd: { keys: "ctrl+k", scope: "editor" },
+	// Text input
+	newLine: { keys: "shift+enter", scope: "editor" },
+	submit: { keys: "enter", scope: "editor" },
+	tab: { keys: "tab", scope: "editor" },
+	// Selection/autocomplete
+	selectUp: { keys: "up", scope: "selection" },
+	selectDown: { keys: "down", scope: "selection" },
+	selectPageUp: { keys: "pageUp", scope: "selection" },
+	selectPageDown: { keys: "pageDown", scope: "selection" },
+	selectConfirm: { keys: "enter", scope: "selection" },
+	selectCancel: { keys: ["escape", "ctrl+c"], scope: "selection" },
+	// Clipboard
+	copy: { keys: "ctrl+c", scope: "editor" },
+	// Kill ring
+	yank: { keys: "ctrl+y", scope: "editor" },
+	yankPop: { keys: "alt+y", scope: "editor" },
+	// Undo
+	undo: { keys: "ctrl+-", scope: "editor" },
+	// Tool output
+	expandTools: { keys: "ctrl+o", scope: "editor" },
+	// Tree navigation
+	treeFoldOrUp: { keys: ["ctrl+left", "alt+left"], scope: "treePicker" },
+	treeUnfoldOrDown: { keys: ["ctrl+right", "alt+right"], scope: "treePicker" },
+	// Session
+	toggleSessionPath: { keys: "ctrl+p", scope: "sessionPicker" },
+	toggleSessionSort: { keys: "ctrl+s", scope: "sessionPicker" },
+	renameSession: { keys: "ctrl+r", scope: "sessionPicker" },
+	deleteSession: { keys: "ctrl+d", scope: "sessionPicker" },
+	deleteSessionNoninvasive: { keys: "ctrl+backspace", scope: "sessionPicker" },
+};
+
 /**
  * Default editor keybindings.
  */
-export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = {
-	// Cursor movement
-	cursorUp: "up",
-	cursorDown: "down",
-	cursorLeft: ["left", "ctrl+b"],
-	cursorRight: ["right", "ctrl+f"],
-	cursorWordLeft: ["alt+left", "ctrl+left", "alt+b"],
-	cursorWordRight: ["alt+right", "ctrl+right", "alt+f"],
-	cursorLineStart: ["home", "ctrl+a"],
-	cursorLineEnd: ["end", "ctrl+e"],
-	jumpForward: "ctrl+]",
-	jumpBackward: "ctrl+alt+]",
-	pageUp: "pageUp",
-	pageDown: "pageDown",
-	// Deletion
-	deleteCharBackward: "backspace",
-	deleteCharForward: ["delete", "ctrl+d"],
-	deleteWordBackward: ["ctrl+w", "alt+backspace"],
-	deleteWordForward: ["alt+d", "alt+delete"],
-	deleteToLineStart: "ctrl+u",
-	deleteToLineEnd: "ctrl+k",
-	// Text input
-	newLine: "shift+enter",
-	submit: "enter",
-	tab: "tab",
-	// Selection/autocomplete
-	selectUp: "up",
-	selectDown: "down",
-	selectPageUp: "pageUp",
-	selectPageDown: "pageDown",
-	selectConfirm: "enter",
-	selectCancel: ["escape", "ctrl+c"],
-	// Clipboard
-	copy: "ctrl+c",
-	// Kill ring
-	yank: "ctrl+y",
-	yankPop: "alt+y",
-	// Undo
-	undo: "ctrl+-",
-	// Tool output
-	expandTools: "ctrl+o",
-	// Tree navigation
-	treeFoldOrUp: ["ctrl+left", "alt+left"],
-	treeUnfoldOrDown: ["ctrl+right", "alt+right"],
-	// Session
-	toggleSessionPath: "ctrl+p",
-	toggleSessionSort: "ctrl+s",
-	renameSession: "ctrl+r",
-	deleteSession: "ctrl+d",
-	deleteSessionNoninvasive: "ctrl+backspace",
-};
+export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = Object.fromEntries(
+	Object.entries(DEFAULT_EDITOR_KEYBINDING_METADATA).map(([action, metadata]) => [action, metadata.keys]),
+) as Required<EditorKeybindingsConfig>;
 
 /**
  * Manages keybindings for the editor.
@@ -134,8 +148,8 @@ export class EditorKeybindingsManager {
 		this.actionToKeys.clear();
 
 		// Start with defaults
-		for (const [action, keys] of Object.entries(DEFAULT_EDITOR_KEYBINDINGS)) {
-			const keyArray = Array.isArray(keys) ? keys : [keys];
+		for (const [action, metadata] of Object.entries(DEFAULT_EDITOR_KEYBINDING_METADATA)) {
+			const keyArray = Array.isArray(metadata.keys) ? metadata.keys : [metadata.keys];
 			this.actionToKeys.set(action as EditorAction, [...keyArray]);
 		}
 


### PR DESCRIPTION
Hello! As mentioned in Discord, this adds typed scopes to built-in keybindings, and then only warns for conflicts on keybinds in the global and default scopes.

At first, I "simply" added the keybinds to warn on to an array but figured agents would miss it if there are new defaults binds added. Instead we're adding type and relying on typescript / the checks run on pre-commit to catch it before it's committed so that agents/humans have to add a scope.

Also went for a detailed list of scopes (i.e. `global`, `editor`, `selection`, `sessionPicker`, `treePicker`) instead of just having "shouldWarn" / "shouldNotWarn" but that might be overkill, lmk what you think.

Thanks!

(Also no session log because i did this from inside a cloudflare sandbox and thrashed it instead of keeping the log, soz, not even sure if you take a look at those 😅 )


------

<details><summary>Summary by gpt-5.4</summary>
<p>

## Summary

This changes built-in shortcut conflict detection so extensions only conflict with built-in shortcuts that are active in normal global/editor contexts.

## Problem

Extension shortcut conflict detection was built from the full built-in keybinding set. That caused false-positive warnings for built-in shortcuts that only apply in narrower contexts such as session picker, tree picker, or selection UIs.

In practice, an extension shortcut could warn even when the built-in shortcut was not active in the editor context where the extension shortcut is actually used.

## packages/tui

### `packages/tui/src/keybindings.ts`
- Added `KeybindingScope` with these first-pass scopes:
  - `global`
  - `editor`
  - `selection`
  - `sessionPicker`
  - `treePicker`
- Added `DEFAULT_EDITOR_KEYBINDING_METADATA` with `{ keys, scope }` metadata per built-in editor action.
- Derived `DEFAULT_EDITOR_KEYBINDINGS` from metadata instead of maintaining a separate default map.
- Scoped built-in editor actions such as:
  - normal editor editing/navigation actions to `editor`
  - autocomplete/selection actions to `selection`
  - session picker actions to `sessionPicker`
  - tree navigation actions to `treePicker`

### `packages/tui/src/index.ts`
- Exported the new scope type and metadata needed by downstream packages.

## packages/coding-agent

### `packages/coding-agent/src/core/keybindings.ts`
- Added `DEFAULT_APP_KEYBINDING_METADATA` with `{ keys, scope }` for app-level actions.
- Derived `DEFAULT_APP_KEYBINDINGS` from that metadata.
- Scoped app actions so conflict detection can distinguish global/editor shortcuts from picker-specific ones.

### `packages/coding-agent/src/core/extensions/runner.ts`
- Updated built-in shortcut collection for extension conflict detection.
- Conflict checking now includes only built-in shortcuts in `global` and `editor` scopes.
- Kept existing reserved-action behavior intact via `RESERVED_ACTIONS_FOR_EXTENSION_CONFLICTS`.
- Warning text now includes the built-in action and scope when an extension overrides a non-reserved built-in shortcut.

## Behavior change

Before:
- extension shortcuts could warn against built-ins that are only active in session-picker/tree-picker/selection contexts

After:
- extension shortcuts are checked only against built-ins active in `global` or `editor` scope
- reserved built-ins still block extension overrides as before
- non-reserved global/editor built-ins still warn, but no longer produce false positives from unrelated scopes

## Files changed

- `packages/tui/src/keybindings.ts`
- `packages/tui/src/index.ts`
- `packages/tui/CHANGELOG.md`
- `packages/coding-agent/src/core/keybindings.ts`
- `packages/coding-agent/src/core/extensions/runner.ts`
- `packages/coding-agent/CHANGELOG.md`

## Validation

Manual validation with a temporary extension confirmed:
- `ctrl+b` still warns because it overlaps an editor-scope built-in shortcut
- `ctrl+r` no longer warns when the only overlapping built-in action is session-picker scoped
- both shortcuts still fire at runtime in the expected contexts

## Notes

This is a first-pass scoped keybinding model.

It intentionally does not add a more complex override policy system or `when`-style predicates. It also preserves the existing last-write-wins behavior when multiple built-ins normalize to the same key in the flat conflict map.

</p>
</details>