### PR TITLE
feat(coding-agent): expose abort signal on ExtensionContext

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -371,6 +371,11 @@ export class Agent {
 		this._state.messages = [];
 	}
 
+	/** The current abort signal, or undefined when the agent is not streaming. */
+	get signal(): AbortSignal | undefined {
+		return this.abortController?.signal;
+	}
+
 	abort() {
 		this.abortController?.abort();
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2219,6 +2219,7 @@ export class AgentSession {
 			{
 				getModel: () => this.model,
 				isIdle: () => !this.isStreaming,
+				getSignal: () => this.agent.signal,
 				abort: () => this.abort(),
 				hasPendingMessages: () => this.pendingMessageCount > 0,
 				shutdown: () => {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -208,6 +208,7 @@ export class ExtensionRunner {
 	private errorListeners: Set<ExtensionErrorListener> = new Set();
 	private getModel: () => Model<any> | undefined = () => undefined;
 	private isIdleFn: () => boolean = () => true;
+	private getSignalFn: () => AbortSignal | undefined = () => undefined;
 	private waitForIdleFn: () => Promise<void> = async () => {};
 	private abortFn: () => void = () => {};
 	private hasPendingMessagesFn: () => boolean = () => false;
@@ -265,6 +266,7 @@ export class ExtensionRunner {
 		// Context actions (required)
 		this.getModel = contextActions.getModel;
 		this.isIdleFn = contextActions.isIdle;
+		this.getSignalFn = contextActions.getSignal;
 		this.abortFn = contextActions.abort;
 		this.hasPendingMessagesFn = contextActions.hasPendingMessages;
 		this.shutdownHandler = contextActions.shutdown;
@@ -541,6 +543,7 @@ export class ExtensionRunner {
 				return getModel();
 			},
 			isIdle: () => this.isIdleFn(),
+			signal: this.getSignalFn(),
 			abort: () => this.abortFn(),
 			hasPendingMessages: () => this.hasPendingMessagesFn(),
 			shutdown: () => this.shutdownHandler(),

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -274,6 +274,8 @@ export interface ExtensionContext {
 	model: Model<any> | undefined;
 	/** Whether the agent is idle (not streaming) */
 	isIdle(): boolean;
+	/** The current abort signal, or undefined when the agent is not streaming. */
+	signal: AbortSignal | undefined;
 	/** Abort the current agent operation */
 	abort(): void;
 	/** Whether there are queued messages waiting */
@@ -1391,6 +1393,7 @@ export interface ExtensionActions {
 export interface ExtensionContextActions {
 	getModel: () => Model<any> | undefined;
 	isIdle: () => boolean;
+	getSignal: () => AbortSignal | undefined;
 	abort: () => void;
 	hasPendingMessages: () => boolean;
 	shutdown: () => void;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1280,6 +1280,7 @@ export class InteractiveMode {
 			modelRegistry: this.session.modelRegistry,
 			model: this.session.model,
 			isIdle: () => !this.session.isStreaming,
+			signal: this.session.agent.signal,
 			abort: () => this.session.abort(),
 			hasPendingMessages: () => this.session.pendingMessageCount > 0,
 			shutdown: () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -71,6 +71,7 @@ describe("ExtensionRunner", () => {
 	const extensionContextActions: ExtensionContextActions = {
 		getModel: () => undefined,
 		isIdle: () => true,
+		getSignal: () => undefined,
 		abort: () => {},
 		hasPendingMessages: () => false,
 		shutdown: () => {},

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -11,6 +11,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		modelRegistry: {} as ExtensionContext["modelRegistry"],
 		model: undefined,
 		isIdle: () => true,
+		signal: undefined,
 		abort: vi.fn(),
 		hasPendingMessages: () => false,
 		shutdown: vi.fn(),


### PR DESCRIPTION
## Problem

Extension event handlers (e.g. `tool_result`) can perform model calls — for example, to
summarise or transform tool output before it reaches the LLM context window. These calls
are long-running and blocking: once started, pressing Esc has no effect on them because
the underlying `fetch` never receives an abort signal.

The root cause is that `ExtensionContext`, which is passed to every event handler and tool
executor, had no way to surface the agent's current `AbortSignal`. The signal existed inside
`Agent.abortController` but was never threaded through to extensions.

## What this PR does

Adds `signal: AbortSignal | undefined` to `ExtensionContext`. The value is the agent's
active abort signal while a turn is in progress, and `undefined` when the agent is idle.

Extensions that perform async work (model calls, network requests, file I/O) can now pass
this signal to their operations and get correct cancellation behaviour when the user aborts.

### Changed files

| File | Change |
|------|--------|
| `packages/agent/src/agent.ts` | Add public `signal` getter on `Agent` |
| `packages/coding-agent/src/core/extensions/types.ts` | Add `signal` to `ExtensionContext`; add `getSignal` to `ExtensionContextActions` |
| `packages/coding-agent/src/core/extensions/runner.ts` | Store `getSignalFn`, wire it in `bindCore`, expose it in `createContext` |
| `packages/coding-agent/src/core/agent-session.ts` | Pass `getSignal: () => this.agent.signal` when binding the runner |
| `packages/coding-agent/src/modes/interactive/interactive-mode.ts` | Populate `signal` in the manually constructed shortcut-handler context |
| `packages/coding-agent/test/extensions-runner.test.ts` | Add `getSignal: () => undefined` to test stub |
| `packages/coding-agent/test/trigger-compact-extension.test.ts` | Add `signal: undefined` to test context fixture |

## Usage

```typescript
pi.on("tool_result", async (event, ctx) => {
    const summary = await myModelCall(event.content, { signal: ctx.signal });
    // If the user presses Esc, ctx.signal is aborted, myModelCall cancels immediately.
});
```

## When is `signal` defined vs. `undefined`?

`tool_result` (and all other event handlers) are invoked from inside `runAgentLoop`, which
runs between `abortController = new AbortController()` and `abortController = undefined`.
So during any event handler triggered by an active turn, `signal` is always a live
`AbortSignal`. It is `undefined` only in contexts that run outside a turn (e.g. shortcut
handlers that fire while the agent is idle).

## No breaking changes

`signal` is added as a new required field on `ExtensionContext`. Existing manually
constructed context objects (tests, SDK users) need to add `signal: undefined` (or a real
signal). The type change is minimal and the compiler will surface any missed sites.
