### PR TITLE
Pass request model to before_provider_request hooks

### DIFF
--- a/packages/coding-agent/examples/extensions/provider-payload.ts
+++ b/packages/coding-agent/examples/extensions/provider-payload.ts
@@ -6,7 +6,11 @@ export default function (pi: ExtensionAPI) {
 	const logFile = join(process.cwd(), ".pi", "provider-payload.log");
 
 	pi.on("before_provider_request", (event) => {
-		appendFileSync(logFile, `${JSON.stringify(event.payload, null, 2)}\n\n`, "utf8");
+		appendFileSync(
+			logFile,
+			`Model: ${event.model.provider}/${event.model.id}\n${JSON.stringify(event.payload, null, 2)}\n\n`,
+			"utf8",
+		);
 
 		// Optional: replace the payload instead of only logging it.
 		// return { ...event.payload, temperature: 0 };

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -743,7 +743,7 @@ export class ExtensionRunner {
 		return currentMessages;
 	}
 
-	async emitBeforeProviderRequest(payload: unknown): Promise<unknown> {
+	async emitBeforeProviderRequest(payload: unknown, model: Model<any>): Promise<unknown> {
 		const ctx = this.createContext();
 		let currentPayload = payload;
 
@@ -756,6 +756,7 @@ export class ExtensionRunner {
 					const event: BeforeProviderRequestEvent = {
 						type: "before_provider_request",
 						payload: currentPayload,
+						model,
 					};
 					const handlerResult = await handler(event, ctx);
 					if (handlerResult !== undefined) {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -273,7 +273,7 @@ export interface ExtensionContext {
 	sessionManager: ReadonlySessionManager;
 	/** Model registry for API key resolution */
 	modelRegistry: ModelRegistry;
-	/** Current model (may be undefined) */
+	/** Current live selected model (may be undefined). For request-scoped hooks like before_provider_request, use event.model for the actual request model snapshot. */
 	model: Model<any> | undefined;
 	/** Whether the agent is idle (not streaming) */
 	isIdle(): boolean;
@@ -542,6 +542,8 @@ export interface ContextEvent {
 export interface BeforeProviderRequestEvent {
 	type: "before_provider_request";
 	payload: unknown;
+	/** Model snapshot for the specific request being prepared. May differ from ctx.model if the user switched models during an active run. */
+	model: Model<any>;
 }
 
 /** Fired after user submits prompt but before agent loop. */

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -304,12 +304,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				headers: auth.headers || options?.headers ? { ...auth.headers, ...options?.headers } : undefined,
 			});
 		},
-		onPayload: async (payload, _model) => {
+		onPayload: async (payload, model) => {
 			const runner = extensionRunnerRef.current;
 			if (!runner?.hasHandlers("before_provider_request")) {
 				return payload;
 			}
-			return runner.emitBeforeProviderRequest(payload);
+			return runner.emitBeforeProviderRequest(payload, model);
 		},
 		sessionId: sessionManager.getSessionId(),
 		transformContext: async (messages) => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -420,6 +420,41 @@ describe("ExtensionRunner", () => {
 		});
 	});
 
+	describe("before_provider_request", () => {
+		it("passes the request model snapshot separately from ctx.model", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.on("before_provider_request", (event, ctx) => {
+						return {
+							requestModel: event.model ? event.model.provider + "/" + event.model.id : null,
+							contextModel: ctx.model ? ctx.model.provider + "/" + ctx.model.id : null,
+						};
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "provider-request.ts"), extCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			const liveModel = modelRegistry.find("openai-codex", "gpt-5.4");
+			const requestModel = modelRegistry.find("anthropic", "claude-opus-4-6");
+			expect(liveModel).toBeDefined();
+			expect(requestModel).toBeDefined();
+
+			runner.bindCore(extensionActions, {
+				...extensionContextActions,
+				getModel: () => liveModel,
+			});
+
+			const payload = await runner.emitBeforeProviderRequest({ ok: true }, requestModel!);
+			expect(payload).toEqual({
+				requestModel: "anthropic/claude-opus-4-6",
+				contextModel: "openai-codex/gpt-5.4",
+			});
+		});
+	});
+
 	describe("error handling", () => {
 		it("calls error listeners when handler throws", async () => {
 			const extCode = `


### PR DESCRIPTION
## Summary
- add `model` to `BeforeProviderRequestEvent`
- thread the actual request model through the SDK and extension runner
- keep `ctx.model` as the live selected model and expose the request snapshot separately
- update the provider-payload example and add runner coverage

## Why
`before_provider_request` is request-scoped, but extensions currently only have `ctx.model`, which is session-scoped/live. If the user switches models during an active run, `ctx.model` can diverge from the model for the queued request. That lets extensions patch the payload for the wrong provider.

I hit this while switching from `anthropic/claude-opus-4-6` to `openai-codex/gpt-5.4` mid-run: the next request still went to Anthropic, but the hook saw GPT-5.4 via `ctx.model` and injected an OpenAI-only top-level `text` field. Anthropic then rejected the payload with `text: Extra inputs are not permitted`.

`ctx.model` should stay live for UI and session state. Request hooks need the request snapshot instead.

## Testing
- `npm run check`
