### PR TITLE
feat(coding-agent): add native multi-scope path resolution

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -17,7 +17,8 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@mariozechner/pi-ai": "^0.61.1"
+		"@mariozechner/pi-ai": "^0.61.1",
+		"@sinclair/typebox": "^0.34.41"
 	},
 	"keywords": [
 		"ai",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -74,6 +74,7 @@
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.73.0",
 		"@aws-sdk/client-bedrock-runtime": "^3.983.0",
+		"@smithy/node-http-handler": "^4.4.5",
 		"@google/genai": "^1.40.0",
 		"@mistralai/mistralai": "1.14.1",
 		"@sinclair/typebox": "^0.34.41",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -44,6 +44,8 @@
 		"@mariozechner/pi-ai": "^0.61.1",
 		"@mariozechner/pi-tui": "^0.61.1",
 		"@silvia-odwyer/photon-node": "^0.3.4",
+		"@sinclair/typebox": "^0.34.41",
+		"ajv": "^8.17.1",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",
 		"diff": "^8.0.2",

--- a/packages/coding-agent/src/cli/file-processor.ts
+++ b/packages/coding-agent/src/cli/file-processor.ts
@@ -18,17 +18,23 @@ export interface ProcessedFiles {
 export interface ProcessFileOptions {
 	/** Whether to auto-resize images to 2000x2000 max. Default: true */
 	autoResizeImages?: boolean;
+	/** Scope paths used to resolve relative @file arguments. Primary scope is cwd. */
+	scopePaths?: string[];
+	/** Base cwd for @file resolution. Defaults to process.cwd(). */
+	cwd?: string;
 }
 
 /** Process @file arguments into text content and image attachments */
 export async function processFileArguments(fileArgs: string[], options?: ProcessFileOptions): Promise<ProcessedFiles> {
 	const autoResizeImages = options?.autoResizeImages ?? true;
+	const cwd = options?.cwd ?? process.cwd();
+	const scopePaths = options?.scopePaths;
 	let text = "";
 	const images: ImageContent[] = [];
 
 	for (const fileArg of fileArgs) {
 		// Expand and resolve path (handles ~ expansion and macOS screenshot Unicode spaces)
-		const absolutePath = resolve(resolveReadPath(fileArg, process.cwd()));
+		const absolutePath = resolve(resolveReadPath(fileArg, cwd, scopePaths));
 
 		// Check if file exists
 		try {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -850,6 +850,7 @@ export class AgentSession {
 
 		return buildSystemPrompt({
 			cwd: this._cwd,
+			scopePaths: this.sessionManager.getScopePaths(),
 			skills: loadedSkills,
 			contextFiles: loadedContextFiles,
 			customPrompt: loaderSystemPrompt,
@@ -858,6 +859,11 @@ export class AgentSession {
 			toolSnippets,
 			promptGuidelines,
 		});
+	}
+
+	refreshSystemPrompt(): void {
+		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+		this.agent.setSystemPrompt(this._baseSystemPrompt);
 	}
 
 	// =========================================================================
@@ -2285,6 +2291,7 @@ export class AgentSession {
 			: createAllToolDefinitions(this._cwd, {
 					read: { autoResizeImages },
 					bash: { commandPrefix: shellCommandPrefix },
+					scopePaths: () => this.sessionManager.getScopePaths(),
 				});
 
 		this._baseToolDefinitions = new Map(

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -24,7 +24,7 @@ import {
 	createCustomMessage,
 } from "./messages.js";
 
-export const CURRENT_SESSION_VERSION = 3;
+export const CURRENT_SESSION_VERSION = 4;
 
 export interface SessionHeader {
 	type: "session";
@@ -32,12 +32,14 @@ export interface SessionHeader {
 	id: string;
 	timestamp: string;
 	cwd: string;
+	scopePaths?: string[];
 	parentSession?: string;
 }
 
 export interface NewSessionOptions {
 	id?: string;
 	parentSession?: string;
+	scopePaths?: string[];
 }
 
 export interface SessionEntryBase {
@@ -181,6 +183,7 @@ export interface SessionInfo {
 export type ReadonlySessionManager = Pick<
 	SessionManager,
 	| "getCwd"
+	| "getScopePaths"
 	| "getSessionDir"
 	| "getSessionId"
 	| "getSessionFile"
@@ -252,6 +255,15 @@ function migrateV2ToV3(entries: FileEntry[]): void {
 	}
 }
 
+/** Migrate v3 → v4: persist scopePaths. Mutates in place. */
+function migrateV3ToV4(entries: FileEntry[]): void {
+	for (const entry of entries) {
+		if (entry.type === "session") {
+			entry.version = 4;
+		}
+	}
+}
+
 /**
  * Run all necessary migrations to bring entries to current version.
  * Mutates entries in place. Returns true if any migration was applied.
@@ -264,6 +276,7 @@ function migrateToCurrentVersion(entries: FileEntry[]): boolean {
 
 	if (version < 2) migrateV1ToV2(entries);
 	if (version < 3) migrateV2ToV3(entries);
+	if (version < 4) migrateV3ToV4(entries);
 
 	return true;
 }
@@ -664,6 +677,7 @@ export class SessionManager {
 	private sessionFile: string | undefined;
 	private sessionDir: string;
 	private cwd: string;
+	private scopePaths: string[];
 	private persist: boolean;
 	private flushed: boolean = false;
 	private fileEntries: FileEntry[] = [];
@@ -673,6 +687,7 @@ export class SessionManager {
 
 	private constructor(cwd: string, sessionDir: string, sessionFile: string | undefined, persist: boolean) {
 		this.cwd = cwd;
+		this.scopePaths = [cwd];
 		this.sessionDir = sessionDir;
 		this.persist = persist;
 		if (persist && sessionDir && !existsSync(sessionDir)) {
@@ -705,6 +720,11 @@ export class SessionManager {
 
 			const header = this.fileEntries.find((e) => e.type === "session") as SessionHeader | undefined;
 			this.sessionId = header?.id ?? randomUUID();
+			this.scopePaths =
+				Array.isArray(header?.scopePaths) && header.scopePaths.length > 0 ? [...header.scopePaths] : [this.cwd];
+			if (header) {
+				header.scopePaths = [...this.scopePaths];
+			}
 
 			if (migrateToCurrentVersion(this.fileEntries)) {
 				this._rewriteFile();
@@ -728,6 +748,7 @@ export class SessionManager {
 			id: this.sessionId,
 			timestamp,
 			cwd: this.cwd,
+			scopePaths: options?.scopePaths ?? this.scopePaths,
 			parentSession: options?.parentSession,
 		};
 		this.fileEntries = [header];
@@ -775,6 +796,35 @@ export class SessionManager {
 		return this.cwd;
 	}
 
+	getScopePaths(): string[] {
+		return [...this.scopePaths];
+	}
+
+	setScopePaths(scopePaths: string[]): void {
+		const normalized = [this.cwd, ...scopePaths.map((scopePath) => resolve(this.cwd, scopePath))].filter(
+			(path, index, all) => path && all.indexOf(path) === index,
+		);
+		this.scopePaths = normalized;
+		const header = this.fileEntries.find((entry): entry is SessionHeader => entry.type === "session");
+		if (header) {
+			header.scopePaths = [...this.scopePaths];
+			this._rewriteFile();
+		}
+	}
+
+	addScopePath(scopePath: string): void {
+		this.setScopePaths([...this.scopePaths, scopePath]);
+	}
+
+	removeScopePath(scopePath: string): void {
+		const resolved = resolve(this.cwd, scopePath);
+		this.setScopePaths(this.scopePaths.filter((path) => path !== resolved && path !== this.cwd));
+	}
+
+	resetScopePaths(): void {
+		this.setScopePaths([this.cwd]);
+	}
+
 	getSessionDir(): string {
 		return this.sessionDir;
 	}
@@ -798,9 +848,11 @@ export class SessionManager {
 		}
 
 		if (!this.flushed) {
-			for (const e of this.fileEntries) {
-				appendFileSync(this.sessionFile, `${JSON.stringify(e)}\n`);
-			}
+			// Rewrite the full file on the first persisted assistant turn.
+			// This avoids duplicating early entries when the session header was
+			// already rewritten before the first assistant message (for example
+			// when scopePaths changes are persisted eagerly).
+			this._rewriteFile();
 			this.flushed = true;
 		} else {
 			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
@@ -1174,6 +1226,7 @@ export class SessionManager {
 			id: newSessionId,
 			timestamp,
 			cwd: this.cwd,
+			scopePaths: this.scopePaths,
 			parentSession: this.persist ? previousSessionFile : undefined,
 		};
 
@@ -1327,6 +1380,7 @@ export class SessionManager {
 			id: newSessionId,
 			timestamp,
 			cwd: targetCwd,
+			scopePaths: [targetCwd],
 			parentSession: sourcePath,
 		};
 		appendFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`);

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -25,6 +25,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{ name: "name", description: "Set session display name" },
 	{ name: "session", description: "Show session info and stats" },
+	{ name: "scope", description: "Show or edit scope paths" },
 	{ name: "changelog", description: "Show changelog entries" },
 	{ name: "hotkeys", description: "Show all keyboard shortcuts" },
 	{ name: "fork", description: "Create a new fork from a previous message" },

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -20,6 +20,8 @@ export interface BuildSystemPromptOptions {
 	cwd?: string;
 	/** Pre-loaded context files. */
 	contextFiles?: Array<{ path: string; content: string }>;
+	/** Ordered scope paths (primary first). */
+	scopePaths?: string[];
 	/** Pre-loaded skills. */
 	skills?: Skill[];
 }
@@ -34,6 +36,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		appendSystemPrompt,
 		cwd,
 		contextFiles: providedContextFiles,
+		scopePaths: providedScopePaths,
 		skills: providedSkills,
 	} = options;
 	const resolvedCwd = cwd ?? process.cwd();
@@ -44,6 +47,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const appendSection = appendSystemPrompt ? `\n\n${appendSystemPrompt}` : "";
 
 	const contextFiles = providedContextFiles ?? [];
+	const scopePaths = providedScopePaths ?? [];
 	const skills = providedSkills ?? [];
 
 	if (customPrompt) {
@@ -71,6 +75,12 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		// Add date and working directory last
 		prompt += `\nCurrent date: ${date}`;
 		prompt += `\nCurrent working directory: ${promptCwd}`;
+		if (scopePaths.length > 0) {
+			prompt += `\nCurrent scopes:\n- primary: ${scopePaths[0]}`;
+			for (const scopePath of scopePaths.slice(1)) {
+				prompt += `\n- additional: ${scopePath}`;
+			}
+		}
 
 		return prompt;
 	}
@@ -108,7 +118,9 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	if (hasBash && !hasGrep && !hasFind && !hasLs) {
 		addGuideline("Use bash for file operations like ls, rg, find");
 	} else if (hasBash && (hasGrep || hasFind || hasLs)) {
-		addGuideline("Prefer grep/find/ls tools over bash for file exploration (faster, respects .gitignore)");
+		addGuideline(
+			"Prefer grep/find/ls tools over bash for file exploration (faster, respects .gitignore, and can search all scopes by default)",
+		);
 	}
 
 	for (const guideline of promptGuidelines ?? []) {
@@ -163,6 +175,12 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
 	// Add date and working directory last
 	prompt += `\nCurrent date: ${date}`;
 	prompt += `\nCurrent working directory: ${promptCwd}`;
+	if (scopePaths.length > 0) {
+		prompt += `\nCurrent scopes:\n- primary: ${scopePaths[0]}`;
+		for (const scopePath of scopePaths.slice(1)) {
+			prompt += `\n- additional: ${scopePath}`;
+		}
+	}
 
 	return prompt;
 }

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -62,6 +62,8 @@ const defaultEditOperations: EditOperations = {
 };
 
 export interface EditToolOptions {
+	/** Scope paths used for relative file resolution. Primary scope is cwd. */
+	scopePaths?: string[] | (() => string[]);
 	/** Custom operations for file editing. Default: local filesystem */
 	operations?: EditOperations;
 }
@@ -120,13 +122,17 @@ export function createEditToolDefinition(
 	options?: EditToolOptions,
 ): ToolDefinition<typeof editSchema, EditToolDetails | undefined, EditRenderState> {
 	const ops = options?.operations ?? defaultEditOperations;
+	const scopePaths = options?.scopePaths;
 	return {
 		name: "edit",
 		label: "edit",
 		description:
 			"Edit a file by replacing exact text. The oldText must match exactly (including whitespace). Use this for precise, surgical edits.",
 		promptSnippet: "Make surgical edits to files (find exact text and replace)",
-		promptGuidelines: ["Use edit for precise changes (old text must match exactly)."],
+		promptGuidelines: [
+			"Use edit for precise changes (old text must match exactly).",
+			"Relative mutation paths are resolved across scopes and fail when ambiguous.",
+		],
 		parameters: editSchema,
 		async execute(
 			_toolCallId,
@@ -135,7 +141,7 @@ export function createEditToolDefinition(
 			_onUpdate?,
 			_ctx?,
 		) {
-			const absolutePath = resolveToCwd(path, cwd);
+			const absolutePath = resolveToCwd(path, cwd, scopePaths);
 
 			return withFileMutationQueue(
 				absolutePath,

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -8,7 +8,7 @@ import path from "path";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
-import { resolveToCwd } from "./path-utils.js";
+import { resolveSearchPaths } from "./path-utils.js";
 import { getTextOutput, invalidArgText, shortenPath, str } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
@@ -52,6 +52,8 @@ const defaultFindOperations: FindOperations = {
 };
 
 export interface FindToolOptions {
+	/** Scope paths used for relative file resolution. Primary scope is cwd. */
+	scopePaths?: string[] | (() => string[]);
 	/** Custom operations for find. Default: local filesystem plus fd */
 	operations?: FindOperations;
 }
@@ -114,11 +116,12 @@ export function createFindToolDefinition(
 	options?: FindToolOptions,
 ): ToolDefinition<typeof findSchema, FindToolDetails | undefined> {
 	const customOps = options?.operations;
+	const scopePaths = options?.scopePaths;
 	return {
 		name: "find",
 		label: "find",
 		description: `Search for files by glob pattern. Returns matching file paths relative to the search directory. Respects .gitignore. Output is truncated to ${DEFAULT_LIMIT} results or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
-		promptSnippet: "Find files by glob pattern (respects .gitignore)",
+		promptSnippet: "Find files by glob pattern (respects .gitignore, defaults to all scopes)",
 		parameters: findSchema,
 		async execute(
 			_toolCallId,
@@ -138,22 +141,31 @@ export function createFindToolDefinition(
 
 				(async () => {
 					try {
-						const searchPath = resolveToCwd(searchDir || ".", cwd);
+						const searchPaths = resolveSearchPaths(searchDir, cwd, scopePaths);
+						const searchPath = searchPaths.length === 1 ? searchPaths[0] : undefined;
 						const effectiveLimit = limit ?? DEFAULT_LIMIT;
 						const ops = customOps ?? defaultFindOperations;
 
 						// If custom operations provide glob(), use that instead of fd.
 						if (customOps?.glob) {
-							if (!(await ops.exists(searchPath))) {
-								reject(new Error(`Path not found: ${searchPath}`));
-								return;
+							const allResults: string[] = [];
+							for (const root of searchPaths) {
+								if (!(await ops.exists(root))) {
+									reject(new Error(`Path not found: ${root}`));
+									return;
+								}
+								const remainingLimit = Math.max(0, effectiveLimit - allResults.length);
+								if (remainingLimit === 0) break;
+								const results = await ops.glob(pattern, root, {
+									ignore: ["**/node_modules/**", "**/.git/**"],
+									limit: remainingLimit,
+								});
+								for (const result of results) {
+									allResults.push(result.startsWith(root) ? result : path.resolve(root, result));
+								}
 							}
-							const results = await ops.glob(pattern, searchPath, {
-								ignore: ["**/node_modules/**", "**/.git/**"],
-								limit: effectiveLimit,
-							});
 							signal?.removeEventListener("abort", onAbort);
-							if (results.length === 0) {
+							if (allResults.length === 0) {
 								resolve({
 									content: [{ type: "text", text: "No files found matching pattern" }],
 									details: undefined,
@@ -162,11 +174,20 @@ export function createFindToolDefinition(
 							}
 
 							// Relativize paths against the search root for stable output.
-							const relativized = results.map((p) => {
-								if (p.startsWith(searchPath)) return toPosixPath(p.slice(searchPath.length + 1));
-								return toPosixPath(path.relative(searchPath, p));
+							const relativized = allResults.map((p) => {
+								if (searchPath) {
+									if (p.startsWith(searchPath)) return toPosixPath(p.slice(searchPath.length + 1));
+									return toPosixPath(path.relative(searchPath, p));
+								}
+								for (const root of searchPaths) {
+									const relative = path.relative(root, p);
+									if (relative && !relative.startsWith("..")) {
+										return toPosixPath(`${path.basename(root)}/${relative}`);
+									}
+								}
+								return toPosixPath(path.basename(p));
 							});
-							const resultLimitReached = relativized.length >= effectiveLimit;
+							const resultLimitReached = allResults.length >= effectiveLimit;
 							const rawOutput = relativized.join("\n");
 							const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
 							let resultOutput = truncation.content;
@@ -205,23 +226,25 @@ export function createFindToolDefinition(
 							"--max-results",
 							String(effectiveLimit),
 						];
-						// Include .gitignore files from the search tree.
+						// Include .gitignore files from all search trees.
 						const gitignoreFiles = new Set<string>();
-						const rootGitignore = path.join(searchPath, ".gitignore");
-						if (existsSync(rootGitignore)) gitignoreFiles.add(rootGitignore);
-						try {
-							const nestedGitignores = globSync("**/.gitignore", {
-								cwd: searchPath,
-								dot: true,
-								absolute: true,
-								ignore: ["**/node_modules/**", "**/.git/**"],
-							});
-							for (const file of nestedGitignores) gitignoreFiles.add(file);
-						} catch {
-							// ignore
+						for (const root of searchPaths) {
+							const rootGitignore = path.join(root, ".gitignore");
+							if (existsSync(rootGitignore)) gitignoreFiles.add(rootGitignore);
+							try {
+								const nestedGitignores = globSync("**/.gitignore", {
+									cwd: root,
+									dot: true,
+									absolute: true,
+									ignore: ["**/node_modules/**", "**/.git/**"],
+								});
+								for (const file of nestedGitignores) gitignoreFiles.add(file);
+							} catch {
+								// ignore
+							}
 						}
 						for (const gitignorePath of gitignoreFiles) args.push("--ignore-file", gitignorePath);
-						args.push(pattern, searchPath);
+						args.push(pattern, ...searchPaths);
 
 						const result = spawnSync(fdPath, args, { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 });
 						signal?.removeEventListener("abort", onAbort);
@@ -253,10 +276,20 @@ export function createFindToolDefinition(
 							if (!line) continue;
 							const hadTrailingSlash = line.endsWith("/") || line.endsWith("\\");
 							let relativePath = line;
-							if (line.startsWith(searchPath)) {
-								relativePath = line.slice(searchPath.length + 1);
+							if (searchPath) {
+								if (line.startsWith(searchPath)) {
+									relativePath = line.slice(searchPath.length + 1);
+								} else {
+									relativePath = path.relative(searchPath, line);
+								}
 							} else {
-								relativePath = path.relative(searchPath, line);
+								for (const root of searchPaths) {
+									const relative = path.relative(root, line);
+									if (relative && !relative.startsWith("..")) {
+										relativePath = `${path.basename(root)}/${relative}`;
+										break;
+									}
+								}
 							}
 							if (hadTrailingSlash && !relativePath.endsWith("/")) relativePath += "/";
 							relativized.push(toPosixPath(relativePath));

--- a/packages/coding-agent/src/core/tools/grep.ts
+++ b/packages/coding-agent/src/core/tools/grep.ts
@@ -8,7 +8,7 @@ import path from "path";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
-import { resolveToCwd } from "./path-utils.js";
+import { resolveSearchPaths } from "./path-utils.js";
 import { getTextOutput, invalidArgText, shortenPath, str } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import {
@@ -60,6 +60,8 @@ const defaultGrepOperations: GrepOperations = {
 };
 
 export interface GrepToolOptions {
+	/** Scope paths used for relative file resolution. Primary scope is cwd. */
+	scopePaths?: string[] | (() => string[]);
 	/** Custom operations for grep. Default: local filesystem plus ripgrep */
 	operations?: GrepOperations;
 }
@@ -124,11 +126,12 @@ export function createGrepToolDefinition(
 	options?: GrepToolOptions,
 ): ToolDefinition<typeof grepSchema, GrepToolDetails | undefined> {
 	const customOps = options?.operations;
+	const scopePaths = options?.scopePaths;
 	return {
 		name: "grep",
 		label: "grep",
 		description: `Search file contents for a pattern. Returns matching lines with file paths and line numbers. Respects .gitignore. Output is truncated to ${DEFAULT_LIMIT} matches or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Long lines are truncated to ${GREP_MAX_LINE_LENGTH} chars.`,
-		promptSnippet: "Search file contents for patterns (respects .gitignore)",
+		promptSnippet: "Search file contents for patterns (respects .gitignore, defaults to all scopes)",
 		parameters: grepSchema,
 		async execute(
 			_toolCallId,
@@ -174,23 +177,32 @@ export function createGrepToolDefinition(
 							return;
 						}
 
-						const searchPath = resolveToCwd(searchDir || ".", cwd);
+						const searchPaths = resolveSearchPaths(searchDir, cwd, scopePaths);
+						const searchPath = searchPaths.length === 1 ? searchPaths[0] : undefined;
 						const ops = customOps ?? defaultGrepOperations;
-						let isDirectory: boolean;
-						try {
-							isDirectory = await ops.isDirectory(searchPath);
-						} catch {
-							settle(() => reject(new Error(`Path not found: ${searchPath}`)));
-							return;
+						let isDirectory = true;
+						if (searchPath) {
+							try {
+								isDirectory = await ops.isDirectory(searchPath);
+							} catch {
+								settle(() => reject(new Error(`Path not found: ${searchPath}`)));
+								return;
+							}
 						}
 
 						const contextValue = context && context > 0 ? context : 0;
 						const effectiveLimit = Math.max(1, limit ?? DEFAULT_LIMIT);
 						const formatPath = (filePath: string): string => {
-							if (isDirectory) {
+							if (searchPath && isDirectory) {
 								const relative = path.relative(searchPath, filePath);
 								if (relative && !relative.startsWith("..")) {
 									return relative.replace(/\\/g, "/");
+								}
+							}
+							for (const root of searchPaths) {
+								const relative = path.relative(root, filePath);
+								if (relative && !relative.startsWith("..")) {
+									return `${path.basename(root)}/${relative}`.replace(/\\/g, "/");
 								}
 							}
 							return path.basename(filePath);
@@ -215,7 +227,7 @@ export function createGrepToolDefinition(
 						if (ignoreCase) args.push("--ignore-case");
 						if (literal) args.push("--fixed-strings");
 						if (glob) args.push("--glob", glob);
-						args.push(pattern, searchPath);
+						args.push(pattern, ...searchPaths);
 
 						const child = spawn(rgPath, args, { stdio: ["ignore", "pipe", "pipe"] });
 						const rl = createInterface({ input: child.stdout });

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -135,59 +135,65 @@ export type ToolName = keyof typeof allTools;
 export interface ToolsOptions {
 	read?: ReadToolOptions;
 	bash?: BashToolOptions;
+	scopePaths?: string[] | (() => string[]);
 }
 
 export function createCodingToolDefinitions(cwd: string, options?: ToolsOptions): ToolDef[] {
 	return [
-		createReadToolDefinition(cwd, options?.read),
+		createReadToolDefinition(cwd, { ...options?.read, scopePaths: options?.scopePaths }),
 		createBashToolDefinition(cwd, options?.bash),
-		createEditToolDefinition(cwd),
-		createWriteToolDefinition(cwd),
+		createEditToolDefinition(cwd, { scopePaths: options?.scopePaths }),
+		createWriteToolDefinition(cwd, { scopePaths: options?.scopePaths }),
 	];
 }
 
 export function createReadOnlyToolDefinitions(cwd: string, options?: ToolsOptions): ToolDef[] {
 	return [
-		createReadToolDefinition(cwd, options?.read),
-		createGrepToolDefinition(cwd),
-		createFindToolDefinition(cwd),
-		createLsToolDefinition(cwd),
+		createReadToolDefinition(cwd, { ...options?.read, scopePaths: options?.scopePaths }),
+		createGrepToolDefinition(cwd, { scopePaths: options?.scopePaths }),
+		createFindToolDefinition(cwd, { scopePaths: options?.scopePaths }),
+		createLsToolDefinition(cwd, { scopePaths: options?.scopePaths }),
 	];
 }
 
 export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): Record<ToolName, ToolDef> {
 	return {
-		read: createReadToolDefinition(cwd, options?.read),
+		read: createReadToolDefinition(cwd, { ...options?.read, scopePaths: options?.scopePaths }),
 		bash: createBashToolDefinition(cwd, options?.bash),
-		edit: createEditToolDefinition(cwd),
-		write: createWriteToolDefinition(cwd),
-		grep: createGrepToolDefinition(cwd),
-		find: createFindToolDefinition(cwd),
-		ls: createLsToolDefinition(cwd),
+		edit: createEditToolDefinition(cwd, { scopePaths: options?.scopePaths }),
+		write: createWriteToolDefinition(cwd, { scopePaths: options?.scopePaths }),
+		grep: createGrepToolDefinition(cwd, { scopePaths: options?.scopePaths }),
+		find: createFindToolDefinition(cwd, { scopePaths: options?.scopePaths }),
+		ls: createLsToolDefinition(cwd, { scopePaths: options?.scopePaths }),
 	};
 }
 
 export function createCodingTools(cwd: string, options?: ToolsOptions): Tool[] {
 	return [
-		createReadTool(cwd, options?.read),
+		createReadTool(cwd, { ...options?.read, scopePaths: options?.scopePaths }),
 		createBashTool(cwd, options?.bash),
-		createEditTool(cwd),
-		createWriteTool(cwd),
+		createEditTool(cwd, { scopePaths: options?.scopePaths }),
+		createWriteTool(cwd, { scopePaths: options?.scopePaths }),
 	];
 }
 
 export function createReadOnlyTools(cwd: string, options?: ToolsOptions): Tool[] {
-	return [createReadTool(cwd, options?.read), createGrepTool(cwd), createFindTool(cwd), createLsTool(cwd)];
+	return [
+		createReadTool(cwd, { ...options?.read, scopePaths: options?.scopePaths }),
+		createGrepTool(cwd, { scopePaths: options?.scopePaths }),
+		createFindTool(cwd, { scopePaths: options?.scopePaths }),
+		createLsTool(cwd, { scopePaths: options?.scopePaths }),
+	];
 }
 
 export function createAllTools(cwd: string, options?: ToolsOptions): Record<ToolName, Tool> {
 	return {
-		read: createReadTool(cwd, options?.read),
+		read: createReadTool(cwd, { ...options?.read, scopePaths: options?.scopePaths }),
 		bash: createBashTool(cwd, options?.bash),
-		edit: createEditTool(cwd),
-		write: createWriteTool(cwd),
-		grep: createGrepTool(cwd),
-		find: createFindTool(cwd),
-		ls: createLsTool(cwd),
+		edit: createEditTool(cwd, { scopePaths: options?.scopePaths }),
+		write: createWriteTool(cwd, { scopePaths: options?.scopePaths }),
+		grep: createGrepTool(cwd, { scopePaths: options?.scopePaths }),
+		find: createFindTool(cwd, { scopePaths: options?.scopePaths }),
+		ls: createLsTool(cwd, { scopePaths: options?.scopePaths }),
 	};
 }

--- a/packages/coding-agent/src/core/tools/ls.ts
+++ b/packages/coding-agent/src/core/tools/ls.ts
@@ -5,7 +5,7 @@ import { existsSync, readdirSync, statSync } from "fs";
 import nodePath from "path";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
-import { resolveToCwd } from "./path-utils.js";
+import { resolveSearchPaths } from "./path-utils.js";
 import { getTextOutput, invalidArgText, shortenPath, str } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
@@ -44,6 +44,8 @@ const defaultLsOperations: LsOperations = {
 };
 
 export interface LsToolOptions {
+	/** Scope paths used for relative file resolution. Primary scope is cwd. */
+	scopePaths?: string[] | (() => string[]);
 	/** Custom operations for directory listing. Default: local filesystem */
 	operations?: LsOperations;
 }
@@ -101,11 +103,12 @@ export function createLsToolDefinition(
 	options?: LsToolOptions,
 ): ToolDefinition<typeof lsSchema, LsToolDetails | undefined> {
 	const ops = options?.operations ?? defaultLsOperations;
+	const scopePaths = options?.scopePaths;
 	return {
 		name: "ls",
 		label: "ls",
 		description: `List directory contents. Returns entries sorted alphabetically, with '/' suffix for directories. Includes dotfiles. Output is truncated to ${DEFAULT_LIMIT} entries or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
-		promptSnippet: "List directory contents",
+		promptSnippet: "List directory contents (defaults to all scopes)",
 		parameters: lsSchema,
 		async execute(
 			_toolCallId,
@@ -125,53 +128,65 @@ export function createLsToolDefinition(
 
 				(async () => {
 					try {
-						const dirPath = resolveToCwd(path || ".", cwd);
+						const dirPaths = resolveSearchPaths(path, cwd, scopePaths);
+						const singleDirPath = dirPaths.length === 1 ? dirPaths[0] : undefined;
 						const effectiveLimit = limit ?? DEFAULT_LIMIT;
 
-						// Check if path exists.
-						if (!(await ops.exists(dirPath))) {
-							reject(new Error(`Path not found: ${dirPath}`));
-							return;
-						}
-
-						// Check if path is a directory.
-						const stat = await ops.stat(dirPath);
-						if (!stat.isDirectory()) {
-							reject(new Error(`Not a directory: ${dirPath}`));
-							return;
-						}
-
 						// Read directory entries.
-						let entries: string[];
-						try {
-							entries = await ops.readdir(dirPath);
-						} catch (e: any) {
-							reject(new Error(`Cannot read directory: ${e.message}`));
-							return;
-						}
-
-						// Sort alphabetically, case-insensitive.
-						entries.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-
-						// Format entries with directory indicators.
 						const results: string[] = [];
 						let entryLimitReached = false;
-						for (const entry of entries) {
+						for (const dirPath of dirPaths) {
 							if (results.length >= effectiveLimit) {
 								entryLimitReached = true;
 								break;
 							}
 
-							const fullPath = nodePath.join(dirPath, entry);
-							let suffix = "";
-							try {
-								const entryStat = await ops.stat(fullPath);
-								if (entryStat.isDirectory()) suffix = "/";
-							} catch {
-								// Skip entries we cannot stat.
-								continue;
+							// Check if path exists.
+							if (!(await ops.exists(dirPath))) {
+								reject(new Error(`Path not found: ${dirPath}`));
+								return;
 							}
-							results.push(entry + suffix);
+
+							// Check if path is a directory.
+							const stat = await ops.stat(dirPath);
+							if (!stat.isDirectory()) {
+								reject(new Error(`Not a directory: ${dirPath}`));
+								return;
+							}
+
+							let entries: string[];
+							try {
+								entries = await ops.readdir(dirPath);
+							} catch (e: any) {
+								reject(new Error(`Cannot read directory: ${e.message}`));
+								return;
+							}
+
+							// Sort alphabetically, case-insensitive.
+							entries.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+
+							for (const entry of entries) {
+								if (results.length >= effectiveLimit) {
+									entryLimitReached = true;
+									break;
+								}
+
+								const fullPath = nodePath.join(dirPath, entry);
+								let suffix = "";
+								try {
+									const entryStat = await ops.stat(fullPath);
+									if (entryStat.isDirectory()) suffix = "/";
+								} catch {
+									// Skip entries we cannot stat.
+									continue;
+								}
+
+								if (singleDirPath) {
+									results.push(entry + suffix);
+								} else {
+									results.push(`${nodePath.basename(dirPath)}/${entry}${suffix}`);
+								}
+							}
 						}
 
 						signal?.removeEventListener("abort", onAbort);

--- a/packages/coding-agent/src/core/tools/path-utils.ts
+++ b/packages/coding-agent/src/core/tools/path-utils.ts
@@ -36,6 +36,33 @@ function normalizeAtPrefix(filePath: string): string {
 	return filePath.startsWith("@") ? filePath.slice(1) : filePath;
 }
 
+function uniquePaths(paths: string[]): string[] {
+	return [...new Set(paths)];
+}
+
+export type ScopePathsInput = string[] | (() => string[]);
+
+export function resolveScopePaths(cwd: string, scopePaths?: ScopePathsInput): string[] {
+	const paths = uniquePaths([cwd, ...(typeof scopePaths === "function" ? scopePaths() : (scopePaths ?? []))]);
+	return paths.filter((path) => path.length > 0);
+}
+
+/**
+ * Resolve one or more search roots for grep/find/ls.
+ * - Missing/"." path fans out across all scopes.
+ * - Any other path resolves to a single path (and can still be ambiguous).
+ */
+export function resolveSearchPaths(
+	searchPath: string | undefined,
+	cwd: string,
+	scopePaths?: ScopePathsInput,
+): string[] {
+	if (!searchPath || searchPath === ".") {
+		return resolveScopePaths(cwd, scopePaths);
+	}
+	return [resolveToCwd(searchPath, cwd, scopePaths)];
+}
+
 export function expandPath(filePath: string): string {
 	const normalized = normalizeUnicodeSpaces(normalizeAtPrefix(filePath));
 	if (normalized === "~") {
@@ -47,48 +74,76 @@ export function expandPath(filePath: string): string {
 	return normalized;
 }
 
-/**
- * Resolve a path relative to the given cwd.
- * Handles ~ expansion and absolute paths.
- */
-export function resolveToCwd(filePath: string, cwd: string): string {
-	const expanded = expandPath(filePath);
-	if (isAbsolute(expanded)) {
-		return expanded;
-	}
-	return resolvePath(cwd, expanded);
-}
-
-export function resolveReadPath(filePath: string, cwd: string): string {
-	const resolved = resolveToCwd(filePath, cwd);
-
-	if (fileExists(resolved)) {
-		return resolved;
-	}
+function resolveReadCandidate(filePath: string): string | undefined {
+	if (fileExists(filePath)) return filePath;
 
 	// Try macOS AM/PM variant (narrow no-break space before AM/PM)
-	const amPmVariant = tryMacOSScreenshotPath(resolved);
-	if (amPmVariant !== resolved && fileExists(amPmVariant)) {
+	const amPmVariant = tryMacOSScreenshotPath(filePath);
+	if (amPmVariant !== filePath && fileExists(amPmVariant)) {
 		return amPmVariant;
 	}
 
 	// Try NFD variant (macOS stores filenames in NFD form)
-	const nfdVariant = tryNFDVariant(resolved);
-	if (nfdVariant !== resolved && fileExists(nfdVariant)) {
+	const nfdVariant = tryNFDVariant(filePath);
+	if (nfdVariant !== filePath && fileExists(nfdVariant)) {
 		return nfdVariant;
 	}
 
 	// Try curly quote variant (macOS uses U+2019 in screenshot names)
-	const curlyVariant = tryCurlyQuoteVariant(resolved);
-	if (curlyVariant !== resolved && fileExists(curlyVariant)) {
+	const curlyVariant = tryCurlyQuoteVariant(filePath);
+	if (curlyVariant !== filePath && fileExists(curlyVariant)) {
 		return curlyVariant;
 	}
 
 	// Try combined NFD + curly quote (for French macOS screenshots like "Capture d'écran")
 	const nfdCurlyVariant = tryCurlyQuoteVariant(nfdVariant);
-	if (nfdCurlyVariant !== resolved && fileExists(nfdCurlyVariant)) {
+	if (nfdCurlyVariant !== filePath && fileExists(nfdCurlyVariant)) {
 		return nfdCurlyVariant;
 	}
 
-	return resolved;
+	return undefined;
+}
+
+function ambiguousPathError(filePath: string, matches: string[]): Error {
+	return new Error(
+		`Ambiguous relative path: ${filePath}\nMatches multiple scopes:\n${matches.map((path) => `- ${path}`).join("\n")}`,
+	);
+}
+
+/**
+ * Resolve a path relative to the given cwd.
+ * Handles ~ expansion and absolute paths.
+ */
+export function resolveToCwd(filePath: string, cwd: string, scopePaths?: ScopePathsInput): string {
+	const expanded = expandPath(filePath);
+	if (isAbsolute(expanded)) {
+		return expanded;
+	}
+
+	const scopeBases = resolveScopePaths(cwd, scopePaths);
+	const matches = scopeBases.map((base) => resolvePath(base, expanded)).filter((candidate) => fileExists(candidate));
+
+	if (matches.length > 1) {
+		throw ambiguousPathError(filePath, matches);
+	}
+
+	return matches[0] ?? resolvePath(scopeBases[0], expanded);
+}
+
+export function resolveReadPath(filePath: string, cwd: string, scopePaths?: ScopePathsInput): string {
+	const expanded = expandPath(filePath);
+	if (isAbsolute(expanded)) {
+		return resolveReadCandidate(expanded) ?? expanded;
+	}
+
+	const scopeBases = resolveScopePaths(cwd, scopePaths);
+	const matches = scopeBases
+		.map((base) => resolveReadCandidate(resolvePath(base, expanded)))
+		.filter((candidate): candidate is string => candidate !== undefined);
+
+	if (matches.length > 1) {
+		throw ambiguousPathError(filePath, matches);
+	}
+
+	return matches[0] ?? resolvePath(scopeBases[0], expanded);
 }

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -48,6 +48,8 @@ const defaultReadOperations: ReadOperations = {
 export interface ReadToolOptions {
 	/** Whether to auto-resize images to 2000x2000 max. Default: true */
 	autoResizeImages?: boolean;
+	/** Scope paths used for relative file resolution. Primary scope is cwd. */
+	scopePaths?: string[] | (() => string[]);
 	/** Custom operations for file reading. Default: local filesystem */
 	operations?: ReadOperations;
 }
@@ -117,12 +119,16 @@ export function createReadToolDefinition(
 ): ToolDefinition<typeof readSchema, ReadToolDetails | undefined> {
 	const autoResizeImages = options?.autoResizeImages ?? true;
 	const ops = options?.operations ?? defaultReadOperations;
+	const scopePaths = options?.scopePaths;
 	return {
 		name: "read",
 		label: "read",
 		description: `Read the contents of a file. Supports text files and images (jpg, png, gif, webp). Images are sent as attachments. For text files, output is truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Use offset/limit for large files. When you need the full file, continue with offset until complete.`,
 		promptSnippet: "Read file contents",
-		promptGuidelines: ["Use read to examine files instead of cat or sed."],
+		promptGuidelines: [
+			"Use read to examine files instead of cat or sed.",
+			"Relative read paths are resolved across scopes and fail when ambiguous.",
+		],
 		parameters: readSchema,
 		async execute(
 			_toolCallId,
@@ -131,7 +137,7 @@ export function createReadToolDefinition(
 			_onUpdate?,
 			_ctx?,
 		) {
-			const absolutePath = resolveReadPath(path, cwd);
+			const absolutePath = resolveReadPath(path, cwd, scopePaths);
 			return new Promise<{ content: (TextContent | ImageContent)[]; details: ReadToolDetails | undefined }>(
 				(resolve, reject) => {
 					if (signal?.aborted) {

--- a/packages/coding-agent/src/core/tools/write.ts
+++ b/packages/coding-agent/src/core/tools/write.ts
@@ -35,6 +35,8 @@ const defaultWriteOperations: WriteOperations = {
 };
 
 export interface WriteToolOptions {
+	/** Scope paths used for relative file resolution. Primary scope is cwd. */
+	scopePaths?: string[] | (() => string[]);
 	/** Custom operations for file writing. Default: local filesystem */
 	operations?: WriteOperations;
 }
@@ -183,13 +185,17 @@ export function createWriteToolDefinition(
 	options?: WriteToolOptions,
 ): ToolDefinition<typeof writeSchema, undefined> {
 	const ops = options?.operations ?? defaultWriteOperations;
+	const scopePaths = options?.scopePaths;
 	return {
 		name: "write",
 		label: "write",
 		description:
 			"Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
 		promptSnippet: "Create or overwrite files",
-		promptGuidelines: ["Use write only for new files or complete rewrites."],
+		promptGuidelines: [
+			"Use write only for new files or complete rewrites.",
+			"Relative mutation paths are resolved across scopes and fail when ambiguous.",
+		],
 		parameters: writeSchema,
 		async execute(
 			_toolCallId,
@@ -198,7 +204,7 @@ export function createWriteToolDefinition(
 			_onUpdate?,
 			_ctx?,
 		) {
-			const absolutePath = resolveToCwd(path, cwd);
+			const absolutePath = resolveToCwd(path, cwd, scopePaths);
 			const dir = dirname(absolutePath);
 			return withFileMutationQueue(
 				absolutePath,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -314,6 +314,8 @@ async function prepareInitialMessage(
 	parsed: Args,
 	autoResizeImages: boolean,
 	stdinContent?: string,
+	scopePaths?: string[],
+	cwd?: string,
 ): Promise<{
 	initialMessage?: string;
 	initialImages?: ImageContent[];
@@ -322,7 +324,7 @@ async function prepareInitialMessage(
 		return buildInitialMessage({ parsed, stdinContent });
 	}
 
-	const { text, images } = await processFileArguments(parsed.fileArgs, { autoResizeImages });
+	const { text, images } = await processFileArguments(parsed.fileArgs, { autoResizeImages, scopePaths, cwd });
 	return buildInitialMessage({
 		parsed,
 		fileText: text,
@@ -753,12 +755,17 @@ export async function main(args: string[]) {
 
 	validateForkFlags(parsed);
 
-	const { initialMessage, initialImages } = await prepareInitialMessage(
+	const isInteractive = !parsed.print && parsed.mode === undefined;
+	// Create session manager early so @file paths can resolve against session scopes.
+	let sessionManager = await createSessionManager(parsed, cwd, extensionsResult);
+
+	let { initialMessage, initialImages } = await prepareInitialMessage(
 		parsed,
 		settingsManager.getImageAutoResize(),
 		stdinContent,
+		sessionManager?.getScopePaths(),
+		cwd,
 	);
-	const isInteractive = !parsed.print && parsed.mode === undefined;
 	const startupBenchmark = isTruthyEnvFlag(process.env.PI_STARTUP_BENCHMARK);
 	if (startupBenchmark && !isInteractive) {
 		console.error(chalk.red("Error: PI_STARTUP_BENCHMARK only supports interactive mode"));
@@ -778,9 +785,6 @@ export async function main(args: string[]) {
 		scopedModels = await resolveModelScope(modelPatterns, modelRegistry);
 	}
 
-	// Create session manager based on CLI flags
-	let sessionManager = await createSessionManager(parsed, cwd, extensionsResult);
-
 	// Handle --resume: show session picker
 	if (parsed.resume) {
 		// Compute effective session dir for resume (same logic as createSessionManager)
@@ -796,6 +800,17 @@ export async function main(args: string[]) {
 			process.exit(0);
 		}
 		sessionManager = SessionManager.open(selectedPath, effectiveSessionDir);
+
+		// Rebuild initial message so @file paths can resolve using resumed session scopes.
+		const initial = await prepareInitialMessage(
+			parsed,
+			settingsManager.getImageAutoResize(),
+			stdinContent,
+			sessionManager.getScopePaths(),
+			cwd,
+		);
+		initialMessage = initial.initialMessage;
+		initialImages = initial.initialImages;
 	}
 
 	const { options: sessionOptions, cliThinkingFromModel } = buildSessionOptions(

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2000,6 +2000,11 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
+			if (text === "/scope" || text.startsWith("/scope ")) {
+				this.handleScopeCommand(text);
+				this.editor.setText("");
+				return;
+			}
 			if (text === "/changelog") {
 				this.handleChangelogCommand();
 				this.editor.setText("");
@@ -4200,6 +4205,49 @@ export class InteractiveMode {
 	 */
 	private getEditorKeyDisplay(action: Keybinding): string {
 		return this.capitalizeKey(keyText(action));
+	}
+
+	private handleScopeCommand(text: string): void {
+		const rest = text.slice("/scope".length).trim();
+		if (!rest) {
+			const scopes = this.sessionManager.getScopePaths();
+			const primary = scopes[0] ?? this.sessionManager.getCwd();
+			const details = [
+				`Scopes:`,
+				`- primary: ${primary}`,
+				...scopes.slice(1).map((scope) => `- additional: ${scope}`),
+			].join("\n");
+			this.chatContainer.addChild(new Spacer(1));
+			this.chatContainer.addChild(new Text(theme.fg("dim", details), 1, 0));
+			this.ui.requestRender();
+			return;
+		}
+
+		const [subcommand, ...argParts] = rest.split(/\s+/);
+		const arg = argParts.join(" ").trim();
+		if (subcommand === "reset") {
+			this.sessionManager.resetScopePaths();
+			this.session.refreshSystemPrompt();
+			this.showStatus("Scopes reset");
+			return;
+		}
+		if (!arg || (subcommand !== "add" && subcommand !== "rm")) {
+			this.showWarning("Usage: /scope add <path> | /scope rm <path> | /scope reset");
+			return;
+		}
+		if (subcommand === "add") {
+			this.sessionManager.addScopePath(arg);
+			this.session.refreshSystemPrompt();
+			this.showStatus(`Scope added: ${arg}`);
+			return;
+		}
+		if (subcommand === "rm") {
+			this.sessionManager.removeScopePath(arg);
+			this.session.refreshSystemPrompt();
+			this.showStatus(`Scope removed: ${arg}`);
+			return;
+		}
+		this.showWarning("Usage: /scope add <path> | /scope rm <path> | /scope reset");
 	}
 
 	private handleHotkeysCommand(): void {

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -253,6 +253,25 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("--tools flag", () => {
+		test("parses the full scoped tool list", () => {
+			const result = parseArgs(["--tools", "read,bash,edit,write,grep,find,ls"]);
+			expect(result.tools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+		});
+
+		test("ignores unknown tool names", () => {
+			const result = parseArgs(["--tools", "read,unknown,ls"]);
+			expect(result.tools).toEqual(["read", "ls"]);
+		});
+
+		test("parses @file arguments alongside --tools", () => {
+			const result = parseArgs(["--tools", "read,bash,grep,find,ls", "@README.md", "check this"]);
+			expect(result.tools).toEqual(["read", "bash", "grep", "find", "ls"]);
+			expect(result.fileArgs).toEqual(["README.md"]);
+			expect(result.messages).toEqual(["check this"]);
+		});
+	});
+
 	describe("messages and file args", () => {
 		test("parses plain text messages", () => {
 			const result = parseArgs(["hello", "world"]);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -675,6 +675,19 @@ describe("ExtensionRunner", () => {
 		});
 	});
 
+	describe("context", () => {
+		it("exposes session scope paths through extension context", () => {
+			sessionManager.addScopePath("/secondary");
+			const runtime = createExtensionRuntime();
+			const runner = new ExtensionRunner([], runtime, tempDir, sessionManager, modelRegistry);
+			runner.bindCore(extensionActions, extensionContextActions);
+
+			const context = runner.createContext();
+			expect(typeof context.sessionManager.getScopePaths).toBe("function");
+			expect(context.sessionManager.getScopePaths()).toEqual(sessionManager.getScopePaths());
+		});
+	});
+
 	describe("hasHandlers", () => {
 		it("returns true when handlers exist for event type", async () => {
 			const extCode = `

--- a/packages/coding-agent/test/file-processor.test.ts
+++ b/packages/coding-agent/test/file-processor.test.ts
@@ -1,0 +1,75 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { processFileArguments } from "../src/cli/file-processor.js";
+
+describe("processFileArguments scope resolution", () => {
+	let root: string;
+	let scopeA: string;
+	let scopeB: string;
+
+	beforeEach(() => {
+		root = join(tmpdir(), `file-processor-test-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+		scopeA = join(root, "scope-a");
+		scopeB = join(root, "scope-b");
+		mkdirSync(scopeA, { recursive: true });
+		mkdirSync(scopeB, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("resolves relative @file against additional scopes", async () => {
+		writeFileSync(join(scopeB, "note.txt"), "from-scope-b");
+
+		const result = await processFileArguments(["note.txt"], {
+			cwd: scopeA,
+			scopePaths: [scopeA, scopeB],
+		});
+
+		expect(result.text).toContain(`<file name="${join(scopeB, "note.txt")}">`);
+		expect(result.text).toContain("from-scope-b");
+	});
+
+	it("fails on ambiguous relative @file paths across scopes", async () => {
+		writeFileSync(join(scopeA, "same.txt"), "a");
+		writeFileSync(join(scopeB, "same.txt"), "b");
+
+		await expect(
+			processFileArguments(["same.txt"], {
+				cwd: scopeA,
+				scopePaths: [scopeA, scopeB],
+			}),
+		).rejects.toThrow(/Ambiguous relative path/);
+	});
+
+	it("supports mixed @file arguments resolved across primary and additional scopes", async () => {
+		writeFileSync(join(scopeA, "primary.txt"), "from-primary");
+		writeFileSync(join(scopeB, "secondary.txt"), "from-secondary");
+
+		const result = await processFileArguments(["primary.txt", "secondary.txt"], {
+			cwd: scopeA,
+			scopePaths: [scopeA, scopeB],
+		});
+
+		expect(result.text).toContain(`<file name="${join(scopeA, "primary.txt")}">`);
+		expect(result.text).toContain("from-primary");
+		expect(result.text).toContain(`<file name="${join(scopeB, "secondary.txt")}">`);
+		expect(result.text).toContain("from-secondary");
+	});
+
+	it("resolves absolute @file paths without scope ambiguity", async () => {
+		const absolute = join(scopeB, "absolute.txt");
+		writeFileSync(absolute, "absolute-content");
+
+		const result = await processFileArguments([absolute], {
+			cwd: scopeA,
+			scopePaths: [scopeA, scopeB],
+		});
+
+		expect(result.text).toContain(`<file name="${absolute}">`);
+		expect(result.text).toContain("absolute-content");
+	});
+});

--- a/packages/coding-agent/test/path-utils.test.ts
+++ b/packages/coding-agent/test/path-utils.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, readdirSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { expandPath, resolveReadPath, resolveToCwd } from "../src/core/tools/path-utils.js";
+import { expandPath, resolveReadPath, resolveSearchPaths, resolveToCwd } from "../src/core/tools/path-utils.js";
 
 describe("path-utils", () => {
 	describe("expandPath", () => {
@@ -34,6 +34,59 @@ describe("path-utils", () => {
 			const result = resolveToCwd("relative/file.txt", "/some/cwd");
 			expect(result).toBe(resolve("/some/cwd", "relative/file.txt"));
 		});
+
+		it("should resolve relative paths against a matching additional scope", () => {
+			const root = mkdtempSync(join(tmpdir(), "path-utils-scope-"));
+			const primary = join(root, "primary");
+			const secondary = join(root, "secondary");
+			mkdirSync(primary);
+			mkdirSync(secondary);
+			mkdirSync(join(secondary, "nested"), { recursive: true });
+			writeFileSync(join(secondary, "nested", "file.txt"), "content");
+
+			const result = resolveToCwd("nested/file.txt", primary, [secondary]);
+			expect(result).toBe(join(secondary, "nested", "file.txt"));
+
+			rmSync(root, { recursive: true, force: true });
+		});
+
+		it("should throw on ambiguous relative paths across scopes", () => {
+			const root = mkdtempSync(join(tmpdir(), "path-utils-scope-"));
+			const primary = join(root, "primary");
+			const secondary = join(root, "secondary");
+			mkdirSync(primary);
+			mkdirSync(secondary);
+			writeFileSync(join(primary, "same.txt"), "a");
+			writeFileSync(join(secondary, "same.txt"), "b");
+
+			expect(() => resolveToCwd("same.txt", primary, [secondary])).toThrow(/Ambiguous relative path/);
+
+			rmSync(root, { recursive: true, force: true });
+		});
+	});
+
+	describe("resolveSearchPaths", () => {
+		it("should fan out to all scopes for missing search path", () => {
+			const result = resolveSearchPaths(undefined, "/primary", ["/secondary"]);
+			expect(result).toEqual(["/primary", "/secondary"]);
+		});
+
+		it("should fan out to all scopes for '.' search path", () => {
+			const result = resolveSearchPaths(".", "/primary", ["/secondary"]);
+			expect(result).toEqual(["/primary", "/secondary"]);
+		});
+
+		it("should resolve explicit relative search paths against a matching additional scope", () => {
+			const root = mkdtempSync(join(tmpdir(), "path-utils-search-"));
+			const primary = join(root, "primary");
+			const secondary = join(root, "secondary");
+			mkdirSync(primary, { recursive: true });
+			mkdirSync(join(secondary, "src"), { recursive: true });
+
+			expect(resolveSearchPaths("src", primary, [secondary])).toEqual([join(secondary, "src")]);
+
+			rmSync(root, { recursive: true, force: true });
+		});
 	});
 
 	describe("resolveReadPath", () => {
@@ -62,6 +115,13 @@ describe("path-utils", () => {
 
 			const result = resolveReadPath(fileName, tempDir);
 			expect(result).toBe(join(tempDir, fileName));
+		});
+
+		it("should fall back to the primary scope when a relative read path does not exist yet", () => {
+			const secondary = join(tempDir, "secondary");
+			mkdirSync(secondary);
+			const result = resolveReadPath("future-file.txt", tempDir, [secondary]);
+			expect(result).toBe(join(tempDir, "future-file.txt"));
 		});
 
 		it("should handle NFC vs NFD Unicode normalization (macOS filenames with accents)", () => {

--- a/packages/coding-agent/test/session-manager/migration.test.ts
+++ b/packages/coding-agent/test/session-manager/migration.test.ts
@@ -24,8 +24,8 @@ describe("migrateSessionEntries", () => {
 
 		migrateSessionEntries(entries);
 
-		// Header should have version set (v3 is current after hookMessage->custom migration)
-		expect((entries[0] as any).version).toBe(3);
+		// Header should have version set to current session version
+		expect((entries[0] as any).version).toBe(4);
 
 		// Entries should have id/parentId
 		const msg1 = entries[1] as any;

--- a/packages/coding-agent/test/session-manager/scope-paths.test.ts
+++ b/packages/coding-agent/test/session-manager/scope-paths.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.js";
+
+describe("SessionManager scopePaths persistence", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `session-scope-test-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("persists scopePaths in the session header", () => {
+		const session = SessionManager.create("/primary", tempDir);
+		session.addScopePath("/secondary");
+
+		const reopened = SessionManager.open(session.getSessionFile()!, tempDir);
+		expect(reopened.getScopePaths()).toEqual(["/primary", "/secondary"]);
+	});
+
+	it("falls back to [cwd] for legacy sessions without scopePaths", () => {
+		const sessionFile = join(tempDir, "legacy.jsonl");
+		writeFileSync(
+			sessionFile,
+			`${JSON.stringify({ type: "session", version: 3, id: "legacy-session", timestamp: "2026-01-01T00:00:00.000Z", cwd: "/legacy" })}\n`,
+		);
+
+		const reopened = SessionManager.open(sessionFile, tempDir);
+		expect(reopened.getScopePaths()).toEqual(["/legacy"]);
+	});
+
+	it("does not duplicate initial entries when scopePaths change before first assistant message", () => {
+		const session = SessionManager.create("/primary", tempDir);
+		session.appendModelChange("test-provider", "test-model");
+		session.appendThinkingLevelChange("off");
+		session.addScopePath("/secondary");
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "hi" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 2,
+		});
+
+		const lines = readFileSync(session.getSessionFile()!, "utf8").trim().split("\n");
+		expect(lines).toHaveLength(5);
+		const entries = lines.map((line) => JSON.parse(line));
+		expect(entries.filter((entry) => entry.type === "session")).toHaveLength(1);
+		expect(entries.filter((entry) => entry.type === "model_change")).toHaveLength(1);
+		expect(entries.filter((entry) => entry.type === "thinking_level_change")).toHaveLength(1);
+		expect(entries.filter((entry) => entry.type === "message")).toHaveLength(2);
+		expect(entries[0].scopePaths).toEqual(["/primary", "/secondary"]);
+	});
+});

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -69,6 +69,22 @@ describe("buildSystemPrompt", () => {
 		});
 	});
 
+	describe("scope rendering", () => {
+		test("includes primary and additional scope paths", () => {
+			const prompt = buildSystemPrompt({
+				cwd: "/primary",
+				scopePaths: ["/primary", "/secondary"],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).toContain("Current working directory: /primary");
+			expect(prompt).toContain("Current scopes:");
+			expect(prompt).toContain("- primary: /primary");
+			expect(prompt).toContain("- additional: /secondary");
+		});
+	});
+
 	describe("prompt guidelines", () => {
 		test("appends promptGuidelines to default guidelines", () => {
 			const prompt = buildSystemPrompt({
@@ -90,6 +106,16 @@ describe("buildSystemPrompt", () => {
 			});
 
 			expect(prompt.match(/- Use dynamic_tool for summaries\./g)).toHaveLength(1);
+		});
+
+		test("mentions multi-scope search behavior when grep/find/ls are available", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: ["bash", "grep", "find", "ls"],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).toContain("can search all scopes by default");
 		});
 	});
 });

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1,15 +1,15 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { executeBash } from "../src/core/bash-executor.js";
 import { bashTool, createBashTool, createLocalBashOperations } from "../src/core/tools/bash.js";
-import { editTool } from "../src/core/tools/edit.js";
-import { findTool } from "../src/core/tools/find.js";
-import { grepTool } from "../src/core/tools/grep.js";
-import { lsTool } from "../src/core/tools/ls.js";
-import { readTool } from "../src/core/tools/read.js";
-import { writeTool } from "../src/core/tools/write.js";
+import { createEditTool } from "../src/core/tools/edit.js";
+import { createFindTool } from "../src/core/tools/find.js";
+import { createGrepTool } from "../src/core/tools/grep.js";
+import { createLsTool } from "../src/core/tools/ls.js";
+import { createReadTool } from "../src/core/tools/read.js";
+import { createWriteTool } from "../src/core/tools/write.js";
 import * as shellModule from "../src/utils/shell.js";
 
 // Helper to extract text from content blocks
@@ -24,11 +24,23 @@ function getTextOutput(result: any): string {
 
 describe("Coding Agent Tools", () => {
 	let testDir: string;
+	let readTool: ReturnType<typeof createReadTool>;
+	let writeTool: ReturnType<typeof createWriteTool>;
+	let editTool: ReturnType<typeof createEditTool>;
+	let grepTool: ReturnType<typeof createGrepTool>;
+	let findTool: ReturnType<typeof createFindTool>;
+	let lsTool: ReturnType<typeof createLsTool>;
 
 	beforeEach(() => {
 		// Create a unique temporary directory for each test
-		testDir = join(tmpdir(), `coding-agent-test-${Date.now()}`);
+		testDir = mkdtempSync(join(tmpdir(), "coding-agent-test-"));
 		mkdirSync(testDir, { recursive: true });
+		readTool = createReadTool(testDir, { autoResizeImages: false });
+		writeTool = createWriteTool(testDir);
+		editTool = createEditTool(testDir);
+		grepTool = createGrepTool(testDir);
+		findTool = createFindTool(testDir);
+		lsTool = createLsTool(testDir);
 	});
 
 	afterEach(() => {
@@ -347,6 +359,146 @@ describe("Coding Agent Tools", () => {
 		});
 	});
 
+	describe("scope behavior", () => {
+		it("grep fans out across scopes by default", async () => {
+			const scopeA = join(testDir, "scope-a");
+			const scopeB = join(testDir, "scope-b");
+			mkdirSync(scopeA, { recursive: true });
+			mkdirSync(scopeB, { recursive: true });
+			writeFileSync(join(scopeA, "a.txt"), "needle");
+			writeFileSync(join(scopeB, "b.txt"), "needle");
+
+			const scopedGrep = createGrepTool(scopeA, { scopePaths: [scopeA, scopeB] });
+			const result = await scopedGrep.execute("scope-grep-1", { pattern: "needle" });
+			const output = getTextOutput(result);
+
+			expect(output).toContain("scope-a/a.txt:1: needle");
+			expect(output).toContain("scope-b/b.txt:1: needle");
+		});
+
+		it("grep fans out across scopes for explicit '.' path", async () => {
+			const scopeA = join(testDir, "scope-a");
+			const scopeB = join(testDir, "scope-b");
+			mkdirSync(scopeA, { recursive: true });
+			mkdirSync(scopeB, { recursive: true });
+			writeFileSync(join(scopeA, "a.txt"), "needle");
+			writeFileSync(join(scopeB, "b.txt"), "needle");
+
+			const scopedGrep = createGrepTool(scopeA, { scopePaths: [scopeA, scopeB] });
+			const result = await scopedGrep.execute("scope-grep-dot-1", { pattern: "needle", path: "." });
+			const output = getTextOutput(result);
+
+			expect(output).toContain("scope-a/a.txt:1: needle");
+			expect(output).toContain("scope-b/b.txt:1: needle");
+		});
+
+		it("find fans out across scopes by default", async () => {
+			const scopeA = join(testDir, "scope-a");
+			const scopeB = join(testDir, "scope-b");
+			mkdirSync(scopeA, { recursive: true });
+			mkdirSync(scopeB, { recursive: true });
+			writeFileSync(join(scopeA, "a.ts"), "export const a = 1;\n");
+			writeFileSync(join(scopeB, "b.ts"), "export const b = 2;\n");
+
+			const scopedFind = createFindTool(scopeA, { scopePaths: [scopeA, scopeB] });
+			const result = await scopedFind.execute("scope-find-1", { pattern: "**/*.ts" });
+			const output = getTextOutput(result);
+
+			expect(output).toContain("scope-a/a.ts");
+			expect(output).toContain("scope-b/b.ts");
+		});
+
+		it("find fans out across scopes for explicit '.' path", async () => {
+			const scopeA = join(testDir, "scope-a");
+			const scopeB = join(testDir, "scope-b");
+			mkdirSync(scopeA, { recursive: true });
+			mkdirSync(scopeB, { recursive: true });
+			writeFileSync(join(scopeA, "a.ts"), "export const a = 1;\n");
+			writeFileSync(join(scopeB, "b.ts"), "export const b = 2;\n");
+
+			const scopedFind = createFindTool(scopeA, { scopePaths: [scopeA, scopeB] });
+			const result = await scopedFind.execute("scope-find-dot-1", { pattern: "**/*.ts", path: "." });
+			const output = getTextOutput(result);
+
+			expect(output).toContain("scope-a/a.ts");
+			expect(output).toContain("scope-b/b.ts");
+		});
+
+		it("ls fans out across scopes by default", async () => {
+			const scopeA = join(testDir, "scope-a");
+			const scopeB = join(testDir, "scope-b");
+			mkdirSync(scopeA, { recursive: true });
+			mkdirSync(scopeB, { recursive: true });
+			writeFileSync(join(scopeA, "a.txt"), "a");
+			writeFileSync(join(scopeB, "b.txt"), "b");
+
+			const scopedLs = createLsTool(scopeA, { scopePaths: [scopeA, scopeB] });
+			const result = await scopedLs.execute("scope-ls-1", {});
+			const output = getTextOutput(result);
+
+			expect(output).toContain("scope-a/a.txt");
+			expect(output).toContain("scope-b/b.txt");
+		});
+
+		it("ls fans out across scopes for explicit '.' path", async () => {
+			const scopeA = join(testDir, "scope-a");
+			const scopeB = join(testDir, "scope-b");
+			mkdirSync(scopeA, { recursive: true });
+			mkdirSync(scopeB, { recursive: true });
+			writeFileSync(join(scopeA, "a.txt"), "a");
+			writeFileSync(join(scopeB, "b.txt"), "b");
+
+			const scopedLs = createLsTool(scopeA, { scopePaths: [scopeA, scopeB] });
+			const result = await scopedLs.execute("scope-ls-dot-1", { path: "." });
+			const output = getTextOutput(result);
+
+			expect(output).toContain("scope-a/a.txt");
+			expect(output).toContain("scope-b/b.txt");
+		});
+
+		it("read rejects ambiguous relative paths across scopes", async () => {
+			const scopeA = join(testDir, "scope-a");
+			const scopeB = join(testDir, "scope-b");
+			mkdirSync(scopeA, { recursive: true });
+			mkdirSync(scopeB, { recursive: true });
+			writeFileSync(join(scopeA, "same.txt"), "a");
+			writeFileSync(join(scopeB, "same.txt"), "b");
+
+			const scopedRead = createReadTool(scopeA, { scopePaths: [scopeA, scopeB] });
+			await expect(scopedRead.execute("scope-read-1", { path: "same.txt" })).rejects.toThrow(
+				/Ambiguous relative path/,
+			);
+		});
+
+		it("edit rejects ambiguous relative mutation paths across scopes", async () => {
+			const scopeA = join(testDir, "scope-a");
+			const scopeB = join(testDir, "scope-b");
+			mkdirSync(scopeA, { recursive: true });
+			mkdirSync(scopeB, { recursive: true });
+			writeFileSync(join(scopeA, "same.txt"), "hello");
+			writeFileSync(join(scopeB, "same.txt"), "hello");
+
+			const scopedEdit = createEditTool(scopeA, { scopePaths: [scopeA, scopeB] });
+			await expect(
+				scopedEdit.execute("scope-edit-1", { path: "same.txt", oldText: "hello", newText: "hi" }),
+			).rejects.toThrow(/Ambiguous relative path/);
+		});
+
+		it("write rejects ambiguous relative mutation paths across scopes", async () => {
+			const scopeA = join(testDir, "scope-a");
+			const scopeB = join(testDir, "scope-b");
+			mkdirSync(scopeA, { recursive: true });
+			mkdirSync(scopeB, { recursive: true });
+			writeFileSync(join(scopeA, "same.txt"), "a");
+			writeFileSync(join(scopeB, "same.txt"), "b");
+
+			const scopedWrite = createWriteTool(scopeA, { scopePaths: [scopeA, scopeB] });
+			await expect(scopedWrite.execute("scope-write-1", { path: "same.txt", content: "c" })).rejects.toThrow(
+				/Ambiguous relative path/,
+			);
+		});
+	});
+
 	describe("grep tool", () => {
 		it("should include filename when searching a single file", async () => {
 			const testFile = join(testDir, "example.txt");
@@ -436,10 +588,12 @@ describe("Coding Agent Tools", () => {
 
 describe("edit tool fuzzy matching", () => {
 	let testDir: string;
+	let editTool: ReturnType<typeof createEditTool>;
 
 	beforeEach(() => {
 		testDir = join(tmpdir(), `coding-agent-fuzzy-test-${Date.now()}`);
 		mkdirSync(testDir, { recursive: true });
+		editTool = createEditTool(testDir);
 	});
 
 	afterEach(() => {
@@ -607,10 +761,12 @@ describe("edit tool fuzzy matching", () => {
 
 describe("edit tool CRLF handling", () => {
 	let testDir: string;
+	let editTool: ReturnType<typeof createEditTool>;
 
 	beforeEach(() => {
 		testDir = join(tmpdir(), `coding-agent-crlf-test-${Date.now()}`);
 		mkdirSync(testDir, { recursive: true });
+		editTool = createEditTool(testDir);
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
## Summary
- add native multi-scope path resolution to coding-agent
- persist session `scopePaths` and surface them in the system prompt
- make `read/edit/write/grep/find/ls` scope-aware
- add `/scope` interactive management
- support scoped `@file` resolution, including ambiguity errors
- add targeted regression coverage and an external smoke workflow

## What changed
- scope-aware path resolution for built-in tools
- multi-scope fanout for `grep`, `find`, and `ls`
- ambiguous relative path failures for duplicated files across scopes
- session header persistence for `scopePaths`
- resumed/interactive sessions use stored scopes
- launcher-side smoke workflow added separately in local shell config repo

## Validation
### Targeted tests
- `tools.test.ts`
- `path-utils.test.ts`
- `file-processor.test.ts`
- `system-prompt.test.ts`
- `session-manager/scope-paths.test.ts`
- `session-manager/migration.test.ts`
- `args.test.ts`

### Result
- 139 pass
- 0 fail

### Live smoke verified
- relative scoped read
- multi-scope `ls`
- multi-scope `find`
- multi-scope `grep`
- ambiguous relative path failure
- `node dist/cli.js --version`
- `bun dist/cli.js --version`

## Notes
This branch was squashed to a single commit on top of `main` to make rebasing/review easier.
