### PR TITLE
fix(ai): avoid replaying reasoning before tool-call turns

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -169,8 +169,23 @@ export function convertResponsesMessages<TApi extends Api>(
 			for (const block of msg.content) {
 				if (block.type === "thinking") {
 					if (block.thinkingSignature) {
-						const reasoningItem = JSON.parse(block.thinkingSignature) as ResponseReasoningItem;
-						output.push(reasoningItem);
+						// The Responses API requires replayed reasoning items to be
+						// followed by their paired assistant message item. A tool call
+						// does not satisfy that requirement. Only replay reasoning when
+						// the next non-thinking block is text, which becomes a message.
+						const blockIdx = msg.content.indexOf(block);
+						let nextNonThinkingType: string | null = null;
+						for (let k = blockIdx + 1; k < msg.content.length; k++) {
+							const next = msg.content[k];
+							if (next && next.type !== "thinking") {
+								nextNonThinkingType = next.type;
+								break;
+							}
+						}
+						if (nextNonThinkingType === "text") {
+							const reasoningItem = JSON.parse(block.thinkingSignature) as ResponseReasoningItem;
+							output.push(reasoningItem);
+						}
 					}
 				} else if (block.type === "text") {
 					const textBlock = block as TextContent;


### PR DESCRIPTION
## Summary

Fix OpenAI/Azure Responses replay for assistant turns shaped like `[thinking, toolCall]`.

Previously, `convertResponsesMessages()` always replayed stored `thinkingSignature` as a `reasoning` item. For tool-call turns this produced replay input like:

- `reasoning`
- `function_call`

Azure/OpenAI Responses rejects that with:

`400 Item 'rs_...' of type 'reasoning' was provided without its required following item.`

## Fix

Only replay a `thinking` block as a `reasoning` item when the next non-thinking block in the same assistant turn is `text`, which becomes the paired assistant `message` item.

This means:
- `[thinking, text]` still replays reasoning
- `[thinking, toolCall]` skips replayed reasoning
- `[thinking]` skips replayed reasoning

## Why this is safe

The Responses API accepts replayed `reasoning -> message`, but rejected `reasoning -> function_call` in live testing.

This change only affects malformed / non-replayable reasoning cases and preserves the normal text-message path.

## Verification

Validated against a live Azure OpenAI Responses setup with reasoning enabled:
- multi-turn tool-calling completed successfully
- consecutive tool-call turns completed successfully
- tool-call turns followed by a long reasoning-heavy text turn completed successfully
- the previous 400s stopped after this change

## Context

Closes #2702
