### PR TITLE
Add device flow option for OpenAI Codex login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out.html
 packages/coding-agent/binaries/
 todo.md
 plans/
+thoughts/

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -39,12 +39,21 @@ import { geminiCliOAuthProvider } from "./google-gemini-cli.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
 
+function normalizeOAuthProvider(provider: OAuthProviderInterface): OAuthProviderInterface {
+	const authFlow = provider.authFlow ?? (provider.usesCallbackServer ? "callback" : "device");
+
+	return {
+		...provider,
+		authFlow,
+	};
+}
+
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
-	anthropicOAuthProvider,
-	githubCopilotOAuthProvider,
-	geminiCliOAuthProvider,
-	antigravityOAuthProvider,
-	openaiCodexOAuthProvider,
+	normalizeOAuthProvider(anthropicOAuthProvider),
+	normalizeOAuthProvider(githubCopilotOAuthProvider),
+	normalizeOAuthProvider(geminiCliOAuthProvider),
+	normalizeOAuthProvider(antigravityOAuthProvider),
+	normalizeOAuthProvider(openaiCodexOAuthProvider),
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(
@@ -62,7 +71,7 @@ export function getOAuthProvider(id: OAuthProviderId): OAuthProviderInterface | 
  * Register a custom OAuth provider
  */
 export function registerOAuthProvider(provider: OAuthProviderInterface): void {
-	oauthProviderRegistry.set(provider.id, provider);
+	oauthProviderRegistry.set(provider.id, normalizeOAuthProvider(provider));
 }
 
 /**

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -1,21 +1,6 @@
 /**
- * OpenAI Codex (ChatGPT OAuth) flow
- *
- * NOTE: This module uses Node.js crypto and http for the OAuth callback.
- * It is only intended for CLI use, not browser environments.
+ * OpenAI Codex (ChatGPT OAuth) device + callback flow
  */
-
-// NEVER convert to top-level imports - breaks browser/Vite builds (web-ui)
-let _randomBytes: typeof import("node:crypto").randomBytes | null = null;
-let _http: typeof import("node:http") | null = null;
-if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
-	import("node:crypto").then((m) => {
-		_randomBytes = m.randomBytes;
-	});
-	import("node:http").then((m) => {
-		_http = m;
-	});
-}
 
 import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
 import { generatePKCE } from "./pkce.js";
@@ -23,10 +8,15 @@ import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderI
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
+const DEVICE_CODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode";
+const DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token";
+const DEVICE_VERIFICATION_URL = "https://auth.openai.com/codex/device";
+const DEVICE_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const REDIRECT_URI = "http://localhost:1455/auth/callback";
 const SCOPE = "openid profile email offline_access";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
+const DEVICE_FLOW_TIMEOUT_MS = 15 * 60 * 1000;
 
 type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
 type TokenFailure = { type: "failed" };
@@ -39,11 +29,57 @@ type JwtPayload = {
 	[key: string]: unknown;
 };
 
-function createState(): string {
-	if (!_randomBytes) {
+type DeviceCodeResponse = {
+	device_auth_id: string;
+	user_code: string;
+	interval: number;
+};
+
+type DeviceTokenSuccess = {
+	authorization_code: string;
+	code_challenge: string;
+	code_verifier: string;
+};
+
+type OAuthServerInfo = {
+	close: () => void;
+	cancelWait: () => void;
+	waitForCode: () => Promise<{ code: string } | null>;
+};
+
+type NodeApis = {
+	randomBytes: typeof import("node:crypto").randomBytes;
+	createServer: typeof import("node:http").createServer;
+};
+
+let nodeApis: NodeApis | null = null;
+let nodeApisPromise: Promise<NodeApis> | null = null;
+
+async function getNodeApis(): Promise<NodeApis> {
+	if (nodeApis) return nodeApis;
+	if (!nodeApisPromise) {
+		if (typeof process === "undefined" || (!process.versions?.node && !process.versions?.bun)) {
+			throw new Error("OpenAI Codex OAuth is only available in Node.js environments");
+		}
+
+		nodeApisPromise = Promise.all([import("node:crypto"), import("node:http")]).then(
+			([cryptoModule, httpModule]) => ({
+				randomBytes: cryptoModule.randomBytes,
+				createServer: httpModule.createServer,
+			}),
+		);
+	}
+
+	nodeApis = await nodeApisPromise;
+	return nodeApis;
+}
+
+async function createState(): Promise<string> {
+	if (typeof process === "undefined" || (!process.versions?.node && !process.versions?.bun)) {
 		throw new Error("OpenAI Codex OAuth is only available in Node.js environments");
 	}
-	return _randomBytes(16).toString("hex");
+	const { randomBytes } = await getNodeApis();
+	return randomBytes(16).toString("hex");
 }
 
 function parseAuthorizationInput(input: string): { code?: string; state?: string } {
@@ -81,11 +117,221 @@ function decodeJwt(token: string): JwtPayload | null {
 		const parts = token.split(".");
 		if (parts.length !== 3) return null;
 		const payload = parts[1] ?? "";
-		const decoded = atob(payload);
+		const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+		const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+		const decoded = Buffer.from(padded, "base64").toString("utf8");
 		return JSON.parse(decoded) as JwtPayload;
 	} catch {
 		return null;
 	}
+}
+
+function getAccountId(accessToken: string): string | null {
+	const payload = decodeJwt(accessToken);
+	const auth = payload?.[JWT_CLAIM_PATH];
+	const accountId = auth?.chatgpt_account_id;
+	return typeof accountId === "string" && accountId.length > 0 ? accountId : null;
+}
+
+function isCloudflareBlockedDeviceFlowError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const message = error.message.toLowerCase();
+	return message.includes("403") && (message.includes("<!doctype html") || message.includes("just a moment"));
+}
+
+async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
+	const response = await fetch(url, init);
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		throw new Error(`${response.status} ${response.statusText}: ${text}`);
+	}
+	return response.json();
+}
+
+function withAbortSignal<T>(promise: Promise<T>, signal?: AbortSignal, onAbort?: () => void): Promise<T> {
+	if (!signal) {
+		return promise;
+	}
+
+	if (signal.aborted) {
+		onAbort?.();
+		throw new Error("Login cancelled");
+	}
+
+	return new Promise<T>((resolve, reject) => {
+		const abort = () => {
+			onAbort?.();
+			reject(new Error("Login cancelled"));
+		};
+
+		signal.addEventListener("abort", abort, { once: true });
+
+		promise.then(
+			(value) => {
+				signal.removeEventListener("abort", abort);
+				resolve(value);
+			},
+			(error: unknown) => {
+				signal.removeEventListener("abort", abort);
+				reject(error);
+			},
+		);
+	});
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Login cancelled"));
+			return;
+		}
+
+		const timeout = setTimeout(resolve, ms);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timeout);
+				reject(new Error("Login cancelled"));
+			},
+			{ once: true },
+		);
+	});
+}
+
+async function startDeviceFlow(): Promise<DeviceCodeResponse> {
+	const data = await fetchJson(DEVICE_CODE_URL, {
+		method: "POST",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ client_id: CLIENT_ID }),
+	});
+
+	if (!data || typeof data !== "object") {
+		throw new Error("Invalid device code response");
+	}
+
+	const deviceAuthId = (data as Record<string, unknown>).device_auth_id;
+	const userCode = (data as Record<string, unknown>).user_code;
+	const interval = (data as Record<string, unknown>).interval;
+	const normalizedInterval =
+		typeof interval === "string"
+			? Number.parseInt(interval, 10)
+			: typeof interval === "number"
+				? interval
+				: Number.NaN;
+
+	if (typeof deviceAuthId !== "string" || typeof userCode !== "string" || !Number.isFinite(normalizedInterval)) {
+		throw new Error("Invalid device code response fields");
+	}
+
+	return {
+		device_auth_id: deviceAuthId,
+		user_code: userCode,
+		interval: normalizedInterval,
+	};
+}
+
+async function createAuthorizationFlow(
+	originator: string = "pi",
+): Promise<{ verifier: string; state: string; url: string }> {
+	const { verifier, challenge } = await generatePKCE();
+	const state = await createState();
+
+	const url = new URL(AUTHORIZE_URL);
+	url.searchParams.set("response_type", "code");
+	url.searchParams.set("client_id", CLIENT_ID);
+	url.searchParams.set("redirect_uri", REDIRECT_URI);
+	url.searchParams.set("scope", SCOPE);
+	url.searchParams.set("code_challenge", challenge);
+	url.searchParams.set("code_challenge_method", "S256");
+	url.searchParams.set("state", state);
+	url.searchParams.set("id_token_add_organizations", "true");
+	url.searchParams.set("codex_cli_simplified_flow", "true");
+	url.searchParams.set("originator", originator);
+
+	return { verifier, state, url: url.toString() };
+}
+
+function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
+	return getNodeApis().then(
+		({ createServer }) =>
+			new Promise((resolve) => {
+				let settleWait: ((value: { code: string } | null) => void) | undefined;
+				const waitForCodePromise = new Promise<{ code: string } | null>((resolveWait) => {
+					let settled = false;
+					settleWait = (value) => {
+						if (settled) return;
+						settled = true;
+						resolveWait(value);
+					};
+				});
+
+				const server = createServer((req, res) => {
+					try {
+						const url = new URL(req.url || "", "http://localhost");
+						if (url.pathname !== "/auth/callback") {
+							res.statusCode = 404;
+							res.setHeader("Content-Type", "text/html; charset=utf-8");
+							res.end(oauthErrorHtml("Callback route not found."));
+							return;
+						}
+						if (url.searchParams.get("state") !== state) {
+							res.statusCode = 400;
+							res.setHeader("Content-Type", "text/html; charset=utf-8");
+							res.end(oauthErrorHtml("State mismatch."));
+							return;
+						}
+						const code = url.searchParams.get("code");
+						if (!code) {
+							res.statusCode = 400;
+							res.setHeader("Content-Type", "text/html; charset=utf-8");
+							res.end(oauthErrorHtml("Missing authorization code."));
+							return;
+						}
+						res.statusCode = 200;
+						res.setHeader("Content-Type", "text/html; charset=utf-8");
+						res.end(oauthSuccessHtml("OpenAI authentication completed. You can close this window."));
+						settleWait?.({ code });
+					} catch {
+						res.statusCode = 500;
+						res.setHeader("Content-Type", "text/html; charset=utf-8");
+						res.end(oauthErrorHtml("Internal error while processing OAuth callback."));
+					}
+				});
+
+				server
+					.listen(1455, "127.0.0.1", () => {
+						resolve({
+							close: () => server.close(),
+							cancelWait: () => {
+								settleWait?.(null);
+							},
+							waitForCode: () => waitForCodePromise,
+						});
+					})
+					.on("error", (err: NodeJS.ErrnoException) => {
+						console.error(
+							"[openai-codex] Failed to bind http://127.0.0.1:1455 (",
+							err.code,
+							") Falling back to manual paste.",
+						);
+						settleWait?.(null);
+						resolve({
+							close: () => {
+								try {
+									server.close();
+								} catch {
+									// ignore
+								}
+							},
+							cancelWait: () => {},
+							waitForCode: async () => null,
+						});
+					});
+			}),
+	);
 }
 
 async function exchangeAuthorizationCode(
@@ -130,6 +376,81 @@ async function exchangeAuthorizationCode(
 	};
 }
 
+async function pollForToken(
+	deviceAuthId: string,
+	userCode: string,
+	intervalSeconds: number,
+	signal?: AbortSignal,
+): Promise<OAuthCredentials> {
+	const deadline = Date.now() + DEVICE_FLOW_TIMEOUT_MS;
+	const intervalMs = Math.max(1000, Math.floor(intervalSeconds * 1000));
+
+	while (Date.now() < deadline) {
+		if (signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+
+		await abortableSleep(Math.min(intervalMs, deadline - Date.now()), signal);
+
+		const response = await fetch(DEVICE_TOKEN_URL, {
+			method: "POST",
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				device_auth_id: deviceAuthId,
+				user_code: userCode,
+			}),
+		});
+
+		if (response.ok) {
+			const raw = (await response.json()) as unknown;
+			if (!raw || typeof raw !== "object") {
+				throw new Error("Invalid device token response");
+			}
+
+			const authorizationCode = (raw as DeviceTokenSuccess).authorization_code;
+			const codeChallenge = (raw as DeviceTokenSuccess).code_challenge;
+			const codeVerifier = (raw as DeviceTokenSuccess).code_verifier;
+
+			if (
+				typeof authorizationCode !== "string" ||
+				typeof codeChallenge !== "string" ||
+				typeof codeVerifier !== "string"
+			) {
+				throw new Error("Invalid device token response fields");
+			}
+
+			const tokenResult = await exchangeAuthorizationCode(authorizationCode, codeVerifier, DEVICE_REDIRECT_URI);
+			if (tokenResult.type !== "success") {
+				throw new Error("Token exchange failed");
+			}
+
+			const accountId = getAccountId(tokenResult.access);
+			if (!accountId) {
+				throw new Error("Failed to extract accountId from token");
+			}
+
+			return {
+				access: tokenResult.access,
+				refresh: tokenResult.refresh,
+				expires: tokenResult.expires,
+				accountId,
+			};
+		}
+
+		if (response.status === 403 || response.status === 404) {
+			continue;
+		}
+
+		const text = await response.text().catch(() => "");
+		throw new Error(`${response.status} ${response.statusText}: ${text}`);
+	}
+
+	throw new Error("Device flow timed out");
+}
+
 async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
 	try {
 		const response = await fetch(TOKEN_URL, {
@@ -171,138 +492,12 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
 	}
 }
 
-async function createAuthorizationFlow(
-	originator: string = "pi",
-): Promise<{ verifier: string; state: string; url: string }> {
-	const { verifier, challenge } = await generatePKCE();
-	const state = createState();
-
-	const url = new URL(AUTHORIZE_URL);
-	url.searchParams.set("response_type", "code");
-	url.searchParams.set("client_id", CLIENT_ID);
-	url.searchParams.set("redirect_uri", REDIRECT_URI);
-	url.searchParams.set("scope", SCOPE);
-	url.searchParams.set("code_challenge", challenge);
-	url.searchParams.set("code_challenge_method", "S256");
-	url.searchParams.set("state", state);
-	url.searchParams.set("id_token_add_organizations", "true");
-	url.searchParams.set("codex_cli_simplified_flow", "true");
-	url.searchParams.set("originator", originator);
-
-	return { verifier, state, url: url.toString() };
-}
-
-type OAuthServerInfo = {
-	close: () => void;
-	cancelWait: () => void;
-	waitForCode: () => Promise<{ code: string } | null>;
-};
-
-function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
-	if (!_http) {
-		throw new Error("OpenAI Codex OAuth is only available in Node.js environments");
-	}
-
-	let settleWait: ((value: { code: string } | null) => void) | undefined;
-	const waitForCodePromise = new Promise<{ code: string } | null>((resolve) => {
-		let settled = false;
-		settleWait = (value) => {
-			if (settled) return;
-			settled = true;
-			resolve(value);
-		};
-	});
-
-	const server = _http.createServer((req, res) => {
-		try {
-			const url = new URL(req.url || "", "http://localhost");
-			if (url.pathname !== "/auth/callback") {
-				res.statusCode = 404;
-				res.setHeader("Content-Type", "text/html; charset=utf-8");
-				res.end(oauthErrorHtml("Callback route not found."));
-				return;
-			}
-			if (url.searchParams.get("state") !== state) {
-				res.statusCode = 400;
-				res.setHeader("Content-Type", "text/html; charset=utf-8");
-				res.end(oauthErrorHtml("State mismatch."));
-				return;
-			}
-			const code = url.searchParams.get("code");
-			if (!code) {
-				res.statusCode = 400;
-				res.setHeader("Content-Type", "text/html; charset=utf-8");
-				res.end(oauthErrorHtml("Missing authorization code."));
-				return;
-			}
-			res.statusCode = 200;
-			res.setHeader("Content-Type", "text/html; charset=utf-8");
-			res.end(oauthSuccessHtml("OpenAI authentication completed. You can close this window."));
-			settleWait?.({ code });
-		} catch {
-			res.statusCode = 500;
-			res.setHeader("Content-Type", "text/html; charset=utf-8");
-			res.end(oauthErrorHtml("Internal error while processing OAuth callback."));
-		}
-	});
-
-	return new Promise((resolve) => {
-		server
-			.listen(1455, "127.0.0.1", () => {
-				resolve({
-					close: () => server.close(),
-					cancelWait: () => {
-						settleWait?.(null);
-					},
-					waitForCode: () => waitForCodePromise,
-				});
-			})
-			.on("error", (err: NodeJS.ErrnoException) => {
-				console.error(
-					"[openai-codex] Failed to bind http://127.0.0.1:1455 (",
-					err.code,
-					") Falling back to manual paste.",
-				);
-				settleWait?.(null);
-				resolve({
-					close: () => {
-						try {
-							server.close();
-						} catch {
-							// ignore
-						}
-					},
-					cancelWait: () => {},
-					waitForCode: async () => null,
-				});
-			});
-	});
-}
-
-function getAccountId(accessToken: string): string | null {
-	const payload = decodeJwt(accessToken);
-	const auth = payload?.[JWT_CLAIM_PATH];
-	const accountId = auth?.chatgpt_account_id;
-	return typeof accountId === "string" && accountId.length > 0 ? accountId : null;
-}
-
-/**
- * Login with OpenAI Codex OAuth
- *
- * @param options.onAuth - Called with URL and instructions when auth starts
- * @param options.onPrompt - Called to prompt user for manual code paste (fallback if no onManualCodeInput)
- * @param options.onProgress - Optional progress messages
- * @param options.onManualCodeInput - Optional promise that resolves with user-pasted code.
- *                                    Races with browser callback - whichever completes first wins.
- *                                    Useful for showing paste input immediately alongside browser flow.
- * @param options.originator - OAuth originator parameter (defaults to "pi")
- */
-export async function loginOpenAICodex(options: {
+async function loginWithCallbackFlow(options: {
 	onAuth: (info: { url: string; instructions?: string }) => void;
 	onPrompt: (prompt: OAuthPrompt) => Promise<string>;
-	onProgress?: (message: string) => void;
 	onManualCodeInput?: () => Promise<string>;
 	originator?: string;
+	signal?: AbortSignal;
 }): Promise<OAuthCredentials> {
 	const { verifier, state, url } = await createAuthorizationFlow(options.originator);
 	const server = await startLocalOAuthServer(state);
@@ -312,7 +507,6 @@ export async function loginOpenAICodex(options: {
 	let code: string | undefined;
 	try {
 		if (options.onManualCodeInput) {
-			// Race between browser callback and manual input
 			let manualCode: string | undefined;
 			let manualError: Error | undefined;
 			const manualPromise = options
@@ -326,18 +520,15 @@ export async function loginOpenAICodex(options: {
 					server.cancelWait();
 				});
 
-			const result = await server.waitForCode();
+			const result = await withAbortSignal(server.waitForCode(), options.signal, () => server.cancelWait());
 
-			// If manual input was cancelled, throw that error
 			if (manualError) {
 				throw manualError;
 			}
 
 			if (result?.code) {
-				// Browser callback won
 				code = result.code;
 			} else if (manualCode) {
-				// Manual input won (or callback timed out and user had entered code)
 				const parsed = parseAuthorizationInput(manualCode);
 				if (parsed.state && parsed.state !== state) {
 					throw new Error("State mismatch");
@@ -345,7 +536,6 @@ export async function loginOpenAICodex(options: {
 				code = parsed.code;
 			}
 
-			// If still no code, wait for manual promise to complete and try that
 			if (!code) {
 				await manualPromise;
 				if (manualError) {
@@ -360,18 +550,20 @@ export async function loginOpenAICodex(options: {
 				}
 			}
 		} else {
-			// Original flow: wait for callback, then prompt if needed
-			const result = await server.waitForCode();
+			const result = await withAbortSignal(server.waitForCode(), options.signal, () => server.cancelWait());
 			if (result?.code) {
 				code = result.code;
 			}
 		}
 
-		// Fallback to onPrompt if still no code
 		if (!code) {
-			const input = await options.onPrompt({
-				message: "Paste the authorization code (or full redirect URL):",
-			});
+			const input = await withAbortSignal(
+				options.onPrompt({
+					message: "Paste the authorization code (or full redirect URL):",
+				}),
+				options.signal,
+				() => server.cancelWait(),
+			);
 			const parsed = parseAuthorizationInput(input);
 			if (parsed.state && parsed.state !== state) {
 				throw new Error("State mismatch");
@@ -404,9 +596,51 @@ export async function loginOpenAICodex(options: {
 	}
 }
 
-/**
- * Refresh OpenAI Codex OAuth token
- */
+export async function loginOpenAICodex(options: {
+	onAuth: (info: { url: string; instructions?: string }) => void;
+	onPrompt: (prompt: OAuthPrompt) => Promise<string>;
+	onProgress?: (message: string) => void;
+	onManualCodeInput?: () => Promise<string>;
+	originator?: string;
+	signal?: AbortSignal;
+}): Promise<OAuthCredentials> {
+	const methodRaw = await withAbortSignal(
+		options.onPrompt({
+			message: "Login method for ChatGPT/Codex (headless/browser)",
+			placeholder: "headless",
+			allowEmpty: true,
+		}),
+		options.signal,
+	);
+	const method = methodRaw.trim().toLowerCase();
+	const normalizedMethod = method === "headless" ? "device" : method === "browser" ? "callback" : method;
+
+	if (normalizedMethod !== "" && normalizedMethod !== "device" && normalizedMethod !== "callback") {
+		throw new Error(`Invalid login method: ${methodRaw}. Expected headless or browser.`);
+	}
+
+	if (normalizedMethod === "" || normalizedMethod === "device") {
+		let device: DeviceCodeResponse;
+		try {
+			device = await startDeviceFlow();
+		} catch (error) {
+			if (isCloudflareBlockedDeviceFlowError(error)) {
+				options.onProgress?.("Headless login blocked; switching to browser login...");
+				return loginWithCallbackFlow(options);
+			}
+			throw error;
+		}
+		options.onAuth({
+			url: DEVICE_VERIFICATION_URL,
+			instructions: `Enter code: ${device.user_code}`,
+		});
+
+		return pollForToken(device.device_auth_id, device.user_code, device.interval, options.signal);
+	}
+
+	return loginWithCallbackFlow(options);
+}
+
 export async function refreshOpenAICodexToken(refreshToken: string): Promise<OAuthCredentials> {
 	const result = await refreshAccessToken(refreshToken);
 	if (result.type !== "success") {
@@ -429,6 +663,7 @@ export async function refreshOpenAICodexToken(refreshToken: string): Promise<OAu
 export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 	id: "openai-codex",
 	name: "ChatGPT Plus/Pro (Codex Subscription)",
+	authFlow: "mixed",
 	usesCallbackServer: true,
 
 	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
@@ -437,6 +672,7 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 			onPrompt: callbacks.onPrompt,
 			onProgress: callbacks.onProgress,
 			onManualCodeInput: callbacks.onManualCodeInput,
+			signal: callbacks.signal,
 		});
 	},
 

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -34,6 +34,7 @@ export interface OAuthLoginCallbacks {
 export interface OAuthProviderInterface {
 	readonly id: OAuthProviderId;
 	readonly name: string;
+	readonly authFlow?: "device" | "callback" | "mixed";
 
 	/** Run the login flow, return credentials to persist */
 	login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>;

--- a/packages/ai/test/oauth-auth-flow.test.ts
+++ b/packages/ai/test/oauth-auth-flow.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getOAuthProviders, resetOAuthProviders } from "../src/utils/oauth/index.js";
+
+describe("OAuth provider authFlow metadata", () => {
+	beforeEach(() => {
+		resetOAuthProviders();
+	});
+
+	afterEach(() => {
+		resetOAuthProviders();
+	});
+
+	it("should expose authFlow for mixed and device providers", () => {
+		const providers = getOAuthProviders();
+
+		const openaiCodex = providers.find((p) => p.id === "openai-codex");
+		expect(openaiCodex).toBeDefined();
+		expect(openaiCodex?.authFlow).toBe("mixed");
+
+		const githubCopilot = providers.find((p) => p.id === "github-copilot");
+		expect(githubCopilot).toBeDefined();
+		expect(githubCopilot?.authFlow).toBe("device");
+	});
+
+	it("should expose authFlow for callback providers", () => {
+		const providers = getOAuthProviders();
+
+		const anthropic = providers.find((p) => p.id === "anthropic");
+		expect(anthropic).toBeDefined();
+		expect(anthropic?.authFlow).toBe("callback");
+
+		const geminiCli = providers.find((p) => p.id === "google-gemini-cli");
+		expect(geminiCli).toBeDefined();
+		expect(geminiCli?.authFlow).toBe("callback");
+
+		const antigravity = providers.find((p) => p.id === "google-antigravity");
+		expect(antigravity).toBeDefined();
+		expect(antigravity?.authFlow).toBe("callback");
+	});
+});

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -1,0 +1,437 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	loginOpenAICodex,
+	openaiCodexOAuthProvider,
+	refreshOpenAICodexToken,
+} from "../src/utils/oauth/openai-codex.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+}
+
+function getUrl(input: unknown): string {
+	if (typeof input === "string") {
+		return input;
+	}
+	if (input instanceof URL) {
+		return input.toString();
+	}
+	if (input instanceof Request) {
+		return input.url;
+	}
+	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+function createAccessToken(accountId = "acct_123"): string {
+	const payload = Buffer.from(
+		JSON.stringify({
+			"https://api.openai.com/auth": {
+				chatgpt_account_id: accountId,
+			},
+		}),
+	).toString("base64url");
+	return `header.${payload}.sig`;
+}
+
+describe("OpenAI Codex OAuth device flow", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it("waits before polling, retries 403/404 device polls, and returns OAuth credentials", async () => {
+		vi.useFakeTimers();
+		const startTime = new Date("2026-03-25T00:00:00Z");
+		vi.setSystemTime(startTime);
+
+		const pollTimes: number[] = [];
+		const authUrls: Array<{ url: string; instructions?: string }> = [];
+		const accessToken = createAccessToken();
+		const pollResponses = [
+			jsonResponse({ message: "pending" }, 403),
+			jsonResponse({ message: "still pending" }, 404),
+			jsonResponse({
+				authorization_code: "device-authorization-code",
+				code_challenge: "device-code-challenge",
+				code_verifier: "device-code-verifier",
+			}),
+		];
+
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/usercode") {
+				expect(init?.method).toBe("POST");
+				expect(init?.headers).toMatchObject({
+					"Content-Type": "application/json",
+				});
+				expect(String(init?.body)).toContain('"client_id"');
+				return jsonResponse({
+					user_code: "ABCD-EFGH",
+					device_auth_id: "device-auth-id",
+					interval: "5",
+				});
+			}
+
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/token") {
+				pollTimes.push(Date.now());
+				expect(init?.method).toBe("POST");
+				expect(init?.headers).toMatchObject({
+					"Content-Type": "application/json",
+				});
+				expect(String(init?.body)).toContain('"device_auth_id":"device-auth-id"');
+				expect(String(init?.body)).toContain('"user_code":"ABCD-EFGH"');
+				const response = pollResponses.shift();
+				if (!response) {
+					throw new Error("Unexpected extra token poll");
+				}
+				return response;
+			}
+
+			if (url === "https://auth.openai.com/oauth/token") {
+				expect(init?.method).toBe("POST");
+				expect(String(init?.body)).toContain("grant_type=authorization_code");
+				expect(String(init?.body)).toContain("code=device-authorization-code");
+				expect(String(init?.body)).toContain("redirect_uri=https%3A%2F%2Fauth.openai.com%2Fdeviceauth%2Fcallback");
+				return jsonResponse({
+					access_token: accessToken,
+					refresh_token: "refresh-token",
+					expires_in: 3600,
+				});
+			}
+
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		const loginPromise = loginOpenAICodex({
+			onAuth: (info) => authUrls.push(info),
+			onPrompt: async () => "device",
+		});
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(authUrls).toEqual([
+			{ url: "https://auth.openai.com/codex/device", instructions: "Enter code: ABCD-EFGH" },
+		]);
+		expect(pollTimes).toHaveLength(0);
+
+		await vi.advanceTimersByTimeAsync(4999);
+		expect(pollTimes).toHaveLength(0);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(pollTimes).toHaveLength(1);
+
+		await vi.advanceTimersByTimeAsync(4999);
+		expect(pollTimes).toHaveLength(1);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(pollTimes).toHaveLength(2);
+
+		await vi.advanceTimersByTimeAsync(4999);
+		expect(pollTimes).toHaveLength(2);
+
+		await vi.advanceTimersByTimeAsync(1);
+		await expect(loginPromise).resolves.toEqual({
+			access: accessToken,
+			refresh: "refresh-token",
+			expires: startTime.getTime() + 15000 + 3600 * 1000,
+			accountId: "acct_123",
+		});
+
+		expect(pollTimes).toEqual([startTime.getTime() + 5000, startTime.getTime() + 10000, startTime.getTime() + 15000]);
+	});
+
+	it("supports cancellation while waiting to poll", async () => {
+		vi.useFakeTimers();
+		const controller = new AbortController();
+
+		const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+			const url = getUrl(input);
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/usercode") {
+				return jsonResponse({
+					user_code: "ABCD-EFGH",
+					device_auth_id: "device-auth-id",
+					interval: "5",
+				});
+			}
+
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		const loginPromise = openaiCodexOAuthProvider.login({
+			onAuth: () => {},
+			onPrompt: async () => "device",
+			signal: controller.signal,
+		});
+		const rejection = expect(loginPromise).rejects.toThrow("Login cancelled");
+
+		await vi.advanceTimersByTimeAsync(1000);
+		controller.abort();
+		await vi.advanceTimersByTimeAsync(0);
+
+		await rejection;
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("supports base64url JWT payloads in device flow tokens", async () => {
+		vi.useFakeTimers();
+		const accessToken = createAccessToken("acct_-_");
+
+		const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+			const url = getUrl(input);
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/usercode") {
+				return jsonResponse({
+					user_code: "ABCD-EFGH",
+					device_auth_id: "device-auth-id",
+					interval: "1",
+				});
+			}
+
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/token") {
+				return jsonResponse({
+					authorization_code: "device-authorization-code",
+					code_challenge: "device-code-challenge",
+					code_verifier: "device-code-verifier",
+				});
+			}
+
+			if (url === "https://auth.openai.com/oauth/token") {
+				return jsonResponse({
+					access_token: accessToken,
+					refresh_token: "refresh-token",
+					expires_in: 3600,
+				});
+			}
+
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		const loginPromise = loginOpenAICodex({
+			onAuth: () => {},
+			onPrompt: async () => "device",
+		});
+
+		await vi.advanceTimersByTimeAsync(1200);
+
+		await expect(loginPromise).resolves.toMatchObject({
+			accountId: "acct_-_",
+		});
+	});
+
+	it("accepts headless as the device login alias", async () => {
+		vi.useFakeTimers();
+		const accessToken = createAccessToken("acct_headless");
+		const authUrls: Array<{ url: string; instructions?: string }> = [];
+
+		const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+			const url = getUrl(input);
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/usercode") {
+				return jsonResponse({
+					user_code: "WXYZ-1234",
+					device_auth_id: "device-auth-id",
+					interval: "1",
+				});
+			}
+
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/token") {
+				return jsonResponse({
+					authorization_code: "device-authorization-code",
+					code_challenge: "device-code-challenge",
+					code_verifier: "device-code-verifier",
+				});
+			}
+
+			if (url === "https://auth.openai.com/oauth/token") {
+				return jsonResponse({
+					access_token: accessToken,
+					refresh_token: "refresh-headless",
+					expires_in: 3600,
+				});
+			}
+
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		const loginPromise = loginOpenAICodex({
+			onAuth: (info) => authUrls.push(info),
+			onPrompt: async () => "headless",
+		});
+
+		await vi.advanceTimersByTimeAsync(1200);
+
+		await expect(loginPromise).resolves.toMatchObject({
+			accountId: "acct_headless",
+		});
+		expect(authUrls[0]?.url).toBe("https://auth.openai.com/codex/device");
+	});
+
+	it("refreshes the token and preserves accountId extraction", async () => {
+		vi.useFakeTimers();
+		const startTime = new Date("2026-03-25T00:00:00Z");
+		vi.setSystemTime(startTime);
+
+		const accessToken = createAccessToken("acct_456");
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url !== "https://auth.openai.com/oauth/token") {
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			}
+
+			expect(init?.method).toBe("POST");
+			expect(String(init?.body)).toContain("grant_type=refresh_token");
+			expect(String(init?.body)).toContain("refresh_token=refresh-token");
+			return jsonResponse({
+				access_token: accessToken,
+				refresh_token: "refresh-token-2",
+				expires_in: 1800,
+			});
+		});
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(refreshOpenAICodexToken("refresh-token")).resolves.toEqual({
+			access: accessToken,
+			refresh: "refresh-token-2",
+			expires: startTime.getTime() + 1800 * 1000,
+			accountId: "acct_456",
+		});
+	});
+
+	it("uses callback flow when browser login method is selected", async () => {
+		const authUrls: Array<{ url: string; instructions?: string }> = [];
+		const accessToken = createAccessToken("acct_callback");
+
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+
+			if (url === "https://auth.openai.com/oauth/token") {
+				expect(init?.method).toBe("POST");
+				expect(String(init?.body)).toContain("grant_type=authorization_code");
+				expect(String(init?.body)).toContain("code=callback-code");
+				return jsonResponse({
+					access_token: accessToken,
+					refresh_token: "refresh-callback",
+					expires_in: 3600,
+				});
+			}
+
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			loginOpenAICodex({
+				onAuth: (info) => authUrls.push(info),
+				onPrompt: async () => "browser",
+				onManualCodeInput: async () => "callback-code",
+			}),
+		).resolves.toEqual({
+			access: accessToken,
+			refresh: "refresh-callback",
+			expires: expect.any(Number),
+			accountId: "acct_callback",
+		});
+
+		expect(authUrls).toHaveLength(1);
+		expect(authUrls[0]?.url).toContain("https://auth.openai.com/oauth/authorize?");
+	});
+
+	it("falls back to browser callback flow when headless login is blocked", async () => {
+		const authUrls: Array<{ url: string; instructions?: string }> = [];
+		const progressMessages: string[] = [];
+		const accessToken = createAccessToken("acct_callback_fallback");
+
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/usercode") {
+				return new Response("<!DOCTYPE html><title>Just a moment...</title>", {
+					status: 403,
+					headers: { "Content-Type": "text/html; charset=utf-8" },
+				});
+			}
+
+			if (url === "https://auth.openai.com/oauth/token") {
+				expect(init?.method).toBe("POST");
+				expect(String(init?.body)).toContain("grant_type=authorization_code");
+				expect(String(init?.body)).toContain("code=callback-code");
+				return jsonResponse({
+					access_token: accessToken,
+					refresh_token: "refresh-callback",
+					expires_in: 3600,
+				});
+			}
+
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			loginOpenAICodex({
+				onAuth: (info) => authUrls.push(info),
+				onPrompt: async () => "headless",
+				onManualCodeInput: async () => "callback-code",
+				onProgress: (message) => progressMessages.push(message),
+			}),
+		).resolves.toEqual({
+			access: accessToken,
+			refresh: "refresh-callback",
+			expires: expect.any(Number),
+			accountId: "acct_callback_fallback",
+		});
+
+		expect(authUrls).toHaveLength(1);
+		expect(authUrls[0]?.url).toContain("https://auth.openai.com/oauth/authorize?");
+		expect(progressMessages).toContain("Headless login blocked; switching to browser login...");
+	});
+
+	it("supports cancellation while waiting for callback login", async () => {
+		const controller = new AbortController();
+		const fetchMock = vi.fn(async (): Promise<Response> => {
+			throw new Error("Token exchange should not run after abort");
+		});
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		const loginPromise = loginOpenAICodex({
+			onAuth: () => {},
+			onPrompt: async () => {
+				await new Promise(() => {});
+				return "";
+			},
+			onManualCodeInput: async () => {
+				await new Promise(() => {});
+				return "";
+			},
+			signal: controller.signal,
+		});
+
+		controller.abort();
+
+		await expect(loginPromise).rejects.toThrow("Login cancelled");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects invalid login method from prompt", async () => {
+		await expect(
+			loginOpenAICodex({
+				onAuth: () => {},
+				onPrompt: async () => "bad-method",
+			}),
+		).rejects.toThrow("Invalid login method: bad-method. Expected headless or browser.");
+	});
+});

--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -1,9 +1,28 @@
 import { getOAuthProviders } from "@mariozechner/pi-ai/oauth";
-import { Container, type Focusable, getKeybindings, Input, Spacer, Text, type TUI } from "@mariozechner/pi-tui";
+import {
+	Container,
+	type Focusable,
+	getKeybindings,
+	Input,
+	type SelectItem,
+	SelectList,
+	type SelectListTheme,
+	Spacer,
+	Text,
+	type TUI,
+} from "@mariozechner/pi-tui";
 import { exec } from "child_process";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
+
+const loginSelectListTheme: SelectListTheme = {
+	selectedPrefix: (text) => theme.fg("accent", text),
+	selectedText: (text) => theme.fg("accent", text),
+	description: (text) => theme.fg("dim", text),
+	scrollInfo: (text) => theme.fg("dim", text),
+	noMatch: (text) => theme.fg("dim", text),
+};
 
 /**
  * Login dialog component - replaces editor during OAuth login flow
@@ -15,6 +34,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	private abortController = new AbortController();
 	private inputResolver?: (value: string) => void;
 	private inputRejecter?: (error: Error) => void;
+	private selectList?: SelectList;
 
 	// Focusable implementation - propagate to input for IME cursor positioning
 	private _focused = false;
@@ -147,6 +167,50 @@ export class LoginDialogComponent extends Container implements Focusable {
 	}
 
 	/**
+	 * Show options for arrow-key navigation selection (e.g., headless vs browser auth)
+	 */
+	showOptions<T extends string>(
+		message: string,
+		options: { label: string; value: T; description?: string }[],
+	): Promise<T> {
+		this.contentContainer.addChild(new Spacer(1));
+		this.contentContainer.addChild(new Text(theme.fg("text", message), 1, 0));
+
+		// Create SelectList for arrow navigation
+		const items: SelectItem[] = options.map((opt) => ({
+			value: opt.value,
+			label: opt.label,
+			description: opt.description,
+		}));
+
+		this.selectList = new SelectList(items, 5, loginSelectListTheme);
+
+		// Add a simple rendering wrapper for SelectList
+		this.contentContainer.addChild({
+			render: (width: number) => this.selectList!.render(width),
+			invalidate: () => {},
+		});
+		this.contentContainer.addChild(
+			new Text(
+				`(${keyHint("tui.select.up", "↑↓ navigate,")} ${keyHint("tui.select.confirm", "select")}, ${keyHint("tui.select.cancel", "cancel")})`,
+				1,
+				0,
+			),
+		);
+
+		this.tui.requestRender();
+
+		return new Promise((resolve, reject) => {
+			this.selectList!.onSelect = (item) => {
+				resolve(item.value as T);
+			};
+			this.selectList!.onCancel = () => {
+				reject(new Error("Login cancelled"));
+			};
+		});
+	}
+
+	/**
 	 * Show waiting message (for polling flows like GitHub Copilot)
 	 */
 	showWaiting(message: string): void {
@@ -172,7 +236,10 @@ export class LoginDialogComponent extends Container implements Focusable {
 			return;
 		}
 
-		// Pass to input
-		this.input.handleInput(data);
+		if (this.selectList) {
+			this.selectList.handleInput(data);
+		} else {
+			this.input.handleInput(data);
+		}
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -126,6 +126,11 @@ type CompactionQueuedMessage = {
 	mode: "steer" | "followUp";
 };
 
+export function normalizeOpenAICodexAuthFlowSelection(value: string): "device" | "callback" {
+	const normalized = value.trim().toLowerCase();
+	return normalized === "browser" || normalized === "callback" ? "callback" : "device";
+}
+
 /**
  * Options for InteractiveMode initialization.
  */
@@ -3839,8 +3844,8 @@ export class InteractiveMode {
 		const providerInfo = this.session.modelRegistry.authStorage.getOAuthProviders().find((p) => p.id === providerId);
 		const providerName = providerInfo?.name || providerId;
 
-		// Providers that use callback servers (can paste redirect URL)
-		const usesCallbackServer = providerInfo?.usesCallbackServer ?? false;
+		const authFlow = providerInfo?.authFlow ?? (providerInfo?.usesCallbackServer ? "callback" : "device");
+		let selectedAuthFlow: "device" | "callback" | undefined = authFlow === "mixed" ? undefined : authFlow;
 
 		// Create login dialog component
 		const dialog = new LoginDialogComponent(this.ui, providerId, (_success, _message) => {
@@ -3874,7 +3879,9 @@ export class InteractiveMode {
 				onAuth: (info: { url: string; instructions?: string }) => {
 					dialog.showAuth(info.url, info.instructions);
 
-					if (usesCallbackServer) {
+					const resolvedAuthFlow = authFlow === "mixed" ? selectedAuthFlow : authFlow;
+
+					if (resolvedAuthFlow === "callback") {
 						// Show input for manual paste, racing with callback
 						dialog
 							.showManualInput("Paste redirect URL below, or complete login in browser:")
@@ -3898,6 +3905,26 @@ export class InteractiveMode {
 				},
 
 				onPrompt: async (prompt: { message: string; placeholder?: string }) => {
+					if (authFlow === "mixed" && prompt.message === "Login method for ChatGPT/Codex (headless/browser)") {
+						// Use arrow-key navigation for auth flow selection
+						const response = await dialog.showOptions<"headless" | "browser">(
+							"Select login method for ChatGPT/Codex:",
+							[
+								{
+									label: "Headless",
+									value: "headless",
+									description: "Device code flow - enter code in browser",
+								},
+								{
+									label: "Browser",
+									value: "browser",
+									description: "OAuth callback - automatic browser login",
+								},
+							],
+						);
+						selectedAuthFlow = normalizeOpenAICodexAuthFlowSelection(response);
+						return response;
+					}
 					return dialog.showPrompt(prompt.message, prompt.placeholder);
 				},
 

--- a/packages/coding-agent/test/interactive-mode-oauth.test.ts
+++ b/packages/coding-agent/test/interactive-mode-oauth.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { normalizeOpenAICodexAuthFlowSelection } from "../src/modes/interactive/interactive-mode.js";
+
+describe("normalizeOpenAICodexAuthFlowSelection", () => {
+	it("maps headless and device to device flow", () => {
+		expect(normalizeOpenAICodexAuthFlowSelection("headless")).toBe("device");
+		expect(normalizeOpenAICodexAuthFlowSelection("device")).toBe("device");
+	});
+
+	it("maps browser and callback to callback flow", () => {
+		expect(normalizeOpenAICodexAuthFlowSelection("browser")).toBe("callback");
+		expect(normalizeOpenAICodexAuthFlowSelection("callback")).toBe("callback");
+	});
+});


### PR DESCRIPTION
Enables headless authentication on Termux and similar environments by prompting users to choose between device flow and browser callback when both are available.

- Added authFlow field to OAuth provider interface
- OpenAI Codex uses 'mixed' flow for user selection
- Added showOptions() for arrow-key selection UI in login dialog

Fixes #2635