### PR TITLE
fix(ai): fix tool result handling for empty text content

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed GitHub Copilot OpenAI Responses requests to omit the `reasoning` field entirely when no reasoning effort is requested, avoiding `400` errors from Copilot `gpt-5-mini` rejecting `reasoning: { effort: "none" }` during internal summary calls ([#2567](https://github.com/badlogic/pi-mono/issues/2567))
+- Fixed tool result handling for empty text content (0-byte files) by checking for text content block existence instead of text length, preventing "(see attached image)" placeholder from being incorrectly used.
 
 ## [0.62.0] - 2026-03-23
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -650,9 +650,8 @@ export function convertMessages(
 					.map((c) => (c as any).text)
 					.join("\n");
 				const hasImages = toolMsg.content.some((c) => c.type === "image");
-
 				// Always send tool result with text (or placeholder if only images)
-				const hasText = textResult.length > 0;
+				const hasText = toolMsg.content.some((c) => c.type === "text");
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {
 					role: "tool",

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -219,7 +219,7 @@ export function convertResponsesMessages<TApi extends Api>(
 				.map((c) => c.text)
 				.join("\n");
 			const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
-			const hasText = textResult.length > 0;
+			const hasText = msg.content.some((c): c is TextContent => c.type === "text");
 			const [callId] = msg.toolCallId.split("|");
 
 			let output: string | ResponseFunctionCallOutputItemList;


### PR DESCRIPTION
Fixes 0-byte tool output incorrectly returning '(see attached image)' due to characters = 0  check.