### PR TITLE
feat(openai-completions): add Azure OpenAI support

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1,4 +1,4 @@
-import OpenAI from "openai";
+import OpenAI, { AzureOpenAI } from "openai";
 import type {
 	ChatCompletionAssistantMessageParam,
 	ChatCompletionChunk,
@@ -352,6 +352,23 @@ function createClient(
 	// Merge options headers last so they can override defaults
 	if (optionsHeaders) {
 		Object.assign(headers, optionsHeaders);
+	}
+
+	// Azure OpenAI: use AzureOpenAI client for correct api-version query parameter
+	// handling. The standard OpenAI client doesn't append ?api-version= which Azure
+	// cognitiveservices endpoints require. Also ensure the api-key header is set,
+	// as Azure uses header-based auth rather than Bearer token auth.
+	if (model.provider === "azure-openai" || (model.baseUrl && model.baseUrl.includes(".openai.azure.com"))) {
+		if (!headers["api-key"] && apiKey) {
+			headers["api-key"] = apiKey;
+		}
+		return new AzureOpenAI({
+			apiKey,
+			apiVersion: process.env.AZURE_OPENAI_API_VERSION || "2025-01-01-preview",
+			baseURL: model.baseUrl,
+			dangerouslyAllowBrowser: true,
+			defaultHeaders: headers,
+		});
 	}
 
 	return new OpenAI({


### PR DESCRIPTION
## Summary

- Adds Azure OpenAI support to the `openai-completions` provider by detecting Azure providers and using the `AzureOpenAI` SDK client instead of the standard `OpenAI` client
- The `AzureOpenAI` client correctly appends the required `?api-version=` query parameter and uses header-based `api-key` authentication
- Without this change, Azure cognitiveservices Chat Completions endpoints return HTTP 404 because the standard OpenAI client doesn't include the `api-version` query parameter

## Problem

When configuring `openai-completions` API with an Azure OpenAI provider (`azure-openai`), the standard `OpenAI` client constructs URLs like:
```
https://{resource}.openai.azure.com/openai/deployments/{model}/chat/completions
```

But Azure requires:
```
https://{resource}.openai.azure.com/openai/deployments/{model}/chat/completions?api-version=2025-01-01-preview
```

The `AzureOpenAI` SDK client handles this automatically via its `apiVersion` parameter.

## Changes

- `packages/ai/src/providers/openai-completions.ts`:
  - Import `AzureOpenAI` from the `openai` package (already a dependency)
  - In `createClient()`, detect Azure providers by `model.provider === "azure-openai"` or `baseUrl` containing `.openai.azure.com`
  - Use `AzureOpenAI` client with `apiVersion` from `AZURE_OPENAI_API_VERSION` env var (defaults to `2025-01-01-preview`)
  - Set `api-key` header for Azure's header-based authentication

## Test plan

- [x] Tested with Azure OpenAI model-router deployment via OpenClaw gateway
- [ ] Verify no regression for standard OpenAI, OpenRouter, and other providers (detection is provider-specific, falls through to existing `OpenAI` client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)