### PR TITLE
fix: make repo checks work from a clean workspace

### DIFF
--- a/packages/web-ui/example/tsconfig.json
+++ b/packages/web-ui/example/tsconfig.json
@@ -4,12 +4,13 @@
 		"module": "ES2022",
 		"lib": ["ES2022", "DOM", "DOM.Iterable"],
 		"moduleResolution": "bundler",
+		"baseUrl": ".",
 		"paths": {
 			"*": ["./*"],
-			"@mariozechner/pi-agent-core": ["../../agent/dist/index.d.ts"],
-			"@mariozechner/pi-ai": ["../../ai/dist/index.d.ts"],
-			"@mariozechner/pi-tui": ["../../tui/dist/index.d.ts"],
-			"@mariozechner/pi-web-ui": ["../dist/index.d.ts"]
+			"@mariozechner/pi-agent-core": ["../../agent/src/index.ts"],
+			"@mariozechner/pi-ai": ["../../ai/src/index.ts"],
+			"@mariozechner/pi-tui": ["../../tui/src/index.ts"],
+			"@mariozechner/pi-web-ui": ["../src/index.ts"]
 		},
 		"strict": true,
 		"skipLibCheck": true,

--- a/packages/web-ui/tsconfig.build.json
+++ b/packages/web-ui/tsconfig.build.json
@@ -4,6 +4,12 @@
     "module": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@mariozechner/pi-agent-core": ["../agent/src/index.ts"],
+      "@mariozechner/pi-ai": ["../ai/src/index.ts"],
+      "@mariozechner/pi-tui": ["../tui/src/index.ts"]
+    },
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/packages/web-ui/tsconfig.json
+++ b/packages/web-ui/tsconfig.json
@@ -1,7 +1,17 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@mariozechner/pi-agent-core": ["../agent/src/index.ts"],
+      "@mariozechner/pi-ai": ["../ai/src/index.ts"],
+      "@mariozechner/pi-tui": ["../tui/src/index.ts"]
+    }
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"paths": {
 			"*": ["./*"],
 			"@mariozechner/pi-ai": ["./packages/ai/src/index.ts"],
+			"@mariozechner/pi-ai/bedrock-provider": ["./packages/ai/src/bedrock-provider.ts"],
 			"@mariozechner/pi-ai/oauth": ["./packages/ai/src/oauth.ts"],
 			"@mariozechner/pi-ai/*": ["./packages/ai/src/*"],
 			"@mariozechner/pi-ai/dist/*": ["./packages/ai/src/*"],


### PR DESCRIPTION
  ## Summary

  This PR fixes local check and commit failures caused by TypeScript resolving workspace packages through missing
  built dist artifacts.

  It does two things:

  - adds an explicit root TypeScript path alias for @mariozechner/pi-ai/bedrock-provider
  - updates packages/web-ui package-local TypeScript configs to resolve workspace packages from source during tsc
    --noEmit instead of depending on built declaration output

  ## Why

  On a clean checkout, pre-commit could fail with:

  - TS2307: Cannot find module '@mariozechner/pi-ai/bedrock-provider'
  - packages/web-ui package-local tsc failures resolving @mariozechner/pi-ai and @mariozechner/pi-agent-core

  The underlying issue was that some checks depended on local dist/*.d.ts files existing, which is not reliable in
  workspace development.

  ## Changes

  - tsconfig.json
    Added an explicit alias for @mariozechner/pi-ai/bedrock-provider
  - packages/web-ui/tsconfig.json
    Added source-based workspace path mappings for package-local typecheck
  - packages/web-ui/tsconfig.build.json
    Added matching workspace path mappings for build config
  - packages/web-ui/example/tsconfig.json
    Switched example package mappings from dist/*.d.ts to source entries

  ## Result

  npm run check now passes from the repo root without requiring prebuilt workspace artifacts.