### PR TITLE
feat(core): auto-load OpenClaw Workspace Context files into system prompt

### DIFF
--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -54,22 +54,23 @@ function resolvePromptInput(input: string | undefined, description: string): str
 	return input;
 }
 
-function loadContextFileFromDir(dir: string): { path: string; content: string } | null {
-	const candidates = ["AGENTS.md", "CLAUDE.md"];
+function loadContextFileFromDir(dir: string): Array<{ path: string; content: string }> {
+	const candidates = ["SOUL.md", "AGENTS.md", "CLAUDE.md", "USER.md", "TOOLS.md", "HEARTBEAT.md"];
+	const results: Array<{ path: string; content: string }> = [];
 	for (const filename of candidates) {
 		const filePath = join(dir, filename);
 		if (existsSync(filePath)) {
 			try {
-				return {
+				results.push({
 					path: filePath,
 					content: readFileSync(filePath, "utf-8"),
-				};
+				});
 			} catch (error) {
 				console.error(chalk.yellow(`Warning: Could not read ${filePath}: ${error}`));
 			}
 		}
 	}
-	return null;
+	return results;
 }
 
 function loadProjectContextFiles(
@@ -81,10 +82,12 @@ function loadProjectContextFiles(
 	const contextFiles: Array<{ path: string; content: string }> = [];
 	const seenPaths = new Set<string>();
 
-	const globalContext = loadContextFileFromDir(resolvedAgentDir);
-	if (globalContext) {
-		contextFiles.push(globalContext);
-		seenPaths.add(globalContext.path);
+	const globalContexts = loadContextFileFromDir(resolvedAgentDir);
+	for (const ctx of globalContexts) {
+		if (!seenPaths.has(ctx.path)) {
+			contextFiles.push(ctx);
+			seenPaths.add(ctx.path);
+		}
 	}
 
 	const ancestorContextFiles: Array<{ path: string; content: string }> = [];
@@ -93,10 +96,12 @@ function loadProjectContextFiles(
 	const root = resolve("/");
 
 	while (true) {
-		const contextFile = loadContextFileFromDir(currentDir);
-		if (contextFile && !seenPaths.has(contextFile.path)) {
-			ancestorContextFiles.unshift(contextFile);
-			seenPaths.add(contextFile.path);
+		const localContexts = loadContextFileFromDir(currentDir);
+		for (const ctx of localContexts) {
+			if (!seenPaths.has(ctx.path)) {
+				ancestorContextFiles.unshift(ctx);
+				seenPaths.add(ctx.path);
+			}
 		}
 
 		if (currentDir === root) break;

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -66,10 +66,17 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 
 		// Append project context files
 		if (contextFiles.length > 0) {
-			prompt += "\n\n# Project Context\n\n";
-			prompt += "Project-specific instructions and guidelines:\n\n";
+			prompt += "\n\n# Workspace Context\n\n";
+
+			const hasSoul = contextFiles.some((f) => f.path.toLowerCase().endsWith("soul.md"));
+			if (hasSoul) {
+				prompt +=
+					"⚠️ SOUL.md is present: Embody its persona and tone.\nAvoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.\n\n";
+			}
+
+			prompt += "The following project context files have been loaded:\n\n";
 			for (const { path: filePath, content } of contextFiles) {
-				prompt += `## ${filePath}\n\n${content}\n\n`;
+				prompt += `## ${filePath}\n${content}\n\n`;
 			}
 		}
 
@@ -190,10 +197,17 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
 
 	// Append project context files
 	if (contextFiles.length > 0) {
-		prompt += "\n\n# Project Context\n\n";
-		prompt += "Project-specific instructions and guidelines:\n\n";
+		prompt += "\n\n# Workspace Context\n\n";
+
+		const hasSoul = contextFiles.some((f) => f.path.toLowerCase().endsWith("soul.md"));
+		if (hasSoul) {
+			prompt +=
+				"⚠️ SOUL.md is present: Embody its persona and tone.\nAvoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.\n\n";
+		}
+
+		prompt += "The following project context files have been loaded:\n\n";
 		for (const { path: filePath, content } of contextFiles) {
-			prompt += `## ${filePath}\n\n${content}\n\n`;
+			prompt += `## ${filePath}\n${content}\n\n`;
 		}
 	}
 


### PR DESCRIPTION
Replaces the hardcoded `AGENTS.md` / `CLAUDE.md` check with a dynamic loop that automatically detects and injects OpenClaw's standard Workspace Context files (`SOUL.md`, `USER.md`, `TOOLS.md`, `HEARTBEAT.md`, etc.) into the system prompt when pi is started in an OpenClaw sandbox. Includes special behavioral triggers when `SOUL.md` is detected.