### PR TITLE
fix(web-ui): show xhigh in thinking selector when supported

### DIFF
--- a/packages/web-ui/src/components/AgentInterface.ts
+++ b/packages/web-ui/src/components/AgentInterface.ts
@@ -8,7 +8,7 @@ import "./MessageList.js";
 import "./Messages.js"; // Import for side effects to register the custom elements
 import { getAppStorage } from "../storage/app-storage.js";
 import "./StreamingMessageContainer.js";
-import type { Agent, AgentEvent } from "@mariozechner/pi-agent-core";
+import type { Agent, AgentEvent, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { Attachment } from "../utils/attachment-utils.js";
 import { formatUsage } from "../utils/format.js";
 import { i18n } from "../utils/i18n.js";
@@ -381,7 +381,7 @@ export class AgentInterface extends LitElement {
 							}}
 							.onThinkingChange=${
 								this.enableThinkingSelector
-									? (level: "off" | "minimal" | "low" | "medium" | "high") => {
+									? (level: ThinkingLevel) => {
 											session.setThinkingLevel(level);
 										}
 									: undefined

--- a/packages/web-ui/src/components/MessageEditor.ts
+++ b/packages/web-ui/src/components/MessageEditor.ts
@@ -1,7 +1,7 @@
 import { icon } from "@mariozechner/mini-lit";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { Select, type SelectOption } from "@mariozechner/mini-lit/dist/Select.js";
-import type { Model } from "@mariozechner/pi-ai";
+import { type Model, supportsXhigh } from "@mariozechner/pi-ai";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { createRef, ref } from "lit/directives/ref.js";
@@ -37,7 +37,7 @@ export class MessageEditor extends LitElement {
 	@property() onSend?: (input: string, attachments: Attachment[]) => void;
 	@property() onAbort?: () => void;
 	@property() onModelSelect?: () => void;
-	@property() onThinkingChange?: (level: "off" | "minimal" | "low" | "medium" | "high") => void;
+	@property() onThinkingChange?: (level: ThinkingLevel) => void;
 	@property() onFilesChange?: (files: Attachment[]) => void;
 	@property() attachments: Attachment[] = [];
 	@property() maxFiles = 10;
@@ -236,6 +236,17 @@ export class MessageEditor extends LitElement {
 		// Check if current model supports thinking/reasoning
 		const model = this.currentModel;
 		const supportsThinking = model?.reasoning === true; // Models with reasoning:true support thinking
+		const thinkingOptions: SelectOption[] = [
+			{ value: "off", label: i18n("Off"), icon: icon(Brain, "sm") },
+			{ value: "minimal", label: i18n("Minimal"), icon: icon(Brain, "sm") },
+			{ value: "low", label: i18n("Low"), icon: icon(Brain, "sm") },
+			{ value: "medium", label: i18n("Medium"), icon: icon(Brain, "sm") },
+			{ value: "high", label: i18n("High"), icon: icon(Brain, "sm") },
+		];
+
+		if (model && supportsXhigh(model)) {
+			thinkingOptions.push({ value: "xhigh", label: i18n("XHigh"), icon: icon(Brain, "sm") });
+		}
 
 		return html`
 			<div
@@ -322,26 +333,20 @@ export class MessageEditor extends LitElement {
 						${
 							supportsThinking && this.showThinkingSelector
 								? html`
-									${Select({
-										value: this.thinkingLevel,
-										placeholder: i18n("Off"),
-										options: [
-											{ value: "off", label: i18n("Off"), icon: icon(Brain, "sm") },
-											{ value: "minimal", label: i18n("Minimal"), icon: icon(Brain, "sm") },
-											{ value: "low", label: i18n("Low"), icon: icon(Brain, "sm") },
-											{ value: "medium", label: i18n("Medium"), icon: icon(Brain, "sm") },
-											{ value: "high", label: i18n("High"), icon: icon(Brain, "sm") },
-										] as SelectOption[],
-										onChange: (value: string) => {
-											const level = value as "off" | "minimal" | "low" | "medium" | "high";
-											this.thinkingLevel = level;
-											this.onThinkingChange?.(level);
-										},
-										width: "80px",
-										size: "sm",
-										variant: "ghost",
-										fitContent: true,
-									})}
+								${Select({
+									value: this.thinkingLevel,
+									placeholder: i18n("Off"),
+									options: thinkingOptions,
+									onChange: (value: string) => {
+										const level = value as ThinkingLevel;
+										this.thinkingLevel = level;
+										this.onThinkingChange?.(level);
+									},
+									width: "80px",
+									size: "sm",
+									variant: "ghost",
+									fitContent: true,
+								})}
 								`
 								: ""
 						}

--- a/packages/web-ui/src/utils/i18n.ts
+++ b/packages/web-ui/src/utils/i18n.ts
@@ -148,6 +148,7 @@ declare module "@mariozechner/mini-lit" {
 		Low: string;
 		Medium: string;
 		High: string;
+		XHigh: string;
 		"Storage Permission Required": string;
 		"This app needs persistent storage to save your conversations": string;
 		"Why is this needed?": string;
@@ -360,6 +361,7 @@ export const translations = {
 		Low: "Low",
 		Medium: "Medium",
 		High: "High",
+		XHigh: "XHigh",
 		"Storage Permission Required": "Storage Permission Required",
 		"This app needs persistent storage to save your conversations":
 			"This app needs persistent storage to save your conversations",
@@ -579,6 +581,7 @@ export const translations = {
 		Low: "Niedrig",
 		Medium: "Mittel",
 		High: "Hoch",
+		XHigh: "Extrem hoch",
 		"Storage Permission Required": "Speicherberechtigung erforderlich",
 		"This app needs persistent storage to save your conversations":
 			"Diese App benötigt dauerhaften Speicher, um Ihre Konversationen zu speichern",


### PR DESCRIPTION
ThinkingLevel already includes xhigh, and pi-ai already exposes supportsXhigh(model), but the web UI selector was still hardcoded to off | minimal | low | medium | high. Discovered while trying to get xhigh working in sitegeist. 

This updates packages/web-ui so the thinking selector shows xhigh only for models that actually support it, and widens the selector callback types to ThinkingLevel. I also added the XHigh i18n label instead of hardcoding it (like the others).

I ran npm run check. 
+ I also verified the remaining failures in ./test.sh reproduce on clean upstream main in unrelated coding-agent tests:
 - test/interactive-mode-status.test.ts
 - test/tools.test.ts