### PR TITLE
fix(coding-agent): freeze bash tool duration timer after execution completes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bash tool duration timer continuing to increase after execution completes when toggling expand/collapse with ctrl+o ([#2485](https://github.com/badlogic/pi-mono/pull/2485) by [@aliou](https://github.com/aliou))
+
 ## [0.61.1] - 2026-03-20
 
 ### New Features

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -106,6 +106,7 @@ export class ToolExecutionComponent extends Container {
 	// When true, this component intentionally renders no lines
 	private hideComponent = false;
 	private bashStartedAt?: number;
+	private bashFinalDurationMs?: number;
 	private bashElapsedInterval?: NodeJS.Timeout;
 
 	constructor(
@@ -178,6 +179,9 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private stopBashElapsedTimer(): void {
+		if (this.bashStartedAt !== undefined) {
+			this.bashFinalDurationMs = Date.now() - this.bashStartedAt;
+		}
 		if (!this.bashElapsedInterval) return;
 		clearInterval(this.bashElapsedInterval);
 		this.bashElapsedInterval = undefined;
@@ -185,6 +189,7 @@ export class ToolExecutionComponent extends Container {
 
 	private getBashDurationMs(): number | undefined {
 		if (this.toolName !== "bash" || this.bashStartedAt === undefined) return undefined;
+		if (this.bashFinalDurationMs !== undefined) return this.bashFinalDurationMs;
 		return Date.now() - this.bashStartedAt;
 	}
 


### PR DESCRIPTION
Hello! Noticed that when doing ctrl+o, the duration would update, even when the bash tool call would be finished.

------

<details><summary>Summary by opus-4-6:</summary>
<p>

## Problem

The bash tool's duration timer (`Took X.Xs`) keeps increasing after the command finishes whenever the TUI re-renders (e.g., pressing ctrl+o to expand/collapse output).

**Root cause**: `getBashDurationMs()` always computes `Date.now() - bashStartedAt`, so every call to `updateDisplay()` produces a new, larger value even after the timer interval has been cleared.

## Fix

**File**: `packages/coding-agent/src/modes/interactive/components/tool-execution.ts`

- Added `bashFinalDurationMs` field to snapshot the elapsed time when `stopBashElapsedTimer()` is called (i.e., when the tool execution completes)
- `getBashDurationMs()` now returns the frozen final value when available, and only falls back to live `Date.now()` computation while the command is still running

This ensures the "Took X.Xs" label stays fixed after completion regardless of subsequent re-renders.

</p>
</details>