### PR TITLE
fix(mom): make LLM provider and model configurable via env vars

### DIFF
--- a/packages/mom/README.md
+++ b/packages/mom/README.md
@@ -62,9 +62,12 @@ npm install @mariozechner/pi-mom
 # Set environment variables
 export MOM_SLACK_APP_TOKEN=xapp-...
 export MOM_SLACK_BOT_TOKEN=xoxb-...
-# Option 1: Anthropic API key
+# Option 1: Anthropic API key (default provider)
 export ANTHROPIC_API_KEY=sk-ant-...
 # Option 2: use /login command in pi agent, then copy/link auth.json to ~/.pi/mom/
+# Option 3: use a different provider (e.g. GitHub Copilot)
+export MOM_PROVIDER=github-copilot
+export MOM_MODEL=claude-sonnet-4.5
 
 # Create Docker sandbox (recommended)
 docker run -d \
@@ -95,11 +98,16 @@ Options:
 |----------|-------------|
 | `MOM_SLACK_APP_TOKEN` | Slack app-level token (xapp-...) |
 | `MOM_SLACK_BOT_TOKEN` | Slack bot token (xoxb-...) |
-| `ANTHROPIC_API_KEY` | (Optional) Anthropic API key |
+| `MOM_PROVIDER` | (Optional) LLM provider — defaults to `anthropic` |
+| `MOM_MODEL` | (Optional) Model ID — defaults to `claude-sonnet-4-5` |
+| `ANTHROPIC_API_KEY` | (Optional) Anthropic API key — or set any other provider key |
 
 ## Authentication
 
-Mom needs credentials for Anthropic API. The options to set it are:
+Mom needs credentials for the LLM provider. By default it uses Anthropic, but any provider supported
+by pi can be used via `MOM_PROVIDER` / `MOM_MODEL` env vars.
+
+### Default (Anthropic)
 
 1. **Environment Variable**
 ```bash
@@ -113,6 +121,18 @@ export ANTHROPIC_API_KEY=sk-ant-...
   - choose "Anthropic" provider
   - follow instructions in the browser
 - link `auth.json` to mom: `ln -s ~/.pi/agent/auth.json ~/.pi/mom/auth.json`
+
+### Other providers (e.g. GitHub Copilot)
+
+```bash
+export MOM_PROVIDER=github-copilot
+export MOM_MODEL=claude-sonnet-4.5   # any model available for that provider
+```
+
+Then authenticate via the coding agent (`/login → GitHub Copilot`) and link `auth.json`:
+```bash
+ln -s ~/.pi/agent/auth.json ~/.pi/mom/auth.json
+```
 
 ## How Mom Works
 

--- a/packages/mom/src/agent.ts
+++ b/packages/mom/src/agent.ts
@@ -1,5 +1,5 @@
 import { Agent, type AgentEvent } from "@mariozechner/pi-agent-core";
-import { getModel, type ImageContent } from "@mariozechner/pi-ai";
+import { getModels, type ImageContent, type KnownProvider, type Model } from "@mariozechner/pi-ai";
 import {
 	AgentSession,
 	AuthStorage,
@@ -23,8 +23,33 @@ import type { ChannelInfo, SlackContext, UserInfo } from "./slack.js";
 import type { ChannelStore } from "./store.js";
 import { createMomTools, setUploadFunction } from "./tools/index.js";
 
-// Hardcoded model for now - TODO: make configurable (issue #63)
-const model = getModel("anthropic", "claude-sonnet-4-5");
+// Model is configurable via MOM_PROVIDER and MOM_MODEL env vars.
+// Defaults to anthropic/claude-sonnet-4-5 for backward compatibility.
+// Closes: https://github.com/badlogic/pi-mono/issues/63
+const DEFAULT_PROVIDER: KnownProvider = "anthropic";
+const DEFAULT_MODEL_ID = "claude-sonnet-4-5";
+
+function resolveModel(): { model: Model<any>; provider: KnownProvider } {
+	const provider = (process.env.MOM_PROVIDER ?? DEFAULT_PROVIDER) as KnownProvider;
+	const modelId = process.env.MOM_MODEL ?? DEFAULT_MODEL_ID;
+
+	const models = getModels(provider);
+	const model = models.find((m) => m.id === modelId);
+
+	if (!model) {
+		const available = models.map((m) => m.id).join(", ");
+		throw new Error(
+			`Unknown model "${modelId}" for provider "${provider}".\n` +
+				`Available models: ${available || "(none — check provider name)"}\n\n` +
+				`Set MOM_PROVIDER and MOM_MODEL environment variables to configure.\n` +
+				`Example: MOM_PROVIDER=github-copilot MOM_MODEL=claude-sonnet-4.5`,
+		);
+	}
+
+	return { model, provider };
+}
+
+const { model, provider: modelProvider } = resolveModel();
 
 export interface PendingMessage {
 	userName: string;
@@ -42,12 +67,12 @@ export interface AgentRunner {
 	abort(): void;
 }
 
-async function getAnthropicApiKey(authStorage: AuthStorage): Promise<string> {
-	const key = await authStorage.getApiKey("anthropic");
+async function getProviderApiKey(authStorage: AuthStorage): Promise<string> {
+	const key = await authStorage.getApiKey(modelProvider);
 	if (!key) {
 		throw new Error(
-			"No API key found for anthropic.\n\n" +
-				"Set an API key environment variable, or use /login with Anthropic and link to auth.json from " +
+			`No API key found for "${modelProvider}".\n\n` +
+				`Use /login or set an API key environment variable. See ` +
 				join(homedir(), ".pi", "mom", "auth.json"),
 		);
 	}
@@ -440,7 +465,7 @@ function createRunner(sandboxConfig: SandboxConfig, channelId: string, channelDi
 			tools,
 		},
 		convertToLlm,
-		getApiKey: async () => getAnthropicApiKey(authStorage),
+		getApiKey: async () => getProviderApiKey(authStorage),
 	});
 
 	// Load existing messages


### PR DESCRIPTION
Closes #63

Previously the model was hardcoded to `anthropic / claude-sonnet-4-5`, causing a hard failure for users who authenticate via OAuth providers (GitHub Copilot, Claude Pro/Max, etc.) rather than a raw Anthropic API key.

Changes:
- Replace hardcoded `getModel("anthropic", "claude-sonnet-4-5")` with a `resolveModel()` function that reads two optional env vars:
    - `MOM_PROVIDER` — provider ID (default: `anthropic`)
    - `MOM_MODEL`    — model ID    (default: `claude-sonnet-4-5`)
- Replace `getAnthropicApiKey()` with `getProviderApiKey()` that uses
  the resolved provider, supporting both API-key and OAuth providers.
- Validate the resolved model at startup with a clear error message that
  lists available models for the given provider.
- Update README with new env vars and a GitHub Copilot usage example.

Example — GitHub Copilot (OAuth, no API key needed):
  MOM_PROVIDER=github-copilot MOM_MODEL=claude-sonnet-4.5 mom --sandbox=host ./data

Default behaviour is unchanged: Anthropic + claude-sonnet-4-5.