### PR TITLE
fix(coding-agent): flush queued messages after tree navigation

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1224,6 +1224,7 @@ export class InteractiveMode {
 						this.editor.setText(result.editorText);
 					}
 					this.showStatus("Navigated to selected point");
+					void this.flushCompactionQueue({ willRetry: false });
 
 					return { cancelled: false };
 				},
@@ -3731,6 +3732,7 @@ export class InteractiveMode {
 							this.editor.setText(result.editorText);
 						}
 						this.showStatus("Navigated to selected point");
+						void this.flushCompactionQueue({ willRetry: false });
 					} catch (error) {
 						this.showError(error instanceof Error ? error.message : String(error));
 					} finally {


### PR DESCRIPTION
Messages sent during branch summarization are added to the compaction queue but never flushed when summarization ends. The user sees the message in the steering queue and has to manually dequeue and resend it.

The fix is to flush the compaction queue after successful tree navigation, matching the existing behavior of auto-compaction and `/compact`. If the user jumps to a user message, the queued message is sent as a prompt, and the jumped-to text is placed in the editor.

Here's a video of the current behavior and the fix:

https://github.com/user-attachments/assets/32d0c0e7-c252-44d6-b85a-23e0a61568bc
