### PR TITLE
docs(coding-agent): document resources_discover event

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Fixed `pi update` for git packages to fetch only the tracked target branch with `--no-tags`, reducing unrelated branch and tag noise while preserving force-push-safe updates ([#2548](https://github.com/badlogic/pi-mono/issues/2548))
 - Fixed print and JSON modes to emit `session_shutdown` before exit, so extensions can release long-lived resources and non-interactive runs terminate cleanly ([#2576](https://github.com/badlogic/pi-mono/issues/2576))
 
+### Changed
+
+- Documented the `resources_discover` extension event in `docs/extensions.md`, including lifecycle timing, reload behavior, and return path fields for dynamic skills, prompts, and themes ([#2597](https://github.com/badlogic/pi-mono/pull/2597) by [@aliou](https://github.com/aliou))
+
 ## [0.62.0] - 2026-03-23
 
 ### New Features

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -229,6 +229,7 @@ pi starts (CLI only)
   │
   ├─► session_directory (CLI startup only, no ctx)
   └─► session_start
+      └─► resources_discover (startup; can add skills/prompts/themes)
       │
       ▼
 user sends prompt ─────────────────────────────────────────┐
@@ -315,6 +316,40 @@ pi.on("session_start", async (_event, ctx) => {
   ctx.ui.notify(`Session: ${ctx.sessionManager.getSessionFile() ?? "ephemeral"}`, "info");
 });
 ```
+
+#### resources_discover
+
+Fired after `session_start` to let extensions provide additional resource paths.
+
+This event fires:
+- On startup with `event.reason === "startup"`
+- On `/reload` with `event.reason === "reload"`
+
+Handlers can return additional paths for:
+- `skillPaths`
+- `promptPaths`
+- `themePaths`
+
+A common pattern is mapping `.claude/skills` to `skillPaths` and `.claude/commands/*.md` to `promptPaths`.
+
+```typescript
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const baseDir = dirname(fileURLToPath(import.meta.url));
+
+pi.on("resources_discover", (event) => {
+  // event.cwd - current working directory
+  // event.reason - "startup" | "reload"
+  return {
+    skillPaths: [join(baseDir, "SKILL.md")],
+    promptPaths: [join(baseDir, "dynamic.md")],
+    themePaths: [join(baseDir, "dynamic.json")],
+  };
+});
+```
+
+See [dynamic-resources example](../examples/extensions/dynamic-resources/index.ts) and [claude-local-resources example](../examples/extensions/claude-local-resources/index.ts).
 
 #### session_before_switch / session_switch
 

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -99,6 +99,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | Extension | Description |
 |-----------|-------------|
 | `dynamic-resources/` | Loads skills, prompts, and themes using `resources_discover` |
+| `claude-local-resources/` | Loads project-local `.claude/skills` and `.claude/commands` (as prompt templates) via `resources_discover` |
 
 ### Messages & Communication
 

--- a/packages/coding-agent/examples/extensions/claude-local-resources/index.ts
+++ b/packages/coding-agent/examples/extensions/claude-local-resources/index.ts
@@ -1,0 +1,64 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+function collectMarkdownFiles(dir: string): string[] {
+	const files: string[] = [];
+
+	if (!existsSync(dir)) {
+		return files;
+	}
+
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const fullPath = join(dir, entry.name);
+
+		if (entry.isDirectory()) {
+			files.push(...collectMarkdownFiles(fullPath));
+			continue;
+		}
+
+		if (entry.isFile() && entry.name.endsWith(".md")) {
+			files.push(fullPath);
+			continue;
+		}
+
+		if (entry.isSymbolicLink()) {
+			try {
+				const stats = statSync(fullPath);
+				if (stats.isDirectory()) {
+					files.push(...collectMarkdownFiles(fullPath));
+				} else if (stats.isFile() && entry.name.endsWith(".md")) {
+					files.push(fullPath);
+				}
+			} catch {
+				// Ignore broken symlinks.
+			}
+		}
+	}
+
+	return files;
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.on("resources_discover", (event) => {
+		const claudeDir = join(event.cwd, ".claude");
+		if (!existsSync(claudeDir)) {
+			return;
+		}
+
+		const skillsDir = join(claudeDir, "skills");
+		const commandsDir = join(claudeDir, "commands");
+
+		const skillPaths = existsSync(skillsDir) ? [skillsDir] : [];
+		const promptPaths = collectMarkdownFiles(commandsDir);
+
+		if (skillPaths.length === 0 && promptPaths.length === 0) {
+			return;
+		}
+
+		return {
+			skillPaths,
+			promptPaths,
+		};
+	});
+}


### PR DESCRIPTION
Hello!

Just noticed that the `resources_discover` wasn't despite having some examples, which made haiku think I was the one hallucinating 😐

Also, added as an example an extension loading Claude code skills and commands as skills and prompts.

------

<details><summary>Summary by gpt-5.3 codex:</summary>
<p>

## Summary

Documented the `resources_discover` extension event in coding-agent docs so all `ExtensionAPI.on(...)` events are explicitly covered in markdown.

## Changes

### `packages/coding-agent/docs/extensions.md`

- Updated lifecycle diagram to include:
  - `resources_discover` firing after `session_start` on startup.
- Added a dedicated **`resources_discover`** event section under Session Events with:
  - when it fires (`startup`, `/reload`)
  - event fields (`cwd`, `reason`)
  - handler return fields (`skillPaths`, `promptPaths`, `themePaths`)
  - a runnable extension snippet
  - a pointer to `examples/extensions/dynamic-resources/index.ts`

## Why

`resources_discover` was present in source types and examples, but not fully documented in the event reference section. This closes the docs gap and aligns docs coverage with the public extension API.

</p>
</details>