### PR TITLE
feat(ai): surface granular cache_creation breakdown from Anthropic API

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -271,6 +271,16 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					output.usage.output = event.message.usage.output_tokens || 0;
 					output.usage.cacheRead = event.message.usage.cache_read_input_tokens || 0;
 					output.usage.cacheWrite = event.message.usage.cache_creation_input_tokens || 0;
+					// Extract granular cache write breakdown by TTL when present
+					const cacheCreation = (event.message.usage as unknown as Record<string, unknown>).cache_creation as
+						| { ephemeral_5m_input_tokens?: number; ephemeral_1h_input_tokens?: number }
+						| undefined;
+					if (cacheCreation) {
+						output.usage.cacheCreation = {
+							ephemeral5mTokens: cacheCreation.ephemeral_5m_input_tokens || 0,
+							ephemeral1hTokens: cacheCreation.ephemeral_1h_input_tokens || 0,
+						};
+					}
 					// Anthropic doesn't provide total_tokens, compute from components
 					output.usage.totalTokens =
 						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
@@ -410,6 +420,16 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					}
 					if (event.usage.cache_creation_input_tokens != null) {
 						output.usage.cacheWrite = event.usage.cache_creation_input_tokens;
+					}
+					// Extract granular cache write breakdown by TTL when present
+					const deltaCreation = (event.usage as unknown as Record<string, unknown>).cache_creation as
+						| { ephemeral_5m_input_tokens?: number; ephemeral_1h_input_tokens?: number }
+						| undefined;
+					if (deltaCreation) {
+						output.usage.cacheCreation = {
+							ephemeral5mTokens: deltaCreation.ephemeral_5m_input_tokens || 0,
+							ephemeral1hTokens: deltaCreation.ephemeral_1h_input_tokens || 0,
+						};
 					}
 					// Anthropic doesn't provide total_tokens, compute from components
 					output.usage.totalTokens =

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -177,6 +177,16 @@ export interface Usage {
 		cacheWrite: number;
 		total: number;
 	};
+	/** Granular cache write breakdown by TTL (Anthropic only).
+	 *  Present when the API returns the `cache_creation` object with
+	 *  per-TTL token counts. Undefined for non-Anthropic providers or
+	 *  when no cache writes occurred. */
+	cacheCreation?: {
+		/** Tokens written to the 5-minute ephemeral cache. */
+		ephemeral5mTokens: number;
+		/** Tokens written to the 1-hour ephemeral cache. */
+		ephemeral1hTokens: number;
+	};
 }
 
 export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";

--- a/packages/ai/test/anthropic-cache-creation-breakdown.test.ts
+++ b/packages/ai/test/anthropic-cache-creation-breakdown.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Test that the Anthropic provider extracts granular cache_creation
+ * breakdown (ephemeral_5m_input_tokens, ephemeral_1h_input_tokens)
+ * from API responses into Usage.cacheCreation.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.js";
+import type { Context } from "../src/types.js";
+
+// --- Mock: message_start includes cache_creation breakdown ---
+vi.mock("@anthropic-ai/sdk", () => {
+	const fakeStream = {
+		async *[Symbol.asyncIterator]() {
+			yield {
+				type: "message_start",
+				message: {
+					id: "msg_test_cache_creation",
+					usage: {
+						input_tokens: 50,
+						output_tokens: 0,
+						cache_read_input_tokens: 8000,
+						cache_creation_input_tokens: 1500,
+						// Granular breakdown by TTL
+						cache_creation: {
+							ephemeral_5m_input_tokens: 1000,
+							ephemeral_1h_input_tokens: 500,
+						},
+					},
+				},
+			};
+			yield {
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "text", text: "" },
+			};
+			yield {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "Hello" },
+			};
+			yield {
+				type: "content_block_stop",
+				index: 0,
+			};
+			yield {
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: {
+					output_tokens: 3,
+					cache_creation_input_tokens: 1500,
+					// Granular breakdown repeated in message_delta
+					cache_creation: {
+						ephemeral_5m_input_tokens: 1000,
+						ephemeral_1h_input_tokens: 500,
+					},
+				},
+			};
+		},
+		finalMessage: async () => ({
+			usage: {
+				input_tokens: 50,
+				output_tokens: 3,
+				cache_creation_input_tokens: 1500,
+				cache_read_input_tokens: 8000,
+			},
+		}),
+	};
+
+	class FakeAnthropic {
+		messages = {
+			stream: () => fakeStream,
+		};
+	}
+
+	return { default: FakeAnthropic };
+});
+
+describe("Anthropic cache_creation breakdown", () => {
+	const context: Context = {
+		systemPrompt: "You are a helpful assistant.",
+		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+	};
+
+	it("extracts ephemeral_5m and ephemeral_1h token counts into cacheCreation", async () => {
+		const model = getModel("anthropic", "claude-sonnet-4-5-20250929");
+		const { streamAnthropic } = await import("../src/providers/anthropic.js");
+		const stream = streamAnthropic(model, context, { apiKey: "test-key" });
+
+		let finalUsage: import("../src/types.js").Usage | undefined;
+		for await (const event of stream) {
+			if (event.type === "done") {
+				finalUsage = event.message.usage;
+			}
+		}
+
+		expect(finalUsage).toBeDefined();
+		// Aggregate fields preserved
+		expect(finalUsage!.cacheRead).toBe(8000);
+		expect(finalUsage!.cacheWrite).toBe(1500);
+
+		// Granular breakdown present
+		expect(finalUsage!.cacheCreation).toBeDefined();
+		expect(finalUsage!.cacheCreation!.ephemeral5mTokens).toBe(1000);
+		expect(finalUsage!.cacheCreation!.ephemeral1hTokens).toBe(500);
+	});
+
+	it("cacheCreation sums to cacheWrite", async () => {
+		const model = getModel("anthropic", "claude-sonnet-4-5-20250929");
+		const { streamAnthropic } = await import("../src/providers/anthropic.js");
+		const stream = streamAnthropic(model, context, { apiKey: "test-key" });
+
+		let finalUsage: import("../src/types.js").Usage | undefined;
+		for await (const event of stream) {
+			if (event.type === "done") {
+				finalUsage = event.message.usage;
+			}
+		}
+
+		expect(finalUsage).toBeDefined();
+		const breakdown = finalUsage!.cacheCreation!;
+		expect(breakdown.ephemeral5mTokens + breakdown.ephemeral1hTokens).toBe(finalUsage!.cacheWrite);
+	});
+});
+
+describe("Usage type contract", () => {
+	it("cacheCreation is optional and defaults to undefined", () => {
+		// Verify the type allows omission (non-Anthropic providers never set it)
+		const usage: import("../src/types.js").Usage = {
+			input: 100,
+			output: 50,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 150,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		expect(usage.cacheCreation).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Closes #2656

## Summary

- Add optional `cacheCreation` field to `Usage` type with `ephemeral5mTokens` and `ephemeral1hTokens`
- Extract `cache_creation.ephemeral_5m_input_tokens` and `cache_creation.ephemeral_1h_input_tokens` from Anthropic API responses in both `message_start` and `message_delta` handlers
- Fully backward compatible: existing `cacheWrite` aggregate field unchanged; `cacheCreation` is optional and undefined for non-Anthropic providers

## Motivation

When using mixed TTLs (5-minute and 1-hour cache), the Anthropic API returns a granular breakdown of cache write tokens by tier in `usage.cache_creation`. The SDK currently collapses this into a single `cacheWrite` number, losing the ability to attribute costs between tiers (1.25x base for 5m writes vs 2x base for 1h writes).

## Changes

| File | Change |
|------|--------|
| `packages/ai/src/types.ts` | Add optional `cacheCreation` to `Usage` interface |
| `packages/ai/src/providers/anthropic.ts` | Extract `cache_creation` sub-fields in `message_start` and `message_delta` handlers |
| `packages/ai/test/anthropic-cache-creation-breakdown.test.ts` | 3 new tests: extraction, sum consistency, type contract |

## Test plan

- [x] New test: extracts ephemeral_5m and ephemeral_1h token counts from mock Anthropic stream
- [x] New test: cacheCreation sub-fields sum to cacheWrite aggregate
- [x] New test: cacheCreation is optional (undefined when not set)
- [x] Existing tests pass: `github-copilot-anthropic.test.ts`, `empty.test.ts`