### PR TITLE
feat(coding-agent): allow project settings to override global resources

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Project-level overrides for global resources. Project `.pi/settings.json` can now disable/enable global skills, extensions, prompts, and themes using `!pattern`, `+name`, and `-name` override patterns.
+
 ## [0.62.0] - 2026-03-23
 
 ### New Features

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -565,6 +565,7 @@ function matchesAnyExactPattern(filePath: string, patterns: string[], baseDir: s
 	const isSkillFile = name === "SKILL.md";
 	const parentDir = isSkillFile ? dirname(filePath) : undefined;
 	const parentRel = isSkillFile ? toPosixPath(relative(baseDir, parentDir!)) : undefined;
+	const parentName = isSkillFile ? basename(parentDir!) : undefined;
 	const parentDirPosix = isSkillFile ? toPosixPath(parentDir!) : undefined;
 
 	return patterns.some((pattern) => {
@@ -573,7 +574,7 @@ function matchesAnyExactPattern(filePath: string, patterns: string[], baseDir: s
 			return true;
 		}
 		if (!isSkillFile) return false;
-		return normalized === parentRel || normalized === parentDirPosix;
+		return normalized === parentRel || normalized === parentName || normalized === parentDirPosix;
 	});
 }
 
@@ -581,13 +582,12 @@ function getOverridePatterns(entries: string[]): string[] {
 	return entries.filter((pattern) => pattern.startsWith("!") || pattern.startsWith("+") || pattern.startsWith("-"));
 }
 
-function isEnabledByOverrides(filePath: string, patterns: string[], baseDir: string): boolean {
-	const overrides = getOverridePatterns(patterns);
-	const excludes = overrides.filter((pattern) => pattern.startsWith("!")).map((pattern) => pattern.slice(1));
-	const forceIncludes = overrides.filter((pattern) => pattern.startsWith("+")).map((pattern) => pattern.slice(1));
-	const forceExcludes = overrides.filter((pattern) => pattern.startsWith("-")).map((pattern) => pattern.slice(1));
+function applyOverrideState(filePath: string, overrides: string[], baseDir: string, currentEnabled: boolean): boolean {
+	const excludes = overrides.filter((p) => p.startsWith("!")).map((p) => p.slice(1));
+	const forceIncludes = overrides.filter((p) => p.startsWith("+")).map((p) => p.slice(1));
+	const forceExcludes = overrides.filter((p) => p.startsWith("-")).map((p) => p.slice(1));
 
-	let enabled = true;
+	let enabled = currentEnabled;
 	if (excludes.length > 0 && matchesAnyPattern(filePath, excludes, baseDir)) {
 		enabled = false;
 	}
@@ -598,6 +598,11 @@ function isEnabledByOverrides(filePath: string, patterns: string[], baseDir: str
 		enabled = false;
 	}
 	return enabled;
+}
+
+function isEnabledByOverrides(filePath: string, patterns: string[], baseDir: string): boolean {
+	const overrides = getOverridePatterns(patterns);
+	return applyOverrideState(filePath, overrides, baseDir, true);
 }
 
 /**
@@ -800,6 +805,7 @@ export class DefaultPackageManager implements PackageManager {
 		}
 
 		this.addAutoDiscoveredResources(accumulator, globalSettings, projectSettings, globalBaseDir, projectBaseDir);
+		this.applyProjectOverrides(accumulator, projectSettings, projectBaseDir);
 
 		return this.toResolvedPaths(accumulator);
 	}
@@ -1963,6 +1969,32 @@ export class DefaultPackageManager implements PackageManager {
 			userOverrides.themes,
 			globalBaseDir,
 		);
+	}
+
+	/**
+	 * Apply project-level override patterns to non-project resources.
+	 * Allows project settings to disable/enable global skills, extensions, etc.
+	 * Patterns are applied on top of the current enabled state:
+	 * - `!pattern` disables matching resources
+	 * - `+path` force-enables matching resources (even if globally disabled)
+	 * - `-path` force-disables matching resources
+	 */
+	private applyProjectOverrides(
+		accumulator: ResourceAccumulator,
+		projectSettings: ReturnType<SettingsManager["getProjectSettings"]>,
+		projectBaseDir: string,
+	): void {
+		for (const resourceType of RESOURCE_TYPES) {
+			const projectEntries = (projectSettings[resourceType] ?? []) as string[];
+			const overridePatterns = getOverridePatterns(projectEntries);
+			if (overridePatterns.length === 0) continue;
+
+			const target = this.getTargetMap(accumulator, resourceType);
+			for (const [path, entry] of target) {
+				if (entry.metadata.scope === "project") continue;
+				entry.enabled = applyOverrideState(path, overridePatterns, projectBaseDir, entry.enabled);
+			}
+		}
 	}
 
 	private collectFilesFromPaths(paths: string[], resourceType: ResourceType): string[] {

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -1444,4 +1444,122 @@ export default function(api) { api.registerTool({ name: "test", description: "te
 			expect(options?.signal).toBeDefined();
 		});
 	});
+
+	describe("project overrides for global resources", () => {
+		it("should disable global auto-discovered skills via project !pattern", async () => {
+			const skillsDir = join(agentDir, "skills");
+			mkdirSync(join(skillsDir, "brave-search"), { recursive: true });
+			mkdirSync(join(skillsDir, "github"), { recursive: true });
+			writeFileSync(
+				join(skillsDir, "brave-search", "SKILL.md"),
+				"---\nname: brave-search\ndescription: Search\n---\nContent",
+			);
+			writeFileSync(join(skillsDir, "github", "SKILL.md"), "---\nname: github\ndescription: GitHub\n---\nContent");
+
+			settingsManager.setProjectSkillPaths(["!brave-search"]);
+
+			const result = await packageManager.resolve();
+			expect(result.skills.some((r) => isDisabled(r, "brave-search", "includes"))).toBe(true);
+			expect(result.skills.some((r) => isEnabled(r, "github", "includes"))).toBe(true);
+		});
+
+		it("should enable only specific global skills via project allowlist (!* + +name)", async () => {
+			const skillsDir = join(agentDir, "skills");
+			mkdirSync(join(skillsDir, "brave-search"), { recursive: true });
+			mkdirSync(join(skillsDir, "github"), { recursive: true });
+			mkdirSync(join(skillsDir, "playwright"), { recursive: true });
+			writeFileSync(
+				join(skillsDir, "brave-search", "SKILL.md"),
+				"---\nname: brave-search\ndescription: Search\n---\nContent",
+			);
+			writeFileSync(join(skillsDir, "github", "SKILL.md"), "---\nname: github\ndescription: GitHub\n---\nContent");
+			writeFileSync(
+				join(skillsDir, "playwright", "SKILL.md"),
+				"---\nname: playwright\ndescription: Browser\n---\nContent",
+			);
+
+			settingsManager.setProjectSkillPaths(["!*", "+brave-search"]);
+
+			const result = await packageManager.resolve();
+			expect(result.skills.some((r) => isEnabled(r, "brave-search", "includes"))).toBe(true);
+			expect(result.skills.some((r) => isDisabled(r, "github", "includes"))).toBe(true);
+			expect(result.skills.some((r) => isDisabled(r, "playwright", "includes"))).toBe(true);
+		});
+
+		it("should not affect project-scoped resources with project overrides", async () => {
+			const globalSkillsDir = join(agentDir, "skills");
+			mkdirSync(join(globalSkillsDir, "global-skill"), { recursive: true });
+			writeFileSync(
+				join(globalSkillsDir, "global-skill", "SKILL.md"),
+				"---\nname: global-skill\ndescription: Global\n---\nContent",
+			);
+
+			const projectSkillsDir = join(tempDir, ".pi", "skills");
+			mkdirSync(join(projectSkillsDir, "project-skill"), { recursive: true });
+			writeFileSync(
+				join(projectSkillsDir, "project-skill", "SKILL.md"),
+				"---\nname: project-skill\ndescription: Project\n---\nContent",
+			);
+
+			settingsManager.setProjectSkillPaths(["!*", "+project-skill"]);
+
+			const result = await packageManager.resolve();
+			// Project skill should remain enabled (project overrides don't affect project-scoped resources)
+			expect(result.skills.some((r) => isEnabled(r, "project-skill", "includes"))).toBe(true);
+			// Global skill should be disabled
+			expect(result.skills.some((r) => isDisabled(r, "global-skill", "includes"))).toBe(true);
+		});
+
+		it("should disable global settings-defined skills via project !pattern", async () => {
+			const skillsDir = join(agentDir, "custom-skills");
+			mkdirSync(join(skillsDir, "custom-a"), { recursive: true });
+			mkdirSync(join(skillsDir, "custom-b"), { recursive: true });
+			writeFileSync(join(skillsDir, "custom-a", "SKILL.md"), "---\nname: custom-a\ndescription: A\n---\nContent");
+			writeFileSync(join(skillsDir, "custom-b", "SKILL.md"), "---\nname: custom-b\ndescription: B\n---\nContent");
+
+			settingsManager.setSkillPaths(["custom-skills"]);
+			settingsManager.setProjectSkillPaths(["!custom-a"]);
+
+			const result = await packageManager.resolve();
+			expect(result.skills.some((r) => isDisabled(r, "custom-a", "includes"))).toBe(true);
+			expect(result.skills.some((r) => isEnabled(r, "custom-b", "includes"))).toBe(true);
+		});
+
+		it("should force-exclude global skills via project -path", async () => {
+			const skillsDir = join(agentDir, "skills");
+			mkdirSync(join(skillsDir, "target-skill"), { recursive: true });
+			writeFileSync(
+				join(skillsDir, "target-skill", "SKILL.md"),
+				"---\nname: target-skill\ndescription: Target\n---\nContent",
+			);
+
+			settingsManager.setProjectSkillPaths(["-target-skill"]);
+
+			const result = await packageManager.resolve();
+			expect(result.skills.some((r) => isDisabled(r, "target-skill", "includes"))).toBe(true);
+		});
+
+		it("should force-enable a globally disabled skill via project +path", async () => {
+			const skillsDir = join(agentDir, "skills");
+			mkdirSync(join(skillsDir, "disabled-skill"), { recursive: true });
+			mkdirSync(join(skillsDir, "other-skill"), { recursive: true });
+			writeFileSync(
+				join(skillsDir, "disabled-skill", "SKILL.md"),
+				"---\nname: disabled-skill\ndescription: Disabled\n---\nContent",
+			);
+			writeFileSync(
+				join(skillsDir, "other-skill", "SKILL.md"),
+				"---\nname: other-skill\ndescription: Other\n---\nContent",
+			);
+
+			// Globally disable the skill
+			settingsManager.setSkillPaths(["!disabled-skill"]);
+			// Project re-enables it
+			settingsManager.setProjectSkillPaths(["+disabled-skill"]);
+
+			const result = await packageManager.resolve();
+			expect(result.skills.some((r) => isEnabled(r, "disabled-skill", "includes"))).toBe(true);
+			expect(result.skills.some((r) => isEnabled(r, "other-skill", "includes"))).toBe(true);
+		});
+	});
 });


### PR DESCRIPTION
Allow project `.pi/settings.json` to override global resources (skills, extensions, prompts, themes) using `!pattern`, `+name`, and `-name` patterns. This lets projects disable unwanted global skills or allowlist specific ones without modifying user-level settings.

Example `.pi/settings.json`:

```json
   {
     "skills": ["!*", "+github", "+brave"]
   }
```

 This disables all global skills except `github` and `brave` skills.