### PR TITLE
docs: fix nested code fence rendering in skill examples

### DIFF
--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -106,7 +106,7 @@ my-skill/
 
 ### SKILL.md Format
 
-```markdown
+````markdown
 ---
 name: my-skill
 description: What this skill does and when to use it. Be specific.
@@ -117,16 +117,16 @@ description: What this skill does and when to use it. Be specific.
 ## Setup
 
 Run once before first use:
-\`\`\`bash
+```bash
 cd /path/to/skill && npm install
-\`\`\`
+```
 
 ## Usage
 
-\`\`\`bash
+```bash
 ./scripts/process.sh <input>
-\`\`\`
 ```
+````
 
 Use relative paths from the skill directory:
 
@@ -198,7 +198,7 @@ brave-search/
 ```
 
 **SKILL.md:**
-```markdown
+````markdown
 ---
 name: brave-search
 description: Web search and content extraction via Brave Search API. Use for searching documentation, facts, or any web content.
@@ -208,23 +208,23 @@ description: Web search and content extraction via Brave Search API. Use for sea
 
 ## Setup
 
-\`\`\`bash
+```bash
 cd /path/to/brave-search && npm install
-\`\`\`
+```
 
 ## Search
 
-\`\`\`bash
+```bash
 ./search.js "query"              # Basic search
 ./search.js "query" --content    # Include page content
-\`\`\`
+```
 
 ## Extract Page Content
 
-\`\`\`bash
+```bash
 ./content.js https://example.com
-\`\`\`
 ```
+````
 
 ## Skill Repositories
 

--- a/packages/mom/README.md
+++ b/packages/mom/README.md
@@ -247,7 +247,7 @@ You can ask mom to create skills for you. For example:
 
 Mom would create something like `/workspace/skills/note/SKILL.md`:
 
-```markdown
+````markdown
 ---
 name: note
 description: Add and read notes from a persistent notes file
@@ -260,30 +260,30 @@ Manage a simple notes file with timestamps.
 ## Usage
 
 Add a note:
-\`\`\`bash
+```bash
 bash {baseDir}/note.sh add "Buy groceries"
-\`\`\`
+```
 
 Read all notes:
-\`\`\`bash
+```bash
 bash {baseDir}/note.sh read
-\`\`\`
+```
 
 Search notes by keyword:
-\`\`\`bash
+```bash
 grep -i "groceries" ~/.notes.txt
-\`\`\`
+```
 
 Search notes by date (format: YYYY-MM-DD):
-\`\`\`bash
+```bash
 grep "2025-12-13" ~/.notes.txt
-\`\`\`
+```
 
 Clear all notes:
-\`\`\`bash
+```bash
 bash {baseDir}/note.sh clear
-\`\`\`
 ```
+````
 
 And `/workspace/skills/note/note.sh`:
 


### PR DESCRIPTION
Backslash-escaped inner fences (`\`\`\`\`) render literally on GitHub because the CommonMark/GFM specs explicitly state that backslash escapes do not work inside fenced code blocks. Use quadruple-backtick outer fences instead so inner triple-backtick blocks nest correctly.