### PR TITLE
Fix the bedrock provider package export

### DIFF
--- a/packages/ai/bedrock-provider.d.ts
+++ b/packages/ai/bedrock-provider.d.ts
@@ -1,1 +1,3 @@
-export * from "./dist/bedrock-provider.js";
+import type { setBedrockProviderModule } from "./dist/index.js";
+
+export declare const bedrockProviderModule: Parameters<typeof setBedrockProviderModule>[0];

--- a/packages/ai/bedrock-provider.js
+++ b/packages/ai/bedrock-provider.js
@@ -1,1 +1,6 @@
-export * from "./dist/bedrock-provider.js";
+import { streamBedrock, streamSimpleBedrock } from "./dist/providers/amazon-bedrock.js";
+
+export const bedrockProviderModule = {
+	streamBedrock,
+	streamSimpleBedrock,
+};

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -51,8 +51,8 @@
 			"import": "./dist/oauth.js"
 		},
 		"./bedrock-provider": {
-			"types": "./dist/bedrock-provider.d.ts",
-			"import": "./dist/bedrock-provider.js"
+			"types": "./bedrock-provider.d.ts",
+			"import": "./bedrock-provider.js"
 		}
 	},
 	"bin": {
@@ -60,6 +60,8 @@
 	},
 	"files": [
 		"dist",
+		"bedrock-provider.js",
+		"bedrock-provider.d.ts",
 		"README.md"
 	],
 	"scripts": {


### PR DESCRIPTION
## Summary

- fix the `@mariozechner/pi-ai/bedrock-provider` export so it resolves in a source checkout
- point the package subpath export at the checked-in wrapper files instead of missing `dist/bedrock-provider.*` artifacts
- make the wrapper expose `bedrockProviderModule` from the built Bedrock provider implementation

## Checks

- `npm run check`
