### PR TITLE
Fix pi-ai subpath resolution in source checkouts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 			"*": ["./*"],
 			"@mariozechner/pi-ai": ["./packages/ai/src/index.ts"],
 			"@mariozechner/pi-ai/oauth": ["./packages/ai/src/oauth.ts"],
-			"@mariozechner/pi-ai/*": ["./packages/ai/src/*"],
+			"@mariozechner/pi-ai/*": ["./packages/ai/src/*.ts", "./packages/ai/src/providers/*.ts"],
 			"@mariozechner/pi-ai/dist/*": ["./packages/ai/src/*"],
 			"@mariozechner/pi-agent-core": ["./packages/agent/src/index.ts"],
 			"@mariozechner/pi-agent-core/*": ["./packages/agent/src/*"],


### PR DESCRIPTION
## Summary

- fix monorepo type resolution for `@mariozechner/pi-ai` subpath imports in source checkouts
- map `@mariozechner/pi-ai/*` to source `.ts` files first, with provider modules falling back to `src/providers/*.ts`
- keep `@mariozechner/pi-ai/oauth` explicitly mapped because it is not under `src/providers/`

## What this fixes concretely

This fixes monorepo source-checkout type resolution for `@mariozechner/pi-ai` subpath imports during `tsgo --noEmit` / `npm run check`.

The concrete failure on current `main` is in `packages/coding-agent/src/bun/register-bedrock.ts`:

```ts
import { bedrockProviderModule } from "@mariozechner/pi-ai/bedrock-provider";
```

Without this `tsconfig` change, that import does not resolve to workspace source during the repo typecheck and falls through to package export / dist resolution instead.

## Repro

From a fresh checkout of current `main`:

```bash
npm install
npm run check
```

Current failure:

```text
packages/coding-agent/src/bun/register-bedrock.ts(2,39): error TS2307:
Cannot find module '@mariozechner/pi-ai/bedrock-provider' or its corresponding type declarations.
```

## Why this fixes it

The repo already maps:
- `@mariozechner/pi-ai` -> `packages/ai/src/index.ts`
- `@mariozechner/pi-ai/oauth` -> `packages/ai/src/oauth.ts`

But other public `@mariozechner/pi-ai/*` subpaths were not resolving consistently to workspace source files during monorepo no-emit typechecking.

This change makes those subpaths resolve to:
- `packages/ai/src/*.ts`
- then `packages/ai/src/providers/*.ts`

So in a source checkout, TS resolves `@mariozechner/pi-ai/bedrock-provider` to `packages/ai/src/bedrock-provider.ts` instead of falling through to dist/package-export resolution.

This is a monorepo typecheck fix only. It does not change runtime behavior or published package behavior.

## Notes

- this is a clean follow-up branch without the earlier wrapper/export experiments

## Checks

- `npm run check`
