### PR TITLE
fix(tui): avoid redraw on large edit output

### DIFF
--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -122,28 +122,6 @@ function getRenderablePreviewInput(args: RenderableEditArgs | undefined): { path
 	return null;
 }
 
-function formatEditCall(
-	args: RenderableEditArgs | undefined,
-	state: EditRenderState,
-	theme: typeof import("../../modes/interactive/theme/theme.js").theme,
-): string {
-	const invalidArg = invalidArgText(theme);
-	const rawPath = str(args?.file_path ?? args?.path);
-	const path = rawPath !== null ? shortenPath(rawPath) : null;
-	const pathDisplay = path === null ? invalidArg : path ? theme.fg("accent", path) : theme.fg("toolOutput", "...");
-	let text = `${theme.fg("toolTitle", theme.bold("edit"))} ${pathDisplay}`;
-
-	if (state.preview) {
-		if ("error" in state.preview) {
-			text += `\n\n${theme.fg("error", state.preview.error)}`;
-		} else if (state.preview.diff) {
-			text += `\n\n${renderDiff(state.preview.diff, { filePath: rawPath ?? undefined })}`;
-		}
-	}
-
-	return text;
-}
-
 function formatEditResult(
 	args: RenderableEditArgs | undefined,
 	state: EditRenderState,
@@ -322,17 +300,40 @@ export function createEditToolDefinition(
 					}
 				}
 			}
-			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-			text.setText(formatEditCall(args, context.state, theme));
-			return text;
+
+			const container = (context.lastComponent as Container | undefined) ?? new Container();
+			let header = container.children[0] as Text | undefined;
+			let diffText = container.children[1] as Text | undefined;
+			if (!header) {
+				header = new Text("", 0, 0);
+				container.addChild(header);
+			}
+			if (!diffText) {
+				diffText = new Text("", 0, 0);
+				container.addChild(diffText);
+			}
+
+			const invalidArg = invalidArgText(theme);
+			const renderArgs = args as RenderableEditArgs | undefined;
+			const rawPath = str(renderArgs?.file_path ?? renderArgs?.path);
+			const path = rawPath !== null ? shortenPath(rawPath) : null;
+			const pathDisplay = path === null ? invalidArg : path ? theme.fg("accent", path) : theme.fg("toolOutput", "...");
+			header.setText(`${theme.fg("toolTitle", theme.bold("edit"))} ${pathDisplay}`);
+
+			let diffOutput = "";
+			if (context.state.preview) {
+				if ("error" in context.state.preview) {
+					diffOutput = `\n\n${theme.fg("error", context.state.preview.error)}`;
+				} else if (context.state.preview.diff) {
+					diffOutput = `\n\n${renderDiff(context.state.preview.diff, { filePath: rawPath ?? undefined })}`;
+				}
+			}
+			diffText.setText(diffOutput);
+
+			return container;
 		},
 		renderResult(result, _options, theme, context) {
-			const output = formatEditResult(context.args, context.state, result as any, theme, context.isError);
-			if (!output) {
-				const component = (context.lastComponent as Container | undefined) ?? new Container();
-				component.clear();
-				return component;
-			}
+			const output = formatEditResult(context.args, context.state, result as any, theme, context.isError) ?? "";
 			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
 			text.setText(output);
 			return text;

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -10,8 +10,12 @@ export interface ToolExecutionOptions {
 }
 
 export class ToolExecutionComponent extends Container {
-	private contentBox: Box;
+	private callBox: Box;
+	private resultBox: Box;
 	private contentText: Text;
+	private resultBoxAttached = false;
+	private resultBgFn?: (text: string) => string;
+	private contentBgFn?: (text: string) => string;
 	private callRendererComponent?: Component;
 	private resultRendererComponent?: Component;
 	private rendererState: any = {};
@@ -58,13 +62,14 @@ export class ToolExecutionComponent extends Container {
 
 		this.addChild(new Spacer(1));
 
-		// Always create both. contentBox is used for tools with renderer-based call/result composition.
+		// Always create both. callBox/resultBox are used for tools with renderer-based call/result composition.
 		// contentText is reserved for generic fallback rendering when no tool definition exists.
-		this.contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		this.callBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		this.resultBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
 		this.contentText = new Text("", 1, 1, (text: string) => theme.bg("toolPendingBg", text));
 
 		if (this.hasRendererDefinition()) {
-			this.addChild(this.contentBox);
+			this.addChild(this.callBox);
 		} else {
 			this.addChild(this.contentText);
 		}
@@ -204,9 +209,22 @@ export class ToolExecutionComponent extends Container {
 		return super.render(width);
 	}
 
+	private setBoxContent(box: Box, component: Component | undefined): void {
+		if (!component) {
+			box.clear();
+			return;
+		}
+		if (box.children.length === 1 && box.children[0] === component) {
+			return;
+		}
+		box.clear();
+		box.addChild(component);
+	}
+
 	private updateDisplay(): void {
-		const bgFn = this.isPartial
-			? (text: string) => theme.bg("toolPendingBg", text)
+		const pendingBgFn = (text: string) => theme.bg("toolPendingBg", text);
+		const resultBgFn = this.isPartial
+			? pendingBgFn
 			: this.result?.isError
 				? (text: string) => theme.bg("toolErrorBg", text)
 				: (text: string) => theme.bg("toolSuccessBg", text);
@@ -214,57 +232,65 @@ export class ToolExecutionComponent extends Container {
 		let hasContent = false;
 		this.hideComponent = false;
 		if (this.hasRendererDefinition()) {
-			this.contentBox.setBgFn(bgFn);
-			this.contentBox.clear();
+			this.callBox.setBgFn(pendingBgFn);
 
 			const callRenderer = this.getCallRenderer();
+			let callComponent: Component | undefined;
 			if (!callRenderer) {
-				this.contentBox.addChild(this.createCallFallback());
-				hasContent = true;
+				callComponent = this.createCallFallback();
 			} else {
 				try {
-					const component = callRenderer(this.args, theme, this.getRenderContext(this.callRendererComponent));
-					this.callRendererComponent = component;
-					this.contentBox.addChild(component);
-					hasContent = true;
+					callComponent = callRenderer(this.args, theme, this.getRenderContext(this.callRendererComponent));
+					this.callRendererComponent = callComponent;
 				} catch {
 					this.callRendererComponent = undefined;
-					this.contentBox.addChild(this.createCallFallback());
-					hasContent = true;
+					callComponent = this.createCallFallback();
 				}
+			}
+
+			if (callComponent) {
+				this.setBoxContent(this.callBox, callComponent);
+				hasContent = true;
 			}
 
 			if (this.result) {
 				const resultRenderer = this.getResultRenderer();
+				let resultComponent: Component | undefined;
 				if (!resultRenderer) {
-					const component = this.createResultFallback();
-					if (component) {
-						this.contentBox.addChild(component);
-						hasContent = true;
-					}
+					resultComponent = this.createResultFallback();
 				} else {
 					try {
-						const component = resultRenderer(
+						resultComponent = resultRenderer(
 							{ content: this.result.content as any, details: this.result.details },
 							{ expanded: this.expanded, isPartial: this.isPartial },
 							theme,
 							this.getRenderContext(this.resultRendererComponent),
 						);
-						this.resultRendererComponent = component;
-						this.contentBox.addChild(component);
-						hasContent = true;
+						this.resultRendererComponent = resultComponent;
 					} catch {
 						this.resultRendererComponent = undefined;
-						const component = this.createResultFallback();
-						if (component) {
-							this.contentBox.addChild(component);
-							hasContent = true;
-						}
+						resultComponent = this.createResultFallback();
 					}
+				}
+
+				if (resultComponent) {
+					if (!this.resultBgFn) {
+						this.resultBgFn = resultBgFn;
+					}
+					this.resultBox.setBgFn(this.resultBgFn);
+					this.setBoxContent(this.resultBox, resultComponent);
+					if (!this.resultBoxAttached) {
+						this.addChild(this.resultBox);
+						this.resultBoxAttached = true;
+					}
+					hasContent = true;
 				}
 			}
 		} else {
-			this.contentText.setCustomBgFn(bgFn);
+			if (!this.contentBgFn) {
+				this.contentBgFn = resultBgFn;
+			}
+			this.contentText.setCustomBgFn(this.contentBgFn);
 			this.contentText.setText(this.formatToolExecution());
 			hasContent = true;
 		}


### PR DESCRIPTION
## Summary
Fixes #2664 by keeping edit tool output and tool-execution rendering append-only, so large multi-edit diffs don't force a full redraw.

## Changes
- render edit call output as header + diff components to only append new lines
- split tool execution call/result rendering into separate boxes and append result output without re-rendering earlier lines
