### PR TITLE
packages/ai: add non-streaming compatibility mode for completions

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -91,6 +91,40 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			if (nextParams !== undefined) {
 				params = nextParams as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
 			}
+			const compat = getCompat(model);
+			if (compat.preferNonStreamingResponses) {
+				const response = await client.chat.completions.create(
+					{
+						...(params as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming),
+						stream: false,
+					},
+					{ signal: options?.signal },
+				);
+				stream.push({ type: "start", partial: output });
+
+				if (response.usage) {
+					output.usage = parseChunkUsage(response.usage, model);
+				}
+
+				const choice = response.choices?.[0];
+				const finishReasonResult = mapStopReason(choice?.finish_reason || "stop");
+				output.stopReason = finishReasonResult.stopReason;
+				if (finishReasonResult.errorMessage) {
+					output.errorMessage = finishReasonResult.errorMessage;
+				}
+				appendNonStreamingMessageContent(output, choice?.message);
+
+				if (options?.signal?.aborted || output.stopReason === "aborted") {
+					throw new Error("Request was aborted");
+				}
+				if (output.stopReason === "error") {
+					throw new Error(output.errorMessage || "Provider returned an error stop reason");
+				}
+
+				stream.push({ type: "done", reason: output.stopReason, message: output });
+				stream.end();
+				return;
+			}
 			const openaiStream = await client.chat.completions.create(params, { signal: options?.signal });
 			stream.push({ type: "start", partial: output });
 
@@ -445,6 +479,58 @@ function mapReasoningEffort(
 	reasoningEffortMap: Partial<Record<NonNullable<OpenAICompletionsOptions["reasoningEffort"]>, string>>,
 ): string {
 	return reasoningEffortMap[effort] ?? effort;
+}
+
+function appendNonStreamingMessageContent(
+	output: AssistantMessage,
+	message:
+		| {
+				content?: unknown;
+				tool_calls?: Array<{
+					id?: string | null;
+					function?: { name?: string | null; arguments?: string | null } | null;
+				}> | null;
+				reasoning_content?: string | null;
+				reasoning?: string | null;
+				reasoning_text?: string | null;
+		  }
+		| null
+		| undefined,
+): void {
+	if (!message) return;
+
+	const reasoning = message.reasoning_content || message.reasoning || message.reasoning_text;
+	if (typeof reasoning === "string" && reasoning.length > 0) {
+		output.content.push({
+			type: "thinking",
+			thinking: reasoning,
+			thinkingSignature: "reasoning",
+		});
+	}
+
+	if (typeof message.content === "string" && message.content.length > 0) {
+		output.content.push({ type: "text", text: message.content });
+	} else if (Array.isArray(message.content)) {
+		const text = message.content
+			.map((part) =>
+				part && typeof part === "object" && "text" in part && typeof part.text === "string"
+					? part.text
+					: "",
+			)
+			.join("");
+		if (text.length > 0) {
+			output.content.push({ type: "text", text });
+		}
+	}
+
+	for (const toolCall of message.tool_calls ?? []) {
+		output.content.push({
+			type: "toolCall",
+			id: toolCall.id || "",
+			name: toolCall.function?.name || "",
+			arguments: parseStreamingJson(toolCall.function?.arguments || "{}"),
+		});
+	}
 }
 
 function maybeAddOpenRouterAnthropicCacheControl(
@@ -832,6 +918,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		openRouterRouting: {},
 		vercelGatewayRouting: {},
 		supportsStrictMode: true,
+		preferNonStreamingResponses: false,
 	};
 }
 
@@ -858,5 +945,7 @@ function getCompat(model: Model<"openai-completions">): Required<OpenAICompletio
 		openRouterRouting: model.compat.openRouterRouting ?? {},
 		vercelGatewayRouting: model.compat.vercelGatewayRouting ?? detected.vercelGatewayRouting,
 		supportsStrictMode: model.compat.supportsStrictMode ?? detected.supportsStrictMode,
+		preferNonStreamingResponses:
+			model.compat.preferNonStreamingResponses ?? detected.preferNonStreamingResponses,
 	};
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -279,6 +279,8 @@ export interface OpenAICompletionsCompat {
 	vercelGatewayRouting?: VercelGatewayRouting;
 	/** Whether the provider supports the `strict` field in tool definitions. Default: true. */
 	supportsStrictMode?: boolean;
+	/** Whether the provider should prefer non-streaming chat completions and map the full response back into stream events. Default: false. */
+	preferNonStreamingResponses?: boolean;
 }
 
 /** Compatibility settings for OpenAI Responses APIs. */

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -21,14 +21,48 @@ const mockState = vi.hoisted(() => ({
 				  }
 		  >
 		| undefined,
+	response: undefined as
+		| {
+				choices?: Array<{
+					message?: {
+						content?: string | null;
+						tool_calls?: Array<{
+							id?: string;
+							function?: { name?: string; arguments?: string };
+						}>;
+						reasoning_content?: string | null;
+					};
+					finish_reason?: string | null;
+				}>;
+				usage?: {
+					prompt_tokens: number;
+					completion_tokens: number;
+					prompt_tokens_details: { cached_tokens: number };
+					completion_tokens_details: { reasoning_tokens: number };
+				};
+		  }
+		| undefined,
 }));
 
 vi.mock("openai", () => {
 	class FakeOpenAI {
 		chat = {
 			completions: {
-				create: async (params: unknown) => {
+				create: async (params: { stream?: boolean }) => {
 					mockState.lastParams = params;
+					if (params.stream === false) {
+						return (
+							mockState.response ?? {
+								choices: [{ message: { content: "OK" }, finish_reason: "stop" }],
+								usage: {
+									prompt_tokens: 1,
+									completion_tokens: 1,
+									prompt_tokens_details: { cached_tokens: 0 },
+									completion_tokens_details: { reasoning_tokens: 0 },
+								},
+							}
+						);
+					}
 					return {
 						async *[Symbol.asyncIterator]() {
 							const chunks = mockState.chunks ?? [
@@ -59,6 +93,7 @@ describe("openai-completions tool_choice", () => {
 	beforeEach(() => {
 		mockState.lastParams = undefined;
 		mockState.chunks = undefined;
+		mockState.response = undefined;
 	});
 
 	it("forwards toolChoice from simple options to payload", async () => {
@@ -310,5 +345,73 @@ describe("openai-completions tool_choice", () => {
 		};
 		expect(params.reasoning).toEqual({ effort: "high" });
 		expect(params.reasoning_effort).toBeUndefined();
+	});
+
+	it("can prefer non-streaming responses for openai-compatible providers", async () => {
+		mockState.response = {
+			choices: [
+				{
+					message: {
+						content: "Used a tool.",
+						reasoning_content: "Need to inspect runtime state first.",
+						tool_calls: [
+							{
+								id: "call_1",
+								function: {
+									name: "exec",
+									arguments: "{\"command\":\"df -h\"}",
+								},
+							},
+						],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+			usage: {
+				prompt_tokens: 10,
+				completion_tokens: 4,
+				prompt_tokens_details: { cached_tokens: 0 },
+				completion_tokens_details: { reasoning_tokens: 2 },
+			},
+		};
+
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = {
+			...baseModel,
+			api: "openai-completions",
+			compat: { preferNonStreamingResponses: true },
+		} as const;
+
+		const response = await streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "How much free disk space is available?",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		expect((mockState.lastParams as { stream?: boolean } | undefined)?.stream).toBe(false);
+		expect(response.stopReason).toBe("toolUse");
+		expect(response.content).toEqual([
+			{
+				type: "thinking",
+				thinking: "Need to inspect runtime state first.",
+				thinkingSignature: "reasoning",
+			},
+			{ type: "text", text: "Used a tool." },
+			{
+				type: "toolCall",
+				id: "call_1",
+				name: "exec",
+				arguments: { command: "df -h" },
+			},
+		]);
+		expect(response.usage.output).toBe(6);
 	});
 });


### PR DESCRIPTION
## Summary
- Add `preferNonStreamingResponses` to `OpenAICompletionsCompat`
- Allow `streamOpenAICompletions()` to execute a non-streaming chat completion when that compat flag is enabled
- Map the full response back into the normal `thinking`, `text`, `toolCall`, `usage`, and `stopReason` output shape
- Add a regression test covering tool-call parsing and usage accounting in non-streaming mode

## Why
Some OpenAI-compatible providers behave correctly for normal chat completions but are unreliable when tool calls must be emitted over the streaming path.

In those cases the provider can still return a valid non-streaming response with:
- reasoning content
- text content
- tool calls
- usage information

but the streaming path is not dependable enough for callers that need correct tool-call behavior.

This change adds a compatibility escape hatch without changing the default behavior for providers that already stream correctly.

## Implementation Notes
- The new compat flag defaults to `false`
- When enabled, the provider sends `stream: false`
- The full response is converted back into the same assistant message structure expected by downstream consumers
- Usage continues to flow through the existing token accounting helper

## Test Plan
- Added a regression test in `packages/ai/test/openai-completions-tool-choice.test.ts`
- Ran:

```sh
./node_modules/.bin/vitest run test/openai-completions-tool-choice.test.ts
```

- Result: `1` test file passed, `8` tests passed

## Notes
- This is more general than a provider-specific `inference.local` workaround
- Callers can opt in only for providers that need it, instead of changing the default streaming behavior for everyone

Made with [Cursor](https://cursor.com)