### PR TITLE
fix(coding-agent): embed WSL clipboard path in PowerShell script

### DIFF
--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -172,17 +172,18 @@ function readClipboardImageViaPowerShell(): ClipboardImage | null {
 			return null;
 		}
 
+		const psQuotedWinPath = winPath.replaceAll("'", "''");
+
 		const psScript = [
 			"Add-Type -AssemblyName System.Windows.Forms",
 			"Add-Type -AssemblyName System.Drawing",
-			"$path = $env:PI_WSL_CLIPBOARD_IMAGE_PATH",
+			`$path = '${psQuotedWinPath}'`,
 			"$img = [System.Windows.Forms.Clipboard]::GetImage()",
 			"if ($img) { $img.Save($path, [System.Drawing.Imaging.ImageFormat]::Png); Write-Output 'ok' } else { Write-Output 'empty' }",
 		].join("; ");
 
 		const result = runCommand("powershell.exe", ["-NoProfile", "-Command", psScript], {
 			timeoutMs: DEFAULT_POWERSHELL_TIMEOUT_MS,
-			env: { ...process.env, PI_WSL_CLIPBOARD_IMAGE_PATH: winPath },
 		});
 		if (!result.ok) {
 			return null;


### PR DESCRIPTION
## Summary
Fixes #2469

## Changes
- embed the resolved Windows path directly in the PowerShell script instead of relying on PI_WSL_CLIPBOARD_IMAGE_PATH