### PR TITLE
Fix markdown formatting in SKILL.md

### DIFF
--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -105,7 +105,7 @@ my-skill/
 
 ### SKILL.md Format
 
-```markdown
+````markdown
 ---
 name: my-skill
 description: What this skill does and when to use it. Be specific.
@@ -116,16 +116,16 @@ description: What this skill does and when to use it. Be specific.
 ## Setup
 
 Run once before first use:
-\`\`\`bash
+```bash
 cd /path/to/skill && npm install
-\`\`\`
+```
 
 ## Usage
 
-\`\`\`bash
+```bash
 ./scripts/process.sh <input>
-\`\`\`
 ```
+````
 
 Use relative paths from the skill directory:
 
@@ -197,7 +197,7 @@ brave-search/
 ```
 
 **SKILL.md:**
-```markdown
+````markdown
 ---
 name: brave-search
 description: Web search and content extraction via Brave Search API. Use for searching documentation, facts, or any web content.
@@ -207,23 +207,23 @@ description: Web search and content extraction via Brave Search API. Use for sea
 
 ## Setup
 
-\`\`\`bash
+```bash
 cd /path/to/brave-search && npm install
-\`\`\`
+```
 
 ## Search
 
-\`\`\`bash
+```bash
 ./search.js "query"              # Basic search
 ./search.js "query" --content    # Include page content
-\`\`\`
+```
 
 ## Extract Page Content
 
-\`\`\`bash
+```bash
 ./content.js https://example.com
-\`\`\`
 ```
+````
 
 ## Skill Repositories
 


### PR DESCRIPTION
Updated markdown backticks formatting inside code block for SKILL.md

found while reading the docs edited online

this is how it looks now
<img width="270" height="224" alt="image" src="https://github.com/user-attachments/assets/f4f8cbf7-672c-48a6-87c5-fa2b2a19a377" />
