### PR TITLE
docs(coding-agent): clarify sandbox example alternative to bash override

### DIFF
--- a/packages/coding-agent/examples/extensions/sandbox/index.ts
+++ b/packages/coding-agent/examples/extensions/sandbox/index.ts
@@ -5,6 +5,10 @@
  * restrictions on bash commands at the OS level (sandbox-exec on macOS,
  * bubblewrap on Linux).
  *
+ * Note: this example intentionally overrides the built-in `bash` tool to show
+ * how built-in tools can be replaced. Alternatively, you could sandbox `bash`
+ * via `tool_call` input mutation without replacing the tool.
+ *
  * Config files (merged, project takes precedence):
  * - ~/.pi/agent/sandbox.json (global)
  * - <cwd>/.pi/sandbox.json (project-local)


### PR DESCRIPTION
After https://github.com/badlogic/pi-mono/commit/7fe70817452c8d03c1620656e84e85029426e8de, noting in the docstring of sandbox/index.ts that while this example intentionally overrides `bash`, `tool_call` input mutation is another option for folks who might adapt this example and use that alongside renderer-only bash override extensions (like this charming one: https://github.com/MasuRii/pi-tool-display).