### PR TITLE
fix(ai): preserve tool call arguments when partialJson is empty

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -383,7 +383,13 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 								partial: output,
 							});
 						} else if (block.type === "toolCall") {
-							block.arguments = parseStreamingJson(block.partialJson);
+							// Only parse partialJson when it was actually accumulated via
+							// input_json_delta. When partialJson is empty, content_block_start
+							// already set block.arguments correctly (Kimi's non-incremental path).
+							// parseStreamingJson("") returns {} which would overwrite valid args.
+							if (block.partialJson) {
+								block.arguments = parseStreamingJson(block.partialJson);
+							}
 							delete (block as any).partialJson;
 							stream.push({
 								type: "toolcall_end",


### PR DESCRIPTION
## Summary

Fixes a bug where `content_block_stop` in the Anthropic streaming handler overwrites valid tool call arguments with `{}` when no `input_json_delta` events were received.

## Problem

Kimi (and potentially other providers using the Anthropic API format) has two streaming behaviors for tool calls:

1. **Incremental**: `content_block_start` with `input: {}`, then `input_json_delta` events accumulate `partialJson`
2. **Non-incremental**: `content_block_start` with full `input: {path: "/some/file"}`, no `input_json_delta` at all

In path 2, `block.partialJson` stays as `""`. At `content_block_stop`, the current code unconditionally runs:

```typescript
block.arguments = parseStreamingJson(block.partialJson);
```

`parseStreamingJson("")` returns `{}`, overwriting the valid arguments that were correctly set from `content_block_start.input`.

## Fix

Guard the `parseStreamingJson` call — only parse when `partialJson` was actually accumulated:

```typescript
if (block.partialJson) {
    block.arguments = parseStreamingJson(block.partialJson);
}
```

## Impact

- **Kimi (kimi-coding/k2p5)**: fixes tool call failures where every invocation gets `{}` arguments on the non-incremental streaming path. This is the most common failure mode reported in the OpenClaw community (50+ related issues).
- **Other providers**: no impact — providers using incremental `input_json_delta` always have non-empty `partialJson`.
- **Related**: OpenClaw PR [openclaw/openclaw#54448](https://github.com/openclaw/openclaw/pull/54448) fixes the downstream repair wrapper; this PR fixes the upstream root cause.

## Test plan

- [x] TypeScript type check passes (`tsgo -p tsconfig.build.json`)
- [x] Full monorepo `check` passes (biome + tsc + browser smoke)
- [ ] Manual verification with kimi-coding/k2p5 on Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)