### PR TITLE
 feat(tui): make @ autocomplete async to avoid UI freezes

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Made `@` file autocomplete async using `spawn` instead of `spawnSync` to prevent UI freezes during `fd` directory walks
+
 ## [0.60.0] - 2026-03-18
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "child_process";
+import { spawn } from "child_process";
 import { readdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { basename, dirname, join } from "path";
@@ -120,13 +120,7 @@ function buildCompletionValue(
 	return `${openQuote}${path}${closeQuote}`;
 }
 
-// Use fd to walk directory tree (fast, respects .gitignore)
-function walkDirectoryWithFd(
-	baseDir: string,
-	fdPath: string,
-	query: string,
-	maxResults: number,
-): Array<{ path: string; isDirectory: boolean }> {
+function buildFdArgs(baseDir: string, query: string, maxResults: number, maxDepth?: number): string[] {
 	const args = [
 		"--base-directory",
 		baseDir,
@@ -146,22 +140,19 @@ function walkDirectoryWithFd(
 		".git/**",
 	];
 
-	// Add query as pattern if provided
+	if (maxDepth !== undefined) {
+		args.push("--max-depth", String(maxDepth));
+	}
+
 	if (query) {
 		args.push(buildFdPathQuery(query));
 	}
 
-	const result = spawnSync(fdPath, args, {
-		encoding: "utf-8",
-		stdio: ["pipe", "pipe", "pipe"],
-		maxBuffer: 10 * 1024 * 1024,
-	});
+	return args;
+}
 
-	if (result.status !== 0 || !result.stdout) {
-		return [];
-	}
-
-	const lines = result.stdout.trim().split("\n").filter(Boolean);
+function parseFdOutput(stdout: string): Array<{ path: string; isDirectory: boolean }> {
+	const lines = stdout.trim().split("\n").filter(Boolean);
 	const results: Array<{ path: string; isDirectory: boolean }> = [];
 
 	for (const line of lines) {
@@ -172,7 +163,6 @@ function walkDirectoryWithFd(
 			continue;
 		}
 
-		// fd outputs directories with trailing /
 		const isDirectory = hasTrailingSeparator;
 		results.push({
 			path: displayLine,
@@ -181,6 +171,58 @@ function walkDirectoryWithFd(
 	}
 
 	return results;
+}
+
+export interface AsyncFdHandle {
+	promise: Promise<Array<{ path: string; isDirectory: boolean }>>;
+	abort: () => void;
+}
+
+function walkDirectoryWithFdAsync(
+	baseDir: string,
+	fdPath: string,
+	query: string,
+	maxResults: number,
+	maxDepth?: number,
+): AsyncFdHandle {
+	const args = buildFdArgs(baseDir, query, maxResults, maxDepth);
+	const child = spawn(fdPath, args, {
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+
+	let aborted = false;
+
+	const promise = new Promise<Array<{ path: string; isDirectory: boolean }>>((resolve) => {
+		let stdout = "";
+		const timeout = setTimeout(() => {
+			aborted = true;
+			child.kill();
+			resolve(parseFdOutput(stdout));
+		}, 5000);
+
+		child.stdout?.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
+
+		child.on("close", () => {
+			clearTimeout(timeout);
+			if (aborted) return;
+			resolve(parseFdOutput(stdout));
+		});
+
+		child.on("error", () => {
+			clearTimeout(timeout);
+			resolve([]);
+		});
+	});
+
+	return {
+		promise,
+		abort: () => {
+			aborted = true;
+			child.kill();
+		},
+	};
 }
 
 export interface AutocompleteItem {
@@ -224,6 +266,11 @@ export interface AutocompleteProvider {
 	};
 }
 
+export interface AsyncSuggestionsHandle {
+	promise: Promise<{ items: AutocompleteItem[]; prefix: string } | null>;
+	abort: () => void;
+}
+
 // Combined provider that handles both slash commands and file paths
 export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	private commands: (SlashCommand | AutocompleteItem)[];
@@ -248,17 +295,10 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 
-		// Check for @ file reference (fuzzy search) - must be after a delimiter or at start
+		// Check for @ file reference (fuzzy search) - handled asynchronously via getSuggestionsAsync
 		const atPrefix = this.extractAtPrefix(textBeforeCursor);
 		if (atPrefix) {
-			const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
-			const suggestions = this.getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix: isQuotedPrefix });
-			if (suggestions.length === 0) return null;
-
-			return {
-				items: suggestions,
-				prefix: atPrefix,
-			};
+			return null;
 		}
 
 		// Check for slash commands
@@ -424,6 +464,47 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			cursorLine,
 			cursorCol: beforePrefix.length + cursorOffset,
 		};
+	}
+
+	/**
+	 * Check if the current input is in an @ fuzzy search context.
+	 * Used by the editor to decide whether to trigger async suggestions.
+	 */
+	isAtFuzzyContext(lines: string[], cursorLine: number, cursorCol: number): string | null {
+		const currentLine = lines[cursorLine] || "";
+		const textBeforeCursor = currentLine.slice(0, cursorCol);
+		return this.extractAtPrefix(textBeforeCursor);
+	}
+
+	/**
+	 * Async fuzzy file suggestions for @ references.
+	 * Returns a handle with a promise and an abort function.
+	 */
+	getSuggestionsAsync(lines: string[], cursorLine: number, cursorCol: number): AsyncSuggestionsHandle | null {
+		const currentLine = lines[cursorLine] || "";
+		const textBeforeCursor = currentLine.slice(0, cursorCol);
+
+		const atPrefix = this.extractAtPrefix(textBeforeCursor);
+		if (!atPrefix || !this.fdPath) {
+			return null;
+		}
+
+		const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
+		const scopedQuery = this.resolveScopedFuzzyQuery(rawPrefix);
+		const fdBaseDir = scopedQuery?.baseDir ?? this.basePath;
+		const fdQuery = scopedQuery?.query ?? rawPrefix;
+		const isOutsideProject =
+			scopedQuery !== null && !fdBaseDir.startsWith(`${this.basePath}/`) && fdBaseDir !== this.basePath;
+		const maxDepth = isOutsideProject ? 3 : undefined;
+		const handle = walkDirectoryWithFdAsync(fdBaseDir, this.fdPath, fdQuery, 100, maxDepth);
+
+		const promise = handle.promise.then((entries) => {
+			const suggestions = this.buildFuzzySuggestions(entries, fdQuery, scopedQuery, isQuotedPrefix);
+			if (suggestions.length === 0) return null;
+			return { items: suggestions, prefix: atPrefix };
+		});
+
+		return { promise, abort: handle.abort };
 	}
 
 	// Extract @ prefix for fuzzy file suggestions
@@ -684,57 +765,44 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	}
 
 	// Fuzzy file search using fd (fast, respects .gitignore)
-	private getFuzzyFileSuggestions(query: string, options: { isQuotedPrefix: boolean }): AutocompleteItem[] {
-		if (!this.fdPath) {
-			// fd not available, return empty results
-			return [];
+	private buildFuzzySuggestions(
+		entries: Array<{ path: string; isDirectory: boolean }>,
+		fdQuery: string,
+		scopedQuery: { baseDir: string; query: string; displayBase: string } | null,
+		isQuotedPrefix: boolean,
+	): AutocompleteItem[] {
+		const scoredEntries = entries
+			.map((entry) => ({
+				...entry,
+				score: fdQuery ? this.scoreEntry(entry.path, fdQuery, entry.isDirectory) : 1,
+			}))
+			.filter((entry) => entry.score > 0);
+
+		scoredEntries.sort((a, b) => b.score - a.score);
+		const topEntries = scoredEntries.slice(0, 20);
+
+		const suggestions: AutocompleteItem[] = [];
+		for (const { path: entryPath, isDirectory } of topEntries) {
+			const pathWithoutSlash = isDirectory ? entryPath.slice(0, -1) : entryPath;
+			const displayPath = scopedQuery
+				? this.scopedPathForDisplay(scopedQuery.displayBase, pathWithoutSlash)
+				: pathWithoutSlash;
+			const entryName = basename(pathWithoutSlash);
+			const completionPath = isDirectory ? `${displayPath}/` : displayPath;
+			const value = buildCompletionValue(completionPath, {
+				isDirectory,
+				isAtPrefix: true,
+				isQuotedPrefix,
+			});
+
+			suggestions.push({
+				value,
+				label: entryName + (isDirectory ? "/" : ""),
+				description: displayPath,
+			});
 		}
 
-		try {
-			const scopedQuery = this.resolveScopedFuzzyQuery(query);
-			const fdBaseDir = scopedQuery?.baseDir ?? this.basePath;
-			const fdQuery = scopedQuery?.query ?? query;
-			const entries = walkDirectoryWithFd(fdBaseDir, this.fdPath, fdQuery, 100);
-
-			// Score entries
-			const scoredEntries = entries
-				.map((entry) => ({
-					...entry,
-					score: fdQuery ? this.scoreEntry(entry.path, fdQuery, entry.isDirectory) : 1,
-				}))
-				.filter((entry) => entry.score > 0);
-
-			// Sort by score (descending) and take top 20
-			scoredEntries.sort((a, b) => b.score - a.score);
-			const topEntries = scoredEntries.slice(0, 20);
-
-			// Build suggestions
-			const suggestions: AutocompleteItem[] = [];
-			for (const { path: entryPath, isDirectory } of topEntries) {
-				// fd already includes trailing / for directories
-				const pathWithoutSlash = isDirectory ? entryPath.slice(0, -1) : entryPath;
-				const displayPath = scopedQuery
-					? this.scopedPathForDisplay(scopedQuery.displayBase, pathWithoutSlash)
-					: pathWithoutSlash;
-				const entryName = basename(pathWithoutSlash);
-				const completionPath = isDirectory ? `${displayPath}/` : displayPath;
-				const value = buildCompletionValue(completionPath, {
-					isDirectory,
-					isAtPrefix: true,
-					isQuotedPrefix: options.isQuotedPrefix,
-				});
-
-				suggestions.push({
-					value,
-					label: entryName + (isDirectory ? "/" : ""),
-					description: displayPath,
-				});
-			}
-
-			return suggestions;
-		} catch {
-			return [];
-		}
+		return suggestions;
 	}
 
 	// Force file completion (called on Tab key) - always returns suggestions

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,4 +1,4 @@
-import type { AutocompleteProvider, CombinedAutocompleteProvider } from "../autocomplete.js";
+import type { AsyncSuggestionsHandle, AutocompleteProvider, CombinedAutocompleteProvider } from "../autocomplete.js";
 import { getEditorKeybindings } from "../keybindings.js";
 import { decodeKittyPrintable, matchesKey } from "../keys.js";
 import { KillRing } from "../kill-ring.js";
@@ -241,6 +241,9 @@ export class Editor implements Component, Focusable {
 	private autocompleteState: "regular" | "force" | null = null;
 	private autocompletePrefix: string = "";
 	private autocompleteMaxVisible: number = 5;
+	private asyncAutocompleteHandle: AsyncSuggestionsHandle | null = null;
+	private asyncAutocompleteDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private autocompleteLoading: boolean = false;
 
 	// Paste tracking for large pastes
 	private pastes: Map<number, string> = new Map();
@@ -511,6 +514,11 @@ export class Editor implements Component, Focusable {
 				const linePadding = " ".repeat(Math.max(0, contentWidth - lineWidth));
 				result.push(`${leftPadding}${line}${linePadding}${rightPadding}`);
 			}
+		} else if (this.autocompleteLoading) {
+			const loadingText = this.theme.borderColor("  Searching...");
+			const lineWidth = visibleWidth(loadingText);
+			const linePadding = " ".repeat(Math.max(0, contentWidth - lineWidth));
+			result.push(`${leftPadding}${loadingText}${linePadding}${rightPadding}`);
 		}
 
 		return result;
@@ -582,7 +590,14 @@ export class Editor implements Component, Focusable {
 				this.cancelAutocomplete();
 				return;
 			}
+		} else if (this.autocompleteLoading) {
+			if (kb.matches(data, "selectCancel")) {
+				this.cancelAutocomplete();
+				return;
+			}
+		}
 
+		if (this.autocompleteState && this.autocompleteList) {
 			if (kb.matches(data, "selectUp") || kb.matches(data, "selectDown")) {
 				this.autocompleteList.handleInput(data);
 				return;
@@ -644,7 +659,7 @@ export class Editor implements Component, Focusable {
 		}
 
 		// Tab - trigger completion
-		if (kb.matches(data, "tab") && !this.autocompleteState) {
+		if (kb.matches(data, "tab") && !this.autocompleteState && !this.autocompleteLoading) {
 			this.handleTabCompletion();
 			return;
 		}
@@ -2065,6 +2080,7 @@ export class Editor implements Component, Focusable {
 		);
 
 		if (suggestions && suggestions.items.length > 0) {
+			this.cancelAsyncAutocomplete();
 			this.autocompletePrefix = suggestions.prefix;
 			this.autocompleteList = this.createAutocompleteList(suggestions.prefix, suggestions.items);
 
@@ -2076,8 +2092,55 @@ export class Editor implements Component, Focusable {
 
 			this.autocompleteState = "regular";
 		} else {
-			this.cancelAutocomplete();
+			this.tryTriggerAsyncAutocomplete();
 		}
+	}
+
+	private tryTriggerAsyncAutocomplete(): void {
+		const provider = this.autocompleteProvider as CombinedAutocompleteProvider;
+		if (typeof provider.isAtFuzzyContext !== "function") return;
+
+		const atPrefix = provider.isAtFuzzyContext(this.state.lines, this.state.cursorLine, this.state.cursorCol);
+		if (!atPrefix) {
+			this.cancelAutocomplete();
+			return;
+		}
+
+		this.cancelAsyncAutocomplete();
+		this.autocompleteLoading = true;
+		this.tui.requestRender();
+
+		this.asyncAutocompleteDebounceTimer = setTimeout(() => {
+			this.asyncAutocompleteDebounceTimer = null;
+
+			if (typeof provider.getSuggestionsAsync !== "function") return;
+			const handle = provider.getSuggestionsAsync(this.state.lines, this.state.cursorLine, this.state.cursorCol);
+			if (!handle) {
+				this.autocompleteLoading = false;
+				this.tui.requestRender();
+				return;
+			}
+
+			this.asyncAutocompleteHandle = handle;
+			handle.promise.then((result) => {
+				if (this.asyncAutocompleteHandle !== handle) return;
+
+				this.asyncAutocompleteHandle = null;
+				this.autocompleteLoading = false;
+
+				if (result && result.items.length > 0) {
+					this.autocompletePrefix = result.prefix;
+					this.autocompleteList = this.createAutocompleteList(result.prefix, result.items);
+					this.autocompleteState = "regular";
+				} else {
+					this.autocompleteState = null;
+					this.autocompleteList = undefined;
+					this.autocompletePrefix = "";
+				}
+
+				this.tui.requestRender();
+			});
+		}, 150);
 	}
 
 	private handleTabCompletion(): void {
@@ -2160,14 +2223,28 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 		this.autocompleteState = null;
 		this.autocompleteList = undefined;
 		this.autocompletePrefix = "";
+		this.cancelAsyncAutocomplete();
+	}
+
+	private cancelAsyncAutocomplete(): void {
+		if (this.asyncAutocompleteDebounceTimer) {
+			clearTimeout(this.asyncAutocompleteDebounceTimer);
+			this.asyncAutocompleteDebounceTimer = null;
+		}
+		if (this.asyncAutocompleteHandle) {
+			this.asyncAutocompleteHandle.abort();
+			this.asyncAutocompleteHandle = null;
+		}
+		this.autocompleteLoading = false;
 	}
 
 	public isShowingAutocomplete(): boolean {
-		return this.autocompleteState !== null;
+		return this.autocompleteState !== null || this.autocompleteLoading;
 	}
 
 	private updateAutocomplete(): void {
-		if (!this.autocompleteState || !this.autocompleteProvider) return;
+		if (!this.autocompleteState && !this.autocompleteLoading) return;
+		if (!this.autocompleteProvider) return;
 
 		if (this.autocompleteState === "force") {
 			this.forceFileAutocomplete();
@@ -2180,17 +2257,19 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 			this.state.cursorCol,
 		);
 		if (suggestions && suggestions.items.length > 0) {
+			this.cancelAsyncAutocomplete();
 			this.autocompletePrefix = suggestions.prefix;
-			// Always create new SelectList to ensure update
 			this.autocompleteList = this.createAutocompleteList(suggestions.prefix, suggestions.items);
 
-			// If typed prefix exactly matches one of the suggestions, select that item
 			const bestMatchIndex = this.getBestAutocompleteMatchIndex(suggestions.items, suggestions.prefix);
 			if (bestMatchIndex >= 0) {
 				this.autocompleteList.setSelectedIndex(bestMatchIndex);
 			}
 		} else {
-			this.cancelAutocomplete();
+			this.autocompleteState = null;
+			this.autocompleteList = undefined;
+			this.autocompletePrefix = "";
+			this.tryTriggerAsyncAutocomplete();
 		}
 	}
 }

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -2,6 +2,7 @@
 
 // Autocomplete support
 export {
+	type AsyncSuggestionsHandle,
 	type AutocompleteItem,
 	type AutocompleteProvider,
 	CombinedAutocompleteProvider,

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -123,7 +123,7 @@ describe("CombinedAutocompleteProvider", () => {
 			rmSync(rootDir, { recursive: true, force: true });
 		});
 
-		test("returns all files and folders for empty @ query", () => {
+		test("returns all files and folders for empty @ query", async () => {
 			setupFolder(baseDir, {
 				dirs: ["src"],
 				files: {
@@ -133,13 +133,15 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const values = result?.items.map((item) => item.value).sort();
 			assert.deepStrictEqual(values, ["@README.md", "@src/"].sort());
 		});
 
-		test("matches file with extension in query", () => {
+		test("matches file with extension in query", async () => {
 			setupFolder(baseDir, {
 				files: {
 					"file.txt": "content",
@@ -148,13 +150,15 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@file.txt";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const values = result?.items.map((item) => item.value);
 			assert.ok(values?.includes("@file.txt"));
 		});
 
-		test("filters are case insensitive", () => {
+		test("filters are case insensitive", async () => {
 			setupFolder(baseDir, {
 				dirs: ["src"],
 				files: {
@@ -164,13 +168,15 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@re";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const values = result?.items.map((item) => item.value).sort();
 			assert.deepStrictEqual(values, ["@README.md"]);
 		});
 
-		test("ranks directories before files", () => {
+		test("ranks directories before files", async () => {
 			setupFolder(baseDir, {
 				dirs: ["src"],
 				files: {
@@ -180,7 +186,9 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@src";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const firstValue = result?.items[0]?.value;
 			const hasSrcFile = result?.items?.some((item) => item.value === "@src.txt");
@@ -188,7 +196,7 @@ describe("CombinedAutocompleteProvider", () => {
 			assert.ok(hasSrcFile);
 		});
 
-		test("returns nested file paths", () => {
+		test("returns nested file paths", async () => {
 			setupFolder(baseDir, {
 				files: {
 					"src/index.ts": "export {};\n",
@@ -197,13 +205,15 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@index";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const values = result?.items.map((item) => item.value);
 			assert.ok(values?.includes("@src/index.ts"));
 		});
 
-		test("matches deeply nested paths", () => {
+		test("matches deeply nested paths", async () => {
 			setupFolder(baseDir, {
 				files: {
 					"packages/tui/src/autocomplete.ts": "export {};",
@@ -213,14 +223,16 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@tui/src/auto";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const values = result?.items.map((item) => item.value);
 			assert.ok(values?.includes("@packages/tui/src/autocomplete.ts"));
 			assert.ok(!values?.includes("@packages/ai/src/autocomplete.ts"));
 		});
 
-		test("matches directory in middle of path with --full-path", () => {
+		test("matches directory in middle of path with --full-path", async () => {
 			setupFolder(baseDir, {
 				files: {
 					"src/components/Button.tsx": "export {};",
@@ -230,14 +242,16 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@components/";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const values = result?.items.map((item) => item.value);
 			assert.ok(values?.includes("@src/components/Button.tsx"));
 			assert.ok(!values?.includes("@src/utils/helpers.ts"));
 		});
 
-		test("scopes fuzzy search to relative directories and searches recursively", () => {
+		test("scopes fuzzy search to relative directories and searches recursively", async () => {
 			setupFolder(outsideDir, {
 				files: {
 					"nested/alpha.ts": "export {};",
@@ -248,7 +262,9 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@../outside/a";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const values = result?.items.map((item) => item.value);
 			assert.ok(values?.includes("@../outside/nested/alpha.ts"));
@@ -256,7 +272,7 @@ describe("CombinedAutocompleteProvider", () => {
 			assert.ok(!values?.includes("@../outside/nested/deeper/zzz.ts"));
 		});
 
-		test("quotes paths with spaces for @ suggestions", () => {
+		test("quotes paths with spaces for @ suggestions", async () => {
 			setupFolder(baseDir, {
 				dirs: ["my folder"],
 				files: {
@@ -266,13 +282,15 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@my";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const values = result?.items.map((item) => item.value);
 			assert.ok(values?.includes('@"my folder/"'));
 		});
 
-		test("includes hidden paths but excludes .git", () => {
+		test("includes hidden paths but excludes .git", async () => {
 			setupFolder(baseDir, {
 				dirs: [".pi", ".github", ".git"],
 				files: {
@@ -284,7 +302,9 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = "@";
-			const result = provider.getSuggestions([line], 0, line.length);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			const values = result?.items.map((item) => item.value) ?? [];
 			assert.ok(values.includes("@.pi/"));
@@ -292,7 +312,7 @@ describe("CombinedAutocompleteProvider", () => {
 			assert.ok(!values.some((value) => value === "@.git" || value.startsWith("@.git/")));
 		});
 
-		test("continues autocomplete inside quoted @ paths", () => {
+		test("continues autocomplete inside quoted @ paths", async () => {
 			setupFolder(baseDir, {
 				files: {
 					"my folder/test.txt": "content",
@@ -302,7 +322,9 @@ describe("CombinedAutocompleteProvider", () => {
 
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = '@"my folder/"';
-			const result = provider.getSuggestions([line], 0, line.length - 1);
+			const handle = provider.getSuggestionsAsync([line], 0, line.length - 1);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			assert.notEqual(result, null, "Should return suggestions for quoted folder path");
 			const values = result?.items.map((item) => item.value);
@@ -310,7 +332,7 @@ describe("CombinedAutocompleteProvider", () => {
 			assert.ok(values?.includes('@"my folder/other.txt"'));
 		});
 
-		test("applies quoted @ completion without duplicating closing quote", () => {
+		test("applies quoted @ completion without duplicating closing quote", async () => {
 			setupFolder(baseDir, {
 				files: {
 					"my folder/test.txt": "content",
@@ -320,7 +342,9 @@ describe("CombinedAutocompleteProvider", () => {
 			const provider = new CombinedAutocompleteProvider([], baseDir, requireFdPath());
 			const line = '@"my folder/te"';
 			const cursorCol = line.length - 1;
-			const result = provider.getSuggestions([line], 0, cursorCol);
+			const handle = provider.getSuggestionsAsync([line], 0, cursorCol);
+			assert.notEqual(handle, null);
+			const result = await handle!.promise;
 
 			assert.notEqual(result, null, "Should return suggestions for quoted @ path");
 			const item = result?.items.find((entry) => entry.value === '@"my folder/test.txt"');


### PR DESCRIPTION
```md
   ## Summary

   make @ autocomplete async to avoid UI freezes

   ### Changes
   - switch `fd`-based `@` file autocomplete from `spawnSync` to `spawn`
   - add async suggestion handles with abort support
   - debounce async `@` lookups in the editor
   - show a loading state while async suggestions are being resolved
   - update `@` autocomplete tests to use the async suggestion API
   - export the async suggestion handle type from `packages/tui`
   - add a changelog entry

   ## Motivation

   Synchronous `fd` directory walks can block the TUI and cause visible UI freezes, especially in larger repositories. This change makes `@` file autocomplete non-blocking while preserving existing behavior as closely as
 possible.

   ## Notes

   - regular slash-command and direct path completion remain synchronous
   - `@` fuzzy search is now resolved asynchronously with cancellation support
 ```