### PR TITLE
fix(coding-agent): harden bash temp output capture

### DIFF
--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -6,12 +6,9 @@
  * - Direct calls from modes that need bash execution
  */
 
-import { randomBytes } from "node:crypto";
-import { createWriteStream, type WriteStream } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { sanitizeBinaryOutput } from "../utils/shell.js";
+import { createTempOutputCapture } from "./temp-output-capture.js";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
 import { DEFAULT_MAX_BYTES, truncateTail } from "./tools/truncate.js";
 
@@ -75,7 +72,7 @@ export async function executeBashWithOperations(
 	const maxOutputBytes = DEFAULT_MAX_BYTES * 2;
 
 	let tempFilePath: string | undefined;
-	let tempFileStream: WriteStream | undefined;
+	let tempOutputCapture: ReturnType<typeof createTempOutputCapture> | undefined;
 	let totalBytes = 0;
 
 	const decoder = new TextDecoder();
@@ -87,18 +84,15 @@ export async function executeBashWithOperations(
 		const text = sanitizeBinaryOutput(stripAnsi(decoder.decode(data, { stream: true }))).replace(/\r/g, "");
 
 		// Start writing to temp file if exceeds threshold
-		if (totalBytes > DEFAULT_MAX_BYTES && !tempFilePath) {
-			const id = randomBytes(8).toString("hex");
-			tempFilePath = join(tmpdir(), `pi-bash-${id}.log`);
-			tempFileStream = createWriteStream(tempFilePath);
+		if (totalBytes > DEFAULT_MAX_BYTES && !tempOutputCapture) {
+			tempOutputCapture = createTempOutputCapture("pi-bash-", ".log");
+			tempFilePath = tempOutputCapture?.path;
 			for (const chunk of outputChunks) {
-				tempFileStream.write(chunk);
+				tempOutputCapture?.write(chunk);
 			}
 		}
 
-		if (tempFileStream) {
-			tempFileStream.write(text);
-		}
+		tempOutputCapture?.write(text);
 
 		// Keep rolling buffer
 		outputChunks.push(text);
@@ -120,9 +114,7 @@ export async function executeBashWithOperations(
 			signal: options?.signal,
 		});
 
-		if (tempFileStream) {
-			tempFileStream.end();
-		}
+		tempOutputCapture?.close();
 
 		const fullOutput = outputChunks.join("");
 		const truncationResult = truncateTail(fullOutput);
@@ -136,9 +128,7 @@ export async function executeBashWithOperations(
 			fullOutputPath: tempFilePath,
 		};
 	} catch (err) {
-		if (tempFileStream) {
-			tempFileStream.end();
-		}
+		tempOutputCapture?.close();
 
 		// Check if it was an abort
 		if (options?.signal?.aborted) {

--- a/packages/coding-agent/src/core/temp-output-capture.ts
+++ b/packages/coding-agent/src/core/temp-output-capture.ts
@@ -1,0 +1,123 @@
+import { randomBytes } from "node:crypto";
+import { createWriteStream, mkdirSync, openSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const STALE_LOG_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
+const cleanupTimestamps = new Map<string, number>();
+
+export interface TempOutputCapture {
+	path: string;
+	write(chunk: string | Buffer): void;
+	close(): void;
+}
+
+function getCandidateTempDirs(): string[] {
+	const candidates = [process.env.TMPDIR, process.env.TMP, process.env.TEMP, tmpdir(), join(homedir(), "tmp")];
+	const seen = new Set<string>();
+	const dirs: string[] = [];
+
+	for (const candidate of candidates) {
+		if (!candidate) continue;
+		const normalized = resolve(candidate);
+		if (seen.has(normalized)) continue;
+		seen.add(normalized);
+		dirs.push(normalized);
+	}
+
+	return dirs;
+}
+
+function maybeCleanupStaleLogs(dir: string, prefix: string, suffix: string): void {
+	const now = Date.now();
+	const lastCleanup = cleanupTimestamps.get(dir);
+	if (lastCleanup !== undefined && now - lastCleanup < CLEANUP_INTERVAL_MS) {
+		return;
+	}
+	cleanupTimestamps.set(dir, now);
+
+	let entries: string[];
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return;
+	}
+
+	const currentUid = process.getuid?.();
+	for (const entry of entries) {
+		if (!entry.startsWith(prefix) || !entry.endsWith(suffix)) continue;
+
+		const filePath = join(dir, entry);
+		try {
+			const stats = statSync(filePath);
+			if (!stats.isFile()) continue;
+			if (currentUid !== undefined && stats.uid !== currentUid) continue;
+			if (now - stats.mtimeMs < STALE_LOG_MAX_AGE_MS) continue;
+			unlinkSync(filePath);
+		} catch {
+			// Ignore races, permission errors, and broken temp entries.
+		}
+	}
+}
+
+function isRecoverableTempError(error: unknown): boolean {
+	return error instanceof Error && "code" in error
+		? error.code === "ENOSPC" ||
+				error.code === "ENOENT" ||
+				error.code === "EACCES" ||
+				error.code === "EPERM" ||
+				error.code === "EROFS" ||
+				error.code === "EMFILE"
+		: false;
+}
+
+export function createTempOutputCapture(prefix: string, suffix: string): TempOutputCapture | undefined {
+	for (const dir of getCandidateTempDirs()) {
+		try {
+			mkdirSync(dir, { recursive: true });
+			maybeCleanupStaleLogs(dir, prefix, suffix);
+		} catch (error) {
+			if (isRecoverableTempError(error)) {
+				continue;
+			}
+			throw error;
+		}
+
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			const filePath = join(dir, `${prefix}${randomBytes(8).toString("hex")}${suffix}`);
+			try {
+				const fd = openSync(filePath, "wx", 0o600);
+				const stream = createWriteStream(filePath, { fd });
+				let writable = true;
+				stream.on("error", () => {
+					writable = false;
+					stream.destroy();
+				});
+
+				return {
+					path: filePath,
+					write(chunk) {
+						if (!writable) return;
+						stream.write(chunk);
+					},
+					close() {
+						if (!writable) return;
+						writable = false;
+						stream.end();
+					},
+				};
+			} catch (error) {
+				if (error instanceof Error && "code" in error && error.code === "EEXIST") {
+					continue;
+				}
+				if (isRecoverableTempError(error)) {
+					break;
+				}
+				throw error;
+			}
+		}
+	}
+
+	return undefined;
+}

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -1,21 +1,11 @@
-import { randomBytes } from "node:crypto";
-import { createWriteStream, existsSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { existsSync } from "node:fs";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { type Static, Type } from "@sinclair/typebox";
 import { spawn } from "child_process";
 import { waitForChildProcess } from "../../utils/child-process.js";
 import { getShellConfig, getShellEnv, killProcessTree } from "../../utils/shell.js";
+import { createTempOutputCapture } from "../temp-output-capture.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateTail } from "./truncate.js";
-
-/**
- * Generate a unique temp file path for bash output
- */
-function getTempFilePath(): string {
-	const id = randomBytes(8).toString("hex");
-	return join(tmpdir(), `pi-bash-${id}.log`);
-}
 
 const bashSchema = Type.Object({
 	command: Type.String({ description: "Bash command to execute" }),
@@ -27,6 +17,12 @@ export type BashToolInput = Static<typeof bashSchema>;
 export interface BashToolDetails {
 	truncation?: TruncationResult;
 	fullOutputPath?: string;
+}
+
+function formatFullOutputNotice(fullOutputPath: string | undefined): string {
+	return fullOutputPath
+		? `Full output: ${fullOutputPath}`
+		: "Full output unavailable: unable to create a temp log file.";
 }
 
 /**
@@ -193,7 +189,7 @@ export function createBashTool(cwd: string, options?: BashToolOptions): AgentToo
 			return new Promise((resolve, reject) => {
 				// We'll stream to a temp file if output gets large
 				let tempFilePath: string | undefined;
-				let tempFileStream: ReturnType<typeof createWriteStream> | undefined;
+				let tempOutputCapture: ReturnType<typeof createTempOutputCapture> | undefined;
 				let totalBytes = 0;
 
 				// Keep a rolling buffer of the last chunk for tail truncation
@@ -206,19 +202,17 @@ export function createBashTool(cwd: string, options?: BashToolOptions): AgentToo
 					totalBytes += data.length;
 
 					// Start writing to temp file once we exceed the threshold
-					if (totalBytes > DEFAULT_MAX_BYTES && !tempFilePath) {
-						tempFilePath = getTempFilePath();
-						tempFileStream = createWriteStream(tempFilePath);
+					if (totalBytes > DEFAULT_MAX_BYTES && !tempOutputCapture) {
+						tempOutputCapture = createTempOutputCapture("pi-bash-", ".log");
+						tempFilePath = tempOutputCapture?.path;
 						// Write all buffered chunks to the file
 						for (const chunk of chunks) {
-							tempFileStream.write(chunk);
+							tempOutputCapture?.write(chunk);
 						}
 					}
 
 					// Write to temp file if we have one
-					if (tempFileStream) {
-						tempFileStream.write(data);
-					}
+					tempOutputCapture?.write(data);
 
 					// Keep rolling buffer of recent data
 					chunks.push(data);
@@ -253,9 +247,7 @@ export function createBashTool(cwd: string, options?: BashToolOptions): AgentToo
 				})
 					.then(({ exitCode }) => {
 						// Close temp file stream
-						if (tempFileStream) {
-							tempFileStream.end();
-						}
+						tempOutputCapture?.close();
 
 						// Combine all buffered chunks
 						const fullBuffer = Buffer.concat(chunks);
@@ -281,11 +273,11 @@ export function createBashTool(cwd: string, options?: BashToolOptions): AgentToo
 							if (truncation.lastLinePartial) {
 								// Edge case: last line alone > 30KB
 								const lastLineSize = formatSize(Buffer.byteLength(fullOutput.split("\n").pop() || "", "utf-8"));
-								outputText += `\n\n[Showing last ${formatSize(truncation.outputBytes)} of line ${endLine} (line is ${lastLineSize}). Full output: ${tempFilePath}]`;
+								outputText += `\n\n[Showing last ${formatSize(truncation.outputBytes)} of line ${endLine} (line is ${lastLineSize}). ${formatFullOutputNotice(tempFilePath)}]`;
 							} else if (truncation.truncatedBy === "lines") {
-								outputText += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}. Full output: ${tempFilePath}]`;
+								outputText += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}. ${formatFullOutputNotice(tempFilePath)}]`;
 							} else {
-								outputText += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Full output: ${tempFilePath}]`;
+								outputText += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). ${formatFullOutputNotice(tempFilePath)}]`;
 							}
 						}
 
@@ -298,9 +290,7 @@ export function createBashTool(cwd: string, options?: BashToolOptions): AgentToo
 					})
 					.catch((err: Error) => {
 						// Close temp file stream
-						if (tempFileStream) {
-							tempFileStream.end();
-						}
+						tempOutputCapture?.close();
 
 						// Combine all buffered chunks for error output
 						const fullBuffer = Buffer.concat(chunks);


### PR DESCRIPTION
Fixes #2512.

## Summary

- add a shared temp-output capture helper for bash spill files
- try `TMPDIR`, `TMP`, `TEMP`, `os.tmpdir()`, then `~/tmp`
- opportunistically clean up stale `pi-bash-*.log` files older than 24h
- downgrade gracefully when no full-output spill file can be created instead of crashing pi
- use the helper from both `src/core/bash-executor.ts` and `src/core/tools/bash.ts`

## Why

If `/tmp` is out of inodes, creating `/tmp/pi-bash-*.log` can fail with `ENOSPC` even when there is still plenty of free space. Today that failure can surface as an unhandled `WriteStream` error and terminate pi, even though the spill file is optional.

This change makes spill-file creation best-effort and falls back to a temp dir under the home directory when needed.

## Validation

- `npm exec --yes --package @biomejs/biome@2.3.5 -- biome check packages/coding-agent/src/core/bash-executor.ts packages/coding-agent/src/core/tools/bash.ts packages/coding-agent/src/core/temp-output-capture.ts`
- smoke-tested fallback by forcing an unusable `TMPDIR` and verifying the helper created a spill file under `~/tmp`

## Notes

I could not run the repo's full `npm run check` in this checkout because the monorepo toolchain is not bootstrapped here (`biome` is not installed in `node_modules/.bin`), so validation is scoped to the changed files plus the fallback smoke test.
