### PR TITLE
fix: Google and Vertex providers double-count cached tokens in cost calculation

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -225,7 +225,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 
 				if (chunk.usageMetadata) {
 					output.usage = {
-						input: chunk.usageMetadata.promptTokenCount || 0,
+						input: (chunk.usageMetadata.promptTokenCount || 0) - (chunk.usageMetadata.cachedContentTokenCount || 0),
 						output:
 							(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
 						cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -211,7 +211,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 
 				if (chunk.usageMetadata) {
 					output.usage = {
-						input: chunk.usageMetadata.promptTokenCount || 0,
+						input: (chunk.usageMetadata.promptTokenCount || 0) - (chunk.usageMetadata.cachedContentTokenCount || 0),
 						output:
 							(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
 						cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,


### PR DESCRIPTION
## Problem

The Google (`google.ts`) and Google Vertex (`google-vertex.ts`) providers assign `chunk.usageMetadata.promptTokenCount` directly to `usage.input`. However, Google's `promptTokenCount` **includes** `cachedContentTokenCount`. When `calculateCost` then computes:

```
cost.input    = inputRate  * usage.input      // includes cached tokens
cost.cacheRead = cacheReadRate * usage.cacheRead  // cached tokens again
```

...the cached tokens are charged at both the full input rate and the cacheRead rate, inflating the reported cost.

### Example from real usage

```json
{
  "input": 70838,
  "cacheRead": 69905,
  "cost": {
    "input": 0.141676,
    "cacheRead": 0.013981,
    "total": 0.162221
  }
}
```

Actual fresh input is only `70838 - 69905 = 933` tokens, but cost was calculated on all 70838 at the input rate.

## Fix

Subtract `cachedContentTokenCount` from `promptTokenCount` when assigning `usage.input`, matching the existing behavior in `google-gemini-cli.ts` which already does this correctly:

```ts
// google-gemini-cli.ts (already correct)
// promptTokenCount includes cachedContentTokenCount, so subtract to get fresh input
const promptTokens = responseData.usageMetadata.promptTokenCount || 0;
const cacheReadTokens = responseData.usageMetadata.cachedContentTokenCount || 0;
output.usage = {
    input: promptTokens - cacheReadTokens,
    ...
};
```

## Changes

- `packages/ai/src/providers/google.ts`: subtract `cachedContentTokenCount` from `promptTokenCount`
- `packages/ai/src/providers/google-vertex.ts`: same fix
