### PR TITLE
fix: add TTL support for shell command API key caching

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -130,6 +130,7 @@ const ProviderConfigSchema = Type.Object({
 	headers: Type.Optional(Type.Record(Type.String(), Type.String())),
 	compat: Type.Optional(OpenAICompatSchema),
 	authHeader: Type.Optional(Type.Boolean()),
+	cacheTtl: Type.Optional(Type.Number({ minimum: 0 })),
 	models: Type.Optional(Type.Array(ModelDefinitionSchema)),
 	modelOverrides: Type.Optional(Type.Record(Type.String(), ModelOverrideSchema)),
 });
@@ -240,6 +241,7 @@ export const clearApiKeyCache = clearConfigValueCache;
 export class ModelRegistry {
 	private models: Model<Api>[] = [];
 	private customProviderApiKeys: Map<string, string> = new Map();
+	private customProviderCacheTtls: Map<string, number> = new Map();
 	private registeredProviders: Map<string, ProviderConfigInput> = new Map();
 	private loadError: string | undefined = undefined;
 
@@ -251,7 +253,7 @@ export class ModelRegistry {
 		this.authStorage.setFallbackResolver((provider) => {
 			const keyConfig = this.customProviderApiKeys.get(provider);
 			if (keyConfig) {
-				return resolveConfigValue(keyConfig);
+				return resolveConfigValue(keyConfig, this.customProviderCacheTtls.get(provider));
 			}
 			return undefined;
 		});
@@ -265,7 +267,11 @@ export class ModelRegistry {
 	 */
 	refresh(): void {
 		this.customProviderApiKeys.clear();
+		this.customProviderCacheTtls.clear();
 		this.loadError = undefined;
+
+		// Clear shell command result cache so ! commands are re-executed
+		clearConfigValueCache();
 
 		// Ensure dynamic API/OAuth registrations are rebuilt from current provider state.
 		resetApiProviders();
@@ -400,6 +406,9 @@ export class ModelRegistry {
 				// Store API key for fallback resolver.
 				if (providerConfig.apiKey) {
 					this.customProviderApiKeys.set(providerName, providerConfig.apiKey);
+					if (providerConfig.cacheTtl !== undefined) {
+						this.customProviderCacheTtls.set(providerName, providerConfig.cacheTtl);
+					}
 				}
 
 				if (providerConfig.modelOverrides) {
@@ -471,6 +480,9 @@ export class ModelRegistry {
 			// Store API key config for fallback resolver
 			if (providerConfig.apiKey) {
 				this.customProviderApiKeys.set(providerName, providerConfig.apiKey);
+				if (providerConfig.cacheTtl !== undefined) {
+					this.customProviderCacheTtls.set(providerName, providerConfig.cacheTtl);
+				}
 			}
 
 			for (const modelDef of modelDefs) {
@@ -479,14 +491,14 @@ export class ModelRegistry {
 
 				// Merge headers: provider headers are base, model headers override
 				// Resolve env vars and shell commands in header values
-				const providerHeaders = resolveHeaders(providerConfig.headers);
-				const modelHeaders = resolveHeaders(modelDef.headers);
+				const providerHeaders = resolveHeaders(providerConfig.headers, providerConfig.cacheTtl);
+				const modelHeaders = resolveHeaders(modelDef.headers, providerConfig.cacheTtl);
 				const compat = mergeCompat(providerConfig.compat, modelDef.compat);
 				let headers = providerHeaders || modelHeaders ? { ...providerHeaders, ...modelHeaders } : undefined;
 
 				// If authHeader is true, add Authorization header with resolved API key
 				if (providerConfig.authHeader && providerConfig.apiKey) {
-					const resolvedKey = resolveConfigValue(providerConfig.apiKey);
+					const resolvedKey = resolveConfigValue(providerConfig.apiKey, providerConfig.cacheTtl);
 					if (resolvedKey) {
 						headers = { ...headers, Authorization: `Bearer ${resolvedKey}` };
 					}
@@ -585,6 +597,7 @@ export class ModelRegistry {
 		if (!this.registeredProviders.has(providerName)) return;
 		this.registeredProviders.delete(providerName);
 		this.customProviderApiKeys.delete(providerName);
+		this.customProviderCacheTtls.delete(providerName);
 		this.refresh();
 	}
 
@@ -617,6 +630,9 @@ export class ModelRegistry {
 		// Store API key for auth resolution
 		if (config.apiKey) {
 			this.customProviderApiKeys.set(providerName, config.apiKey);
+			if (config.cacheTtl !== undefined) {
+				this.customProviderCacheTtls.set(providerName, config.cacheTtl);
+			}
 		}
 
 		if (config.models && config.models.length > 0) {
@@ -639,13 +655,13 @@ export class ModelRegistry {
 				}
 
 				// Merge headers
-				const providerHeaders = resolveHeaders(config.headers);
-				const modelHeaders = resolveHeaders(modelDef.headers);
+				const providerHeaders = resolveHeaders(config.headers, config.cacheTtl);
+				const modelHeaders = resolveHeaders(modelDef.headers, config.cacheTtl);
 				let headers = providerHeaders || modelHeaders ? { ...providerHeaders, ...modelHeaders } : undefined;
 
 				// If authHeader is true, add Authorization header
 				if (config.authHeader && config.apiKey) {
-					const resolvedKey = resolveConfigValue(config.apiKey);
+					const resolvedKey = resolveConfigValue(config.apiKey, config.cacheTtl);
 					if (resolvedKey) {
 						headers = { ...headers, Authorization: `Bearer ${resolvedKey}` };
 					}
@@ -699,6 +715,8 @@ export interface ProviderConfigInput {
 	streamSimple?: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream;
 	headers?: Record<string, string>;
 	authHeader?: boolean;
+	/** TTL in seconds for shell command (!) cache entries. When set, cached results expire and commands are re-executed. */
+	cacheTtl?: number;
 	/** OAuth provider for /login support */
 	oauth?: Omit<OAuthProviderInterface, "id">;
 	models?: Array<{

--- a/packages/coding-agent/src/core/resolve-config-value.ts
+++ b/packages/coding-agent/src/core/resolve-config-value.ts
@@ -6,17 +6,25 @@
 import { execSync, spawnSync } from "child_process";
 import { getShellConfig } from "../utils/shell.js";
 
-// Cache for shell command results (persists for process lifetime)
-const commandResultCache = new Map<string, string | undefined>();
+interface CacheEntry {
+	value: string | undefined;
+	timestamp: number;
+}
+
+// Cache for shell command results (supports optional TTL)
+const commandResultCache = new Map<string, CacheEntry>();
 
 /**
  * Resolve a config value (API key, header value, etc.) to an actual value.
  * - If starts with "!", executes the rest as a shell command and uses stdout (cached)
  * - Otherwise checks environment variable first, then treats as literal (not cached)
+ * @param cacheTtlSeconds Optional TTL in seconds for shell command cache entries.
+ *   When set, cached results expire after this duration and the command is re-executed.
+ *   When unset, results are cached for the process lifetime.
  */
-export function resolveConfigValue(config: string): string | undefined {
+export function resolveConfigValue(config: string, cacheTtlSeconds?: number): string | undefined {
 	if (config.startsWith("!")) {
-		return executeCommand(config);
+		return executeCommand(config, cacheTtlSeconds);
 	}
 	const envValue = process.env[config];
 	return envValue || config;
@@ -65,9 +73,14 @@ function executeWithDefaultShell(command: string): string | undefined {
 	}
 }
 
-function executeCommand(commandConfig: string): string | undefined {
-	if (commandResultCache.has(commandConfig)) {
-		return commandResultCache.get(commandConfig);
+function executeCommand(commandConfig: string, cacheTtlSeconds?: number): string | undefined {
+	const cached = commandResultCache.get(commandConfig);
+	if (cached) {
+		// Check if cache entry is still valid
+		if (cacheTtlSeconds === undefined || Date.now() - cached.timestamp < cacheTtlSeconds * 1000) {
+			return cached.value;
+		}
+		// TTL expired — fall through to re-execute
 	}
 
 	const command = commandConfig.slice(1);
@@ -79,18 +92,21 @@ function executeCommand(commandConfig: string): string | undefined {
 				})()
 			: executeWithDefaultShell(command);
 
-	commandResultCache.set(commandConfig, result);
+	commandResultCache.set(commandConfig, { value: result, timestamp: Date.now() });
 	return result;
 }
 
 /**
  * Resolve all header values using the same resolution logic as API keys.
  */
-export function resolveHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+export function resolveHeaders(
+	headers: Record<string, string> | undefined,
+	cacheTtlSeconds?: number,
+): Record<string, string> | undefined {
 	if (!headers) return undefined;
 	const resolved: Record<string, string> = {};
 	for (const [key, value] of Object.entries(headers)) {
-		const resolvedValue = resolveConfigValue(value);
+		const resolvedValue = resolveConfigValue(value, cacheTtlSeconds);
 		if (resolvedValue) {
 			resolved[key] = resolvedValue;
 		}

--- a/packages/coding-agent/test/resolve-config-value.test.ts
+++ b/packages/coding-agent/test/resolve-config-value.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for resolve-config-value cache TTL behavior.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearConfigValueCache, resolveConfigValue } from "../src/core/resolve-config-value.js";
+
+describe("resolveConfigValue", () => {
+	afterEach(() => {
+		clearConfigValueCache();
+		vi.restoreAllMocks();
+	});
+
+	it("should resolve literal values directly", () => {
+		expect(resolveConfigValue("my-api-key")).toBe("my-api-key");
+	});
+
+	it("should resolve environment variables", () => {
+		process.env.TEST_PI_API_KEY = "env-value";
+		expect(resolveConfigValue("TEST_PI_API_KEY")).toBe("env-value");
+		delete process.env.TEST_PI_API_KEY;
+	});
+
+	it("should cache shell command results", () => {
+		const result1 = resolveConfigValue("!echo test-value");
+		const result2 = resolveConfigValue("!echo test-value");
+		expect(result1).toBe("test-value");
+		expect(result2).toBe("test-value");
+	});
+
+	it("should re-execute shell command after TTL expires", () => {
+		vi.useFakeTimers();
+
+		// First call — caches the result
+		const result1 = resolveConfigValue("!echo ttl-test", 1);
+		expect(result1).toBe("ttl-test");
+
+		// Within TTL — returns cached
+		vi.advanceTimersByTime(500);
+		const result2 = resolveConfigValue("!echo ttl-test", 1);
+		expect(result2).toBe("ttl-test");
+
+		// After TTL — re-executes
+		vi.advanceTimersByTime(600);
+		const result3 = resolveConfigValue("!echo ttl-test", 1);
+		expect(result3).toBe("ttl-test");
+
+		vi.useRealTimers();
+	});
+
+	it("should cache forever when no TTL is specified", () => {
+		vi.useFakeTimers();
+
+		const result1 = resolveConfigValue("!echo forever-cached");
+		expect(result1).toBe("forever-cached");
+
+		// Even after a long time, cached value persists
+		vi.advanceTimersByTime(3600 * 1000);
+		const result2 = resolveConfigValue("!echo forever-cached");
+		expect(result2).toBe("forever-cached");
+
+		vi.useRealTimers();
+	});
+
+	it("should clear all cached values", () => {
+		resolveConfigValue("!echo clear-test");
+		clearConfigValueCache();
+		// After clear, the command will be re-executed
+		const result = resolveConfigValue("!echo clear-test");
+		expect(result).toBe("clear-test");
+	});
+});


### PR DESCRIPTION
Fixes #1835

Shell commands (`!`) used for `apiKey` in provider config are cached forever, causing expired token errors with short-lived credentials (e.g., Azure AD tokens via `az cli`).

## Changes

**resolve-config-value.ts**:
- Cache entries now store timestamps alongside values
- `resolveConfigValue()` accepts optional `cacheTtlSeconds` parameter
- Expired entries are automatically re-executed on next access
- Without TTL, cache-forever behavior is preserved for static secrets

**model-registry.ts**:
- Add `cacheTtl` field to `ProviderConfigSchema`
- Call `clearConfigValueCache()` in `refresh()` so `/model` re-selection picks up fresh tokens
- Pass `cacheTtl` through to all `resolveConfigValue()` / `resolveHeaders()` call sites

## Usage

```json
{
  "providers": {
    "azure-foundry": {
      "apiKey": "!az account get-access-token --resource https://cognitiveservices.azure.com --query accessToken -o tsv",
      "cacheTtl": 1800,
      "authHeader": true,
      "models": [...]
    }
  }
}
```

## Testing

Added `resolve-config-value.test.ts` — 6 tests covering literal values, env vars, caching, TTL expiry, cache-forever, and cache clearing.
