### PR TITLE
show system prompt overrides in home listing

### DIFF
--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -33,6 +33,7 @@ export interface ResourceLoader {
 	getAgentsFiles(): { agentsFiles: Array<{ path: string; content: string }> };
 	getSystemPrompt(): string | undefined;
 	getAppendSystemPrompt(): string[];
+	getLoadedSystemPromptFiles?(): string[];
 	extendResources(paths: ResourceExtensionPaths): void;
 	reload(): Promise<void>;
 }
@@ -193,6 +194,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private agentsFiles: Array<{ path: string; content: string }>;
 	private systemPrompt?: string;
 	private appendSystemPrompt: string[];
+	private loadedSystemPromptFiles: string[];
 	private lastSkillPaths: string[];
 	private extensionSkillSourceInfos: Map<string, SourceInfo>;
 	private extensionPromptSourceInfos: Map<string, SourceInfo>;
@@ -238,6 +240,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.themeDiagnostics = [];
 		this.agentsFiles = [];
 		this.appendSystemPrompt = [];
+		this.loadedSystemPromptFiles = [];
 		this.lastSkillPaths = [];
 		this.extensionSkillSourceInfos = new Map();
 		this.extensionPromptSourceInfos = new Map();
@@ -272,6 +275,10 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 	getAppendSystemPrompt(): string[] {
 		return this.appendSystemPrompt;
+	}
+
+	getLoadedSystemPromptFiles(): string[] {
+		return this.loadedSystemPromptFiles;
 	}
 
 	extendResources(paths: ResourceExtensionPaths): void {
@@ -430,10 +437,8 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const resolvedAgentsFiles = this.agentsFilesOverride ? this.agentsFilesOverride(agentsFiles) : agentsFiles;
 		this.agentsFiles = resolvedAgentsFiles.agentsFiles;
 
-		const baseSystemPrompt = resolvePromptInput(
-			this.systemPromptSource ?? this.discoverSystemPromptFile(),
-			"system prompt",
-		);
+		const systemPromptSource = this.systemPromptSource ?? this.discoverSystemPromptFile();
+		const baseSystemPrompt = resolvePromptInput(systemPromptSource, "system prompt");
 		this.systemPrompt = this.systemPromptOverride ? this.systemPromptOverride(baseSystemPrompt) : baseSystemPrompt;
 
 		const appendSource = this.appendSystemPromptSource ?? this.discoverAppendSystemPromptFile();
@@ -442,6 +447,10 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.appendSystemPrompt = this.appendSystemPromptOverride
 			? this.appendSystemPromptOverride(baseAppend)
 			: baseAppend;
+		this.loadedSystemPromptFiles = [
+			...(appendSource ? [appendSource] : []),
+			...(systemPromptSource ? [systemPromptSource] : []),
+		];
 	}
 
 	private normalizeExtensionPaths(

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1032,9 +1032,19 @@ export class InteractiveMode {
 		}
 
 		if (showListing) {
+			this.chatContainer.addChild(new Spacer(1));
+
+			const systemPromptFiles = this.session.resourceLoader.getLoadedSystemPromptFiles?.() ?? [];
+			if (systemPromptFiles.length > 0) {
+				const systemList = systemPromptFiles
+					.map((file) => theme.fg("dim", `  ${this.formatDisplayPath(file)}`))
+					.join("\n");
+				this.chatContainer.addChild(new Text(`${sectionHeader("System")}\n${systemList}`, 0, 0));
+				this.chatContainer.addChild(new Spacer(1));
+			}
+
 			const contextFiles = this.session.resourceLoader.getAgentsFiles().agentsFiles;
 			if (contextFiles.length > 0) {
-				this.chatContainer.addChild(new Spacer(1));
 				const contextList = contextFiles
 					.map((f) => theme.fg("dim", `  ${this.formatDisplayPath(f.path)}`))
 					.join("\n");


### PR DESCRIPTION
implements https://github.com/badlogic/pi-mono/issues/2585

tested locally with
```
cd packages/coding-agent && npm run build && cd -
node packages/coding-agent/dist/cli.js
```

<img width="451" height="615" alt="image" src="https://github.com/user-attachments/assets/3ca8fc7a-7f87-45eb-a2d8-e92eb58bbe1a" />
