### PR TITLE
fix: use APP_NAME in /quit command description

### DIFF
--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -15,6 +15,8 @@ export interface BuiltinSlashCommand {
 	description: string;
 }
 
+import { APP_NAME } from "../config.js";
+
 export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
@@ -35,5 +37,5 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "compact", description: "Manually compact the session context" },
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
-	{ name: "quit", description: "Quit pi" },
+	{ name: "quit", description: `Quit ${APP_NAME}` },
 ];


### PR DESCRIPTION
## Summary

The `/quit` command description is hardcoded as `"Quit pi"` in `slash-commands.ts`, but it should use `APP_NAME` from the config so that apps rebranding pi-coding-agent (via `package.json` `piConfig.name`) get the correct name in the slash command menu.