### PR TITLE
fix: prevent extension streamSimple from overriding built-in providers

### DIFF
--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -22,12 +22,20 @@ function resolveApiProvider(api: Api) {
 	return provider;
 }
 
+function resolveApiProviderForModel<TApi extends Api>(model: Model<TApi>) {
+	// Try provider-specific first (e.g., "nvidia-nim:openai-completions")
+	const providerSpecific = getApiProvider(`${model.provider}:${model.api}` as Api);
+	if (providerSpecific) return providerSpecific;
+	// Fallback to api-only
+	return resolveApiProvider(model.api);
+}
+
 export function stream<TApi extends Api>(
 	model: Model<TApi>,
 	context: Context,
 	options?: ProviderStreamOptions,
 ): AssistantMessageEventStream {
-	const provider = resolveApiProvider(model.api);
+	const provider = resolveApiProviderForModel(model);
 	return provider.stream(model, context, options as StreamOptions);
 }
 
@@ -45,7 +53,7 @@ export function streamSimple<TApi extends Api>(
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
-	const provider = resolveApiProvider(model.api);
+	const provider = resolveApiProviderForModel(model);
 	return provider.streamSimple(model, context, options);
 }
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -703,9 +703,10 @@ export class ModelRegistry {
 
 		if (config.streamSimple) {
 			const streamSimple = config.streamSimple;
+			// Register with provider:api key to avoid overriding built-in providers
 			registerApiProvider(
 				{
-					api: config.api!,
+					api: `${providerName}:${config.api!}` as Api,
 					stream: (model, context, options) => streamSimple(model, context, options as SimpleStreamOptions),
 					streamSimple,
 				},


### PR DESCRIPTION
# Extension `streamSimple` overrides built-in providers when using same `api` type

## Problem

When an extension registers with `streamSimple` using an existing `api` type (e.g., `"openai-completions"`), it overwrites the built-in provider. This causes ALL models with that `api` type to incorrectly use the extension's `streamSimple`.

## Example

NVIDIA NIM extension registers:
```typescript
pi.registerProvider("nvidia-nim", {
  api: "openai-completions",
  streamSimple: nimStreamSimple,
});
```

Now OpenAI, Ollama, LM Studio models all incorrectly use `nimStreamSimple`.

## Root Cause

Extensions register with `api` key, overwriting built-in providers in `apiProviderRegistry` Map.

## Solution

1. **Register extensions with compound key** - Use `provider:api` instead of `api`
2. **Provider-aware lookup** - Try `provider:api` first, fallback to `api`

## Files Changed

- `packages/ai/src/stream.ts` - Add `resolveApiProviderForModel()` 
- `packages/coding-agent/src/core/model-registry.ts` - Register with `provider:api` key

## Labels

- `pkg:ai`
- `pkg:coding-agent`
