### PR TITLE
fix(subagent): reuse current pi invocation for child agents

### DIFF
--- a/packages/coding-agent/examples/extensions/subagent/index.ts
+++ b/packages/coding-agent/examples/extensions/subagent/index.ts
@@ -217,6 +217,21 @@ async function writePromptToTempFile(agentName: string, prompt: string): Promise
 	return { dir: tmpDir, filePath };
 }
 
+function getPiInvocation(args: string[]): { command: string; args: string[] } {
+	const currentScript = process.argv[1];
+	if (currentScript && fs.existsSync(currentScript)) {
+		return { command: process.execPath, args: [currentScript, ...args] };
+	}
+
+	const execName = path.basename(process.execPath).toLowerCase();
+	const isGenericRuntime = /^(node|bun)(\.exe)?$/.test(execName);
+	if (!isGenericRuntime) {
+		return { command: process.execPath, args };
+	}
+
+	return { command: "pi", args };
+}
+
 type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void;
 
 async function runSingleAgent(
@@ -286,7 +301,12 @@ async function runSingleAgent(
 		let wasAborted = false;
 
 		const exitCode = await new Promise<number>((resolve) => {
-			const proc = spawn("pi", args, { cwd: cwd ?? defaultCwd, shell: false, stdio: ["ignore", "pipe", "pipe"] });
+			const invocation = getPiInvocation(args);
+			const proc = spawn(invocation.command, invocation.args, {
+				cwd: cwd ?? defaultCwd,
+				shell: false,
+				stdio: ["ignore", "pipe", "pipe"],
+			});
 			let buffer = "";
 
 			const processLine = (line: string) => {


### PR DESCRIPTION
## Summary

Reuse the current pi invocation when launching subagents instead of assuming `pi` is directly spawnable.

- use `process.execPath + process.argv[1]` when running through Node/Bun
- use `process.execPath` directly when running as a compiled binary
- fall back to `pi` only if neither case applies

## Why

On Windows, `spawn("pi", args, { shell: false })` can fail with `spawn pi ENOENT` when `pi` is installed through an npm/scoop `.cmd` shim.

## Scope

- `packages/coding-agent/examples/extensions/subagent/index.ts`

## Validation

Ran `npm run check`, but current `main` already fails with unrelated pre-existing type issues:
- `packages/ai/src/providers/openai-responses-shared.ts`
- `packages/coding-agent/src/bun/register-bedrock.ts`
- `packages/coding-agent/src/utils/tools-manager.ts`

Closes #2464
