### PR TITLE
Add extension API for assistant message persistence

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1202,6 +1202,38 @@ export class AgentSession {
 		}
 	}
 
+	async appendAssistantMessage(
+		message: {
+			content: TextContent[];
+			api: AssistantMessage["api"];
+			provider: AssistantMessage["provider"];
+			model: AssistantMessage["model"];
+			usage: AssistantMessage["usage"];
+			stopReason: AssistantMessage["stopReason"];
+			errorMessage?: AssistantMessage["errorMessage"];
+		},
+	): Promise<AssistantMessage> {
+		if (!message.content.every((block) => block.type === "text")) {
+			throw new Error("appendAssistantMessage only supports text content blocks");
+		}
+		const appMessage: AssistantMessage = {
+			role: "assistant",
+			content: message.content.map((block) => ({ ...block })),
+			api: message.api,
+			provider: message.provider,
+			model: message.model,
+			usage: message.usage,
+			stopReason: message.stopReason,
+			errorMessage: message.errorMessage,
+			timestamp: Date.now(),
+		};
+		this.agent.appendMessage(appMessage);
+		this.sessionManager.appendMessage(appMessage);
+		this._emit({ type: "message_start", message: appMessage });
+		this._emit({ type: "message_end", message: appMessage });
+		return appMessage;
+	}
+
 	/**
 	 * Send a user message to the agent. Always triggers a turn.
 	 * When the agent is streaming, use deliverAs to specify how to queue the message.
@@ -2135,6 +2167,7 @@ export class AgentSession {
 				appendEntry: (customType, data) => {
 					this.sessionManager.appendCustomEntry(customType, data);
 				},
+				appendAssistantMessage: (message) => this.appendAssistantMessage(message),
 				setSessionName: (name) => {
 					this.sessionManager.appendSessionInfo(name);
 				},

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -24,6 +24,8 @@ export type {
 	// Re-exports
 	AgentToolResult,
 	AgentToolUpdateCallback,
+	AppendAssistantMessageHandler,
+	AppendAssistantMessageInput,
 	AppendEntryHandler,
 	// App keybindings (for custom editors)
 	AppKeybinding,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -125,6 +125,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		sendMessage: notInitialized,
 		sendUserMessage: notInitialized,
 		appendEntry: notInitialized,
+		appendAssistantMessage: () => Promise.reject(new Error("Extension runtime not initialized")),
 		setSessionName: notInitialized,
 		getSessionName: notInitialized,
 		setLabel: notInitialized,
@@ -224,6 +225,10 @@ function createExtensionAPI(
 
 		appendEntry(customType: string, data?: unknown): void {
 			runtime.appendEntry(customType, data);
+		},
+
+		appendAssistantMessage(message) {
+			return runtime.appendAssistantMessage(message);
 		},
 
 		setSessionName(name: string): void {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -249,6 +249,7 @@ export class ExtensionRunner {
 		this.runtime.sendMessage = actions.sendMessage;
 		this.runtime.sendUserMessage = actions.sendUserMessage;
 		this.runtime.appendEntry = actions.appendEntry;
+		this.runtime.appendAssistantMessage = actions.appendAssistantMessage;
 		this.runtime.setSessionName = actions.setSessionName;
 		this.runtime.getSessionName = actions.getSessionName;
 		this.runtime.setLabel = actions.setLabel;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1057,6 +1057,9 @@ export interface ExtensionAPI {
 	/** Append a custom entry to the session for state persistence (not sent to LLM). */
 	appendEntry<T = unknown>(customType: string, data?: T): void;
 
+	/** Append a real assistant message to the session without triggering a new turn. */
+	appendAssistantMessage(message: AppendAssistantMessageInput): Promise<AssistantMessage>;
+
 	// =========================================================================
 	// Session Metadata
 	// =========================================================================
@@ -1275,6 +1278,15 @@ export type SendUserMessageHandler = (
 
 export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
 
+export type AppendAssistantMessageInput = Omit<
+	Pick<AssistantMessage, "content" | "api" | "provider" | "model" | "usage" | "stopReason" | "errorMessage">,
+	"content"
+> & {
+	content: TextContent[];
+};
+
+export type AppendAssistantMessageHandler = (message: AppendAssistantMessageInput) => Promise<AssistantMessage>;
+
 export type SetSessionNameHandler = (name: string) => void;
 
 export type GetSessionNameHandler = () => string | undefined;
@@ -1326,6 +1338,7 @@ export interface ExtensionActions {
 	sendMessage: SendMessageHandler;
 	sendUserMessage: SendUserMessageHandler;
 	appendEntry: AppendEntryHandler;
+	appendAssistantMessage: AppendAssistantMessageHandler;
 	setSessionName: SetSessionNameHandler;
 	getSessionName: GetSessionNameHandler;
 	setLabel: SetLabelHandler;


### PR DESCRIPTION
## Summary
- add `appendAssistantMessage(...)` to the extension API
- wire the new action through the extension runtime/runner/loader
- let extensions persist a real assistant session message without triggering a new turn

## Why
Extensions can already:
- send a `custom_message`
- append custom state entries

But they cannot currently append a genuine assistant `type:"message"` entry to session history.

A small additive API makes that possible for extension flows that need to persist a real assistant note into the session JSONL and conversation history.

## API shape
`appendAssistantMessage(message): Promise<AssistantMessage>`

Current input is intentionally constrained to:
- assistant metadata (`api`, `provider`, `model`, `usage`, `stopReason`, `errorMessage`)
- **text-only** content blocks

That keeps the surface small and avoids extensions synthesizing tool-call messages.

## Implementation notes
- `AgentSession.appendAssistantMessage(...)` appends the message to agent state and session history
- it emits `message_start` / `message_end` like other persisted extension-originated messages
- the change is additive and does not alter existing extension behavior
