### PR TITLE
packages/ai: add google-vertex gemini-3.1-pro-preview-customtools

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1321,6 +1321,18 @@ async function generateModels() {
 			maxTokens: 65536,
 		},
 		{
+			id: "gemini-3.1-pro-preview-customtools",
+			name: "Gemini 3.1 Pro Preview Custom Tools (Vertex)",
+			api: "google-vertex",
+			provider: "google-vertex",
+			baseUrl: VERTEX_BASE_URL,
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0 },
+			contextWindow: 1048576,
+			maxTokens: 65536,
+		},
+		{
 			id: "gemini-3-flash-preview",
 			name: "Gemini 3 Flash Preview (Vertex)",
 			api: "google-vertex",

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -3928,6 +3928,23 @@ export const MODELS = {
 			contextWindow: 1048576,
 			maxTokens: 65536,
 		} satisfies Model<"google-vertex">,
+		"gemini-3.1-pro-preview-customtools": {
+			id: "gemini-3.1-pro-preview-customtools",
+			name: "Gemini 3.1 Pro Preview Custom Tools (Vertex)",
+			api: "google-vertex",
+			provider: "google-vertex",
+			baseUrl: "https://{location}-aiplatform.googleapis.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 2,
+				output: 12,
+				cacheRead: 0.2,
+				cacheWrite: 0,
+			},
+			contextWindow: 1048576,
+			maxTokens: 65536,
+		} satisfies Model<"google-vertex">,
 	},
 	"groq": {
 		"deepseek-r1-distill-llama-70b": {


### PR DESCRIPTION
Refs #2609

Add `google-vertex/gemini-3.1-pro-preview-customtools` to the built-in model catalog.

This model is documented by Vertex as a Gemini 3.1 Pro Preview variant:
https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-pro

This is a minimal catalog-only change:
- update `packages/ai/scripts/generate-models.ts`
- regenerate `packages/ai/src/models.generated.ts`

