### PR TITLE
feat(skills): dynamic shell interpolation with \!`command` syntax

### DIFF
--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -11,6 +11,7 @@ Pi implements the [Agent Skills standard](https://agentskills.io/specification),
 - [Locations](#locations)
 - [How Skills Work](#how-skills-work)
 - [Skill Commands](#skill-commands)
+- [Dynamic Content](#dynamic-content)
 - [Skill Structure](#skill-structure)
 - [Frontmatter](#frontmatter)
 - [Validation](#validation)
@@ -87,6 +88,36 @@ Toggle skill commands via `/settings` in interactive mode or in `settings.json`:
   "enableSkillCommands": true
 }
 ```
+
+## Dynamic Content
+
+Skills can embed shell commands that execute at invocation time using `!`command`` syntax. The command runs, and the model sees only the output.
+
+**Security:** Interpolation only runs when the skill declares `allowed-tools` with a Bash permission in its frontmatter. Without it, `!`command`` patterns are left as-is. This prevents untrusted skills from executing arbitrary commands.
+
+```markdown
+---
+name: pr-summary
+description: Summarize changes in a pull request
+allowed-tools: Bash(git:*) Bash(gh:*)
+---
+
+# PR Summary
+
+- PR diff: !`gh pr diff`
+- Changed files: !`gh pr diff --name-only`
+- Current branch: !`git branch --show-current`
+```
+
+When invoked via `/skill:pr-summary`, pi replaces each `!`command`` with its stdout before the model sees the content.
+
+**Behavior:**
+- Requires `allowed-tools` with `Bash` or `Bash(pattern)` in frontmatter
+- Commands run in the skill's directory (where SKILL.md lives)
+- Each command has a 10-second timeout
+- Failed commands produce an inline error marker: `[error: \`command\` failed: ...]`
+- Content without `!`...`` patterns passes through unchanged
+- Compatible with [Claude Code's skill interpolation syntax](https://x.com/lydiahallie/status/2034337963820327017)
 
 ## Skill Structure
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -75,6 +75,7 @@ import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.j
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.js";
 import { CURRENT_SESSION_VERSION, getLatestCompactionEntry, type SessionHeader } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
+import { interpolateShellCommands } from "./skills.js";
 import { BUILTIN_SLASH_COMMANDS, type SlashCommandInfo, type SlashCommandLocation } from "./slash-commands.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import type { BashOperations } from "./tools/bash.js";
@@ -1051,7 +1052,8 @@ export class AgentSession {
 
 		try {
 			const content = readFileSync(skill.filePath, "utf-8");
-			const body = stripFrontmatter(content).trim();
+			let body = stripFrontmatter(content).trim();
+			body = interpolateShellCommands(body, skill.baseDir, skill.allowedTools);
 			const skillBlock = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
 			return args ? `${skillBlock}\n\n${args}` : skillBlock;
 		} catch (err) {

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "fs";
 import ignore from "ignore";
 import { homedir } from "os";
@@ -67,6 +68,7 @@ export interface SkillFrontmatter {
 	name?: string;
 	description?: string;
 	"disable-model-invocation"?: boolean;
+	"allowed-tools"?: string;
 	[key: string]: unknown;
 }
 
@@ -77,6 +79,7 @@ export interface Skill {
 	baseDir: string;
 	source: string;
 	disableModelInvocation: boolean;
+	allowedTools: string | undefined;
 }
 
 export interface LoadSkillsResult {
@@ -293,6 +296,7 @@ function loadSkillFromFile(
 				baseDir: skillDir,
 				source,
 				disableModelInvocation: frontmatter["disable-model-invocation"] === true,
+				allowedTools: typeof frontmatter["allowed-tools"] === "string" ? frontmatter["allowed-tools"] : undefined,
 			},
 			diagnostics,
 		};
@@ -301,6 +305,48 @@ function loadSkillFromFile(
 		diagnostics.push({ type: "warning", message, path: filePath });
 		return { skill: null, diagnostics };
 	}
+}
+
+/** Max time for a single shell interpolation command */
+const INTERPOLATION_TIMEOUT_MS = 10_000;
+
+/**
+ * Check whether allowed-tools includes a Bash permission.
+ * Accepts "Bash", "Bash(*)", "Bash(git:*)", etc.
+ */
+function allowsBash(allowedTools: string | undefined): boolean {
+	if (!allowedTools) return false;
+	return allowedTools.split(/\s+/).some((t) => t === "Bash" || t.startsWith("Bash("));
+}
+
+/**
+ * Replace !`command` patterns in skill content with their shell output.
+ * Runs each command via execSync in the given cwd (typically the skill's baseDir).
+ * On failure or timeout, replaces with an inline error marker.
+ *
+ * Only executes when the skill declares allowed-tools with a Bash permission
+ * in its frontmatter. Without it, !`command` patterns are left as-is.
+ * This prevents untrusted skills from executing arbitrary commands.
+ *
+ * Matches Claude Code's skill interpolation syntax for cross-compatibility.
+ * See: https://x.com/lydiahallie/status/2034337963820327017
+ */
+export function interpolateShellCommands(content: string, cwd: string, allowedTools?: string): string {
+	if (!allowsBash(allowedTools)) return content;
+
+	return content.replace(/!`([^`]+)`/g, (_match, command: string) => {
+		try {
+			return execSync(command, {
+				cwd,
+				timeout: INTERPOLATION_TIMEOUT_MS,
+				encoding: "utf-8",
+				stdio: ["pipe", "pipe", "pipe"],
+			}).trimEnd();
+		} catch (err) {
+			const message = err instanceof Error ? err.message.split("\n")[0] : String(err);
+			return `[error: \`${command}\` failed: ${message}]`;
+		}
+	});
 }
 
 /**

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -2,7 +2,13 @@ import { homedir } from "os";
 import { join, resolve } from "path";
 import { describe, expect, it } from "vitest";
 import type { ResourceDiagnostic } from "../src/core/diagnostics.js";
-import { formatSkillsForPrompt, loadSkills, loadSkillsFromDir, type Skill } from "../src/core/skills.js";
+import {
+	formatSkillsForPrompt,
+	interpolateShellCommands,
+	loadSkills,
+	loadSkillsFromDir,
+	type Skill,
+} from "../src/core/skills.js";
 
 const fixturesDir = resolve(__dirname, "fixtures/skills");
 const collisionFixturesDir = resolve(__dirname, "fixtures/skills-collision");
@@ -418,6 +424,56 @@ describe("skills", () => {
 			expect(skillMap.get("calendar")?.source).toBe("first");
 			expect(collisionWarnings).toHaveLength(1);
 			expect(collisionWarnings[0].message).toContain("name collision");
+		});
+	});
+
+	describe("interpolateShellCommands", () => {
+		it("should replace !`command` with stdout when allowed-tools includes Bash", () => {
+			const result = interpolateShellCommands("output: !`echo hello`", "/tmp", "Bash");
+			expect(result).toBe("output: hello");
+		});
+
+		it("should handle multiple commands", () => {
+			const result = interpolateShellCommands("a: !`echo one` b: !`echo two`", "/tmp", "Bash");
+			expect(result).toBe("a: one b: two");
+		});
+
+		it("should pass through content without interpolation patterns", () => {
+			const content = "no commands here, just `backticks`";
+			expect(interpolateShellCommands(content, "/tmp", "Bash")).toBe(content);
+		});
+
+		it("should produce error marker on failed command", () => {
+			const result = interpolateShellCommands("!`command_that_does_not_exist_xyz`", "/tmp", "Bash");
+			expect(result).toMatch(/\[error: `command_that_does_not_exist_xyz` failed:/);
+		});
+
+		it("should use the provided cwd", () => {
+			const result = interpolateShellCommands("!`pwd`", "/tmp", "Bash");
+			// /tmp may resolve to /private/tmp on macOS
+			expect(result).toMatch(/\/tmp/);
+		});
+
+		it("should trim trailing newlines from output", () => {
+			const result = interpolateShellCommands("!`echo hello`", "/tmp", "Bash");
+			expect(result).toBe("hello");
+			expect(result.endsWith("\n")).toBe(false);
+		});
+
+		it("should NOT execute when allowed-tools is undefined", () => {
+			const content = "output: !`echo hello`";
+			expect(interpolateShellCommands(content, "/tmp")).toBe(content);
+			expect(interpolateShellCommands(content, "/tmp", undefined)).toBe(content);
+		});
+
+		it("should NOT execute when allowed-tools has no Bash permission", () => {
+			const content = "output: !`echo hello`";
+			expect(interpolateShellCommands(content, "/tmp", "Read Write")).toBe(content);
+		});
+
+		it("should execute with Bash(pattern) allowed-tools", () => {
+			const result = interpolateShellCommands("!`echo ok`", "/tmp", "Bash(git:*) Read");
+			expect(result).toBe("ok");
 		});
 	});
 });


### PR DESCRIPTION
Replace `!\`command\`` patterns in skill content with shell output at `/skill:name` invocation time. The model sees only the result.

Gated on `allowed-tools` frontmatter — without a Bash permission declared, `!\`command\`` patterns pass through unchanged. Matches Claude Code's skill interpolation syntax for cross-compatibility.

Ref: https://x.com/lydiahallie/status/2034337963820327017

**Example skill:**

```markdown
---
name: pr-summary
description: Summarize changes in a pull request
allowed-tools: Bash(git:*) Bash(gh:*)
---

- PR diff: !\`gh pr diff\`
- Changed files: !\`gh pr diff --name-only\`
```

**Changes (4 files, 137 insertions):**

- `skills.ts`: `interpolateShellCommands()` + `allowsBash()` guard, `allowedTools` on Skill interface
- `agent-session.ts`: one call in `_expandSkillCommand()` after stripping frontmatter
- `skills.test.ts`: 9 tests (execution + security gate)
- `docs/skills.md`: "Dynamic Content" section

Commands run in skill's baseDir, 10s timeout, inline error markers on failure. No behavior change when `allowed-tools` is absent.