### PR TITLE
Add a startup onboarding hint

### DIFF
--- a/packages/ai/bedrock-provider.d.ts
+++ b/packages/ai/bedrock-provider.d.ts
@@ -1,1 +1,3 @@
-export * from "./dist/bedrock-provider.js";
+import type { setBedrockProviderModule } from "./dist/index.js";
+
+export declare const bedrockProviderModule: Parameters<typeof setBedrockProviderModule>[0];

--- a/packages/ai/bedrock-provider.js
+++ b/packages/ai/bedrock-provider.js
@@ -1,1 +1,6 @@
-export * from "./dist/bedrock-provider.js";
+import { streamBedrock, streamSimpleBedrock } from "./dist/providers/amazon-bedrock.js";
+
+export const bedrockProviderModule = {
+	streamBedrock,
+	streamSimpleBedrock,
+};

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -401,7 +401,11 @@ export class InteractiveMode {
 				hint("pasteImage", "to paste image"),
 				rawKeyHint("drop files", "to attach"),
 			].join("\n");
-			this.builtInHeader = new Text(`${logo}\n${instructions}`, 1, 0);
+			const onboarding = theme.fg(
+				"dim",
+				`Pi can explain its own features, look up its docs, and inspect source code. Ask it how to use or extend Pi.`,
+			);
+			this.builtInHeader = new Text(`${logo}\n${instructions}\n\n${onboarding}`, 1, 0);
 
 			// Setup UI layout
 			this.headerContainer.addChild(new Spacer(1));


### PR DESCRIPTION
## Summary

- add a startup onboarding line telling new users that pi can explain its own features, docs, and source code
- fix the `@mariozechner/pi-ai/bedrock-provider` wrapper so the coding-agent CLI import type-checks cleanly in the monorepo

## Checks

- `npm run check`
