### PR TITLE
docs(coding-agent): document using custom models for compaction

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -230,7 +230,7 @@ Long sessions can exhaust context windows. Compaction summarizes older messages 
 
 **Automatic:** Enabled by default. Triggers on context overflow (recovers and retries) or when approaching the limit (proactive). Configure via `/settings` or `settings.json`.
 
-Compaction is lossy. The full history remains in the JSONL file; use `/tree` to revisit. Customize compaction behavior via [extensions](#extensions). See [docs/compaction.md](docs/compaction.md) for internals.
+Compaction is lossy. The full history remains in the JSONL file; use `/tree` to revisit. Customize compaction behavior via [extensions](#extensions), including running compaction with a different model than the main conversation model. See [docs/compaction.md](docs/compaction.md) for internals and the [custom compaction example](examples/extensions/custom-compaction.ts).
 
 ---
 

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -338,6 +338,25 @@ pi.on("session_before_compact", async (event, ctx) => {
 
 See [custom-compaction.ts](../examples/extensions/custom-compaction.ts) for a complete example using a different model.
 
+#### Why Use a Different Model?
+
+By default, compaction uses the active conversation model. That is often the right choice, but an extension can route summarization to a different model when you want different trade-offs:
+
+- **Lower cost**: use a cheaper model for summarization than for the main conversation.
+- **Lower latency**: use a faster model so auto-compaction or `/compact` finishes sooner.
+- **Different summary style**: use a model that is better at concise summaries, long-context condensation, or structured output.
+- **Provider separation**: keep your main conversation on one provider while running compaction on another.
+
+The extension API keeps this flexible on purpose. Pi does not have a built-in `compaction.model` setting. Instead, use `session_before_compact` to resolve whatever model fits your workflow, then fall back to the default compaction path if that model is unavailable.
+
+Common patterns:
+
+- Use a fast/cheap model for compaction and keep your main conversation on a stronger model.
+- Keep the default compaction logic, but swap only the summarization model.
+- Customize the prompt for compaction without changing the conversation model.
+
+The [custom-compaction.ts](../examples/extensions/custom-compaction.ts) example shows one concrete version of this pattern.
+
 ### session_before_tree
 
 Fired before `/tree` navigation. Always fires regardless of whether user chose to summarize. Can cancel navigation or provide custom summary.

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -85,7 +85,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 |-----------|-------------|
 | `pirate.ts` | Demonstrates `systemPromptAppend` to dynamically modify system prompt |
 | `claude-rules.ts` | Scans `.claude/rules/` folder and lists rules in system prompt |
-| `custom-compaction.ts` | Custom compaction that summarizes entire conversation |
+| `custom-compaction.ts` | Custom compaction that summarizes the entire conversation with a different model (useful for cheaper or faster summarization) |
 | `trigger-compact.ts` | Triggers compaction when context usage exceeds 100k tokens and adds `/trigger-compact` command |
 
 ### System Integration


### PR DESCRIPTION
## Summary
- explain when to route compaction through a different model than the active conversation model
- document that this is done via the existing `session_before_compact` extension hook rather than a built-in setting
- improve discoverability of the existing `custom-compaction.ts` example from the README and examples index

## Why
Users looking for faster or cheaper compaction already have the extension API they need, but the current docs focus on internals and make this pattern easy to miss. This PR makes the intended extension-based workflow easier to find without adding new settings or hardcoding provider-specific behavior.
