### PR TITLE
fix(coding-agent): debounce reftable watcher and use async git resolution

### DIFF
--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "child_process";
+import { execFile, spawnSync } from "child_process";
 import { existsSync, type FSWatcher, readFileSync, statSync, watch } from "fs";
 import { dirname, join, resolve } from "path";
 
@@ -46,9 +46,11 @@ function findGitPaths(): GitPaths | null {
 	}
 }
 
-/** Ask git for the current branch. Returns null on detached HEAD or if git is unavailable. */
-function resolveBranchWithGit(repoDir: string): string | null {
-	const result = spawnSync("git", ["--no-optional-locks", "symbolic-ref", "--quiet", "--short", "HEAD"], {
+const GIT_SYMBOLIC_REF_ARGS = ["--no-optional-locks", "symbolic-ref", "--quiet", "--short", "HEAD"] as const;
+
+/** Ask git for the current branch (sync, for initial resolution). */
+function resolveBranchWithGitSync(repoDir: string): string | null {
+	const result = spawnSync("git", GIT_SYMBOLIC_REF_ARGS, {
 		cwd: repoDir,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
@@ -56,6 +58,19 @@ function resolveBranchWithGit(repoDir: string): string | null {
 	const branch = result.status === 0 ? result.stdout.trim() : "";
 	return branch || null;
 }
+
+/** Ask git for the current branch (async, for watcher-triggered refreshes). */
+function resolveBranchWithGitAsync(repoDir: string): Promise<string | null> {
+	return new Promise((res) => {
+		execFile("git", [...GIT_SYMBOLIC_REF_ARGS], { cwd: repoDir, encoding: "utf8" }, (error, stdout) => {
+			const branch = !error ? stdout.trim() : "";
+			res(branch || null);
+		});
+	});
+}
+
+/** Debounce delay for watcher-triggered branch refreshes (ms). */
+const WATCHER_DEBOUNCE_MS = 200;
 
 /**
  * Provides git branch and extension statuses - data not otherwise accessible to extensions.
@@ -67,6 +82,7 @@ export class FooterDataProvider {
 	private gitPaths: GitPaths | null | undefined = undefined;
 	private headWatcher: FSWatcher | null = null;
 	private reftableWatcher: FSWatcher | null = null;
+	private refreshTimer: ReturnType<typeof setTimeout> | null = null;
 	private branchChangeCallbacks = new Set<() => void>();
 	private availableProviderCount = 0;
 
@@ -78,7 +94,7 @@ export class FooterDataProvider {
 	/** Current git branch, null if not in repo, "detached" if detached HEAD */
 	getGitBranch(): string | null {
 		if (this.cachedBranch === undefined) {
-			this.cachedBranch = this.resolveGitBranch();
+			this.cachedBranch = this.resolveGitBranchSync();
 		}
 		return this.cachedBranch;
 	}
@@ -128,6 +144,10 @@ export class FooterDataProvider {
 			this.reftableWatcher.close();
 			this.reftableWatcher = null;
 		}
+		if (this.refreshTimer) {
+			clearTimeout(this.refreshTimer);
+			this.refreshTimer = null;
+		}
 		this.branchChangeCallbacks.clear();
 	}
 
@@ -135,8 +155,18 @@ export class FooterDataProvider {
 		for (const cb of this.branchChangeCallbacks) cb();
 	}
 
-	private refreshGitBranch(): void {
-		const nextBranch = this.resolveGitBranch();
+	/** Schedule a debounced, async branch refresh. Collapses rapid watcher events. */
+	private scheduleRefresh(): void {
+		if (this.refreshTimer) clearTimeout(this.refreshTimer);
+		this.refreshTimer = setTimeout(() => {
+			this.refreshTimer = null;
+			this.refreshGitBranchAsync();
+		}, WATCHER_DEBOUNCE_MS);
+	}
+
+	/** Async branch refresh for watcher events. Avoids blocking the event loop. */
+	private async refreshGitBranchAsync(): Promise<void> {
+		const nextBranch = await this.resolveGitBranchAsync();
 		if (this.cachedBranch !== undefined && this.cachedBranch !== nextBranch) {
 			this.cachedBranch = nextBranch;
 			this.notifyBranchChange();
@@ -145,13 +175,31 @@ export class FooterDataProvider {
 		this.cachedBranch = nextBranch;
 	}
 
-	private resolveGitBranch(): string | null {
+	/** Sync branch resolution (used once for the initial getGitBranch() call). */
+	private resolveGitBranchSync(): string | null {
 		try {
 			if (!this.gitPaths) return null;
 			const content = readFileSync(this.gitPaths.headPath, "utf8").trim();
 			if (content.startsWith("ref: refs/heads/")) {
 				const branch = content.slice(16);
-				return branch === ".invalid" ? (resolveBranchWithGit(this.gitPaths.repoDir) ?? "detached") : branch;
+				return branch === ".invalid" ? (resolveBranchWithGitSync(this.gitPaths.repoDir) ?? "detached") : branch;
+			}
+			return "detached";
+		} catch {
+			return null;
+		}
+	}
+
+	/** Async branch resolution (used for watcher-triggered refreshes). */
+	private async resolveGitBranchAsync(): Promise<string | null> {
+		try {
+			if (!this.gitPaths) return null;
+			const content = readFileSync(this.gitPaths.headPath, "utf8").trim();
+			if (content.startsWith("ref: refs/heads/")) {
+				const branch = content.slice(16);
+				return branch === ".invalid"
+					? ((await resolveBranchWithGitAsync(this.gitPaths.repoDir)) ?? "detached")
+					: branch;
 			}
 			return "detached";
 		} catch {
@@ -168,7 +216,7 @@ export class FooterDataProvider {
 		try {
 			this.headWatcher = watch(dirname(this.gitPaths.headPath), (_eventType, filename) => {
 				if (!filename || filename.toString() === "HEAD") {
-					this.refreshGitBranch();
+					this.scheduleRefresh();
 				}
 			});
 		} catch {
@@ -181,7 +229,7 @@ export class FooterDataProvider {
 		if (existsSync(reftableDir)) {
 			try {
 				this.reftableWatcher = watch(reftableDir, () => {
-					this.refreshGitBranch();
+					this.scheduleRefresh();
 				});
 			} catch {
 				// Silently fail if we can't watch

--- a/packages/coding-agent/test/footer-data-provider.test.ts
+++ b/packages/coding-agent/test/footer-data-provider.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "child_process";
+import { execFile, spawnSync } from "child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -13,6 +13,17 @@ vi.mock("child_process", () => ({
 		}
 		return { status: 1, stdout: "", stderr: "" };
 	}),
+	execFile: vi.fn(
+		(
+			_command: string,
+			_args: readonly string[],
+			_opts: unknown,
+			cb: (err: Error | null, stdout: string, stderr: string) => void,
+		) => {
+			const branch = resolvedBranch;
+			process.nextTick(() => cb(branch ? null : new Error("not on branch"), branch ? `${branch}\n` : "", ""));
+		},
+	),
 }));
 
 import { FooterDataProvider } from "../src/core/footer-data-provider.js";
@@ -74,6 +85,7 @@ describe("FooterDataProvider reftable branch detection", () => {
 		tempDir = mkdtempSync(join(tmpdir(), "footer-data-provider-"));
 		resolvedBranch = "main";
 		vi.mocked(spawnSync).mockClear();
+		vi.mocked(execFile).mockClear();
 	});
 
 	afterEach(() => {
@@ -151,12 +163,15 @@ describe("FooterDataProvider reftable branch detection", () => {
 		const provider = new FooterDataProvider();
 		try {
 			expect(provider.getGitBranch()).toBe("main");
-			vi.mocked(spawnSync).mockClear();
+			vi.mocked(execFile).mockClear();
 			const onBranchChange = vi.fn();
 			provider.onBranchChange(onBranchChange);
 
 			writeFileSync(join(reftableDir, "tables.list"), "1\n");
-			await waitFor(() => vi.mocked(spawnSync).mock.calls.length > 0);
+			// Wait for debounce + async execFile to complete
+			await waitFor(() => vi.mocked(execFile).mock.calls.length > 0);
+			// Let the async callback settle
+			await new Promise((resolve) => setTimeout(resolve, 50));
 
 			expect(provider.getGitBranch()).toBe("main");
 			expect(onBranchChange).not.toHaveBeenCalled();
@@ -175,7 +190,7 @@ describe("FooterDataProvider reftable branch detection", () => {
 			resolvedBranch = "foo";
 
 			await new Promise<void>((resolve, reject) => {
-				const timeout = setTimeout(() => reject(new Error("Timed out waiting for branch change")), 2000);
+				const timeout = setTimeout(() => reject(new Error("Timed out waiting for branch change")), 3000);
 				provider.onBranchChange(() => {
 					clearTimeout(timeout);
 					resolve();


### PR DESCRIPTION
## Problem

The reftable watcher introduced in #2300 calls `refreshGitBranch()` synchronously on every `fs.watch` event. In repos with background git maintenance (e.g. Shopify monorepo with fsmonitor daemons), this fires ~61 times/sec. Each call does `readFileSync` of HEAD + `spawnSync("git", "symbolic-ref", ...)`, blocking the event loop ~10ms per call — **59% of the event loop is blocked** just processing reftable churn. Keystrokes feel sluggish because they wait for the current `spawnSync` to finish.

## Changes

**`packages/coding-agent/src/core/footer-data-provider.ts`**

- Debounce watcher callbacks with a 200ms trailing timer so bursts of reftable events collapse into a single check
- Use async `execFile` instead of sync `spawnSync` for watcher-triggered branch resolution, keeping `spawnSync` only for the initial `getGitBranch()` call
- Clean up debounce timer in `dispose()`

**`packages/coding-agent/test/footer-data-provider.test.ts`**

- Mock `execFile` alongside `spawnSync` for the async watcher path
- Update async tests to wait for debounced `execFile` instead of immediate `spawnSync`
