### PR TITLE
fix(image): prevent infinite error loop from oversized images

### DIFF
--- a/packages/coding-agent/src/cli/file-processor.ts
+++ b/packages/coding-agent/src/cli/file-processor.ts
@@ -57,6 +57,11 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 
 			if (autoResizeImages) {
 				const resized = await resizeImage({ type: "image", data: base64Content, mimeType });
+				if (!resized) {
+					// Image too large and cannot be resized — include as text error
+					text += `<file name="${absolutePath}">[Error: Image exceeds maximum size limit and could not be resized]</file>\n`;
+					continue;
+				}
 				dimensionNote = formatDimensionNote(resized);
 				attachment = {
 					type: "image",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -500,6 +500,12 @@ export class AgentSession {
 			const msg = this._lastAssistantMessage;
 			this._lastAssistantMessage = undefined;
 
+			// Check for image-too-large errors first — strip oversized images so the loop can continue
+			if (this._isImageTooLargeError(msg)) {
+				this._handleImageTooLargeError(msg);
+				return;
+			}
+
 			// Check for retryable errors first (overloaded, rate limit, server errors)
 			if (this._isRetryableError(msg)) {
 				const didRetry = await this._handleRetryableError(msg);
@@ -2297,6 +2303,51 @@ export class AgentSession {
 		if (this._extensionRunner && hasBindings) {
 			await this._extensionRunner.emit({ type: "session_start" });
 			await this.extendResourcesFromExtensions("reload");
+		}
+	}
+
+	// =========================================================================
+	// Image Too Large Recovery
+	// =========================================================================
+
+	/**
+	 * Check if an error is caused by an oversized image in tool results.
+	 * These are 400 errors from the API when base64 images exceed size limits.
+	 */
+	private _isImageTooLargeError(message: AssistantMessage): boolean {
+		if (message.stopReason !== "error" || !message.errorMessage) return false;
+		return /image exceeds \d+ MB|image.source.base64|payload too large|request too large/i.test(message.errorMessage);
+	}
+
+	/**
+	 * Handle image-too-large errors by stripping oversized image blocks from message history.
+	 * Replaces image blocks with text explanations so the agent can continue cleanly.
+	 */
+	private _handleImageTooLargeError(message: AssistantMessage): void {
+		const messages = this.agent.state.messages;
+
+		// Strip oversized image blocks from tool results in message history
+		for (const msg of messages) {
+			if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+			for (let i = 0; i < msg.content.length; i++) {
+				const block = msg.content[i];
+				if (block.type === "image") {
+					const imageBlock = block as ImageContent;
+					const sizeBytes = Buffer.from(imageBlock.data, "base64").length;
+					if (sizeBytes > 5 * 1024 * 1024) {
+						// Replace with text explanation
+						(msg.content as (TextContent | ImageContent)[])[i] = {
+							type: "text",
+							text: `[Image removed: exceeded 5MB API limit (${(sizeBytes / 1024 / 1024).toFixed(1)}MB). Use bash to inspect the file directly.]`,
+						};
+					}
+				}
+			}
+		}
+
+		// Remove the error assistant message so the agent can continue
+		if (messages.length > 0 && messages[messages.length - 1] === message) {
+			messages.pop();
 		}
 	}
 

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -107,17 +107,28 @@ export function createReadTool(cwd: string, options?: ReadToolOptions): AgentToo
 								if (autoResizeImages) {
 									// Resize image if needed
 									const resized = await resizeImage({ type: "image", data: base64, mimeType });
-									const dimensionNote = formatDimensionNote(resized);
 
-									let textNote = `Read image file [${resized.mimeType}]`;
-									if (dimensionNote) {
-										textNote += `\n${dimensionNote}`;
+									if (!resized) {
+										// Image too large and cannot be resized below limit
+										content = [
+											{
+												type: "text",
+												text: `Error: Image ${absolutePath} exceeds the maximum size limit and could not be resized. The file is too large to include as an image.`,
+											},
+										];
+									} else {
+										const dimensionNote = formatDimensionNote(resized);
+
+										let textNote = `Read image file [${resized.mimeType}]`;
+										if (dimensionNote) {
+											textNote += `\n${dimensionNote}`;
+										}
+
+										content = [
+											{ type: "text", text: textNote },
+											{ type: "image", data: resized.data, mimeType: resized.mimeType },
+										];
 									}
-
-									content = [
-										{ type: "text", text: textNote },
-										{ type: "image", data: resized.data, mimeType: resized.mimeType },
-									];
 								} else {
 									const textNote = `Read image file [${mimeType}]`;
 									content = [

--- a/packages/coding-agent/src/utils/image-resize.ts
+++ b/packages/coding-agent/src/utils/image-resize.ts
@@ -50,13 +50,16 @@ function pickSmaller(
  * 3. If still too large, try JPEG with decreasing quality
  * 4. If still too large, progressively reduce dimensions
  */
-export async function resizeImage(img: ImageContent, options?: ImageResizeOptions): Promise<ResizedImage> {
+export async function resizeImage(img: ImageContent, options?: ImageResizeOptions): Promise<ResizedImage | null> {
 	const opts = { ...DEFAULT_OPTIONS, ...options };
 	const inputBuffer = Buffer.from(img.data, "base64");
 
 	const photon = await loadPhoton();
 	if (!photon) {
-		// Photon not available, return original image
+		// Photon not available — return null if original exceeds maxBytes
+		if (inputBuffer.length > opts.maxBytes) {
+			return null;
+		}
 		return {
 			data: img.data,
 			mimeType: img.mimeType,
@@ -193,7 +196,10 @@ export async function resizeImage(img: ImageContent, options?: ImageResizeOption
 			}
 		}
 
-		// Last resort: return smallest version we produced
+		// Last resort: return null if still exceeds maxBytes
+		if (best.buffer.length > opts.maxBytes) {
+			return null;
+		}
 		return {
 			data: Buffer.from(best.buffer).toString("base64"),
 			mimeType: best.mimeType,
@@ -204,7 +210,10 @@ export async function resizeImage(img: ImageContent, options?: ImageResizeOption
 			wasResized: true,
 		};
 	} catch {
-		// Failed to load image
+		// Failed to load image — return null if original exceeds maxBytes
+		if (inputBuffer.length > opts.maxBytes) {
+			return null;
+		}
 		return {
 			data: img.data,
 			mimeType: img.mimeType,

--- a/packages/coding-agent/test/image-processing.test.ts
+++ b/packages/coding-agent/test/image-processing.test.ts
@@ -52,12 +52,13 @@ describe("resizeImage", () => {
 			{ maxWidth: 100, maxHeight: 100, maxBytes: 1024 * 1024 },
 		);
 
-		expect(result.wasResized).toBe(false);
-		expect(result.data).toBe(TINY_PNG);
-		expect(result.originalWidth).toBe(2);
-		expect(result.originalHeight).toBe(2);
-		expect(result.width).toBe(2);
-		expect(result.height).toBe(2);
+		expect(result).not.toBeNull();
+		expect(result!.wasResized).toBe(false);
+		expect(result!.data).toBe(TINY_PNG);
+		expect(result!.originalWidth).toBe(2);
+		expect(result!.originalHeight).toBe(2);
+		expect(result!.width).toBe(2);
+		expect(result!.height).toBe(2);
 	});
 
 	it("should resize image exceeding dimension limits", async () => {
@@ -66,26 +67,38 @@ describe("resizeImage", () => {
 			{ maxWidth: 50, maxHeight: 50, maxBytes: 1024 * 1024 },
 		);
 
-		expect(result.wasResized).toBe(true);
-		expect(result.originalWidth).toBe(100);
-		expect(result.originalHeight).toBe(100);
-		expect(result.width).toBeLessThanOrEqual(50);
-		expect(result.height).toBeLessThanOrEqual(50);
+		expect(result).not.toBeNull();
+		expect(result!.wasResized).toBe(true);
+		expect(result!.originalWidth).toBe(100);
+		expect(result!.originalHeight).toBe(100);
+		expect(result!.width).toBeLessThanOrEqual(50);
+		expect(result!.height).toBeLessThanOrEqual(50);
 	});
 
 	it("should resize image exceeding byte limit", async () => {
 		const originalBuffer = Buffer.from(LARGE_PNG_200x200, "base64");
 		const originalSize = originalBuffer.length;
 
-		// Set maxBytes to less than the original image size
+		// Set maxBytes below original but achievable with resize (90% of original)
 		const result = await resizeImage(
 			{ type: "image", data: LARGE_PNG_200x200, mimeType: "image/png" },
-			{ maxWidth: 2000, maxHeight: 2000, maxBytes: Math.floor(originalSize / 2) },
+			{ maxWidth: 2000, maxHeight: 2000, maxBytes: Math.floor(originalSize * 0.9) },
 		);
 
 		// Should have tried to reduce size
-		const resultBuffer = Buffer.from(result.data, "base64");
+		expect(result).not.toBeNull();
+		const resultBuffer = Buffer.from(result!.data, "base64");
 		expect(resultBuffer.length).toBeLessThan(originalSize);
+	});
+
+	it("should return null when image cannot be resized below maxBytes", async () => {
+		// Set impossibly small maxBytes that can never be satisfied
+		const result = await resizeImage(
+			{ type: "image", data: LARGE_PNG_200x200, mimeType: "image/png" },
+			{ maxWidth: 2000, maxHeight: 2000, maxBytes: 1 },
+		);
+
+		expect(result).toBeNull();
 	});
 
 	it("should handle JPEG input", async () => {
@@ -94,9 +107,10 @@ describe("resizeImage", () => {
 			{ maxWidth: 100, maxHeight: 100, maxBytes: 1024 * 1024 },
 		);
 
-		expect(result.wasResized).toBe(false);
-		expect(result.originalWidth).toBe(2);
-		expect(result.originalHeight).toBe(2);
+		expect(result).not.toBeNull();
+		expect(result!.wasResized).toBe(false);
+		expect(result!.originalWidth).toBe(2);
+		expect(result!.originalHeight).toBe(2);
 	});
 });
 


### PR DESCRIPTION
Fixes #2055

When the `read` tool returns an image that exceeds Anthropic's 5MB base64 limit, the API returns a 400 error. The oversized image stays in message history, causing every subsequent API call to fail — creating an infinite loop.

## Changes

**image-resize.ts**: Return `null` instead of oversized originals when:
- Photon is unavailable and original exceeds maxBytes
- Image processing fails and original exceeds maxBytes
- Image cannot be resized below limit even at minimum dimensions

**read.ts**: Handle `null` return from `resizeImage()` by returning a text error instead of the image.

**file-processor.ts**: Handle `null` from `resizeImage()` with text error fallback.

**agent-session.ts**: Add `_isImageTooLargeError()` and `_handleImageTooLargeError()` to detect 400 errors for oversized images, strip them from message history (replacing with text explanations), and allow the agent to continue cleanly.

## Testing

Updated `image-processing.test.ts` — all 9 tests pass, including new test for impossible resize constraints returning `null`.
