### PR TITLE
fix(coding-agent): prevent compact() deadlock when called from tool execution

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1625,7 +1625,15 @@ export class AgentSession {
 	 */
 	async compact(customInstructions?: string): Promise<CompactionResult> {
 		this._disconnectFromAgent();
-		await this.abort();
+		const hasPendingToolCalls = this.agent.state.pendingToolCalls.size > 0;
+		if (hasPendingToolCalls) {
+			this.abortRetry();
+			// Avoid waiting for idle when compact() is called from a running tool.
+			// The run loop is blocked on that tool, so waitForIdle() would deadlock.
+			this.agent.abort();
+		} else {
+			await this.abort();
+		}
 		this._compactionAbortController = new AbortController();
 
 		try {

--- a/packages/coding-agent/test/agent-session-compaction-deadlock.test.ts
+++ b/packages/coding-agent/test/agent-session-compaction-deadlock.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression test: compact() called from inside a tool must not deadlock.
+ *
+ * Before the fix, AgentSession.compact() called `await this.abort()` which
+ * called `waitForIdle()`. But `waitForIdle()` waits for the agent loop to
+ * finish, and the agent loop is blocked waiting for the tool that called
+ * compact() — circular deadlock.
+ */
+
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./test-harness.js";
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timeout = setTimeout(() => reject(new Error(message)), ms);
+		void promise.then(
+			(value) => {
+				clearTimeout(timeout);
+				resolve(value);
+			},
+			(error: unknown) => {
+				clearTimeout(timeout);
+				reject(error);
+			},
+		);
+	});
+}
+
+describe("AgentSession compact deadlock regression", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+	});
+
+	it("should not deadlock when compact() is called during tool execution", async () => {
+		let resolveToolStarted!: () => void;
+		const toolStarted = new Promise<void>((resolve) => {
+			resolveToolStarted = resolve;
+		});
+
+		let resolveCompactionFinished!: () => void;
+		const compactionFinished = new Promise<void>((resolve) => {
+			resolveCompactionFinished = resolve;
+		});
+
+		let compactedDuringTool = false;
+		let session = null as Harness["session"] | null;
+
+		const compactTool: AgentTool = {
+			name: "compact_self",
+			description: "Trigger session compaction",
+			label: "compact_self",
+			parameters: Type.Object({}),
+			execute: async () => {
+				if (!session) {
+					throw new Error("Session not initialized");
+				}
+
+				// Inject a fake extension runner that provides compaction content
+				// so we don't need a real LLM call for the summarization step.
+				const sessionWithRunner = session as unknown as {
+					_extensionRunner?: {
+						hasHandlers: (eventType: string) => boolean;
+						emit: (event: {
+							type: string;
+							preparation?: { firstKeptEntryId: string; tokensBefore: number };
+						}) => Promise<unknown>;
+					};
+				};
+				sessionWithRunner._extensionRunner = {
+					hasHandlers: (eventType: string) => eventType === "session_before_compact",
+					emit: async (event: {
+						type: string;
+						preparation?: { firstKeptEntryId: string; tokensBefore: number };
+					}) => {
+						if (event.type === "session_before_compact" && event.preparation) {
+							return {
+								compaction: {
+									summary: "summary from test extension",
+									firstKeptEntryId: event.preparation.firstKeptEntryId,
+									tokensBefore: event.preparation.tokensBefore,
+								},
+							};
+						}
+						return undefined;
+					},
+				};
+
+				resolveToolStarted();
+				await session.compact();
+				compactedDuringTool = true;
+				resolveCompactionFinished();
+
+				return {
+					content: [{ type: "text" as const, text: "tool finished" }],
+					details: {},
+				};
+			},
+		};
+
+		harness = createHarness({
+			responses: [
+				"first response",
+				"second response",
+				{
+					text: "calling compact tool",
+					toolCalls: [{ id: "compact-call-1", name: "compact_self", args: {} }],
+				},
+				"done after compaction",
+			],
+			tools: [compactTool],
+			baseToolsOverride: { compact_self: compactTool },
+			settings: {
+				compaction: {
+					keepRecentTokens: 1,
+				},
+			},
+		});
+		session = harness.session;
+
+		// Build up enough conversation history for compaction to work
+		await session.prompt("first prompt");
+		await session.agent.waitForIdle();
+
+		await session.prompt("second prompt");
+		await session.agent.waitForIdle();
+
+		// This prompt triggers the tool call which calls compact() from inside execute()
+		const promptPromise = session.prompt("trigger compaction tool");
+
+		// All of these should resolve quickly. If any times out, the deadlock is present.
+		await expect(withTimeout(toolStarted, 5000, "tool execution did not start")).resolves.toBeUndefined();
+		await expect(
+			withTimeout(compactionFinished, 5000, "compact() deadlocked during tool execution"),
+		).resolves.toBeUndefined();
+		await expect(withTimeout(promptPromise, 5000, "prompt did not settle after compaction")).resolves.toBeUndefined();
+		await expect(
+			withTimeout(session.agent.waitForIdle(), 5000, "agent did not become idle"),
+		).resolves.toBeUndefined();
+
+		expect(compactedDuringTool).toBe(true);
+		expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Problem

`ctx.compact()` deadlocks when called from within a tool's `execute()` function. Neither `onComplete` nor `onError` callbacks ever fire — the agent shows "Working..." forever.

### Root cause

`AgentSession.compact()` calls `await this.abort()` which calls `await this.agent.waitForIdle()`. But `waitForIdle()` waits for `runningPrompt` to resolve, which only happens when the agent loop finishes. The agent loop is stuck at `await tool.execute()` — the very tool that called `compact()`. Circular deadlock.

```
agent._runLoop() → await tool.execute() → tool Promise (waiting for callbacks)
    ↓ (tool calls ctx.compact())
    ctx.compact wrapper fires async IIFE → this.compact()
    → await this.abort()
    → await this.agent.waitForIdle()  ← waits for runningPrompt
    → runningPrompt waits for _runLoop  ← waits for tool.execute()
    CIRCULAR DEADLOCK
```

## Fix

Check `pendingToolCalls` before aborting. When tools are executing, signal abort without waiting for idle:

```typescript
const hasPendingToolCalls = this.agent.state.pendingToolCalls.size > 0;
if (hasPendingToolCalls) {
    this.abortRetry();
    this.agent.abort();  // Signal only, don't wait
} else {
    await this.abort();  // Existing behavior
}
```

Normal compaction paths (manual `/compact`, auto-compaction, extension event handlers) are unaffected — they run when no tools are pending.

## Test

Added `agent-session-compaction-deadlock.test.ts` that triggers `session.compact()` from inside a tool execution and uses timeouts to detect the deadlock. Without the fix, the test hangs; with the fix, it completes in ~11ms.

## Verification

- New deadlock regression test: ✅ passes
- Full test suite: 827 passed, 47 skipped, 1 pre-existing failure (unrelated `dark.json` ENOENT)
- `biome check` + `tsgo --noEmit`: ✅ passes