### PR TITLE
fix(coding-agent): wait for in-flight prompts before RPC shutdown

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -588,6 +588,16 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 	let detachInput = () => {};
 
 	async function shutdown(): Promise<never> {
+		// Wait for any in-flight prompt to complete before exiting.
+		// Without this, stdin EOF races with prompt execution — the process
+		// exits before the LLM call completes (0 tokens, silent failure).
+		// See: https://github.com/badlogic/pi-mono/issues/2645
+		try {
+			await session.agent.waitForIdle();
+		} catch {
+			// Best-effort: proceed with shutdown even if waitForIdle rejects
+		}
+
 		const currentRunner = session.extensionRunner;
 		if (currentRunner?.hasHandlers("session_shutdown")) {
 			await currentRunner.emit({ type: "session_shutdown" });


### PR DESCRIPTION
## Problem

RPC mode exits immediately on stdin EOF without waiting for in-flight prompts. Any consumer that pipes a prompt then closes stdin gets 0 tokens and an empty response (exit code 0 — looks like success).

Closes #2645

## Root cause

`shutdown()` calls `process.exit(0)` immediately. The `prompt` command handler fires `session.prompt()` without awaiting it and returns `success` immediately. When stdin EOF fires before the LLM call completes, the process exits mid-flight.

## Fix

Add `await session.agent.waitForIdle()` at the top of `shutdown()`. This method already exists and tracks `runningPrompt` — it resolves when the agent loop finishes (including tool execution and event flushing).

Wrapped in try/catch so a rejected promise does not prevent shutdown.

## Repro

```bash
# Broken (0 tokens, empty response)
echo '{"type":"prompt","message":"say hello"}' | pi --mode rpc --provider anthropic --model claude-sonnet-4-5

# Works (stdin stays open)
(echo '{"type":"prompt","message":"say hello"}'; sleep 30) | pi --mode rpc --provider anthropic --model claude-sonnet-4-5
```

## Testing

- `npm run check` passes
- Existing RPC tests pass (they use SIGTERM via `RpcClient.stop()`, not stdin EOF)
- Manual verification: with the fix applied, the piped command produces a full response with tokens before exiting

## Related

- #2646 — `compact()` deadlock from tool execution (same `waitForIdle()` pattern causing issues within agent lifecycle)