### PR TITLE
feat(coding-agent): add reconnectable RPC socket mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added reconnectable Unix-socket RPC mode via `--rpc-socket <path>`, keeping pi alive across client disconnects while accepting one connected RPC client at a time.
+
 ### Fixed
 
 - Fixed interactive input fields backed by the TUI `Input` component to scroll by visual column width for wide Unicode text (CJK, fullwidth characters), preventing rendered line overflow and TUI crashes in places like search and filter inputs ([#1982](https://github.com/badlogic/pi-mono/issues/1982))

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -10,19 +10,36 @@ RPC mode enables headless operation of the coding agent via a JSON protocol over
 pi --mode rpc [options]
 ```
 
+Unix socket server mode:
+
+```bash
+pi --mode rpc --rpc-socket /tmp/pi.sock [options]
+```
+
 Common options:
 - `--provider <name>`: Set the LLM provider (anthropic, openai, google, etc.)
 - `--model <pattern>`: Model pattern or ID (supports `provider/id` and optional `:<thinking>`)
 - `--no-session`: Disable session persistence
 - `--session-dir <path>`: Custom session storage directory
+- `--rpc-socket <path>`: Listen on a Unix socket instead of stdio, keeping pi alive across client disconnects
 
 ## Protocol Overview
 
-- **Commands**: JSON objects sent to stdin, one per line
+- **Commands**: JSON objects sent over stdin or the RPC socket, one per line
 - **Responses**: JSON objects with `type: "response"` indicating command success/failure
-- **Events**: Agent events streamed to stdout as JSON lines
+- **Events**: Agent events streamed back over stdout or the RPC socket as JSON lines
 
 All commands support an optional `id` field for request/response correlation. If provided, the corresponding response will include the same `id`.
+
+### Socket mode
+
+With `--rpc-socket <path>`, pi listens on a Unix socket instead of stdio. The protocol is still strict JSONL; only the transport changes.
+
+Socket mode is designed for reconnectable embeddings:
+- pi stays alive when the client disconnects
+- a new client can reconnect later and continue using the same session
+- only one client can be connected at a time; additional concurrent connections are rejected immediately
+- events are not replayed while no client is connected, so reconnecting clients should resync with `get_state`, `get_messages`, or both
 
 ### Framing
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -21,6 +21,7 @@ export interface Args {
 	help?: boolean;
 	version?: boolean;
 	mode?: Mode;
+	rpcSocket?: string;
 	noSession?: boolean;
 	session?: string;
 	sessionDir?: string;
@@ -71,6 +72,8 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			if (mode === "text" || mode === "json" || mode === "rpc") {
 				result.mode = mode;
 			}
+		} else if (arg === "--rpc-socket" && i + 1 < args.length) {
+			result.rpcSocket = args[++i];
 		} else if (arg === "--continue" || arg === "-c") {
 			result.continue = true;
 		} else if (arg === "--resume" || arg === "-r") {
@@ -197,6 +200,7 @@ ${chalk.bold("Options:")}
   --system-prompt <text>         System prompt (default: coding assistant prompt)
   --append-system-prompt <text>  Append text or file contents to the system prompt
   --mode <mode>                  Output mode: text (default), json, or rpc
+  --rpc-socket <path>            Listen on a Unix socket in RPC mode and keep pi alive across disconnects
   --print, -p                    Non-interactive mode: process prompt and exit
   --continue, -c                 Continue previous session
   --resume, -r                   Select a session to resume

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -271,6 +271,7 @@ export {
 	InteractiveMode,
 	type InteractiveModeOptions,
 	type PrintModeOptions,
+	type RpcModeOptions,
 	runPrintMode,
 	runRpcMode,
 } from "./modes/index.js";

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -691,6 +691,11 @@ export async function main(args: string[]) {
 		process.exit(0);
 	}
 
+	if (parsed.rpcSocket && parsed.mode !== "rpc") {
+		console.error(chalk.red("Error: --rpc-socket requires --mode rpc"));
+		process.exit(1);
+	}
+
 	if (parsed.mode === "rpc" && parsed.fileArgs.length > 0) {
 		console.error(chalk.red("Error: @file arguments are not supported in RPC mode"));
 		process.exit(1);
@@ -783,7 +788,7 @@ export async function main(args: string[]) {
 	}
 
 	if (mode === "rpc") {
-		await runRpcMode(session);
+		await runRpcMode(session, { socketPath: parsed.rpcSocket });
 	} else if (isInteractive) {
 		if (scopedModels.length > 0 && (parsed.verbose || !settingsManager.getQuietStartup())) {
 			const modelList = scopedModels

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -5,5 +5,5 @@
 export { InteractiveMode, type InteractiveModeOptions } from "./interactive/interactive-mode.js";
 export { type PrintModeOptions, runPrintMode } from "./print-mode.js";
 export { type ModelInfo, RpcClient, type RpcClientOptions, type RpcEventListener } from "./rpc/rpc-client.js";
-export { runRpcMode } from "./rpc/rpc-mode.js";
+export { type RpcModeOptions, runRpcMode } from "./rpc/rpc-mode.js";
 export type { RpcCommand, RpcResponse, RpcSessionState } from "./rpc/rpc-types.js";

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -5,6 +5,7 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { createConnection, type Socket } from "node:net";
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { SessionStats } from "../../core/agent-session.js";
@@ -36,6 +37,11 @@ export interface RpcClientOptions {
 	model?: string;
 	/** Additional CLI arguments */
 	args?: string[];
+	/**
+	 * Connect to an already-running RPC socket instead of spawning a process.
+	 * When set, cliPath/cwd/env/provider/model/args are ignored.
+	 */
+	socketPath?: string;
 }
 
 export interface ModelInfo {
@@ -53,6 +59,7 @@ export type RpcEventListener = (event: AgentEvent) => void;
 
 export class RpcClient {
 	private process: ChildProcess | null = null;
+	private socket: Socket | null = null;
 	private stopReadingStdout: (() => void) | null = null;
 	private eventListeners: RpcEventListener[] = [];
 	private pendingRequests: Map<string, { resolve: (response: RpcResponse) => void; reject: (error: Error) => void }> =
@@ -63,11 +70,40 @@ export class RpcClient {
 	constructor(private options: RpcClientOptions = {}) {}
 
 	/**
-	 * Start the RPC agent process.
+	 * Start the RPC agent process or connect to an existing RPC socket.
 	 */
 	async start(): Promise<void> {
-		if (this.process) {
+		if (this.process || this.socket) {
 			throw new Error("Client already started");
+		}
+
+		const socketPath = this.options.socketPath;
+		if (socketPath) {
+			const socket = await new Promise<Socket>((resolve, reject) => {
+				const conn = createConnection(socketPath);
+				const onError = (error: Error) => {
+					conn.off("connect", onConnect);
+					reject(error);
+				};
+				const onConnect = () => {
+					conn.off("error", onError);
+					resolve(conn);
+				};
+				conn.once("error", onError);
+				conn.once("connect", onConnect);
+			});
+
+			this.socket = socket;
+			socket.on("error", (error) => {
+				this.stderr += `${error.message}\n`;
+			});
+			socket.on("close", () => {
+				this.handleTransportClosed("RPC socket closed");
+			});
+			this.stopReadingStdout = attachJsonlLineReader(socket, (line) => {
+				this.handleLine(line);
+			});
+			return;
 		}
 
 		const cliPath = this.options.cliPath ?? "dist/cli.js";
@@ -93,6 +129,9 @@ export class RpcClient {
 		this.process.stderr?.on("data", (data) => {
 			this.stderr += data.toString();
 		});
+		this.process.on("exit", () => {
+			this.handleTransportClosed("RPC process exited");
+		});
 
 		// Set up strict JSONL reader for stdout.
 		this.stopReadingStdout = attachJsonlLineReader(this.process.stdout!, (line) => {
@@ -108,29 +147,48 @@ export class RpcClient {
 	}
 
 	/**
-	 * Stop the RPC agent process.
+	 * Stop the RPC agent process or disconnect from the RPC socket.
 	 */
 	async stop(): Promise<void> {
-		if (!this.process) return;
-
 		this.stopReadingStdout?.();
 		this.stopReadingStdout = null;
-		this.process.kill("SIGTERM");
+
+		if (this.socket) {
+			const socket = this.socket;
+			this.socket = null;
+			await new Promise<void>((resolve) => {
+				const timeout = setTimeout(() => {
+					socket.destroy();
+					resolve();
+				}, 1000);
+				socket.once("close", () => {
+					clearTimeout(timeout);
+					resolve();
+				});
+				socket.end();
+			});
+			this.pendingRequests.clear();
+			return;
+		}
+
+		if (!this.process) return;
+		const processRef = this.process;
+		this.process = null;
+		processRef.kill("SIGTERM");
 
 		// Wait for process to exit
 		await new Promise<void>((resolve) => {
 			const timeout = setTimeout(() => {
-				this.process?.kill("SIGKILL");
+				processRef.kill("SIGKILL");
 				resolve();
 			}, 1000);
 
-			this.process?.on("exit", () => {
+			processRef.once("exit", () => {
 				clearTimeout(timeout);
 				resolve();
 			});
 		});
 
-		this.process = null;
 		this.pendingRequests.clear();
 	}
 
@@ -440,6 +498,18 @@ export class RpcClient {
 	// Internal
 	// =========================================================================
 
+	private handleTransportClosed(message: string): void {
+		this.stopReadingStdout?.();
+		this.stopReadingStdout = null;
+		this.process = null;
+		this.socket = null;
+
+		for (const [id, pending] of this.pendingRequests) {
+			this.pendingRequests.delete(id);
+			pending.reject(new Error(`${message}. Stderr: ${this.stderr}`));
+		}
+	}
+
 	private handleLine(line: string): void {
 		try {
 			const data = JSON.parse(line);
@@ -462,7 +532,8 @@ export class RpcClient {
 	}
 
 	private async send(command: RpcCommandBody): Promise<RpcResponse> {
-		if (!this.process?.stdin) {
+		const input = this.socket ?? this.process?.stdin;
+		if (!input) {
 			throw new Error("Client not started");
 		}
 
@@ -488,7 +559,7 @@ export class RpcClient {
 				},
 			});
 
-			this.process!.stdin!.write(serializeJsonLine(fullCommand));
+			input.write(serializeJsonLine(fullCommand));
 		});
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -28,6 +28,7 @@ import type {
 	RpcSessionState,
 	RpcSlashCommand,
 } from "./rpc-types.js";
+import { createRpcSocketServer } from "./socket-server.js";
 
 // Re-export types for consumers
 export type {
@@ -38,13 +39,30 @@ export type {
 	RpcSessionState,
 } from "./rpc-types.js";
 
+export interface RpcModeOptions {
+	/**
+	 * Listen on a Unix socket instead of stdio. Socket mode keeps the process alive
+	 * across client disconnects and accepts one client connection at a time.
+	 */
+	socketPath?: string;
+}
+
 /**
  * Run in RPC mode.
  * Listens for JSON commands on stdin, outputs events and responses on stdout.
  */
-export async function runRpcMode(session: AgentSession): Promise<never> {
+export async function runRpcMode(session: AgentSession, options: RpcModeOptions = {}): Promise<never> {
+	let detachStdioInput = () => {};
+	let closeTransport = async () => {
+		detachStdioInput();
+		process.stdin.pause();
+	};
+	let writeLine = (line: string) => {
+		process.stdout.write(line);
+	};
+
 	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
-		process.stdout.write(serializeJsonLine(obj));
+		writeLine(serializeJsonLine(obj));
 	};
 
 	const success = <T extends RpcCommand["type"]>(
@@ -65,11 +83,36 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 	// Pending extension UI requests waiting for response
 	const pendingExtensionRequests = new Map<
 		string,
-		{ resolve: (value: any) => void; reject: (error: Error) => void }
+		{ resolve: (value: RpcExtensionUIResponse) => void; reject: (error: Error) => void }
 	>();
+
+	const rejectPendingExtensionRequests = (message: string) => {
+		for (const [id, pending] of pendingExtensionRequests) {
+			pendingExtensionRequests.delete(id);
+			pending.reject(new Error(message));
+		}
+	};
 
 	// Shutdown request flag
 	let shutdownRequested = false;
+
+	if (options.socketPath) {
+		const socketServer = await createRpcSocketServer({
+			socketPath: options.socketPath,
+			onLine: (line) => {
+				void handleInputLine(line);
+			},
+			onClientDisconnected: () => {
+				rejectPendingExtensionRequests("RPC client disconnected");
+			},
+		});
+		closeTransport = async () => {
+			await socketServer.close();
+		};
+		writeLine = (line: string) => {
+			socketServer.send(line);
+		};
+	}
 
 	/** Helper for dialog methods with signal/timeout support */
 	function createDialogPromise<T>(
@@ -587,19 +630,20 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 	 * Check if shutdown was requested and perform shutdown if so.
 	 * Called after handling each command when waiting for the next command.
 	 */
-	let detachInput = () => {};
-
-	async function checkShutdownRequested(): Promise<void> {
-		if (!shutdownRequested) return;
-
+	async function shutdown(): Promise<void> {
 		const currentRunner = session.extensionRunner;
 		if (currentRunner?.hasHandlers("session_shutdown")) {
 			await currentRunner.emit({ type: "session_shutdown" });
 		}
 
-		detachInput();
-		process.stdin.pause();
+		rejectPendingExtensionRequests("RPC mode shutting down");
+		await closeTransport();
 		process.exit(0);
+	}
+
+	async function checkShutdownRequested(): Promise<void> {
+		if (!shutdownRequested) return;
+		await shutdown();
 	}
 
 	const handleInputLine = async (line: string) => {
@@ -624,14 +668,17 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 
 			// Check for deferred shutdown request (idle between commands)
 			await checkShutdownRequested();
-		} catch (e: any) {
-			output(error(undefined, "parse", `Failed to parse command: ${e.message}`));
+		} catch (errorValue: unknown) {
+			const message = errorValue instanceof Error ? errorValue.message : String(errorValue);
+			output(error(undefined, "parse", `Failed to parse command: ${message}`));
 		}
 	};
 
-	detachInput = attachJsonlLineReader(process.stdin, (line) => {
-		void handleInputLine(line);
-	});
+	if (!options.socketPath) {
+		detachStdioInput = attachJsonlLineReader(process.stdin, (line) => {
+			void handleInputLine(line);
+		});
+	}
 
 	// Keep process alive forever
 	return new Promise(() => {});

--- a/packages/coding-agent/src/modes/rpc/socket-server.ts
+++ b/packages/coding-agent/src/modes/rpc/socket-server.ts
@@ -1,0 +1,116 @@
+import { lstat, unlink } from "node:fs/promises";
+import { createServer, type Socket } from "node:net";
+import { attachJsonlLineReader } from "./jsonl.js";
+
+export interface RpcSocketServerOptions {
+	socketPath: string;
+	onLine: (line: string) => void;
+	onClientDisconnected?: () => void;
+}
+
+export interface RpcSocketServer {
+	send(line: string): void;
+	close(): Promise<void>;
+}
+
+async function removeExistingSocket(socketPath: string): Promise<void> {
+	try {
+		const stats = await lstat(socketPath);
+		if (!stats.isSocket()) {
+			throw new Error(`RPC socket path exists and is not a socket: ${socketPath}`);
+		}
+		await unlink(socketPath);
+	} catch (error: unknown) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			typeof error.code === "string" &&
+			error.code === "ENOENT"
+		) {
+			return;
+		}
+		throw error;
+	}
+}
+
+export async function createRpcSocketServer(options: RpcSocketServerOptions): Promise<RpcSocketServer> {
+	await removeExistingSocket(options.socketPath);
+
+	let activeSocket: Socket | null = null;
+	let detachReader: (() => void) | null = null;
+
+	const clearActiveSocket = () => {
+		const socket = activeSocket;
+		const hadClient = socket !== null || detachReader !== null;
+		activeSocket = null;
+		if (detachReader) {
+			detachReader();
+			detachReader = null;
+		}
+		if (socket && !socket.destroyed) {
+			socket.destroy();
+		}
+		if (hadClient) {
+			options.onClientDisconnected?.();
+		}
+	};
+
+	const server = createServer((socket) => {
+		if (activeSocket) {
+			socket.end();
+			socket.destroy();
+			return;
+		}
+
+		activeSocket = socket;
+		socket.setNoDelay(true);
+		detachReader = attachJsonlLineReader(socket, options.onLine);
+
+		const handleClose = () => {
+			if (activeSocket === socket) {
+				clearActiveSocket();
+			}
+		};
+
+		socket.on("close", handleClose);
+		socket.on("error", () => {
+			if (activeSocket === socket) {
+				clearActiveSocket();
+			}
+		});
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		const onError = (error: Error) => {
+			server.off("listening", onListening);
+			reject(error);
+		};
+		const onListening = () => {
+			server.off("error", onError);
+			resolve();
+		};
+		server.once("error", onError);
+		server.once("listening", onListening);
+		server.listen(options.socketPath);
+	});
+
+	return {
+		send(line: string) {
+			activeSocket?.write(line);
+		},
+		async close() {
+			clearActiveSocket();
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+			await removeExistingSocket(options.socketPath);
+		},
+	};
+}

--- a/packages/coding-agent/test/rpc-socket.test.ts
+++ b/packages/coding-agent/test/rpc-socket.test.ts
@@ -1,0 +1,179 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createConnection, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { attachJsonlLineReader, serializeJsonLine } from "../src/modes/rpc/jsonl.js";
+import { RpcClient } from "../src/modes/rpc/rpc-client.js";
+import { createRpcSocketServer, type RpcSocketServer } from "../src/modes/rpc/socket-server.js";
+
+type Cleanup = () => void | Promise<void>;
+
+async function connectSocket(socketPath: string): Promise<Socket> {
+	return await new Promise<Socket>((resolve, reject) => {
+		const socket = createConnection(socketPath);
+		const onError = (error: Error) => {
+			socket.off("connect", onConnect);
+			reject(error);
+		};
+		const onConnect = () => {
+			socket.off("error", onError);
+			resolve(socket);
+		};
+		socket.once("error", onError);
+		socket.once("connect", onConnect);
+	});
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 1000): Promise<void> {
+	const start = Date.now();
+	while (!check()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("Timed out waiting for condition");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+describe("RPC socket server", () => {
+	let tempDir: string | null = null;
+	const cleanups: Cleanup[] = [];
+
+	afterEach(async () => {
+		while (cleanups.length > 0) {
+			const cleanup = cleanups.pop();
+			await cleanup?.();
+		}
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = null;
+		}
+	});
+
+	function nextSocketPath(name: string): string {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-rpc-socket-"));
+		return join(tempDir, `${name}.sock`);
+	}
+
+	test("accepts reconnecting clients on the same socket", async () => {
+		const receivedLines: string[] = [];
+		const socketPath = nextSocketPath("reconnect");
+		const server = await createRpcSocketServer({
+			socketPath,
+			onLine: (line) => {
+				receivedLines.push(line);
+			},
+		});
+		cleanups.push(() => server.close());
+
+		const clientOne = await connectSocket(socketPath);
+		cleanups.push(() => {
+			clientOne.destroy();
+		});
+		const clientOneReceived: string[] = [];
+		attachJsonlLineReader(clientOne, (line) => {
+			clientOneReceived.push(line);
+		});
+
+		clientOne.write(serializeJsonLine({ hello: 1 }));
+		await waitFor(() => receivedLines.length === 1);
+		expect(JSON.parse(receivedLines[0])).toEqual({ hello: 1 });
+
+		server.send(serializeJsonLine({ server: 1 }));
+		await waitFor(() => clientOneReceived.length === 1);
+		expect(JSON.parse(clientOneReceived[0])).toEqual({ server: 1 });
+
+		await new Promise<void>((resolve) => {
+			clientOne.once("close", () => resolve());
+			clientOne.end();
+		});
+
+		const clientTwo = await connectSocket(socketPath);
+		cleanups.push(() => {
+			clientTwo.destroy();
+		});
+		const clientTwoReceived: string[] = [];
+		attachJsonlLineReader(clientTwo, (line) => {
+			clientTwoReceived.push(line);
+		});
+
+		clientTwo.write(serializeJsonLine({ hello: 2 }));
+		await waitFor(() => receivedLines.length === 2);
+		expect(JSON.parse(receivedLines[1])).toEqual({ hello: 2 });
+
+		server.send(serializeJsonLine({ server: 2 }));
+		await waitFor(() => clientTwoReceived.length === 1);
+		expect(JSON.parse(clientTwoReceived[0])).toEqual({ server: 2 });
+	});
+
+	test("rejects a second concurrent client while keeping the first active", async () => {
+		const receivedLines: string[] = [];
+		const socketPath = nextSocketPath("single-client");
+		const server = await createRpcSocketServer({
+			socketPath,
+			onLine: (line) => {
+				receivedLines.push(line);
+			},
+		});
+		cleanups.push(() => server.close());
+
+		const clientOne = await connectSocket(socketPath);
+		cleanups.push(() => {
+			clientOne.destroy();
+		});
+		const clientTwo = await connectSocket(socketPath);
+		cleanups.push(() => {
+			clientTwo.destroy();
+		});
+
+		await new Promise<void>((resolve) => {
+			clientTwo.once("close", () => resolve());
+		});
+
+		clientOne.write(serializeJsonLine({ stillActive: true }));
+		await waitFor(() => receivedLines.length === 1);
+		expect(JSON.parse(receivedLines[0])).toEqual({ stillActive: true });
+	});
+
+	test("RpcClient can connect to an existing RPC socket", async () => {
+		const socketPath = nextSocketPath("client");
+		let server: RpcSocketServer | null = null;
+		server = await createRpcSocketServer({
+			socketPath,
+			onLine: (line) => {
+				const command = JSON.parse(line) as { id?: string; type: string };
+				if (command.type === "get_state") {
+					server?.send(
+						serializeJsonLine({
+							id: command.id,
+							type: "response",
+							command: "get_state",
+							success: true,
+							data: {
+								thinkingLevel: "medium",
+								isStreaming: false,
+								isCompacting: false,
+								steeringMode: "one-at-a-time",
+								followUpMode: "one-at-a-time",
+								sessionId: "socket-session",
+								autoCompactionEnabled: true,
+								messageCount: 0,
+								pendingMessageCount: 0,
+							},
+						}),
+					);
+				}
+			},
+		});
+		cleanups.push(() => server?.close());
+
+		const client = new RpcClient({ socketPath });
+		cleanups.push(() => {
+			return client.stop();
+		});
+		await client.start();
+		const state = await client.getState();
+		expect(state.sessionId).toBe("socket-session");
+		expect(state.thinkingLevel).toBe("medium");
+	});
+});


### PR DESCRIPTION
Add a Unix-socket transport for RPC mode via --rpc-socket. Socket mode keeps pi alive across client disconnects, accepts one client at a time, and preserves the existing JSONL protocol so hosts can reconnect and resync with get_state/get_messages instead of starting a new pi process.

This also adds RpcClient socket support, a dedicated socket server implementation, targeted socket transport tests, and RPC docs/changelog updates.

Validated with:
- npx vitest --run test/rpc-jsonl.test.ts test/rpc-socket.test.ts

The repo-wide pre-commit check is currently blocked by an unrelated existing Bedrock export/type issue in packages/coding-agent/src/cli.ts, so this commit is being created with --no-verify at explicit user request.