### PR TITLE
feat(bash): show start time and elapsed duration for timeout commands

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -105,6 +105,7 @@ export class ToolExecutionComponent extends Container {
 	private writeHighlightCache?: WriteHighlightCache;
 	// When true, this component intentionally renders no lines
 	private hideComponent = false;
+	private bashStartTime?: number;
 
 	constructor(
 		toolName: string,
@@ -509,8 +510,25 @@ export class ToolExecutionComponent extends Container {
 		const command = str(this.args?.command);
 		const timeout = this.args?.timeout as number | undefined;
 
+		// Record start time on first render with timeout (idempotent)
+		if (timeout && !this.bashStartTime) {
+			this.bashStartTime = Date.now();
+		}
+
 		// Header
-		const timeoutSuffix = timeout ? theme.fg("muted", ` (timeout ${timeout}s)`) : "";
+		let timeoutSuffix = '';
+		if (timeout && this.bashStartTime) {
+			if (this.result) {
+				const elapsed = ((Date.now() - this.bashStartTime) / 1000).toFixed(1);
+				timeoutSuffix = theme.fg('muted', ` (timeout ${timeout}s, took ${elapsed}s)`);
+			} else {
+				const startDate = new Date(this.bashStartTime);
+				const hh = String(startDate.getHours()).padStart(2, '0');
+				const mm = String(startDate.getMinutes()).padStart(2, '0');
+				const ss = String(startDate.getSeconds()).padStart(2, '0');
+				timeoutSuffix = theme.fg('muted', ` (timeout ${timeout}s, started ${hh}:${mm}:${ss})`);
+			}
+		}
 		const commandDisplay =
 			command === null ? theme.fg("error", "[invalid arg]") : command ? command : theme.fg("toolOutput", "...");
 		this.contentBox.addChild(


### PR DESCRIPTION
## What

When a bash command is executed with a timeout parameter, show timing information:
- **While running**: `$ cmd (timeout 300s, started 09:15:30)` — users can estimate remaining time
- **After completion**: `$ cmd (timeout 300s, took 47.2s)` — elapsed duration

## Why

When executing long-running commands with timeouts (e.g., `sleep 360 && tmux capture-pane... (timeout 375s)`), users have no indication of when the command started, making it hard to gauge how much longer they need to wait.

## How

- Added `bashStartTime` field to `ToolExecutionComponent` (idempotent initialization on first render)
- Modified `renderBashContent()` to show contextual timing info based on command state
- Zero external dependencies, single file change (~19 lines added)

## Testing

Tested by running pi with a `sleep 3 && echo done` command with timeout=10:
```
$ sleep 3 && echo TIMEOUT_TEST_OK (timeout 10s, took 3.0s)
```

Commands without timeout are unaffected.