### PR TITLE
fix(ai): explicitly disable thinking for reasoning models in Google provider

### DIFF
--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -331,7 +331,7 @@ function createClient(
 	});
 }
 
-function buildParams(
+export function buildParams(
 	model: Model<"google-generative-ai">,
 	context: Context,
 	options: GoogleOptions = {},
@@ -371,6 +371,13 @@ function buildParams(
 			thinkingConfig.thinkingBudget = options.thinking.budgetTokens;
 		}
 		config.thinkingConfig = thinkingConfig;
+	} else if (model.reasoning && options.thinking && !options.thinking.enabled) {
+		// Reasoning-capable model with thinking explicitly disabled: send thinkingBudget: 0.
+		// Without this, models like gemini-2.5-flash default to thinking ON when
+		// thinkingConfig is omitted, consuming maxOutputTokens with thinking tokens.
+		// Only triggers when thinking is explicitly passed as { enabled: false },
+		// preserving API default behavior when thinking option is omitted entirely.
+		config.thinkingConfig = { thinkingBudget: 0 };
 	}
 
 	if (options.signal) {

--- a/packages/ai/test/google-buildparams-thinking-disable.test.ts
+++ b/packages/ai/test/google-buildparams-thinking-disable.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildParams } from "../src/providers/google.js";
+import type { Context, Model } from "../src/types.js";
+
+function makeModel(overrides: Partial<Model<"google-generative-ai">> = {}): Model<"google-generative-ai"> {
+	return {
+		id: "gemini-2.5-flash",
+		name: "Gemini 2.5 Flash",
+		api: "google-generative-ai",
+		provider: "google",
+		baseUrl: "",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+		...overrides,
+	};
+}
+
+const minimalContext: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+};
+
+describe("buildParams thinkingConfig for reasoning models", () => {
+	it("sets thinkingConfig when thinking is enabled on a reasoning model", () => {
+		const params = buildParams(makeModel(), minimalContext, {
+			thinking: { enabled: true, budgetTokens: 4096 },
+		});
+		expect(params.config?.thinkingConfig).toEqual({
+			includeThoughts: true,
+			thinkingBudget: 4096,
+		});
+	});
+
+	it("explicitly disables thinking on a reasoning model when thinking.enabled is false", () => {
+		const params = buildParams(makeModel(), minimalContext, {
+			thinking: { enabled: false },
+		});
+		expect(params.config?.thinkingConfig).toEqual({ thinkingBudget: 0 });
+	});
+
+	it("preserves API default when thinking option is omitted on a reasoning model", () => {
+		const params = buildParams(makeModel(), minimalContext, {});
+		expect(params.config?.thinkingConfig).toBeUndefined();
+	});
+
+	it("does not set thinkingConfig on a non-reasoning model", () => {
+		const params = buildParams(makeModel({ reasoning: false }), minimalContext, {});
+		expect(params.config?.thinkingConfig).toBeUndefined();
+	});
+
+	it("does not set thinkingConfig on a non-reasoning model even with thinking.enabled", () => {
+		const params = buildParams(makeModel({ reasoning: false }), minimalContext, {
+			thinking: { enabled: true, budgetTokens: 4096 },
+		});
+		expect(params.config?.thinkingConfig).toBeUndefined();
+	});
+
+	it("does not set thinkingConfig on a non-reasoning model with thinking.enabled false", () => {
+		const params = buildParams(makeModel({ reasoning: false }), minimalContext, {
+			thinking: { enabled: false },
+		});
+		expect(params.config?.thinkingConfig).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Fixes #2490.

When `streamSimpleGoogle` passes `thinking: { enabled: false }` to `streamGoogle`, `buildParams()` skips setting `thinkingConfig` because `options.thinking?.enabled` is false. Gemini 2.5 Flash treats the omission as thinking ON, consuming the output token budget with thinking tokens.

Adds `thinkingConfig: { thinkingBudget: 0 }` when thinking is explicitly disabled on a reasoning model. Preserves API default when thinking is omitted entirely.

Same pattern as #2022 (Anthropic provider). Only fixes google.ts — vertex and gemini-cli have the same issue but are left for a follow-up.

`buildParams` is exported for direct unit testing. Happy to switch to `onPayload`-based testing if preferred.

6 tests, all existing Google tests pass (29/29).