### PR TITLE
fix(coding-agent): wire tools option through to AgentSession as baseToolsOverride

### DIFF
--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -364,6 +364,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		modelRegistry,
 		initialActiveToolNames,
 		extensionRunnerRef,
+		...(options.tools ? { baseToolsOverride: Object.fromEntries(options.tools.map((t) => [t.name, t])) } : {}),
 	});
 	const extensionsResult = resourceLoader.getExtensions();
 

--- a/packages/coding-agent/test/sdk-session-manager.test.ts
+++ b/packages/coding-agent/test/sdk-session-manager.test.ts
@@ -5,6 +5,8 @@ import { getModel } from "@mariozechner/pi-ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createAgentSession } from "../src/core/sdk.js";
 import { SessionManager } from "../src/core/session-manager.js";
+import { createCodingTools } from "../src/core/tools/index.js";
+import type { BashSpawnHook } from "../src/core/tools/bash.js";
 
 describe("createAgentSession session manager defaults", () => {
 	let tempDir: string;
@@ -60,6 +62,48 @@ describe("createAgentSession session manager defaults", () => {
 
 		expect(session.sessionManager).toBe(sessionManager);
 		expect(session.sessionManager.isPersisted()).toBe(false);
+
+		session.dispose();
+	});
+});
+
+describe("createAgentSession tools option", () => {
+	let tempDir: string;
+	let cwd: string;
+	let agentDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-sdk-tools-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		cwd = join(tempDir, "project");
+		agentDir = join(tempDir, "agent");
+		mkdirSync(cwd, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("wires custom tool instances through as baseToolsOverride", async () => {
+		let hookCalled = false;
+		const spawnHook: BashSpawnHook = (ctx) => {
+			hookCalled = true;
+			return ctx;
+		};
+
+		const tools = createCodingTools(cwd, { bash: { spawnHook } });
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			sessionManager: SessionManager.inMemory(cwd),
+			tools,
+		});
+
+		const bash = session.agent.state.tools.find((t) => t.name === "bash")!;
+		await bash.execute("test", { command: "true" });
+		expect(hookCalled).toBe(true);
 
 		session.dispose();
 	});


### PR DESCRIPTION
`createAgentSession({ tools })` only uses the array to derive active tool names. The instances are discarded, so `AgentSession._buildRuntime()` creates fresh default tools. Any customisation on built-in tools (`BashSpawnHook`, custom `BashOperations`, `commandPrefix`) is silently lost.

**Use case:** SDK consumer that uses `createCodingTools(cwd, { bash: { spawnHook } })` to inject a direnv-based hook for per-directory environment isolation. The hook is constructed but never fires.

**Fix:** pass `options.tools` through as `baseToolsOverride` (the same pattern `mom` uses when constructing `AgentSession` directly).

**Scope:** `packages/coding-agent/src/core/sdk.ts` (one line)

**Validation:** added test to `sdk-session-manager.test.ts`, verified it fails without fix and passes with it. Full test suite shows no regressions (8 pre-existing failures in `git-update.test.ts`).
