### PR TITLE
feat: expose contextUsage in get_session_stats RPC response

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -193,6 +193,8 @@ export interface SessionStats {
 		total: number;
 	};
 	cost: number;
+	/** Current context window usage (estimated tokens, percent, window size). */
+	contextUsage?: ContextUsage;
 }
 
 // ============================================================================
@@ -2994,6 +2996,7 @@ export class AgentSession {
 				total: totalInput + totalOutput + totalCacheRead + totalCacheWrite,
 			},
 			cost: totalCost,
+			contextUsage: this.getContextUsage(),
 		};
 	}
 


### PR DESCRIPTION
## Problem

RPC clients (e.g. VS Code extensions) need accurate context window usage to display a context bar. Currently `get_session_stats` only returns cumulative token counts, which don't reflect actual context usage — they grow unboundedly across turns while context stays within the window.

The `getContextUsage()` method already exists on `AgentSession` and provides the accurate estimate (handling compaction, aborted responses, etc.), but it's not exposed via RPC.

## Solution

Include `contextUsage` (the result of `getContextUsage()`) in the `SessionStats` returned by `get_session_stats`. This is a 3-line change:

1. Add `contextUsage?: ContextUsage` to `SessionStats` interface
2. Call `this.getContextUsage()` in `getSessionStats()` and include it in the return value

The field is optional (`undefined` when no model is selected or context window is 0), matching the existing behavior of `getContextUsage()`.

## Usage

```json
// RPC: {"type": "get_session_stats", "id": "1"}
// Response includes:
{
  "contextUsage": {
    "tokens": 12450,
    "contextWindow": 200000,
    "percent": 6.225
  }
}
```

`tokens` and `percent` are `null` when unknown (e.g. right after compaction, before the next LLM response).