### PR TITLE
feat(mom): add trusted extensions and startup model selection

### DIFF
--- a/packages/mom/CHANGELOG.md
+++ b/packages/mom/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added trusted extension loading with strict trusted-root mode, Slack-aware hook bridging, and native `MOM_MODEL=provider:model` startup resolution
+
+### Changed
+
+- Changed mom to read workspace settings from `.pi/settings.json`, ignore workspace extension authorities in strict mode, and post channel mention replies in the triggering Slack thread
+
 ## [0.64.0] - 2026-03-29
 
 ## [0.63.2] - 2026-03-29

--- a/packages/mom/README.md
+++ b/packages/mom/README.md
@@ -17,6 +17,7 @@ A Slack bot powered by an LLM that can execute bash commands, read/write files, 
 
 - [Artifacts Server](docs/artifacts-server.md) - Share HTML/JS visualizations publicly with live reload
 - [Events System](docs/events.md) - Schedule reminders and periodic tasks
+- [Extensions and Trust Model](docs/extensions.md) - Trusted roots, strict mode, and Slack hook behavior
 - [Sandbox Guide](docs/sandbox.md) - Docker vs host mode security
 - [Slack Bot Setup](docs/slack-bot-minimal-guide.md) - Minimal Slack integration guide
 
@@ -62,9 +63,17 @@ npm install @mariozechner/pi-mom
 # Set environment variables
 export MOM_SLACK_APP_TOKEN=xapp-...
 export MOM_SLACK_BOT_TOKEN=xoxb-...
-# Option 1: Anthropic API key
-export ANTHROPIC_API_KEY=sk-ant-...
-# Option 2: use /login command in pi agent, then copy/link auth.json to ~/.pi/mom/
+
+# Select a startup model/provider
+export MOM_MODEL=openai:gpt-5.4-mini
+
+# Set the matching provider credential
+export OPENAI_API_KEY=sk-...
+
+# Optional: enable strict trusted-extension mode
+export MOM_TRUSTED_EXTENSION_ROOT=/absolute/path/outside/your-workspace
+
+# Or use /login in pi, then copy/link auth.json to ~/.pi/mom/
 
 # Create Docker sandbox (recommended)
 docker run -d \
@@ -95,24 +104,41 @@ Options:
 |----------|-------------|
 | `MOM_SLACK_APP_TOKEN` | Slack app-level token (xapp-...) |
 | `MOM_SLACK_BOT_TOKEN` | Slack bot token (xoxb-...) |
-| `ANTHROPIC_API_KEY` | (Optional) Anthropic API key |
+| `MOM_MODEL` | Optional startup model in `provider:model` form |
+| Provider API key env vars | Optional provider credentials such as `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` |
+| `MOM_TRUSTED_EXTENSION_ROOT` | Optional absolute trusted extension root outside the workspace; enables strict mode |
 
 ## Authentication
 
-Mom needs credentials for Anthropic API. The options to set it are:
+Mom resolves credentials from the selected model's provider. If `MOM_MODEL=openai:gpt-5.4-mini`, mom looks up OpenAI credentials. If the startup model is Anthropic, mom looks up Anthropic credentials.
+
+You can provide credentials in two ways:
 
 1. **Environment Variable**
 ```bash
+export OPENAI_API_KEY=sk-...
+# or
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-2. **OAuth Login via coding agent command** (Recommended for Claude Pro/Max)
-
+2. **OAuth Login via coding agent command**
 - run interactive coding agent session: `npx @mariozechner/pi-coding-agent`
 - enter `/login` command
-  - choose "Anthropic" provider
-  - follow instructions in the browser
+- choose the provider you want mom to use
+- follow instructions in the browser
 - link `auth.json` to mom: `ln -s ~/.pi/agent/auth.json ~/.pi/mom/auth.json`
+
+## Extensions and model selection
+
+Workspace settings live at `<workspace>/.pi/settings.json`.
+- `MOM_MODEL=provider:model` selects the startup model without changing workspace defaults
+- `mom` resolves provider credentials from the selected model
+- channel mention replies are posted in the same Slack thread as the user's message
+- set `MOM_TRUSTED_EXTENSION_ROOT=/absolute/path/outside/workspace` to load extensions only from that trusted root
+- in strict mode, workspace `extensions` and `packages` entries do not affect extension loading
+- without strict mode, `mom` loads extensions from `workspace/.pi/settings.json` `extensions` and `workspace/.pi/extensions`
+
+See [docs/extensions.md](docs/extensions.md) for extension discovery, trust settings, and Slack bridge behavior.
 
 ## How Mom Works
 
@@ -182,8 +208,9 @@ You provide mom with a **data directory** (e.g., `./data`) as her workspace. Whi
 
 ```
 ./data/                         # Your host directory
+  ├── .pi/
+  │   └── settings.json         # Workspace settings (model defaults, hideThinkingBlock, extensions)
   ├── MEMORY.md                 # Global memory (shared across channels)
-  ├── settings.json             # Global settings (compaction, retry, etc.)
   ├── skills/                   # Global custom CLI tools mom creates
   ├── C123ABC/                  # Each Slack channel gets a directory
   │   ├── MEMORY.md             # Channel-specific memory

--- a/packages/mom/docs/extensions.md
+++ b/packages/mom/docs/extensions.md
@@ -1,0 +1,59 @@
+# Extensions and trust model
+
+`mom` supports two extension modes: strict and permissive.
+
+## Strict mode
+
+Set `MOM_TRUSTED_EXTENSION_ROOT` to an absolute path outside the workspace to enable strict mode.
+
+In strict mode:
+- only extensions from the trusted root are loaded
+- workspace `.pi/settings.json` is still read for `defaultProvider`, `defaultModel`, and `hideThinkingBlock`
+- workspace `extensions` and `packages` settings do not affect extension loading
+- mom refuses to start if the workspace contains its own extension infrastructure (any `.pi/extensions` directory or `.ts`/`.js` files under an `extensions/` directory anywhere in the workspace tree)
+- trusted entries are loaded deterministically from the trusted root
+
+Symlinks within the trusted root that resolve back into the workspace are rejected.
+
+## Permissive mode
+
+Permissive mode is the default when `MOM_TRUSTED_EXTENSION_ROOT` is not set.
+
+In permissive mode, `mom` loads extensions from:
+- `workspace/.pi/settings.json` `extensions`, in listed order
+- `workspace/.pi/extensions`, discovered deterministically
+
+`mom` does not load extensions from `settings.packages`, the home directory, or the global agent directory.
+
+## Discovery rules
+
+Extension discovery follows the same rules in both modes:
+- a `.ts` or `.js` file is loaded directly
+- a directory contributes its immediate `.ts` and `.js` children
+- an immediate subdirectory contributes its `index.ts` or `index.js` if present (no deeper recursion)
+- entries within a root are sorted lexicographically by relative path
+- if the same file appears more than once (after symlink resolution), only the first occurrence is kept
+
+## Runtime behavior
+
+Extensions run in the `mom` host process, not inside the bash sandbox.
+
+Each run exposes Slack-aware context to extension hooks, including channel, user, thread, message, and session metadata.
+
+Before the LLM sees a message, `mom` emits the raw Slack text as an `input` event with `source: "interactive"`. Extensions can intercept this event to handle messages directly — for example, returning a canned response or routing the message elsewhere. When an extension handles the input, the LLM is never called: no thinking indicator, tool calls, or agent turns occur for that message.
+
+If no extension handles the raw input, `mom` formats the prompt and sends it through the normal agent path, which emits a second `input` event with `source: "extension"`. Extensions that only want to intercept raw Slack messages should ignore events where `source === "extension"`.
+
+During a normal LLM turn, extensions can observe and modify behavior through hooks such as `input`, `before_agent_start`, `context`, `turn_start`, `turn_end`, `tool_call`, `tool_result`, `before_provider_request`, and `model_select`. Extensions can use `tool_result` hooks to redact sensitive content in tool output before it is rendered to Slack.
+
+## Built-in Slack bridge
+
+`mom` bridges extension `pi.sendMessage(...)` calls to Slack.
+
+The built-in `mom-direct-response` custom type supports:
+- `content.mainText` — primary visible Slack reply
+- `content.threadText` — optional secondary thread reply
+
+`mom` always renders this custom type to Slack, even when `display: false`.
+
+For other custom message types, `mom` renders plain-string content to the Slack reply when `display !== false`. Other custom payloads are not rendered to Slack.

--- a/packages/mom/src/agent-internals.ts
+++ b/packages/mom/src/agent-internals.ts
@@ -1,0 +1,133 @@
+export interface AgentRunResult {
+	stopReason: string;
+	errorMessage?: string;
+	fatalInitializationError?: boolean;
+}
+
+export interface AgentSessionPromptInternals {
+	_baseSystemPrompt: string;
+	_rebuildSystemPrompt(toolNames: string[]): string;
+	getActiveToolNames(): string[];
+	agent: {
+		state: {
+			systemPrompt: string;
+		};
+	};
+}
+
+export type InputPreflightResult =
+	| { action: "continue" }
+	| { action: "transform"; text: string; images?: unknown[] }
+	| { action: "handled" };
+
+export interface AssistantProgressPart {
+	type: string;
+	text?: string;
+	thinking?: string;
+}
+
+export interface AssistantProgressPublisher {
+	respond(text: string, shouldLog: boolean): Promise<void>;
+	respondInThread(text: string): Promise<void>;
+}
+
+export interface AssistantProgressQueue {
+	enqueue(fn: () => Promise<void>, errorContext: string): void;
+}
+
+function getPromptSessionInternals(session: unknown): AgentSessionPromptInternals {
+	const promptSession = session as Partial<AgentSessionPromptInternals>;
+
+	if (
+		typeof promptSession._rebuildSystemPrompt !== "function" ||
+		typeof promptSession.getActiveToolNames !== "function" ||
+		typeof promptSession.agent?.state?.systemPrompt !== "string" ||
+		!("_baseSystemPrompt" in promptSession)
+	) {
+		throw new Error("Unsupported @mariozechner/pi-coding-agent AgentSession shape for mom system-prompt refresh");
+	}
+
+	return promptSession as AgentSessionPromptInternals;
+}
+
+export function refreshSessionBaseSystemPrompt(session: unknown): void {
+	// Intentional narrow private seam: AgentSession.prompt() reads _baseSystemPrompt on every turn
+	// when extensions are enabled, so mom must refresh that canonical prompt, not just agent.state.systemPrompt
+	const promptSession = getPromptSessionInternals(session);
+	const nextBaseSystemPrompt = promptSession._rebuildSystemPrompt(promptSession.getActiveToolNames());
+	promptSession._baseSystemPrompt = nextBaseSystemPrompt;
+	promptSession.agent.state.systemPrompt = nextBaseSystemPrompt;
+}
+
+export function refreshSessionBaseSystemPromptForRun(session: unknown): AgentRunResult | undefined {
+	try {
+		refreshSessionBaseSystemPrompt(session);
+		return undefined;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			stopReason: "error",
+			errorMessage: message,
+			fatalInitializationError: true,
+		};
+	}
+}
+
+export function getAssistantProgressMessages(
+	content: AssistantProgressPart[] | undefined,
+	hideThinkingBlock: boolean,
+): string[] {
+	if (!content) {
+		return [];
+	}
+
+	const messages: string[] = [];
+	if (!hideThinkingBlock) {
+		for (const part of content) {
+			if (part.type === "thinking" && typeof part.thinking === "string" && part.thinking.trim().length > 0) {
+				messages.push(`_${part.thinking}_`);
+			}
+		}
+	}
+
+	for (const part of content) {
+		if (part.type === "text" && typeof part.text === "string" && part.text.trim().length > 0) {
+			messages.push(part.text);
+		}
+	}
+
+	return messages;
+}
+
+export function enqueueAssistantProgressMessages({
+	content,
+	hideThinkingBlock,
+	clearThinkingTimer,
+	queue,
+	publisher,
+}: {
+	content: AssistantProgressPart[] | undefined;
+	hideThinkingBlock: boolean;
+	clearThinkingTimer: () => void;
+	queue: AssistantProgressQueue;
+	publisher: AssistantProgressPublisher;
+}): void {
+	for (const message of getAssistantProgressMessages(content, hideThinkingBlock)) {
+		clearThinkingTimer();
+		queue.enqueue(() => publisher.respond(message, false), "assistant progress");
+	}
+}
+
+export async function shortCircuitHandledPreflight(
+	preflight: InputPreflightResult,
+	flushPendingSlackEffects: () => Promise<void>,
+	flushQueue: () => Promise<void>,
+): Promise<AgentRunResult | undefined> {
+	if (preflight.action !== "handled") {
+		return undefined;
+	}
+
+	await flushPendingSlackEffects();
+	await flushQueue();
+	return { stopReason: "handled" };
+}

--- a/packages/mom/src/agent.ts
+++ b/packages/mom/src/agent.ts
@@ -1,11 +1,13 @@
-import { Agent, type AgentEvent } from "@mariozechner/pi-agent-core";
-import { getModel, type ImageContent } from "@mariozechner/pi-ai";
+import { Agent } from "@mariozechner/pi-agent-core";
+import type { ImageContent, Model, TextContent } from "@mariozechner/pi-ai";
 import {
 	AgentSession,
+	type AgentSessionEvent,
 	AuthStorage,
 	convertToLlm,
-	createExtensionRuntime,
+	type ExtensionRunner,
 	formatSkillsForPrompt,
+	type LoadExtensionsResult,
 	loadSkillsFromDir,
 	ModelRegistry,
 	type ResourceLoader,
@@ -16,43 +18,27 @@ import { existsSync, readFileSync } from "fs";
 import { mkdir, writeFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
+import {
+	enqueueAssistantProgressMessages,
+	refreshSessionBaseSystemPromptForRun,
+	shortCircuitHandledPreflight,
+} from "./agent-internals.js";
 import { createMomSettingsManager, syncLogToSessionManager } from "./context.js";
+import {
+	createExtensionLoadPlan,
+	createMomExtensionBridge,
+	loadMomExtensions,
+	type MomRequestContext,
+	type MomTrustConfig,
+} from "./extensions.js";
 import * as log from "./log.js";
+import { resolveMomStartupModel } from "./model-selection.js";
 import { createExecutor, type SandboxConfig } from "./sandbox.js";
 import type { ChannelInfo, SlackContext, UserInfo } from "./slack.js";
 import type { ChannelStore } from "./store.js";
 import { createMomTools, setUploadFunction } from "./tools/index.js";
 
-// Hardcoded model for now - TODO: make configurable (issue #63)
-const model = getModel("anthropic", "claude-sonnet-4-5");
-
-export interface PendingMessage {
-	userName: string;
-	text: string;
-	attachments: { local: string }[];
-	timestamp: number;
-}
-
-export interface AgentRunner {
-	run(
-		ctx: SlackContext,
-		store: ChannelStore,
-		pendingMessages?: PendingMessage[],
-	): Promise<{ stopReason: string; errorMessage?: string }>;
-	abort(): void;
-}
-
-async function getAnthropicApiKey(authStorage: AuthStorage): Promise<string> {
-	const key = await authStorage.getApiKey("anthropic");
-	if (!key) {
-		throw new Error(
-			"No API key found for anthropic.\n\n" +
-				"Set an API key environment variable, or use /login with Anthropic and link to auth.json from " +
-				join(homedir(), ".pi", "mom", "auth.json"),
-		);
-	}
-	return key;
-}
+type StartupModelSelectSource = "set" | "restore";
 
 const IMAGE_MIME_TYPES: Record<string, string> = {
 	jpg: "image/jpeg",
@@ -61,16 +47,751 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 	gif: "image/gif",
 	webp: "image/webp",
 };
+const SLACK_MAX_LENGTH = 40000;
+const THINKING_DELAY_MS = 900;
+
+export interface PendingMessage {
+	userName: string;
+	text: string;
+	attachments: { local: string }[];
+	timestamp: number;
+}
+
+export interface AgentRunResult {
+	stopReason: string;
+	errorMessage?: string;
+	fatalInitializationError?: boolean;
+}
+
+export interface AgentRunner {
+	run(ctx: SlackContext, store: ChannelStore, pendingMessages?: PendingMessage[]): Promise<AgentRunResult>;
+	abort(): void;
+}
+
+interface CreateRunnerOptions {
+	sandboxConfig: SandboxConfig;
+	channelId: string;
+	channelDir: string;
+	workspaceDir: string;
+	trustConfig: MomTrustConfig;
+}
+
+interface InitializedRunnerState {
+	session: AgentSession;
+	sessionManager: SessionManager;
+	settingsManager: ReturnType<typeof createMomSettingsManager>;
+	modelRegistry: ModelRegistry;
+	authStorage: AuthStorage;
+	currentModelRef: { current: Model<any> };
+	startupModelSelectPending: boolean;
+	startupModelSelectSource: StartupModelSelectSource;
+	requestContextRef: { current?: MomRequestContext };
+	extensionsResult: LoadExtensionsResult;
+	extensionRunner?: ExtensionRunner;
+	extensionBridge: ReturnType<typeof createMomExtensionBridge>;
+	workspacePath: string;
+	executor: ReturnType<typeof createExecutor>;
+	tools: ReturnType<typeof createMomTools>;
+	systemPromptRef: { current: string };
+}
+
+interface PendingToolState {
+	toolName: string;
+	args: unknown;
+	startTime: number;
+}
+
+interface UsageTotals {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	cost: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+		total: number;
+	};
+}
+
+interface RunQueue {
+	enqueue(fn: () => Promise<void>, errorContext: string): void;
+	enqueueMessage(text: string, target: "main" | "thread", errorContext: string, shouldLog?: boolean): void;
+	flush(): Promise<void>;
+}
+
+interface RunState {
+	ctx: SlackContext | null;
+	logCtx: { channelId: string; userName?: string; channelName?: string } | null;
+	queue: RunQueue | null;
+	pendingTools: Map<string, PendingToolState>;
+	totalUsage: UsageTotals;
+	stopReason: string;
+	errorMessage?: string;
+	customResponseHandled: boolean;
+	thinkingTimer?: NodeJS.Timeout;
+}
+
+export function createRunner({
+	sandboxConfig,
+	channelId,
+	channelDir,
+	workspaceDir,
+	trustConfig,
+}: CreateRunnerOptions): AgentRunner {
+	let initializedState: InitializedRunnerState | undefined;
+	let initializationPromise: Promise<InitializedRunnerState> | undefined;
+	let abortRequestedBeforeInit = false;
+
+	const runState: RunState = {
+		ctx: null,
+		logCtx: null,
+		queue: null,
+		pendingTools: new Map(),
+		totalUsage: createUsageTotals(),
+		stopReason: "stop",
+		customResponseHandled: false,
+	};
+
+	const clearThinkingTimer = (): void => {
+		if (runState.thinkingTimer) {
+			clearTimeout(runState.thinkingTimer);
+			runState.thinkingTimer = undefined;
+		}
+	};
+
+	const armThinkingTimer = (ctx: SlackContext, hideThinkingBlock: boolean): void => {
+		if (hideThinkingBlock) {
+			return;
+		}
+		clearThinkingTimer();
+		runState.thinkingTimer = setTimeout(() => {
+			void ctx.setTyping(true);
+		}, THINKING_DELAY_MS);
+	};
+
+	const ensureInitialized = async (): Promise<InitializedRunnerState> => {
+		if (initializedState) {
+			return initializedState;
+		}
+		if (initializationPromise) {
+			return initializationPromise;
+		}
+
+		initializationPromise = initializeRunner({
+			sandboxConfig,
+			channelId,
+			channelDir,
+			workspaceDir,
+			trustConfig,
+			runState,
+			clearThinkingTimer,
+		});
+		initializedState = await initializationPromise;
+		return initializedState;
+	};
+
+	return {
+		async run(ctx: SlackContext, _store: ChannelStore): Promise<AgentRunResult> {
+			let state: InitializedRunnerState;
+			try {
+				state = await ensureInitialized();
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				await ctx.publishFinal("_Sorry, mom failed to initialize_", true);
+				await ctx.respondInThread(`_Error: ${message}_`);
+				return {
+					stopReason: "error",
+					errorMessage: message,
+					fatalInitializationError: true,
+				};
+			}
+
+			if (abortRequestedBeforeInit) {
+				abortRequestedBeforeInit = false;
+				return { stopReason: "aborted" };
+			}
+
+			const result = await runInitializedRunner({
+				ctx,
+				channelId,
+				channelDir,
+				sandboxConfig,
+				state,
+				runState,
+				clearThinkingTimer,
+				armThinkingTimer,
+			});
+			if (result.fatalInitializationError) {
+				initializedState = undefined;
+				initializationPromise = undefined;
+			}
+			return result;
+		},
+
+		abort(): void {
+			if (!initializedState) {
+				abortRequestedBeforeInit = true;
+				return;
+			}
+			initializedState.session.abort();
+		},
+	};
+}
+
+async function initializeRunner({
+	sandboxConfig,
+	channelId,
+	channelDir,
+	workspaceDir,
+	trustConfig,
+	runState,
+	clearThinkingTimer,
+}: {
+	sandboxConfig: SandboxConfig;
+	channelId: string;
+	channelDir: string;
+	workspaceDir: string;
+	trustConfig: MomTrustConfig;
+	runState: RunState;
+	clearThinkingTimer: () => void;
+}): Promise<InitializedRunnerState> {
+	const executor = createExecutor(sandboxConfig);
+	const workspacePath = executor.getWorkspacePath(workspaceDir);
+	const tools = createMomTools(executor);
+	const memory = getMemory(workspaceDir, channelDir);
+	const skills = loadMomSkills(channelDir, workspaceDir, workspacePath);
+	const initialSystemPrompt = buildSystemPrompt(workspacePath, channelId, memory, sandboxConfig, [], [], skills);
+	const contextFile = join(channelDir, "context.jsonl");
+	const sessionManager = SessionManager.open(contextFile, channelDir);
+	const settingsManager = createMomSettingsManager(workspaceDir);
+	const authStorage = AuthStorage.create(join(homedir(), ".pi", "mom", "auth.json"));
+	const modelRegistry = ModelRegistry.create(authStorage);
+	const startupModel = resolveMomStartupModel(modelRegistry, settingsManager);
+	const currentModelRef = { current: startupModel.model };
+	const requestContextRef: { current?: MomRequestContext } = {};
+	const extensionRunnerRef: { current?: ExtensionRunner } = {};
+	const extensionLoadPlan = createExtensionLoadPlan(workspaceDir, trustConfig);
+	for (const warning of extensionLoadPlan.warnings) {
+		log.logWarning(`[${channelId}] Extension loading`, warning);
+	}
+
+	const extensionsResult = await loadMomExtensions(extensionLoadPlan, workspaceDir);
+	for (const { path, error } of extensionsResult.errors) {
+		log.logWarning(`[${channelId}] Failed to load extension`, `${path}: ${error}`);
+	}
+
+	const systemPromptRef = { current: initialSystemPrompt };
+	const resourceLoader: ResourceLoader = {
+		getExtensions: () => extensionsResult,
+		getSkills: () => ({ skills: [], diagnostics: [] }),
+		getPrompts: () => ({ prompts: [], diagnostics: [] }),
+		getThemes: () => ({ themes: [], diagnostics: [] }),
+		getAgentsFiles: () => ({ agentsFiles: [] }),
+		getSystemPrompt: () => systemPromptRef.current,
+		getAppendSystemPrompt: () => [],
+		extendResources: () => {},
+		reload: async () => {},
+	};
+	const baseToolsOverride = Object.fromEntries(tools.map((tool) => [tool.name, tool]));
+	const agent = new Agent({
+		initialState: {
+			systemPrompt: initialSystemPrompt,
+			model: startupModel.model,
+			thinkingLevel: "off",
+			tools,
+		},
+		convertToLlm,
+		getApiKey: (provider) => modelRegistry.getApiKeyForProvider(provider),
+		onPayload: async (payload) => {
+			const runner = extensionRunnerRef.current;
+			if (!runner?.hasHandlers("before_provider_request")) {
+				return payload;
+			}
+			return runner.emitBeforeProviderRequest(payload);
+		},
+		sessionId: sessionManager.getSessionId(),
+		transformContext: async (messages) => {
+			const runner = extensionRunnerRef.current;
+			if (!runner) {
+				return messages;
+			}
+			return runner.emitContext(messages);
+		},
+		steeringMode: settingsManager.getSteeringMode(),
+		followUpMode: settingsManager.getFollowUpMode(),
+		transport: settingsManager.getTransport(),
+		thinkingBudgets: settingsManager.getThinkingBudgets(),
+		maxRetryDelayMs: settingsManager.getRetrySettings().maxDelayMs,
+	});
+
+	const loadedSession = sessionManager.buildSessionContext();
+	if (loadedSession.messages.length > 0) {
+		agent.state.messages = loadedSession.messages;
+		log.logInfo(`[${channelId}] Loaded ${loadedSession.messages.length} messages from context.jsonl`);
+	}
+
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settingsManager,
+		cwd: process.cwd(),
+		modelRegistry,
+		resourceLoader,
+		baseToolsOverride,
+		extensionRunnerRef,
+	});
+	const extensionBridge = createMomExtensionBridge(session, currentModelRef);
+
+	session.subscribe(async (event: AgentSessionEvent) => {
+		await handleSessionEvent({
+			event,
+			runState,
+			settingsManager,
+			clearThinkingTimer,
+		});
+	});
+
+	return {
+		session,
+		sessionManager,
+		settingsManager,
+		modelRegistry,
+		authStorage,
+		currentModelRef,
+		startupModelSelectPending: true,
+		startupModelSelectSource: startupModel.source === "env" ? "set" : "restore",
+		requestContextRef,
+		extensionsResult,
+		extensionRunner: session.extensionRunner,
+		extensionBridge,
+		workspacePath,
+		executor,
+		tools,
+		systemPromptRef,
+	};
+}
+
+async function runInitializedRunner({
+	ctx,
+	channelId,
+	channelDir,
+	sandboxConfig,
+	state,
+	runState,
+	clearThinkingTimer,
+	armThinkingTimer,
+}: {
+	ctx: SlackContext;
+	channelId: string;
+	channelDir: string;
+	sandboxConfig: SandboxConfig;
+	state: InitializedRunnerState;
+	runState: RunState;
+	clearThinkingTimer: () => void;
+	armThinkingTimer: (ctx: SlackContext, hideThinkingBlock: boolean) => void;
+}): Promise<AgentRunResult> {
+	await mkdir(channelDir, { recursive: true });
+
+	const syncedCount = syncLogToSessionManager(state.sessionManager, channelDir, ctx.message.ts);
+	if (syncedCount > 0) {
+		log.logInfo(`[${channelId}] Synced ${syncedCount} messages from log.jsonl`);
+	}
+
+	const reloadedSession = state.sessionManager.buildSessionContext();
+	if (reloadedSession.messages.length > 0) {
+		state.session.agent.state.messages = reloadedSession.messages;
+		log.logInfo(`[${channelId}] Reloaded ${reloadedSession.messages.length} messages from context`);
+	}
+
+	const memory = getMemory(join(channelDir, ".."), channelDir);
+	const skills = loadMomSkills(channelDir, join(channelDir, ".."), state.workspacePath);
+	state.systemPromptRef.current = buildSystemPrompt(
+		state.workspacePath,
+		channelId,
+		memory,
+		sandboxConfig,
+		ctx.channels,
+		ctx.users,
+		skills,
+	);
+	const promptRefreshFailure = refreshSessionBaseSystemPromptForRun(state.session);
+	if (promptRefreshFailure) {
+		await ctx.publishFinal("_Sorry, mom failed to initialize_", true);
+		await ctx.respondInThread(`_Error: ${promptRefreshFailure.errorMessage}_`);
+		return promptRefreshFailure;
+	}
+
+	setUploadFunction(async (filePath: string, title?: string) => {
+		const hostPath = translateToHostPath(filePath, channelDir, state.workspacePath, channelId);
+		await ctx.uploadFile(hostPath, title);
+	});
+
+	runState.ctx = ctx;
+	runState.logCtx = {
+		channelId: ctx.message.channel,
+		userName: ctx.message.userName,
+		channelName: ctx.channelName,
+	};
+	runState.pendingTools.clear();
+	runState.totalUsage = createUsageTotals();
+	runState.stopReason = "stop";
+	runState.errorMessage = undefined;
+	runState.customResponseHandled = false;
+	state.requestContextRef.current = buildRequestContext(ctx);
+	state.extensionBridge.setRequestContext(state.requestContextRef.current);
+	state.extensionBridge.setSlackCallbacks({
+		clearThinking: clearThinkingTimer,
+		markCustomResponseHandled: () => {
+			runState.customResponseHandled = true;
+		},
+		publishFinal: (text, shouldLog) => ctx.publishFinal(text, shouldLog),
+		respond: (text, shouldLog) => ctx.respond(text, shouldLog),
+		respondInThread: (text) => ctx.respondInThread(text),
+	});
+
+	let queueChain = Promise.resolve();
+	runState.queue = {
+		enqueue(fn, errorContext): void {
+			queueChain = queueChain.then(async () => {
+				try {
+					await fn();
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					log.logWarning(`Slack API error (${errorContext})`, message);
+					try {
+						await ctx.respondInThread(`_Error: ${message}_`);
+					} catch {
+						// Ignore secondary Slack failures
+					}
+				}
+			});
+		},
+		enqueueMessage(text, target, errorContext, shouldLog = false): void {
+			if (target === "main") {
+				clearThinkingTimer();
+			}
+			for (const part of splitForSlack(text)) {
+				this.enqueue(
+					() => (target === "main" ? ctx.respond(part, shouldLog) : ctx.respondInThread(part)),
+					errorContext,
+				);
+			}
+		},
+		async flush(): Promise<void> {
+			await queueChain;
+		},
+	};
+
+	log.logInfo(`Context sizes - system: ${state.systemPromptRef.current.length} chars, memory: ${memory.length} chars`);
+	log.logInfo(`Channels: ${ctx.channels.length}, Users: ${ctx.users.length}`);
+
+	const { promptText, imageAttachments } = buildPromptInput(ctx, state.workspacePath);
+	const debugContext = {
+		systemPrompt: state.systemPromptRef.current,
+		messages: state.session.messages,
+		newUserMessage: promptText,
+		imageAttachmentCount: imageAttachments.length,
+	};
+	await writeFile(join(channelDir, "last_prompt.jsonl"), JSON.stringify(debugContext, null, 2));
+
+	try {
+		const preflight = await state.extensionBridge.emitRawInput(ctx.message.rawText, imageAttachments, "interactive");
+		const handledResult = await shortCircuitHandledPreflight(
+			preflight,
+			() => state.extensionBridge.flushPendingSlackEffects(),
+			() => runState.queue!.flush(),
+		);
+		if (handledResult) {
+			return handledResult;
+		}
+
+		let promptTextForSession = promptText;
+		let promptImages = imageAttachments;
+		if (preflight.action === "transform") {
+			promptImages = preflight.images ?? promptImages;
+			promptTextForSession = rebuildSlackPrompt(ctx, state.workspacePath, preflight.text);
+		}
+
+		armThinkingTimer(ctx, state.settingsManager.getHideThinkingBlock());
+		if (state.startupModelSelectPending) {
+			await state.extensionBridge.emitStartupModelSelect(
+				state.currentModelRef.current,
+				state.startupModelSelectSource,
+			);
+			state.startupModelSelectPending = false;
+		}
+
+		await state.session.prompt(
+			promptTextForSession,
+			promptImages.length > 0 ? { images: promptImages, source: "extension" } : { source: "extension" },
+		);
+		await state.extensionBridge.flushPendingSlackEffects();
+		await runState.queue.flush();
+
+		clearThinkingTimer();
+		await finalizeRun(ctx, state.currentModelRef.current, runState, state.session);
+		return { stopReason: runState.stopReason, errorMessage: runState.errorMessage };
+	} finally {
+		clearThinkingTimer();
+		state.requestContextRef.current = undefined;
+		state.extensionBridge.clearRequestContext();
+		state.extensionBridge.clearSlackCallbacks();
+		runState.ctx = null;
+		runState.logCtx = null;
+		runState.queue = null;
+	}
+}
+
+async function handleSessionEvent({
+	event,
+	runState,
+	settingsManager,
+	clearThinkingTimer,
+}: {
+	event: AgentSessionEvent;
+	runState: RunState;
+	settingsManager: ReturnType<typeof createMomSettingsManager>;
+	clearThinkingTimer: () => void;
+}): Promise<void> {
+	if (!runState.ctx || !runState.logCtx || !runState.queue) {
+		return;
+	}
+
+	const { ctx, logCtx, queue, pendingTools } = runState;
+
+	if (event.type === "tool_execution_start") {
+		const toolEvent = event as AgentSessionEvent & { type: "tool_execution_start" };
+		const args = toolEvent.args as { label?: string };
+		const label = args.label || toolEvent.toolName;
+		pendingTools.set(toolEvent.toolCallId, {
+			toolName: toolEvent.toolName,
+			args: toolEvent.args,
+			startTime: Date.now(),
+		});
+		log.logToolStart(logCtx, toolEvent.toolName, label, toolEvent.args as Record<string, unknown>);
+		clearThinkingTimer();
+		queue.enqueue(() => ctx.respond(`_→ ${label}_`, false), "tool label");
+		return;
+	}
+
+	if (event.type === "tool_execution_end") {
+		const toolEvent = event as AgentSessionEvent & { type: "tool_execution_end" };
+		const resultText = extractToolResultText(toolEvent.result);
+		const pendingTool = pendingTools.get(toolEvent.toolCallId);
+		pendingTools.delete(toolEvent.toolCallId);
+		const durationMs = pendingTool ? Date.now() - pendingTool.startTime : 0;
+
+		if (toolEvent.isError) {
+			log.logToolError(logCtx, toolEvent.toolName, durationMs, resultText);
+		} else {
+			log.logToolSuccess(logCtx, toolEvent.toolName, durationMs, resultText);
+		}
+
+		const label = pendingTool?.args ? (pendingTool.args as { label?: string }).label : undefined;
+		const argsText = pendingTool
+			? formatToolArgsForSlack(toolEvent.toolName, pendingTool.args as Record<string, unknown>)
+			: "(args not found)";
+		const duration = (durationMs / 1000).toFixed(1);
+		let threadMessage = `*${toolEvent.isError ? "✗" : "✓"} ${toolEvent.toolName}*`;
+		if (label) {
+			threadMessage += `: ${label}`;
+		}
+		threadMessage += ` (${duration}s)\n`;
+		if (argsText) {
+			threadMessage += `\`\`\`\n${argsText}\n\`\`\`\n`;
+		}
+		threadMessage += `*Result:*\n\`\`\`\n${resultText}\n\`\`\``;
+		queue.enqueueMessage(threadMessage, "thread", "tool result thread", false);
+		if (toolEvent.isError) {
+			clearThinkingTimer();
+			queue.enqueue(() => ctx.respond(`_Error: ${truncate(resultText, 200)}_`, false), "tool error");
+		}
+		return;
+	}
+
+	if (event.type === "message_start") {
+		const messageEvent = event as AgentSessionEvent & { type: "message_start" };
+		if (messageEvent.message.role === "assistant") {
+			log.logResponseStart(logCtx);
+		}
+		return;
+	}
+
+	if (event.type === "message_end") {
+		const messageEvent = event as AgentSessionEvent & { type: "message_end" };
+		if (messageEvent.message.role !== "assistant") {
+			return;
+		}
+
+		const assistantMessage = messageEvent.message as {
+			stopReason?: string;
+			errorMessage?: string;
+			usage?: UsageTotals & { total?: number };
+			content?: Array<{ type: string; text?: string; thinking?: string }>;
+		};
+		if (assistantMessage.stopReason) {
+			runState.stopReason = assistantMessage.stopReason;
+		}
+		if (assistantMessage.errorMessage) {
+			runState.errorMessage = assistantMessage.errorMessage;
+		}
+		if (assistantMessage.usage) {
+			runState.totalUsage.input += assistantMessage.usage.input;
+			runState.totalUsage.output += assistantMessage.usage.output;
+			runState.totalUsage.cacheRead += assistantMessage.usage.cacheRead;
+			runState.totalUsage.cacheWrite += assistantMessage.usage.cacheWrite;
+			runState.totalUsage.cost.input += assistantMessage.usage.cost.input;
+			runState.totalUsage.cost.output += assistantMessage.usage.cost.output;
+			runState.totalUsage.cost.cacheRead += assistantMessage.usage.cost.cacheRead;
+			runState.totalUsage.cost.cacheWrite += assistantMessage.usage.cost.cacheWrite;
+			runState.totalUsage.cost.total += assistantMessage.usage.cost.total;
+		}
+
+		if (!runState.customResponseHandled) {
+			enqueueAssistantProgressMessages({
+				content: assistantMessage.content,
+				hideThinkingBlock: settingsManager.getHideThinkingBlock(),
+				clearThinkingTimer,
+				queue,
+				publisher: ctx,
+			});
+		}
+		return;
+	}
+
+	if (event.type === "compaction_start") {
+		log.logInfo(`Compaction started (reason: ${event.reason})`);
+		clearThinkingTimer();
+		queue.enqueue(() => ctx.respond("_Compacting context..._", false), "compaction start");
+		return;
+	}
+
+	if (event.type === "compaction_end") {
+		if (event.result) {
+			log.logInfo(`Compaction complete: ${event.result.tokensBefore} tokens compacted`);
+		} else if (event.aborted) {
+			log.logInfo("Compaction aborted");
+		}
+		return;
+	}
+
+	if (event.type === "auto_retry_start") {
+		const retryEvent = event as AgentSessionEvent & {
+			type: "auto_retry_start";
+			attempt: number;
+			maxAttempts: number;
+			errorMessage: string;
+		};
+		log.logWarning(`Retrying (${retryEvent.attempt}/${retryEvent.maxAttempts})`, retryEvent.errorMessage);
+		clearThinkingTimer();
+		queue.enqueue(
+			() => ctx.respond(`_Retrying (${retryEvent.attempt}/${retryEvent.maxAttempts})..._`, false),
+			"retry",
+		);
+		return;
+	}
+}
+
+async function finalizeRun(
+	ctx: SlackContext,
+	currentModel: Model<any>,
+	runState: RunState,
+	session: AgentSession,
+): Promise<void> {
+	if (runState.stopReason === "error" && runState.errorMessage) {
+		await ctx.publishFinal("_Sorry, something went wrong_", true);
+		await ctx.respondInThread(`_Error: ${runState.errorMessage}_`);
+		return;
+	}
+
+	const lastAssistant = session.messages
+		.slice()
+		.reverse()
+		.find((message) => message.role === "assistant") as
+		| { role: "assistant"; content: Array<TextContent | { type: string; text?: string }>; usage?: UsageTotals }
+		| undefined;
+	const finalText =
+		lastAssistant?.content
+			.filter((content): content is TextContent => content.type === "text")
+			.map((content) => content.text)
+			.join("\n") ?? "";
+
+	if (finalText.trim() === "[SILENT]" || finalText.trim().startsWith("[SILENT]")) {
+		await ctx.deleteMessage();
+		log.logInfo("Silent response - deleted message and thread");
+		return;
+	}
+
+	if (!runState.customResponseHandled && finalText.trim()) {
+		log.logResponse(runState.logCtx!, finalText);
+		await ctx.publishFinal(finalText, true);
+	}
+
+	if (runState.totalUsage.cost.total > 0) {
+		const assistantMessage = session.messages
+			.slice()
+			.reverse()
+			.find(
+				(message) => message.role === "assistant" && (message as { stopReason?: string }).stopReason !== "aborted",
+			) as
+			| {
+					role: "assistant";
+					usage: UsageTotals;
+			  }
+			| undefined;
+		const contextTokens = assistantMessage
+			? assistantMessage.usage.input +
+				assistantMessage.usage.output +
+				assistantMessage.usage.cacheRead +
+				assistantMessage.usage.cacheWrite
+			: 0;
+		const contextWindow = currentModel.contextWindow || 200000;
+		const summary = log.logUsageSummary(runState.logCtx!, runState.totalUsage, contextTokens, contextWindow);
+		await ctx.respondInThread(summary);
+	}
+}
+
+function buildRequestContext(ctx: SlackContext): MomRequestContext {
+	return {
+		channel: ctx.message.channel,
+		channelId: ctx.message.channel,
+		channelName: ctx.channelName,
+		user: ctx.message.user,
+		userId: ctx.message.user,
+		userName: ctx.message.userName,
+		threadTs: ctx.message.threadTs,
+		slackTs: ctx.message.ts,
+		rawText: ctx.message.rawText,
+		attachments: ctx.message.attachments.map((attachment) => attachment.local),
+		isEvent: ctx.isEvent ?? false,
+	};
+}
+
+function createUsageTotals(): UsageTotals {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0,
+		},
+	};
+}
 
 function getImageMimeType(filename: string): string | undefined {
 	return IMAGE_MIME_TYPES[filename.toLowerCase().split(".").pop() || ""];
 }
 
-function getMemory(channelDir: string): string {
+function getMemory(workspaceDir: string, channelDir: string): string {
 	const parts: string[] = [];
-
-	// Read workspace-level memory (shared across all channels)
-	const workspaceMemoryPath = join(channelDir, "..", "MEMORY.md");
+	const workspaceMemoryPath = join(workspaceDir, "MEMORY.md");
 	if (existsSync(workspaceMemoryPath)) {
 		try {
 			const content = readFileSync(workspaceMemoryPath, "utf-8").trim();
@@ -82,7 +803,6 @@ function getMemory(channelDir: string): string {
 		}
 	}
 
-	// Read channel-specific memory
 	const channelMemoryPath = join(channelDir, "MEMORY.md");
 	if (existsSync(channelMemoryPath)) {
 		try {
@@ -95,39 +815,25 @@ function getMemory(channelDir: string): string {
 		}
 	}
 
-	if (parts.length === 0) {
-		return "(no working memory yet)";
-	}
-
-	return parts.join("\n\n");
+	return parts.length > 0 ? parts.join("\n\n") : "(no working memory yet)";
 }
 
-function loadMomSkills(channelDir: string, workspacePath: string): Skill[] {
+function loadMomSkills(channelDir: string, workspaceDir: string, workspacePath: string): Skill[] {
 	const skillMap = new Map<string, Skill>();
-
-	// channelDir is the host path (e.g., /Users/.../data/C0A34FL8PMH)
-	// hostWorkspacePath is the parent directory on host
-	// workspacePath is the container path (e.g., /workspace)
-	const hostWorkspacePath = join(channelDir, "..");
-
-	// Helper to translate host paths to container paths
 	const translatePath = (hostPath: string): string => {
-		if (hostPath.startsWith(hostWorkspacePath)) {
-			return workspacePath + hostPath.slice(hostWorkspacePath.length);
+		if (hostPath.startsWith(workspaceDir)) {
+			return workspacePath + hostPath.slice(workspaceDir.length);
 		}
 		return hostPath;
 	};
 
-	// Load workspace-level skills (global)
-	const workspaceSkillsDir = join(hostWorkspacePath, "skills");
+	const workspaceSkillsDir = join(workspaceDir, "skills");
 	for (const skill of loadSkillsFromDir({ dir: workspaceSkillsDir, source: "workspace" }).skills) {
-		// Translate paths to container paths for system prompt
 		skill.filePath = translatePath(skill.filePath);
 		skill.baseDir = translatePath(skill.baseDir);
 		skillMap.set(skill.name, skill);
 	}
 
-	// Load channel-specific skills (override workspace skills on collision)
 	const channelSkillsDir = join(channelDir, "skills");
 	for (const skill of loadSkillsFromDir({ dir: channelSkillsDir, source: "channel" }).skills) {
 		skill.filePath = translatePath(skill.filePath);
@@ -149,23 +855,17 @@ function buildSystemPrompt(
 ): string {
 	const channelPath = `${workspacePath}/${channelId}`;
 	const isDocker = sandboxConfig.type === "docker";
-
-	// Format channel mappings
 	const channelMappings =
-		channels.length > 0 ? channels.map((c) => `${c.id}\t#${c.name}`).join("\n") : "(no channels loaded)";
-
-	// Format user mappings
+		channels.length > 0
+			? channels.map((channel) => `${channel.id}\t#${channel.name}`).join("\n")
+			: "(no channels loaded)";
 	const userMappings =
-		users.length > 0 ? users.map((u) => `${u.id}\t@${u.userName}\t${u.displayName}`).join("\n") : "(no users loaded)";
-
+		users.length > 0
+			? users.map((user) => `${user.id}\t@${user.userName}\t${user.displayName}`).join("\n")
+			: "(no users loaded)";
 	const envDescription = isDocker
-		? `You are running inside a Docker container (Alpine Linux).
-- Bash working directory: / (use cd or absolute paths)
-- Install tools with: apk add <package>
-- Your changes persist across sessions`
-		: `You are running directly on the host machine.
-- Bash working directory: ${process.cwd()}
-- Be careful with system modifications`;
+		? `You are running inside a Docker container (Alpine Linux).\n- Bash working directory: / (use cd or absolute paths)\n- Install tools with: apk add <package>\n- Your changes persist across sessions`
+		: `You are running directly on the host machine.\n- Bash working directory: ${process.cwd()}\n- Be careful with system modifications`;
 
 	return `You are mom, a Slack bot assistant. Be concise. No emojis.
 
@@ -190,14 +890,16 @@ ${envDescription}
 
 ## Workspace Layout
 ${workspacePath}/
-├── MEMORY.md                    # Global memory (all channels)
-├── skills/                      # Global CLI tools you create
-└── ${channelId}/                # This channel
-    ├── MEMORY.md                # Channel-specific memory
-    ├── log.jsonl                # Message history (no tool results)
-    ├── attachments/             # User-shared files
-    ├── scratch/                 # Your working directory
-    └── skills/                  # Channel-specific tools
+├── .pi/
+│   └── settings.json           # Workspace settings
+├── MEMORY.md                   # Global memory (all channels)
+├── skills/                     # Global CLI tools you create
+└── ${channelId}/               # This channel
+	├── MEMORY.md               # Channel-specific memory
+	├── log.jsonl               # Message history (no tool results)
+	├── attachments/            # User-shared files
+	├── scratch/                # Your working directory
+	└── skills/                 # Channel-specific tools
 
 ## Skills (Custom CLI Tools)
 You can create reusable CLI tools for recurring tasks (email, APIs, data processing, etc.).
@@ -328,9 +1030,29 @@ Each tool requires a "label" parameter (shown to user).
 `;
 }
 
-function truncate(text: string, maxLen: number): string {
-	if (text.length <= maxLen) return text;
-	return `${text.substring(0, maxLen - 3)}...`;
+function splitForSlack(text: string): string[] {
+	if (text.length <= SLACK_MAX_LENGTH) {
+		return [text];
+	}
+
+	const parts: string[] = [];
+	let remaining = text;
+	let partNumber = 1;
+	while (remaining.length > 0) {
+		const chunk = remaining.substring(0, SLACK_MAX_LENGTH - 50);
+		remaining = remaining.substring(SLACK_MAX_LENGTH - 50);
+		const suffix = remaining.length > 0 ? `\n_(continued ${partNumber}...)_` : "";
+		parts.push(chunk + suffix);
+		partNumber++;
+	}
+	return parts;
+}
+
+function truncate(text: string, maxLength: number): string {
+	if (text.length <= maxLength) {
+		return text;
+	}
+	return `${text.substring(0, maxLength - 3)}...`;
 }
 
 function extractToolResultText(result: unknown): string {
@@ -361,10 +1083,10 @@ function extractToolResultText(result: unknown): string {
 
 function formatToolArgsForSlack(_toolName: string, args: Record<string, unknown>): string {
 	const lines: string[] = [];
-
 	for (const [key, value] of Object.entries(args)) {
-		if (key === "label") continue;
-
+		if (key === "label") {
+			continue;
+		}
 		if (key === "path" && typeof value === "string") {
 			const offset = args.offset as number | undefined;
 			const limit = args.limit as number | undefined;
@@ -375,494 +1097,70 @@ function formatToolArgsForSlack(_toolName: string, args: Record<string, unknown>
 			}
 			continue;
 		}
-
-		if (key === "offset" || key === "limit") continue;
-
-		if (typeof value === "string") {
-			lines.push(value);
-		} else {
-			lines.push(JSON.stringify(value));
+		if (key === "offset" || key === "limit") {
+			continue;
 		}
+		lines.push(typeof value === "string" ? value : JSON.stringify(value));
 	}
-
 	return lines.join("\n");
 }
 
-// Cache runners per channel
-const channelRunners = new Map<string, AgentRunner>();
+function buildPromptInput(
+	ctx: SlackContext,
+	workspacePath: string,
+): { promptText: string; imageAttachments: ImageContent[] } {
+	const timestamp = buildSlackTimestamp();
+	let promptText = `[${timestamp}] [${ctx.message.userName || "unknown"}]: ${ctx.message.text}`;
+	const imageAttachments: ImageContent[] = [];
+	const nonImagePaths: string[] = [];
 
-/**
- * Get or create an AgentRunner for a channel.
- * Runners are cached - one per channel, persistent across messages.
- */
-export function getOrCreateRunner(sandboxConfig: SandboxConfig, channelId: string, channelDir: string): AgentRunner {
-	const existing = channelRunners.get(channelId);
-	if (existing) return existing;
-
-	const runner = createRunner(sandboxConfig, channelId, channelDir);
-	channelRunners.set(channelId, runner);
-	return runner;
-}
-
-/**
- * Create a new AgentRunner for a channel.
- * Sets up the session and subscribes to events once.
- */
-function createRunner(sandboxConfig: SandboxConfig, channelId: string, channelDir: string): AgentRunner {
-	const executor = createExecutor(sandboxConfig);
-	const workspacePath = executor.getWorkspacePath(channelDir.replace(`/${channelId}`, ""));
-
-	// Create tools
-	const tools = createMomTools(executor);
-
-	// Initial system prompt (will be updated each run with fresh memory/channels/users/skills)
-	const memory = getMemory(channelDir);
-	const skills = loadMomSkills(channelDir, workspacePath);
-	const systemPrompt = buildSystemPrompt(workspacePath, channelId, memory, sandboxConfig, [], [], skills);
-
-	// Create session manager and settings manager
-	// Use a fixed context.jsonl file per channel (not timestamped like coding-agent)
-	const contextFile = join(channelDir, "context.jsonl");
-	const sessionManager = SessionManager.open(contextFile, channelDir);
-	const settingsManager = createMomSettingsManager(join(channelDir, ".."));
-
-	// Create AuthStorage and ModelRegistry
-	// Auth stored outside workspace so agent can't access it
-	const authStorage = AuthStorage.create(join(homedir(), ".pi", "mom", "auth.json"));
-	const modelRegistry = ModelRegistry.create(authStorage);
-
-	// Create agent
-	const agent = new Agent({
-		initialState: {
-			systemPrompt,
-			model,
-			thinkingLevel: "off",
-			tools,
-		},
-		convertToLlm,
-		getApiKey: async () => getAnthropicApiKey(authStorage),
-	});
-
-	// Load existing messages
-	const loadedSession = sessionManager.buildSessionContext();
-	if (loadedSession.messages.length > 0) {
-		agent.state.messages = loadedSession.messages;
-		log.logInfo(`[${channelId}] Loaded ${loadedSession.messages.length} messages from context.jsonl`);
+	for (const attachment of ctx.message.attachments) {
+		const fullPath = `${workspacePath}/${attachment.local}`;
+		const mimeType = getImageMimeType(attachment.local);
+		if (mimeType && existsSync(fullPath)) {
+			try {
+				imageAttachments.push({
+					type: "image",
+					mimeType,
+					data: readFileSync(fullPath).toString("base64"),
+				});
+				continue;
+			} catch {
+				// Fall through and include as a non-image attachment reference
+			}
+		}
+		nonImagePaths.push(fullPath);
 	}
 
-	const resourceLoader: ResourceLoader = {
-		getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
-		getSkills: () => ({ skills: [], diagnostics: [] }),
-		getPrompts: () => ({ prompts: [], diagnostics: [] }),
-		getThemes: () => ({ themes: [], diagnostics: [] }),
-		getAgentsFiles: () => ({ agentsFiles: [] }),
-		getSystemPrompt: () => systemPrompt,
-		getAppendSystemPrompt: () => [],
-		extendResources: () => {},
-		reload: async () => {},
-	};
+	if (nonImagePaths.length > 0) {
+		promptText += `\n\n<slack_attachments>\n${nonImagePaths.join("\n")}\n</slack_attachments>`;
+	}
 
-	const baseToolsOverride = Object.fromEntries(tools.map((tool) => [tool.name, tool]));
-
-	// Create AgentSession wrapper
-	const session = new AgentSession({
-		agent,
-		sessionManager,
-		settingsManager,
-		cwd: process.cwd(),
-		modelRegistry,
-		resourceLoader,
-		baseToolsOverride,
-	});
-
-	// Mutable per-run state - event handler references this
-	const runState = {
-		ctx: null as SlackContext | null,
-		logCtx: null as { channelId: string; userName?: string; channelName?: string } | null,
-		queue: null as {
-			enqueue(fn: () => Promise<void>, errorContext: string): void;
-			enqueueMessage(text: string, target: "main" | "thread", errorContext: string, doLog?: boolean): void;
-		} | null,
-		pendingTools: new Map<string, { toolName: string; args: unknown; startTime: number }>(),
-		totalUsage: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		},
-		stopReason: "stop",
-		errorMessage: undefined as string | undefined,
-	};
-
-	// Subscribe to events ONCE
-	session.subscribe(async (event) => {
-		// Skip if no active run
-		if (!runState.ctx || !runState.logCtx || !runState.queue) return;
-
-		const { ctx, logCtx, queue, pendingTools } = runState;
-
-		if (event.type === "tool_execution_start") {
-			const agentEvent = event as AgentEvent & { type: "tool_execution_start" };
-			const args = agentEvent.args as { label?: string };
-			const label = args.label || agentEvent.toolName;
-
-			pendingTools.set(agentEvent.toolCallId, {
-				toolName: agentEvent.toolName,
-				args: agentEvent.args,
-				startTime: Date.now(),
-			});
-
-			log.logToolStart(logCtx, agentEvent.toolName, label, agentEvent.args as Record<string, unknown>);
-			queue.enqueue(() => ctx.respond(`_→ ${label}_`, false), "tool label");
-		} else if (event.type === "tool_execution_end") {
-			const agentEvent = event as AgentEvent & { type: "tool_execution_end" };
-			const resultStr = extractToolResultText(agentEvent.result);
-			const pending = pendingTools.get(agentEvent.toolCallId);
-			pendingTools.delete(agentEvent.toolCallId);
-
-			const durationMs = pending ? Date.now() - pending.startTime : 0;
-
-			if (agentEvent.isError) {
-				log.logToolError(logCtx, agentEvent.toolName, durationMs, resultStr);
-			} else {
-				log.logToolSuccess(logCtx, agentEvent.toolName, durationMs, resultStr);
-			}
-
-			// Post args + result to thread
-			const label = pending?.args ? (pending.args as { label?: string }).label : undefined;
-			const argsFormatted = pending
-				? formatToolArgsForSlack(agentEvent.toolName, pending.args as Record<string, unknown>)
-				: "(args not found)";
-			const duration = (durationMs / 1000).toFixed(1);
-			let threadMessage = `*${agentEvent.isError ? "✗" : "✓"} ${agentEvent.toolName}*`;
-			if (label) threadMessage += `: ${label}`;
-			threadMessage += ` (${duration}s)\n`;
-			if (argsFormatted) threadMessage += `\`\`\`\n${argsFormatted}\n\`\`\`\n`;
-			threadMessage += `*Result:*\n\`\`\`\n${resultStr}\n\`\`\``;
-
-			queue.enqueueMessage(threadMessage, "thread", "tool result thread", false);
-
-			if (agentEvent.isError) {
-				queue.enqueue(() => ctx.respond(`_Error: ${truncate(resultStr, 200)}_`, false), "tool error");
-			}
-		} else if (event.type === "message_start") {
-			const agentEvent = event as AgentEvent & { type: "message_start" };
-			if (agentEvent.message.role === "assistant") {
-				log.logResponseStart(logCtx);
-			}
-		} else if (event.type === "message_end") {
-			const agentEvent = event as AgentEvent & { type: "message_end" };
-			if (agentEvent.message.role === "assistant") {
-				const assistantMsg = agentEvent.message as any;
-
-				if (assistantMsg.stopReason) {
-					runState.stopReason = assistantMsg.stopReason;
-				}
-				if (assistantMsg.errorMessage) {
-					runState.errorMessage = assistantMsg.errorMessage;
-				}
-
-				if (assistantMsg.usage) {
-					runState.totalUsage.input += assistantMsg.usage.input;
-					runState.totalUsage.output += assistantMsg.usage.output;
-					runState.totalUsage.cacheRead += assistantMsg.usage.cacheRead;
-					runState.totalUsage.cacheWrite += assistantMsg.usage.cacheWrite;
-					runState.totalUsage.cost.input += assistantMsg.usage.cost.input;
-					runState.totalUsage.cost.output += assistantMsg.usage.cost.output;
-					runState.totalUsage.cost.cacheRead += assistantMsg.usage.cost.cacheRead;
-					runState.totalUsage.cost.cacheWrite += assistantMsg.usage.cost.cacheWrite;
-					runState.totalUsage.cost.total += assistantMsg.usage.cost.total;
-				}
-
-				const content = agentEvent.message.content;
-				const thinkingParts: string[] = [];
-				const textParts: string[] = [];
-				for (const part of content) {
-					if (part.type === "thinking") {
-						thinkingParts.push((part as any).thinking);
-					} else if (part.type === "text") {
-						textParts.push((part as any).text);
-					}
-				}
-
-				const text = textParts.join("\n");
-
-				for (const thinking of thinkingParts) {
-					log.logThinking(logCtx, thinking);
-					queue.enqueueMessage(`_${thinking}_`, "main", "thinking main");
-					queue.enqueueMessage(`_${thinking}_`, "thread", "thinking thread", false);
-				}
-
-				if (text.trim()) {
-					log.logResponse(logCtx, text);
-					queue.enqueueMessage(text, "main", "response main");
-					queue.enqueueMessage(text, "thread", "response thread", false);
-				}
-			}
-		} else if (event.type === "compaction_start") {
-			log.logInfo(`Compaction started (reason: ${event.reason})`);
-			queue.enqueue(() => ctx.respond("_Compacting context..._", false), "compaction start");
-		} else if (event.type === "compaction_end") {
-			if (event.result) {
-				log.logInfo(`Compaction complete: ${event.result.tokensBefore} tokens compacted`);
-			} else if (event.aborted) {
-				log.logInfo("Compaction aborted");
-			}
-		} else if (event.type === "auto_retry_start") {
-			const retryEvent = event as any;
-			log.logWarning(`Retrying (${retryEvent.attempt}/${retryEvent.maxAttempts})`, retryEvent.errorMessage);
-			queue.enqueue(
-				() => ctx.respond(`_Retrying (${retryEvent.attempt}/${retryEvent.maxAttempts})..._`, false),
-				"retry",
-			);
-		}
-	});
-
-	// Slack message limit
-	const SLACK_MAX_LENGTH = 40000;
-	const splitForSlack = (text: string): string[] => {
-		if (text.length <= SLACK_MAX_LENGTH) return [text];
-		const parts: string[] = [];
-		let remaining = text;
-		let partNum = 1;
-		while (remaining.length > 0) {
-			const chunk = remaining.substring(0, SLACK_MAX_LENGTH - 50);
-			remaining = remaining.substring(SLACK_MAX_LENGTH - 50);
-			const suffix = remaining.length > 0 ? `\n_(continued ${partNum}...)_` : "";
-			parts.push(chunk + suffix);
-			partNum++;
-		}
-		return parts;
-	};
-
-	return {
-		async run(
-			ctx: SlackContext,
-			_store: ChannelStore,
-			_pendingMessages?: PendingMessage[],
-		): Promise<{ stopReason: string; errorMessage?: string }> {
-			// Ensure channel directory exists
-			await mkdir(channelDir, { recursive: true });
-
-			// Sync messages from log.jsonl that arrived while we were offline or busy
-			// Exclude the current message (it will be added via prompt())
-			const syncedCount = syncLogToSessionManager(sessionManager, channelDir, ctx.message.ts);
-			if (syncedCount > 0) {
-				log.logInfo(`[${channelId}] Synced ${syncedCount} messages from log.jsonl`);
-			}
-
-			// Reload messages from context.jsonl
-			// This picks up any messages synced above
-			const reloadedSession = sessionManager.buildSessionContext();
-			if (reloadedSession.messages.length > 0) {
-				agent.state.messages = reloadedSession.messages;
-				log.logInfo(`[${channelId}] Reloaded ${reloadedSession.messages.length} messages from context`);
-			}
-
-			// Update system prompt with fresh memory, channel/user info, and skills
-			const memory = getMemory(channelDir);
-			const skills = loadMomSkills(channelDir, workspacePath);
-			const systemPrompt = buildSystemPrompt(
-				workspacePath,
-				channelId,
-				memory,
-				sandboxConfig,
-				ctx.channels,
-				ctx.users,
-				skills,
-			);
-			session.agent.state.systemPrompt = systemPrompt;
-
-			// Set up file upload function
-			setUploadFunction(async (filePath: string, title?: string) => {
-				const hostPath = translateToHostPath(filePath, channelDir, workspacePath, channelId);
-				await ctx.uploadFile(hostPath, title);
-			});
-
-			// Reset per-run state
-			runState.ctx = ctx;
-			runState.logCtx = {
-				channelId: ctx.message.channel,
-				userName: ctx.message.userName,
-				channelName: ctx.channelName,
-			};
-			runState.pendingTools.clear();
-			runState.totalUsage = {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			};
-			runState.stopReason = "stop";
-			runState.errorMessage = undefined;
-
-			// Create queue for this run
-			let queueChain = Promise.resolve();
-			runState.queue = {
-				enqueue(fn: () => Promise<void>, errorContext: string): void {
-					queueChain = queueChain.then(async () => {
-						try {
-							await fn();
-						} catch (err) {
-							const errMsg = err instanceof Error ? err.message : String(err);
-							log.logWarning(`Slack API error (${errorContext})`, errMsg);
-							try {
-								await ctx.respondInThread(`_Error: ${errMsg}_`);
-							} catch {
-								// Ignore
-							}
-						}
-					});
-				},
-				enqueueMessage(text: string, target: "main" | "thread", errorContext: string, doLog = true): void {
-					const parts = splitForSlack(text);
-					for (const part of parts) {
-						this.enqueue(
-							() => (target === "main" ? ctx.respond(part, doLog) : ctx.respondInThread(part)),
-							errorContext,
-						);
-					}
-				},
-			};
-
-			// Log context info
-			log.logInfo(`Context sizes - system: ${systemPrompt.length} chars, memory: ${memory.length} chars`);
-			log.logInfo(`Channels: ${ctx.channels.length}, Users: ${ctx.users.length}`);
-
-			// Build user message with timestamp and username prefix
-			// Format: "[YYYY-MM-DD HH:MM:SS+HH:MM] [username]: message" so LLM knows when and who
-			const now = new Date();
-			const pad = (n: number) => n.toString().padStart(2, "0");
-			const offset = -now.getTimezoneOffset();
-			const offsetSign = offset >= 0 ? "+" : "-";
-			const offsetHours = pad(Math.floor(Math.abs(offset) / 60));
-			const offsetMins = pad(Math.abs(offset) % 60);
-			const timestamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}${offsetSign}${offsetHours}:${offsetMins}`;
-			let userMessage = `[${timestamp}] [${ctx.message.userName || "unknown"}]: ${ctx.message.text}`;
-
-			const imageAttachments: ImageContent[] = [];
-			const nonImagePaths: string[] = [];
-
-			for (const a of ctx.message.attachments || []) {
-				const fullPath = `${workspacePath}/${a.local}`;
-				const mimeType = getImageMimeType(a.local);
-
-				if (mimeType && existsSync(fullPath)) {
-					try {
-						imageAttachments.push({
-							type: "image",
-							mimeType,
-							data: readFileSync(fullPath).toString("base64"),
-						});
-					} catch {
-						nonImagePaths.push(fullPath);
-					}
-				} else {
-					nonImagePaths.push(fullPath);
-				}
-			}
-
-			if (nonImagePaths.length > 0) {
-				userMessage += `\n\n<slack_attachments>\n${nonImagePaths.join("\n")}\n</slack_attachments>`;
-			}
-
-			// Debug: write context to last_prompt.jsonl
-			const debugContext = {
-				systemPrompt,
-				messages: session.messages,
-				newUserMessage: userMessage,
-				imageAttachmentCount: imageAttachments.length,
-			};
-			await writeFile(join(channelDir, "last_prompt.jsonl"), JSON.stringify(debugContext, null, 2));
-
-			await session.prompt(userMessage, imageAttachments.length > 0 ? { images: imageAttachments } : undefined);
-
-			// Wait for queued messages
-			await queueChain;
-
-			// Handle error case - update main message and post error to thread
-			if (runState.stopReason === "error" && runState.errorMessage) {
-				try {
-					await ctx.replaceMessage("_Sorry, something went wrong_");
-					await ctx.respondInThread(`_Error: ${runState.errorMessage}_`);
-				} catch (err) {
-					const errMsg = err instanceof Error ? err.message : String(err);
-					log.logWarning("Failed to post error message", errMsg);
-				}
-			} else {
-				// Final message update
-				const messages = session.messages;
-				const lastAssistant = messages.filter((m) => m.role === "assistant").pop();
-				const finalText =
-					lastAssistant?.content
-						.filter((c): c is { type: "text"; text: string } => c.type === "text")
-						.map((c) => c.text)
-						.join("\n") || "";
-
-				// Check for [SILENT] marker - delete message and thread instead of posting
-				if (finalText.trim() === "[SILENT]" || finalText.trim().startsWith("[SILENT]")) {
-					try {
-						await ctx.deleteMessage();
-						log.logInfo("Silent response - deleted message and thread");
-					} catch (err) {
-						const errMsg = err instanceof Error ? err.message : String(err);
-						log.logWarning("Failed to delete message for silent response", errMsg);
-					}
-				} else if (finalText.trim()) {
-					try {
-						const mainText =
-							finalText.length > SLACK_MAX_LENGTH
-								? `${finalText.substring(0, SLACK_MAX_LENGTH - 50)}\n\n_(see thread for full response)_`
-								: finalText;
-						await ctx.replaceMessage(mainText);
-					} catch (err) {
-						const errMsg = err instanceof Error ? err.message : String(err);
-						log.logWarning("Failed to replace message with final text", errMsg);
-					}
-				}
-			}
-
-			// Log usage summary with context info
-			if (runState.totalUsage.cost.total > 0) {
-				// Get last non-aborted assistant message for context calculation
-				const messages = session.messages;
-				const lastAssistantMessage = messages
-					.slice()
-					.reverse()
-					.find((m) => m.role === "assistant" && (m as any).stopReason !== "aborted") as any;
-
-				const contextTokens = lastAssistantMessage
-					? lastAssistantMessage.usage.input +
-						lastAssistantMessage.usage.output +
-						lastAssistantMessage.usage.cacheRead +
-						lastAssistantMessage.usage.cacheWrite
-					: 0;
-				const contextWindow = model.contextWindow || 200000;
-
-				const summary = log.logUsageSummary(runState.logCtx!, runState.totalUsage, contextTokens, contextWindow);
-				runState.queue.enqueue(() => ctx.respondInThread(summary), "usage summary");
-				await queueChain;
-			}
-
-			// Clear run state
-			runState.ctx = null;
-			runState.logCtx = null;
-			runState.queue = null;
-
-			return { stopReason: runState.stopReason, errorMessage: runState.errorMessage };
-		},
-
-		abort(): void {
-			session.abort();
-		},
-	};
+	return { promptText, imageAttachments };
 }
 
-/**
- * Translate container path back to host path for file operations
- */
+function rebuildSlackPrompt(ctx: SlackContext, workspacePath: string, rawText: string): string {
+	const nextContext: SlackContext = {
+		...ctx,
+		message: {
+			...ctx.message,
+			text: rawText,
+			rawText: rawText,
+		},
+	};
+	return buildPromptInput(nextContext, workspacePath).promptText;
+}
+
+function buildSlackTimestamp(): string {
+	const now = new Date();
+	const pad = (value: number) => value.toString().padStart(2, "0");
+	const offsetMinutes = -now.getTimezoneOffset();
+	const sign = offsetMinutes >= 0 ? "+" : "-";
+	const offsetHours = pad(Math.floor(Math.abs(offsetMinutes) / 60));
+	const remainingOffsetMinutes = pad(Math.abs(offsetMinutes) % 60);
+	return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}${sign}${offsetHours}:${remainingOffsetMinutes}`;
+}
+
 function translateToHostPath(
 	containerPath: string,
 	channelDir: string,
@@ -870,9 +1168,9 @@ function translateToHostPath(
 	channelId: string,
 ): string {
 	if (workspacePath === "/workspace") {
-		const prefix = `/workspace/${channelId}/`;
-		if (containerPath.startsWith(prefix)) {
-			return join(channelDir, containerPath.slice(prefix.length));
+		const channelPrefix = `/workspace/${channelId}/`;
+		if (containerPath.startsWith(channelPrefix)) {
+			return join(channelDir, containerPath.slice(channelPrefix.length));
 		}
 		if (containerPath.startsWith("/workspace/")) {
 			return join(channelDir, "..", containerPath.slice("/workspace/".length));

--- a/packages/mom/src/context.ts
+++ b/packages/mom/src/context.ts
@@ -7,7 +7,7 @@
  *
  * This module provides:
  * - syncLogToSessionManager: Syncs messages from log.jsonl to SessionManager
- * - createMomSettingsManager: Creates a SettingsManager backed by workspace settings.json
+ * - createMomSettingsManager: Creates a SettingsManager backed by workspace .pi/settings.json
  */
 
 import type { UserMessage } from "@mariozechner/pi-ai";
@@ -151,7 +151,7 @@ class WorkspaceSettingsStorage implements MomSettingsStorage {
 	private settingsPath: string;
 
 	constructor(workspaceDir: string) {
-		this.settingsPath = join(workspaceDir, "settings.json");
+		this.settingsPath = join(workspaceDir, ".pi", "settings.json");
 	}
 
 	withLock(scope: "global" | "project", fn: (current: string | undefined) => string | undefined): void {

--- a/packages/mom/src/extensions.ts
+++ b/packages/mom/src/extensions.ts
@@ -1,0 +1,544 @@
+import type { ImageContent, Model } from "@mariozechner/pi-ai";
+import {
+	type AgentSession,
+	createExtensionRuntime,
+	discoverAndLoadExtensions,
+	type ExtensionContext,
+	type ExtensionRunner,
+	type ExtensionRuntime,
+	type InputEventResult,
+	type InputSource,
+	type LoadExtensionsResult,
+} from "@mariozechner/pi-coding-agent";
+
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from "fs";
+import { isAbsolute, join, relative, resolve } from "path";
+
+type StartupModelSelectSource = "set" | "cycle" | "restore";
+
+const DIRECT_RESPONSE_CUSTOM_TYPE = "mom-direct-response";
+
+interface WorkspaceExtensionSettings {
+	extensions?: string[];
+	packages?: unknown;
+}
+
+interface DiscoveredEntry {
+	absolutePath: string;
+	realPath: string;
+	sortKey: string;
+}
+
+interface MomAugmentedExtensionContext extends ExtensionContext {
+	channel?: string;
+	channelId?: string;
+	channelName?: string;
+	user?: string;
+	userId?: string;
+	userName?: string;
+	threadTs?: string;
+	requestContext?: MomRequestContext;
+	message?: {
+		channel: string;
+		user: string;
+		ts: string;
+		threadTs?: string;
+		text: string;
+		attachments: string[];
+	};
+}
+
+interface RuntimeBackdoor {
+	runtime: ExtensionRuntime;
+	createContext(): ExtensionContext;
+}
+
+interface SlackDirectResponseContent {
+	mainText: string;
+	threadText?: string;
+}
+
+export interface MomTrustConfig {
+	strict: boolean;
+	trustedRoot?: string;
+}
+
+export interface ExtensionLoadPlan {
+	mode: "strict" | "permissive";
+	entries: string[];
+	trustedRoot?: string;
+	ignoredWorkspaceAuthorities: string[];
+	warnings: string[];
+}
+
+export interface MomRequestContext {
+	channel: string;
+	channelId: string;
+	channelName?: string;
+	user: string;
+	userId: string;
+	userName?: string;
+	threadTs?: string;
+	slackTs: string;
+	rawText: string;
+	attachments: string[];
+	isEvent: boolean;
+}
+
+export interface MomSlackMessageCallbacks {
+	clearThinking(): void;
+	markCustomResponseHandled(): void;
+	publishFinal(text: string, shouldLog?: boolean): Promise<void>;
+	respond(text: string, shouldLog?: boolean): Promise<void>;
+	respondInThread(text: string): Promise<void>;
+}
+
+export interface MomExtensionBridge {
+	runner?: ExtensionRunner;
+	setRequestContext(requestContext: MomRequestContext): void;
+	clearRequestContext(): void;
+	setSlackCallbacks(callbacks: MomSlackMessageCallbacks): void;
+	clearSlackCallbacks(): void;
+	emitRawInput(text: string, images: ImageContent[] | undefined, source: InputSource): Promise<InputEventResult>;
+	emitStartupModelSelect(model: Model<any>, source: StartupModelSelectSource): Promise<void>;
+	flushPendingSlackEffects(): Promise<void>;
+}
+
+type RuntimeCustomMessage = Parameters<ExtensionRuntime["sendMessage"]>[0];
+
+export function resolveMomTrustConfig(workspaceDir: string): MomTrustConfig {
+	const configuredRoot = process.env.MOM_TRUSTED_EXTENSION_ROOT?.trim();
+	if (!configuredRoot) {
+		return { strict: false };
+	}
+
+	if (!isAbsolute(configuredRoot)) {
+		throw new Error("MOM_TRUSTED_EXTENSION_ROOT must be an absolute path");
+	}
+
+	const workspaceRealPath = realpathSync(workspaceDir);
+	const trustedRootRealPath = realpathSync(configuredRoot);
+	if (isSameOrInside(trustedRootRealPath, workspaceRealPath)) {
+		throw new Error(`MOM_TRUSTED_EXTENSION_ROOT must be outside the workspace: ${trustedRootRealPath}`);
+	}
+
+	return {
+		strict: true,
+		trustedRoot: trustedRootRealPath,
+	};
+}
+
+export function validateStrictTrustBoundary(workspaceDir: string, trustConfig: MomTrustConfig): void {
+	if (!trustConfig.strict) {
+		return;
+	}
+
+	const offenders = findWorkspaceTrustBoundaryOffenders(workspaceDir);
+	if (offenders.length === 0) {
+		return;
+	}
+
+	throw new Error(
+		`Strict trust mode blocked workspace extension authority: ${offenders[0]}. ` +
+			`Allowed runtime extensions are only repo-managed files under ${trustConfig.trustedRoot}`,
+	);
+}
+
+export function createExtensionLoadPlan(workspaceDir: string, trustConfig: MomTrustConfig): ExtensionLoadPlan {
+	const settings = readWorkspaceExtensionSettings(workspaceDir);
+	const warnings = [...settings.warnings];
+	const ignoredWorkspaceAuthorities: string[] = [];
+
+	if (trustConfig.strict) {
+		if (settings.values.extensions && settings.values.extensions.length > 0) {
+			ignoredWorkspaceAuthorities.push("workspace .pi/settings.json extensions");
+			warnings.push("Ignoring workspace .pi/settings.json extensions in strict trust mode");
+		}
+		if (settings.values.packages !== undefined) {
+			ignoredWorkspaceAuthorities.push("workspace .pi/settings.json packages");
+			warnings.push("Ignoring workspace .pi/settings.json packages in strict trust mode");
+		}
+
+		const trustedRoot = trustConfig.trustedRoot;
+		if (!trustedRoot) {
+			throw new Error("Strict trust mode requires a trusted extension root");
+		}
+
+		return {
+			mode: "strict",
+			entries: dedupeEntries(discoverExtensionEntries(trustedRoot, workspaceDir).map((entry) => entry.realPath)),
+			trustedRoot,
+			ignoredWorkspaceAuthorities,
+			warnings,
+		};
+	}
+
+	if (settings.values.packages !== undefined) {
+		ignoredWorkspaceAuthorities.push("workspace .pi/settings.json packages");
+		warnings.push("Ignoring workspace .pi/settings.json packages in permissive mode");
+	}
+
+	const settingsEntries: string[] = [];
+	for (const configuredPath of settings.values.extensions ?? []) {
+		const resolvedPath = resolve(workspaceDir, configuredPath);
+		for (const entry of discoverExtensionEntries(resolvedPath)) {
+			settingsEntries.push(entry.realPath);
+		}
+	}
+
+	const workspaceExtensionsDir = join(workspaceDir, ".pi", "extensions");
+	const discoveredWorkspaceEntries = existsSync(workspaceExtensionsDir)
+		? discoverExtensionEntries(workspaceExtensionsDir).map((entry) => entry.realPath)
+		: [];
+
+	return {
+		mode: "permissive",
+		entries: dedupeEntries([...settingsEntries, ...discoveredWorkspaceEntries]),
+		ignoredWorkspaceAuthorities,
+		warnings,
+	};
+}
+
+export async function loadMomExtensions(plan: ExtensionLoadPlan, workspaceDir: string): Promise<LoadExtensionsResult> {
+	if (plan.entries.length === 0) {
+		return {
+			extensions: [],
+			errors: [],
+			runtime: createExtensionRuntime(),
+		};
+	}
+
+	const disabledAutoDiscoveryCwd = join(workspaceDir, ".__mom_disabled_extension_autodiscovery_cwd__");
+	const disabledAutoDiscoveryAgentDir = join(workspaceDir, ".__mom_disabled_extension_autodiscovery_agent_dir__");
+	return discoverAndLoadExtensions(plan.entries, disabledAutoDiscoveryCwd, disabledAutoDiscoveryAgentDir);
+}
+
+export function createMomExtensionBridge(
+	session: AgentSession,
+	currentModelRef: { current: Model<any> },
+): MomExtensionBridge {
+	const runner = session.extensionRunner;
+	if (!runner) {
+		return createNoOpBridge();
+	}
+
+	let requestContext: MomRequestContext | undefined;
+	let slackCallbacks: MomSlackMessageCallbacks | undefined;
+	let slackEffectChain = Promise.resolve();
+	let pendingSlackEffectError: unknown;
+
+	patchCreateContext(runner, () => requestContext);
+
+	const runtime = getRunnerRuntime(runner);
+	const originalSetModel = runtime.setModel.bind(runtime);
+	runtime.setModel = async (model) => {
+		const didSetModel = await originalSetModel(model);
+		if (didSetModel) {
+			currentModelRef.current = model;
+		}
+		return didSetModel;
+	};
+
+	const originalSendMessage = runtime.sendMessage.bind(runtime);
+	const enqueueSlackEffect = (effect: () => Promise<void>): void => {
+		const nextEffect = slackEffectChain.catch(() => {}).then(effect);
+		slackEffectChain = nextEffect.catch((error) => {
+			pendingSlackEffectError = error;
+		});
+	};
+	runtime.sendMessage = (message, options) => {
+		if (!slackCallbacks) {
+			originalSendMessage(message, options);
+			return;
+		}
+
+		enqueueSlackEffect(async () => {
+			try {
+				await renderCustomMessageToSlack(message, slackCallbacks!);
+			} finally {
+				originalSendMessage(message, options);
+			}
+		});
+	};
+
+	return {
+		runner,
+		setRequestContext(nextRequestContext: MomRequestContext): void {
+			requestContext = nextRequestContext;
+		},
+		clearRequestContext(): void {
+			requestContext = undefined;
+		},
+		setSlackCallbacks(callbacks: MomSlackMessageCallbacks): void {
+			slackCallbacks = callbacks;
+		},
+		clearSlackCallbacks(): void {
+			slackCallbacks = undefined;
+		},
+		async emitRawInput(
+			text: string,
+			images: ImageContent[] | undefined,
+			source: InputSource,
+		): Promise<InputEventResult> {
+			if (!runner.hasHandlers("input")) {
+				return { action: "continue" };
+			}
+			return runner.emitInput(text, images, source);
+		},
+		async emitStartupModelSelect(model: Model<any>, source: StartupModelSelectSource): Promise<void> {
+			if (!runner.hasHandlers("model_select")) {
+				return;
+			}
+			await runner.emit({
+				type: "model_select",
+				model,
+				previousModel: undefined,
+				source,
+			});
+		},
+		async flushPendingSlackEffects(): Promise<void> {
+			await slackEffectChain;
+			if (pendingSlackEffectError) {
+				const error = pendingSlackEffectError;
+				pendingSlackEffectError = undefined;
+				throw error;
+			}
+		},
+	};
+}
+
+function createNoOpBridge(): MomExtensionBridge {
+	return {
+		setRequestContext(): void {},
+		clearRequestContext(): void {},
+		setSlackCallbacks(): void {},
+		clearSlackCallbacks(): void {},
+		async emitRawInput(): Promise<InputEventResult> {
+			return { action: "continue" };
+		},
+		async emitStartupModelSelect(): Promise<void> {},
+		async flushPendingSlackEffects(): Promise<void> {},
+	};
+}
+
+function patchCreateContext(runner: ExtensionRunner, getRequestContext: () => MomRequestContext | undefined): void {
+	const backdoor = runner as unknown as RuntimeBackdoor;
+	const originalCreateContext = backdoor.createContext.bind(runner);
+
+	backdoor.createContext = () => {
+		const context = originalCreateContext() as MomAugmentedExtensionContext;
+		const requestContext = getRequestContext();
+		if (!requestContext) {
+			return context;
+		}
+
+		context.channel = requestContext.channel;
+		context.channelId = requestContext.channelId;
+		context.channelName = requestContext.channelName;
+		context.user = requestContext.user;
+		context.userId = requestContext.userId;
+		context.userName = requestContext.userName;
+		context.threadTs = requestContext.threadTs;
+		context.requestContext = requestContext;
+		context.message = {
+			channel: requestContext.channel,
+			user: requestContext.user,
+			ts: requestContext.slackTs,
+			threadTs: requestContext.threadTs,
+			text: requestContext.rawText,
+			attachments: requestContext.attachments,
+		};
+		return context;
+	};
+}
+
+function getRunnerRuntime(runner: ExtensionRunner): ExtensionRuntime {
+	return (runner as unknown as RuntimeBackdoor).runtime;
+}
+
+async function renderCustomMessageToSlack(
+	message: RuntimeCustomMessage,
+	callbacks: MomSlackMessageCallbacks,
+): Promise<void> {
+	if (message.customType === DIRECT_RESPONSE_CUSTOM_TYPE && isSlackDirectResponseContent(message.content)) {
+		callbacks.clearThinking();
+		callbacks.markCustomResponseHandled();
+		await callbacks.publishFinal(message.content.mainText, true);
+		if (message.content.threadText) {
+			await callbacks.respondInThread(message.content.threadText);
+		}
+		return;
+	}
+
+	if (message.display !== false && typeof message.content === "string") {
+		callbacks.clearThinking();
+		await callbacks.respond(message.content, false);
+	}
+}
+
+function isSlackDirectResponseContent(content: unknown): content is SlackDirectResponseContent {
+	return (
+		typeof content === "object" &&
+		content !== null &&
+		"mainText" in content &&
+		typeof (content as { mainText?: unknown }).mainText === "string" &&
+		(!("threadText" in content) || typeof (content as { threadText?: unknown }).threadText === "string")
+	);
+}
+
+function readWorkspaceExtensionSettings(workspaceDir: string): {
+	values: WorkspaceExtensionSettings;
+	warnings: string[];
+} {
+	const settingsPath = join(workspaceDir, ".pi", "settings.json");
+	if (!existsSync(settingsPath)) {
+		return { values: {}, warnings: [] };
+	}
+
+	try {
+		const parsed = JSON.parse(readFileSync(settingsPath, "utf-8")) as WorkspaceExtensionSettings;
+		return { values: parsed, warnings: [] };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			values: {},
+			warnings: [`Ignoring invalid workspace settings file ${settingsPath}: ${message}`],
+		};
+	}
+}
+
+function discoverExtensionEntries(rootPath: string, workspaceDir?: string): DiscoveredEntry[] {
+	if (!existsSync(rootPath)) {
+		return [];
+	}
+
+	const stat = lstatSync(rootPath);
+	if (stat.isFile()) {
+		if (!isExtensionEntryFile(rootPath)) {
+			return [];
+		}
+		const realPath = realpathSync(rootPath);
+		if (workspaceDir && isSameOrInside(realPath, realpathSync(workspaceDir))) {
+			throw new Error(`Trusted extension entry resolves inside workspace: ${realPath}`);
+		}
+		return [
+			{
+				absolutePath: rootPath,
+				realPath,
+				sortKey: fileName(rootPath),
+			},
+		];
+	}
+
+	if (!stat.isDirectory()) {
+		return [];
+	}
+
+	const discovered: DiscoveredEntry[] = [];
+	for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
+		const absolutePath = join(rootPath, entry.name);
+		if (entry.isFile()) {
+			if (!isExtensionEntryFile(entry.name)) {
+				continue;
+			}
+			discovered.push(createDiscoveredEntry(rootPath, absolutePath, workspaceDir));
+			continue;
+		}
+
+		if (!entry.isDirectory()) {
+			continue;
+		}
+
+		const indexTs = join(absolutePath, "index.ts");
+		const indexJs = join(absolutePath, "index.js");
+		if (existsSync(indexTs)) {
+			discovered.push(createDiscoveredEntry(rootPath, indexTs, workspaceDir));
+			continue;
+		}
+		if (existsSync(indexJs)) {
+			discovered.push(createDiscoveredEntry(rootPath, indexJs, workspaceDir));
+		}
+	}
+
+	return discovered.sort((left, right) => left.sortKey.localeCompare(right.sortKey));
+}
+
+function createDiscoveredEntry(rootPath: string, entryPath: string, workspaceDir?: string): DiscoveredEntry {
+	const realPath = realpathSync(entryPath);
+	if (workspaceDir && isSameOrInside(realPath, realpathSync(workspaceDir))) {
+		throw new Error(`Trusted extension entry resolves inside workspace: ${realPath}`);
+	}
+
+	return {
+		absolutePath: entryPath,
+		realPath,
+		sortKey: relative(rootPath, entryPath).replaceAll("\\", "/"),
+	};
+}
+
+function dedupeEntries(entries: string[]): string[] {
+	const dedupedEntries: string[] = [];
+	const seen = new Set<string>();
+
+	for (const entry of entries) {
+		if (seen.has(entry)) {
+			continue;
+		}
+		seen.add(entry);
+		dedupedEntries.push(entry);
+	}
+
+	return dedupedEntries;
+}
+
+function findWorkspaceTrustBoundaryOffenders(workspaceDir: string): string[] {
+	const offenders: string[] = [];
+	const rootPath = realpathSync(workspaceDir);
+	const stack = [rootPath];
+
+	while (stack.length > 0) {
+		const currentPath = stack.pop();
+		if (!currentPath) {
+			continue;
+		}
+
+		for (const entry of readdirSync(currentPath, { withFileTypes: true })) {
+			const entryPath = join(currentPath, entry.name);
+			const relativePath = relative(rootPath, entryPath).replaceAll("\\", "/");
+
+			if (entry.isDirectory()) {
+				if (relativePath.endsWith("/.pi/extensions") || relativePath === ".pi/extensions") {
+					offenders.push(relativePath);
+					continue;
+				}
+				stack.push(entryPath);
+				continue;
+			}
+
+			if (!entry.isFile() || !isExtensionEntryFile(entry.name)) {
+				continue;
+			}
+
+			const segments = relativePath.split("/");
+			if (segments.includes("extensions")) {
+				offenders.push(relativePath);
+			}
+		}
+	}
+
+	return offenders.sort((left, right) => left.localeCompare(right));
+}
+
+function isExtensionEntryFile(filePath: string): boolean {
+	return filePath.endsWith(".ts") || filePath.endsWith(".js");
+}
+
+function isSameOrInside(candidatePath: string, parentPath: string): boolean {
+	const relativePath = relative(parentPath, candidatePath);
+	return relativePath === "" || (!relativePath.startsWith("..") && !relativePath.startsWith("../"));
+}
+
+function fileName(filePath: string): string {
+	const segments = filePath.replaceAll("\\", "/").split("/");
+	return segments[segments.length - 1] ?? filePath;
+}

--- a/packages/mom/src/main.ts
+++ b/packages/mom/src/main.ts
@@ -1,17 +1,28 @@
 #!/usr/bin/env node
 
 import { join, resolve } from "path";
-import { type AgentRunner, getOrCreateRunner } from "./agent.js";
+import { type AgentRunner, createRunner } from "./agent.js";
 import { downloadChannel } from "./download.js";
 import { createEventsWatcher } from "./events.js";
+import { resolveMomTrustConfig, validateStrictTrustBoundary } from "./extensions.js";
 import * as log from "./log.js";
 import { parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
-import { type MomHandler, type SlackBot, SlackBot as SlackBotClass, type SlackEvent } from "./slack.js";
+import {
+	type MomHandler,
+	type SlackBot,
+	SlackBot as SlackBotClass,
+	type SlackContext,
+	type SlackEvent,
+} from "./slack.js";
+import {
+	MAX_MAIN_MESSAGE_LENGTH,
+	MAX_THREAD_MESSAGE_LENGTH,
+	publishSplitFinalSlackReply,
+	THREAD_TRUNCATION_NOTE,
+	TRUNCATION_NOTE,
+	truncateSlackText,
+} from "./slack-message-utils.js";
 import { ChannelStore } from "./store.js";
-
-// ============================================================================
-// Config
-// ============================================================================
 
 const MOM_SLACK_APP_TOKEN = process.env.MOM_SLACK_APP_TOKEN;
 const MOM_SLACK_BOT_TOKEN = process.env.MOM_SLACK_BOT_TOKEN;
@@ -22,22 +33,31 @@ interface ParsedArgs {
 	downloadChannel?: string;
 }
 
+interface ChannelState {
+	running: boolean;
+	runner?: AgentRunner;
+	store: ChannelStore;
+	stopRequested: boolean;
+	stopMessageTs?: string;
+	channelDir: string;
+}
+
 function parseArgs(): ParsedArgs {
 	const args = process.argv.slice(2);
 	let sandbox: SandboxConfig = { type: "host" };
 	let workingDir: string | undefined;
 	let downloadChannelId: string | undefined;
 
-	for (let i = 0; i < args.length; i++) {
-		const arg = args[i];
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
 		if (arg.startsWith("--sandbox=")) {
 			sandbox = parseSandboxArg(arg.slice("--sandbox=".length));
 		} else if (arg === "--sandbox") {
-			sandbox = parseSandboxArg(args[++i] || "");
+			sandbox = parseSandboxArg(args[++index] || "");
 		} else if (arg.startsWith("--download=")) {
 			downloadChannelId = arg.slice("--download=".length);
 		} else if (arg === "--download") {
-			downloadChannelId = args[++i];
+			downloadChannelId = args[++index];
 		} else if (!arg.startsWith("-")) {
 			workingDir = arg;
 		}
@@ -52,7 +72,6 @@ function parseArgs(): ParsedArgs {
 
 const parsedArgs = parseArgs();
 
-// Handle --download mode
 if (parsedArgs.downloadChannel) {
 	if (!MOM_SLACK_BOT_TOKEN) {
 		console.error("Missing env: MOM_SLACK_BOT_TOKEN");
@@ -62,32 +81,29 @@ if (parsedArgs.downloadChannel) {
 	process.exit(0);
 }
 
-// Normal bot mode - require working dir
 if (!parsedArgs.workingDir) {
 	console.error("Usage: mom [--sandbox=host|docker:<name>] <working-directory>");
 	console.error("       mom --download <channel-id>");
 	process.exit(1);
 }
 
-const { workingDir, sandbox } = { workingDir: parsedArgs.workingDir, sandbox: parsedArgs.sandbox };
+const workingDir = parsedArgs.workingDir;
+const sandbox = parsedArgs.sandbox;
 
 if (!MOM_SLACK_APP_TOKEN || !MOM_SLACK_BOT_TOKEN) {
 	console.error("Missing env: MOM_SLACK_APP_TOKEN, MOM_SLACK_BOT_TOKEN");
 	process.exit(1);
 }
 
+process.chdir(workingDir);
 await validateSandbox(sandbox);
 
-// ============================================================================
-// State (per channel)
-// ============================================================================
+const trustConfig = resolveMomTrustConfig(workingDir);
+validateStrictTrustBoundary(workingDir, trustConfig);
 
-interface ChannelState {
-	running: boolean;
-	runner: AgentRunner;
-	store: ChannelStore;
-	stopRequested: boolean;
-	stopMessageTs?: string;
+log.logStartup(workingDir, sandbox.type === "host" ? "host" : `docker:${sandbox.container}`);
+if (trustConfig.strict) {
+	log.logInfo(`Strict trusted-extension mode enabled: ${trustConfig.trustedRoot}`);
 }
 
 const channelStates = new Map<string, ChannelState>();
@@ -95,34 +111,122 @@ const channelStates = new Map<string, ChannelState>();
 function getState(channelId: string): ChannelState {
 	let state = channelStates.get(channelId);
 	if (!state) {
-		const channelDir = join(workingDir, channelId);
 		state = {
 			running: false,
-			runner: getOrCreateRunner(sandbox, channelId, channelDir),
 			store: new ChannelStore({ workingDir, botToken: MOM_SLACK_BOT_TOKEN! }),
 			stopRequested: false,
+			channelDir: join(workingDir, channelId),
 		};
 		channelStates.set(channelId, state);
 	}
 	return state;
 }
 
-// ============================================================================
-// Create SlackContext adapter
-// ============================================================================
+function ensureRunner(state: ChannelState, channelId: string): AgentRunner {
+	if (!state.runner) {
+		state.runner = createRunner({
+			sandboxConfig: sandbox,
+			channelId,
+			channelDir: state.channelDir,
+			workspaceDir: workingDir,
+			trustConfig,
+		});
+	}
+	return state.runner;
+}
 
-function createSlackContext(event: SlackEvent, slack: SlackBot, state: ChannelState, isEvent?: boolean) {
+function createSlackContext(event: SlackEvent, slack: SlackBot, isEvent = false): SlackContext {
 	let messageTs: string | null = null;
 	const threadMessageTs: string[] = [];
 	let accumulatedText = "";
 	let isWorking = true;
-	const workingIndicator = " ...";
+	let finalMessageLogged = false;
 	let updatePromise = Promise.resolve();
 
+	const workingIndicator = " ...";
 	const user = slack.getUser(event.user);
-
-	// Extract event filename for status message
+	const channelMentionThreadRootTs = !isEvent && event.type === "mention" ? (event.threadTs ?? event.ts) : undefined;
 	const eventFilename = isEvent ? event.text.match(/^\[EVENT:([^:]+):/)?.[1] : undefined;
+
+	const postPrimaryMessage = async (text: string): Promise<string> => {
+		if (channelMentionThreadRootTs) {
+			return slack.postInThread(event.channel, channelMentionThreadRootTs, text);
+		}
+		return slack.postMessage(event.channel, text);
+	};
+
+	const updatePrimaryMessage = async (text: string): Promise<void> => {
+		if (messageTs) {
+			await slack.updateMessage(event.channel, messageTs, text);
+			return;
+		}
+		messageTs = await postPrimaryMessage(text);
+	};
+
+	const respond: SlackContext["respond"] = async (text, shouldLog = false) => {
+		updatePromise = updatePromise.then(async () => {
+			try {
+				accumulatedText = accumulatedText ? `${accumulatedText}\n${text}` : text;
+				const displayText = isWorking
+					? truncateSlackText(accumulatedText, MAX_MAIN_MESSAGE_LENGTH, TRUNCATION_NOTE) + workingIndicator
+					: truncateSlackText(accumulatedText, MAX_MAIN_MESSAGE_LENGTH, TRUNCATION_NOTE);
+				await updatePrimaryMessage(displayText);
+				if (shouldLog && messageTs) {
+					slack.logBotResponse(event.channel, text, messageTs);
+				}
+			} catch (error) {
+				log.logWarning("Slack respond error", error instanceof Error ? error.message : String(error));
+			}
+		});
+		await updatePromise;
+	};
+
+	const publishFinal: SlackContext["publishFinal"] = async (text, shouldLog = false) => {
+		updatePromise = updatePromise.then(async () => {
+			try {
+				const { mainText } = await publishSplitFinalSlackReply({
+					text,
+					updateMainMessage: async (nextText) => {
+						accumulatedText = nextText;
+						await updatePrimaryMessage(accumulatedText);
+					},
+					postInThread: async (overflowPart) => {
+						const ts = await slack.postInThread(
+							event.channel,
+							channelMentionThreadRootTs ?? messageTs!,
+							overflowPart,
+						);
+						threadMessageTs.push(ts);
+					},
+				});
+				if (shouldLog && !finalMessageLogged && messageTs) {
+					slack.logBotResponse(event.channel, mainText, messageTs);
+					finalMessageLogged = true;
+				}
+			} catch (error) {
+				log.logWarning("Slack publishFinal error", error instanceof Error ? error.message : String(error));
+			}
+		});
+		await updatePromise;
+	};
+
+	const respondInThread: SlackContext["respondInThread"] = async (text) => {
+		updatePromise = updatePromise.then(async () => {
+			try {
+				const threadRootTs = channelMentionThreadRootTs ?? messageTs;
+				if (!threadRootTs) {
+					return;
+				}
+
+				const threadText = truncateSlackText(text, MAX_THREAD_MESSAGE_LENGTH, THREAD_TRUNCATION_NOTE);
+				const ts = await slack.postInThread(event.channel, threadRootTs, threadText);
+				threadMessageTs.push(ts);
+			} catch (error) {
+				log.logWarning("Slack respondInThread error", error instanceof Error ? error.message : String(error));
+			}
+		});
+		await updatePromise;
+	};
 
 	return {
 		message: {
@@ -132,138 +236,65 @@ function createSlackContext(event: SlackEvent, slack: SlackBot, state: ChannelSt
 			userName: user?.userName,
 			channel: event.channel,
 			ts: event.ts,
-			attachments: (event.attachments || []).map((a) => ({ local: a.local })),
+			threadTs: channelMentionThreadRootTs ?? event.threadTs,
+			attachments: (event.attachments || []).map((attachment) => ({ local: attachment.local })),
 		},
 		channelName: slack.getChannel(event.channel)?.name,
-		store: state.store,
-		channels: slack.getAllChannels().map((c) => ({ id: c.id, name: c.name })),
-		users: slack.getAllUsers().map((u) => ({ id: u.id, userName: u.userName, displayName: u.displayName })),
-
-		respond: async (text: string, shouldLog = true) => {
-			updatePromise = updatePromise.then(async () => {
-				try {
-					accumulatedText = accumulatedText ? `${accumulatedText}\n${text}` : text;
-
-					// Truncate accumulated text if too long (Slack limit is 40K, we use 35K for safety)
-					const MAX_MAIN_LENGTH = 35000;
-					const truncationNote = "\n\n_(message truncated, ask me to elaborate on specific parts)_";
-					if (accumulatedText.length > MAX_MAIN_LENGTH) {
-						accumulatedText =
-							accumulatedText.substring(0, MAX_MAIN_LENGTH - truncationNote.length) + truncationNote;
-					}
-
-					const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
-
-					if (messageTs) {
-						await slack.updateMessage(event.channel, messageTs, displayText);
-					} else {
-						messageTs = await slack.postMessage(event.channel, displayText);
-					}
-
-					if (shouldLog && messageTs) {
-						slack.logBotResponse(event.channel, text, messageTs);
-					}
-				} catch (err) {
-					log.logWarning("Slack respond error", err instanceof Error ? err.message : String(err));
-				}
-			});
-			await updatePromise;
-		},
-
-		replaceMessage: async (text: string) => {
-			updatePromise = updatePromise.then(async () => {
-				try {
-					// Replace the accumulated text entirely, with truncation
-					const MAX_MAIN_LENGTH = 35000;
-					const truncationNote = "\n\n_(message truncated, ask me to elaborate on specific parts)_";
-					if (text.length > MAX_MAIN_LENGTH) {
-						accumulatedText = text.substring(0, MAX_MAIN_LENGTH - truncationNote.length) + truncationNote;
-					} else {
-						accumulatedText = text;
-					}
-
-					const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
-
-					if (messageTs) {
-						await slack.updateMessage(event.channel, messageTs, displayText);
-					} else {
-						messageTs = await slack.postMessage(event.channel, displayText);
-					}
-				} catch (err) {
-					log.logWarning("Slack replaceMessage error", err instanceof Error ? err.message : String(err));
-				}
-			});
-			await updatePromise;
-		},
-
-		respondInThread: async (text: string) => {
-			updatePromise = updatePromise.then(async () => {
-				try {
-					if (messageTs) {
-						// Truncate thread messages if too long (20K limit for safety)
-						const MAX_THREAD_LENGTH = 20000;
-						let threadText = text;
-						if (threadText.length > MAX_THREAD_LENGTH) {
-							threadText = `${threadText.substring(0, MAX_THREAD_LENGTH - 50)}\n\n_(truncated)_`;
-						}
-
-						const ts = await slack.postInThread(event.channel, messageTs, threadText);
-						threadMessageTs.push(ts);
-					}
-				} catch (err) {
-					log.logWarning("Slack respondInThread error", err instanceof Error ? err.message : String(err));
-				}
-			});
-			await updatePromise;
-		},
-
-		setTyping: async (isTyping: boolean) => {
-			if (isTyping && !messageTs) {
-				updatePromise = updatePromise.then(async () => {
-					try {
-						if (!messageTs) {
-							accumulatedText = eventFilename ? `_Starting event: ${eventFilename}_` : "_Thinking_";
-							messageTs = await slack.postMessage(event.channel, accumulatedText + workingIndicator);
-						}
-					} catch (err) {
-						log.logWarning("Slack setTyping error", err instanceof Error ? err.message : String(err));
-					}
-				});
-				await updatePromise;
+		isEvent,
+		channels: slack.getAllChannels().map((channel) => ({ id: channel.id, name: channel.name })),
+		users: slack.getAllUsers().map((slackUser) => ({
+			id: slackUser.id,
+			userName: slackUser.userName,
+			displayName: slackUser.displayName,
+		})),
+		respond,
+		publishFinal,
+		replaceMessage: async (text) => publishFinal(text, false),
+		respondInThread,
+		setTyping: async (isTyping) => {
+			if (!isTyping || messageTs) {
+				return;
 			}
-		},
 
-		uploadFile: async (filePath: string, title?: string) => {
+			updatePromise = updatePromise.then(async () => {
+				try {
+					if (!messageTs) {
+						accumulatedText = eventFilename ? `_Starting event: ${eventFilename}_` : "_Thinking_";
+						messageTs = await postPrimaryMessage(`${accumulatedText}${workingIndicator}`);
+					}
+				} catch (error) {
+					log.logWarning("Slack setTyping error", error instanceof Error ? error.message : String(error));
+				}
+			});
+			await updatePromise;
+		},
+		uploadFile: async (filePath, title) => {
 			await slack.uploadFile(event.channel, filePath, title);
 		},
-
-		setWorking: async (working: boolean) => {
+		setWorking: async (working) => {
 			updatePromise = updatePromise.then(async () => {
 				try {
 					isWorking = working;
 					if (messageTs) {
-						const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
+						const displayText = isWorking ? `${accumulatedText}${workingIndicator}` : accumulatedText;
 						await slack.updateMessage(event.channel, messageTs, displayText);
 					}
-				} catch (err) {
-					log.logWarning("Slack setWorking error", err instanceof Error ? err.message : String(err));
+				} catch (error) {
+					log.logWarning("Slack setWorking error", error instanceof Error ? error.message : String(error));
 				}
 			});
 			await updatePromise;
 		},
-
 		deleteMessage: async () => {
 			updatePromise = updatePromise.then(async () => {
-				// Delete thread messages first (in reverse order)
-				for (let i = threadMessageTs.length - 1; i >= 0; i--) {
+				for (let index = threadMessageTs.length - 1; index >= 0; index--) {
 					try {
-						await slack.deleteMessage(event.channel, threadMessageTs[i]);
+						await slack.deleteMessage(event.channel, threadMessageTs[index]);
 					} catch {
-						// Ignore errors deleting thread messages
+						// Ignore thread deletion failures
 					}
 				}
 				threadMessageTs.length = 0;
-				// Then delete main message
 				if (messageTs) {
 					await slack.deleteMessage(event.channel, messageTs);
 					messageTs = null;
@@ -274,10 +305,6 @@ function createSlackContext(event: SlackEvent, slack: SlackBot, state: ChannelSt
 	};
 }
 
-// ============================================================================
-// Handler
-// ============================================================================
-
 const handler: MomHandler = {
 	isRunning(channelId: string): boolean {
 		const state = channelStates.get(channelId);
@@ -286,34 +313,32 @@ const handler: MomHandler = {
 
 	async handleStop(channelId: string, slack: SlackBot): Promise<void> {
 		const state = channelStates.get(channelId);
-		if (state?.running) {
+		if (state?.running && state.runner) {
 			state.stopRequested = true;
 			state.runner.abort();
-			const ts = await slack.postMessage(channelId, "_Stopping..._");
-			state.stopMessageTs = ts; // Save for updating later
-		} else {
-			await slack.postMessage(channelId, "_Nothing running_");
+			state.stopMessageTs = await slack.postMessage(channelId, "_Stopping..._");
+			return;
 		}
+
+		await slack.postMessage(channelId, "_Nothing running_");
 	},
 
-	async handleEvent(event: SlackEvent, slack: SlackBot, isEvent?: boolean): Promise<void> {
+	async handleEvent(event: SlackEvent, slack: SlackBot, isEvent = false): Promise<void> {
 		const state = getState(event.channel);
-
-		// Start run
+		const runner = ensureRunner(state, event.channel);
 		state.running = true;
 		state.stopRequested = false;
 
 		log.logInfo(`[${event.channel}] Starting run: ${event.text.substring(0, 50)}`);
 
 		try {
-			// Create context adapter
-			const ctx = createSlackContext(event, slack, state, isEvent);
-
-			// Run the agent
-			await ctx.setTyping(true);
-			await ctx.setWorking(true);
-			const result = await state.runner.run(ctx as any, state.store);
+			const ctx = createSlackContext(event, slack, isEvent);
+			const result = await runner.run(ctx, state.store);
 			await ctx.setWorking(false);
+
+			if (result.fatalInitializationError) {
+				state.runner = undefined;
+			}
 
 			if (result.stopReason === "aborted" && state.stopRequested) {
 				if (state.stopMessageTs) {
@@ -323,23 +348,15 @@ const handler: MomHandler = {
 					await slack.postMessage(event.channel, "_Stopped_");
 				}
 			}
-		} catch (err) {
-			log.logWarning(`[${event.channel}] Run error`, err instanceof Error ? err.message : String(err));
+		} catch (error) {
+			log.logWarning(`[${event.channel}] Run error`, error instanceof Error ? error.message : String(error));
 		} finally {
 			state.running = false;
 		}
 	},
 };
 
-// ============================================================================
-// Start
-// ============================================================================
-
-log.logStartup(workingDir, sandbox.type === "host" ? "host" : `docker:${sandbox.container}`);
-
-// Shared store for attachment downloads (also used per-channel in getState)
 const sharedStore = new ChannelStore({ workingDir, botToken: MOM_SLACK_BOT_TOKEN! });
-
 const bot = new SlackBotClass(handler, {
 	appToken: MOM_SLACK_APP_TOKEN,
 	botToken: MOM_SLACK_BOT_TOKEN,
@@ -347,11 +364,9 @@ const bot = new SlackBotClass(handler, {
 	store: sharedStore,
 });
 
-// Start events watcher
 const eventsWatcher = createEventsWatcher(workingDir, bot);
 eventsWatcher.start();
 
-// Handle shutdown
 process.on("SIGINT", () => {
 	log.logInfo("Shutting down...");
 	eventsWatcher.stop();
@@ -364,4 +379,4 @@ process.on("SIGTERM", () => {
 	process.exit(0);
 });
 
-bot.start();
+await bot.start();

--- a/packages/mom/src/model-selection.ts
+++ b/packages/mom/src/model-selection.ts
@@ -1,0 +1,92 @@
+import type { Model } from "@mariozechner/pi-ai";
+import type { ModelRegistry, SettingsManager } from "@mariozechner/pi-coding-agent";
+
+export interface ResolvedMomModel {
+	provider: string;
+	modelId: string;
+	model: Model<any>;
+	source: "env" | "settings" | "available";
+}
+
+export function resolveMomStartupModel(
+	modelRegistry: ModelRegistry,
+	settingsManager: SettingsManager,
+): ResolvedMomModel {
+	const configuredModel = process.env.MOM_MODEL?.trim();
+	if (configuredModel) {
+		const { provider, modelId } = parseMomModel(configuredModel);
+		const model = resolveConfiguredModel(modelRegistry, provider, modelId, `MOM_MODEL=${configuredModel}`);
+		assertConfiguredAuth(modelRegistry, model, `MOM_MODEL=${configuredModel}`);
+		return { provider, modelId, model, source: "env" };
+	}
+
+	const defaultProvider = settingsManager.getDefaultProvider();
+	const defaultModel = settingsManager.getDefaultModel();
+	if (defaultProvider && defaultModel) {
+		const model = resolveConfiguredModel(modelRegistry, defaultProvider, defaultModel, "workspace .pi/settings.json");
+		assertConfiguredAuth(modelRegistry, model, "workspace .pi/settings.json");
+		return {
+			provider: defaultProvider,
+			modelId: defaultModel,
+			model,
+			source: "settings",
+		};
+	}
+
+	const availableModels = modelRegistry.getAvailable();
+	if (availableModels.length === 0) {
+		throw new Error(
+			"No available models configured for mom. Set MOM_MODEL=provider:model or configure provider auth.",
+		);
+	}
+
+	const model = availableModels[0];
+	return {
+		provider: model.provider,
+		modelId: model.id,
+		model,
+		source: "available",
+	};
+}
+
+function parseMomModel(configuredModel: string): { provider: string; modelId: string } {
+	const separatorIndex = configuredModel.indexOf(":");
+	if (separatorIndex <= 0 || separatorIndex === configuredModel.length - 1) {
+		throw new Error(`Invalid MOM_MODEL format: ${configuredModel}. Expected provider:model`);
+	}
+
+	const provider = configuredModel.slice(0, separatorIndex).trim();
+	const modelId = configuredModel.slice(separatorIndex + 1).trim();
+	if (!provider || !modelId) {
+		throw new Error(`Invalid MOM_MODEL format: ${configuredModel}. Expected provider:model`);
+	}
+
+	return { provider, modelId };
+}
+
+function resolveConfiguredModel(
+	modelRegistry: ModelRegistry,
+	provider: string,
+	modelId: string,
+	sourceLabel: string,
+): Model<any> {
+	const model = modelRegistry.find(provider, modelId);
+	if (model) {
+		return model;
+	}
+
+	const hasProvider = modelRegistry.getAll().some((candidate) => candidate.provider === provider);
+	if (!hasProvider) {
+		throw new Error(`Unknown model provider in ${sourceLabel}: ${provider}`);
+	}
+
+	throw new Error(`Unknown model ID in ${sourceLabel}: ${provider}:${modelId}`);
+}
+
+function assertConfiguredAuth(modelRegistry: ModelRegistry, model: Model<any>, sourceLabel: string): void {
+	if (modelRegistry.hasConfiguredAuth(model)) {
+		return;
+	}
+
+	throw new Error(`No API key configured for ${model.provider}:${model.id} selected from ${sourceLabel}`);
+}

--- a/packages/mom/src/slack-message-utils.ts
+++ b/packages/mom/src/slack-message-utils.ts
@@ -1,0 +1,59 @@
+export const MAX_MAIN_MESSAGE_LENGTH = 35000;
+export const MAX_THREAD_MESSAGE_LENGTH = 20000;
+export const MAIN_OVERFLOW_NOTE = "\n\n_(continued in thread)_";
+export const TRUNCATION_NOTE = "\n\n_(message truncated, ask me to elaborate on specific parts)_";
+export const THREAD_TRUNCATION_NOTE = "\n\n_(truncated)_";
+
+export function truncateSlackText(text: string, maxLength: number, suffix: string): string {
+	if (text.length <= maxLength) {
+		return text;
+	}
+	return `${text.substring(0, maxLength - suffix.length)}${suffix}`;
+}
+
+export function splitSlackMessage(text: string, maxLength: number): string[] {
+	if (text.length <= maxLength) {
+		return [text];
+	}
+
+	const parts: string[] = [];
+	let remaining = text;
+	while (remaining.length > 0) {
+		parts.push(remaining.slice(0, maxLength));
+		remaining = remaining.slice(maxLength);
+	}
+	return parts;
+}
+
+export function splitFinalSlackReply(text: string): { mainText: string; overflowParts: string[] } {
+	if (text.length <= MAX_MAIN_MESSAGE_LENGTH) {
+		return {
+			mainText: text,
+			overflowParts: [],
+		};
+	}
+
+	const mainText = `${text.slice(0, MAX_MAIN_MESSAGE_LENGTH - MAIN_OVERFLOW_NOTE.length)}${MAIN_OVERFLOW_NOTE}`;
+	const overflowText = text.slice(MAX_MAIN_MESSAGE_LENGTH - MAIN_OVERFLOW_NOTE.length);
+	return {
+		mainText,
+		overflowParts: splitSlackMessage(overflowText, MAX_THREAD_MESSAGE_LENGTH),
+	};
+}
+
+export async function publishSplitFinalSlackReply({
+	text,
+	updateMainMessage,
+	postInThread,
+}: {
+	text: string;
+	updateMainMessage: (text: string) => Promise<void>;
+	postInThread: (text: string) => Promise<void>;
+}): Promise<{ mainText: string; overflowParts: string[] }> {
+	const result = splitFinalSlackReply(text);
+	await updateMainMessage(result.mainText);
+	for (const overflowPart of result.overflowParts) {
+		await postInThread(overflowPart);
+	}
+	return result;
+}

--- a/packages/mom/src/slack.ts
+++ b/packages/mom/src/slack.ts
@@ -13,6 +13,7 @@ export interface SlackEvent {
 	type: "mention" | "dm";
 	channel: string;
 	ts: string;
+	threadTs?: string;
 	user: string;
 	text: string;
 	files?: Array<{ name?: string; url_private_download?: string; url_private?: string }>;
@@ -51,12 +52,15 @@ export interface SlackContext {
 		userName?: string;
 		channel: string;
 		ts: string;
+		threadTs?: string;
 		attachments: Array<{ local: string }>;
 	};
 	channelName?: string;
+	isEvent?: boolean;
 	channels: ChannelInfo[];
 	users: UserInfo[];
 	respond: (text: string, shouldLog?: boolean) => Promise<void>;
+	publishFinal: (text: string, shouldLog?: boolean) => Promise<void>;
 	replaceMessage: (text: string) => Promise<void>;
 	respondInThread: (text: string) => Promise<void>;
 	setTyping: (isTyping: boolean) => Promise<void>;
@@ -277,6 +281,7 @@ export class SlackBot {
 				channel: string;
 				user: string;
 				ts: string;
+				thread_ts?: string;
 				files?: Array<{ name: string; url_private_download?: string; url_private?: string }>;
 			};
 
@@ -290,6 +295,7 @@ export class SlackBot {
 				type: "mention",
 				channel: e.channel,
 				ts: e.ts,
+				threadTs: e.thread_ts,
 				user: e.user,
 				text: e.text.replace(/<@[A-Z0-9]+>/gi, "").trim(),
 				files: e.files,
@@ -336,6 +342,7 @@ export class SlackBot {
 				channel: string;
 				user?: string;
 				ts: string;
+				thread_ts?: string;
 				channel_type?: string;
 				subtype?: string;
 				bot_id?: string;
@@ -369,6 +376,7 @@ export class SlackBot {
 				type: isDM ? "dm" : "mention",
 				channel: e.channel,
 				ts: e.ts,
+				threadTs: e.thread_ts,
 				user: e.user,
 				text: (e.text || "").replace(/<@[A-Z0-9]+>/gi, "").trim(),
 				files: e.files,

--- a/packages/mom/test/agent-regressions.test.ts
+++ b/packages/mom/test/agent-regressions.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	enqueueAssistantProgressMessages,
+	refreshSessionBaseSystemPrompt,
+	refreshSessionBaseSystemPromptForRun,
+	shortCircuitHandledPreflight,
+} from "../src/agent-internals.js";
+import {
+	MAIN_OVERFLOW_NOTE,
+	MAX_MAIN_MESSAGE_LENGTH,
+	MAX_THREAD_MESSAGE_LENGTH,
+	publishSplitFinalSlackReply,
+} from "../src/slack-message-utils.js";
+
+describe("mom agent regressions", () => {
+	it("refreshes the canonical base prompt used for extension-enabled turns", () => {
+		const session = {
+			_baseSystemPrompt: "stale prompt",
+			_rebuildSystemPrompt: vi.fn().mockReturnValue("fresh canonical prompt"),
+			getActiveToolNames: vi.fn().mockReturnValue(["bash", "read"]),
+			agent: {
+				state: {
+					systemPrompt: "stale prompt",
+				},
+			},
+		} as any;
+
+		refreshSessionBaseSystemPrompt(session);
+
+		expect(session._rebuildSystemPrompt).toHaveBeenCalledWith(["bash", "read"]);
+		expect(session._baseSystemPrompt).toBe("fresh canonical prompt");
+		expect(session.agent.state.systemPrompt).toBe("fresh canonical prompt");
+	});
+
+	it("returns a fatal initialization result when the AgentSession seam drifts", () => {
+		expect(refreshSessionBaseSystemPromptForRun({})).toEqual({
+			stopReason: "error",
+			errorMessage: "Unsupported @mariozechner/pi-coding-agent AgentSession shape for mom system-prompt refresh",
+			fatalInitializationError: true,
+		});
+	});
+
+	it("publishes oversized final replies with a continued-in-thread main message and thread overflow", async () => {
+		const text = "a".repeat(MAX_MAIN_MESSAGE_LENGTH + MAX_THREAD_MESSAGE_LENGTH + 123);
+		const mainMessages: string[] = [];
+		const threadMessages: string[] = [];
+
+		const result = await publishSplitFinalSlackReply({
+			text,
+			updateMainMessage: async (mainText) => {
+				mainMessages.push(mainText);
+			},
+			postInThread: async (threadText) => {
+				threadMessages.push(threadText);
+			},
+		});
+
+		expect(result.mainText.endsWith(MAIN_OVERFLOW_NOTE)).toBe(true);
+		expect(mainMessages).toEqual([result.mainText]);
+		expect(threadMessages.length).toBe(2);
+		expect(threadMessages.every((part) => part.length <= MAX_THREAD_MESSAGE_LENGTH)).toBe(true);
+		expect(threadMessages.join("")).toBe(text.slice(MAX_MAIN_MESSAGE_LENGTH - MAIN_OVERFLOW_NOTE.length));
+	});
+
+	it("queues assistant thinking and text progress in the main message only", async () => {
+		const mainMessages: string[] = [];
+		const queueTasks: Array<Promise<void>> = [];
+		const respondSpy = vi.fn(async (text: string) => {
+			mainMessages.push(text);
+		});
+		const respondInThreadSpy = vi.fn(async () => {});
+		const clearThinkingTimer = vi.fn();
+
+		enqueueAssistantProgressMessages({
+			content: [
+				{ type: "thinking", thinking: "intermediate thought" },
+				{ type: "text", text: "partial answer" },
+			],
+			hideThinkingBlock: false,
+			clearThinkingTimer,
+			queue: {
+				enqueue(fn) {
+					queueTasks.push(fn());
+				},
+			},
+			publisher: {
+				respond: respondSpy,
+				respondInThread: respondInThreadSpy,
+			},
+		});
+		await Promise.all(queueTasks);
+
+		expect(mainMessages).toEqual(["_intermediate thought_", "partial answer"]);
+		expect(clearThinkingTimer).toHaveBeenCalledTimes(2);
+		expect(respondInThreadSpy).not.toHaveBeenCalled();
+	});
+
+	it("hides assistant thinking while still queuing assistant text progress in the main message", async () => {
+		const mainMessages: string[] = [];
+		const queueTasks: Array<Promise<void>> = [];
+		const respondInThreadSpy = vi.fn(async () => {});
+
+		enqueueAssistantProgressMessages({
+			content: [
+				{ type: "thinking", thinking: "hidden thought" },
+				{ type: "text", text: "visible partial answer" },
+			],
+			hideThinkingBlock: true,
+			clearThinkingTimer: vi.fn(),
+			queue: {
+				enqueue(fn) {
+					queueTasks.push(fn());
+				},
+			},
+			publisher: {
+				respond: vi.fn(async (text: string) => {
+					mainMessages.push(text);
+				}),
+				respondInThread: respondInThreadSpy,
+			},
+		});
+		await Promise.all(queueTasks);
+
+		expect(mainMessages).toEqual(["visible partial answer"]);
+		expect(respondInThreadSpy).not.toHaveBeenCalled();
+	});
+
+	it("short-circuits handled input by flushing side effects and returning handled immediately", async () => {
+		const flushPendingSlackEffectsSpy = vi.fn(async () => {});
+		const flushQueueSpy = vi.fn(async () => {});
+
+		const result = await shortCircuitHandledPreflight(
+			{ action: "handled" },
+			flushPendingSlackEffectsSpy,
+			flushQueueSpy,
+		);
+
+		expect(result).toEqual({ stopReason: "handled" });
+		expect(flushPendingSlackEffectsSpy).toHaveBeenCalledTimes(1);
+		expect(flushQueueSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not short-circuit non-handled preflight results", async () => {
+		const flushPendingSlackEffectsSpy = vi.fn(async () => {});
+		const flushQueueSpy = vi.fn(async () => {});
+
+		await expect(
+			shortCircuitHandledPreflight({ action: "continue" }, flushPendingSlackEffectsSpy, flushQueueSpy),
+		).resolves.toBeUndefined();
+		expect(flushPendingSlackEffectsSpy).not.toHaveBeenCalled();
+		expect(flushQueueSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Until now, mom loaded no extensions, hardcoded Anthropic for model selection and auth, posted channel replies as top-level messages, and read workspace settings from `<workspace>/settings.json` instead of `<workspace>/.pi/settings.json`.  Anyone building a Slack integration on top of mom (for example, a bot that needs to intercept certain messages, redact sensitive tool output, or short-circuit specific inputs without calling the LLM) had to patch mom externally to get any of that working.  This patch makes those capabilities native.

Mom now supports two extension modes (strict and permissive), resolves its startup model and provider credentials from `MOM_MODEL=provider:model`, workspace defaults, or the first available configured model, threads channel mention replies correctly, and exposes the standard extension hook surface during mom runs with Slack-aware request context.  Strict mode enforces a trust boundary: only extensions from an explicit trusted root outside the workspace are loaded, workspace extension authorities are blocked before Slack startup, and symlink escapes are rejected.  This means an operator can lock down which code runs in the mom host process while still letting the workspace control safe settings like model defaults.

Summary of changes:
- extensions: new `src/extensions.ts` with strict/permissive trust planning, deterministic discovery, trust boundary validation, extension loading, request-context augmentation, raw input preflight, startup `model_select` emission, and Slack custom-message bridge (`mom-direct-response`)
- model selection: new `src/model-selection.ts` replacing hardcoded Anthropic with `MOM_MODEL` → workspace settings → first available fallback; provider credentials are derived from the resolved model
- agent: refactored `src/agent.ts` with lazy async runner initialization, raw Slack input preflight before the formatted LLM prompt, `publishFinal` for exactly-once main reply logging, and delayed thinking indicator that skips handled fast paths
- main: refactored `src/main.ts` with `process.chdir(workingDir)`, trust config resolution and validation before Slack connect, thread-root routing for channel mentions, `publishFinal`/`respondInThread` split, and runner lifecycle owned by `main.ts`
- slack: added `threadTs` capture from Slack events, `publishFinal` on `SlackContext`, and `isEvent` flag
- settings: moved workspace settings path from `<workspace>/settings.json` to `<workspace>/.pi/settings.json`
- slack messages: new `src/slack-message-utils.ts` with overflow splitting and truncation for Slack's message length limits
- internals: new `src/agent-internals.ts` extracting prompt refresh, progress message enqueueing, and handled-preflight short-circuit logic
- tests: new `test/agent-regressions.test.ts` covering prompt refresh, progress message enqueueing, handled-preflight short-circuit, and Slack message overflow splitting
- docs: new `docs/extensions.md` documenting the trust model, discovery rules, runtime behavior, and Slack bridge; updated `README.md` with model selection, authentication, extension settings, and corrected workspace layout
- changelog: added entries for trusted extension loading, hook bridging, model selection, settings path change, and thread routing

Validation:
- `npm run check`
- `cd packages/mom && npx vitest --run test/agent-regressions.test.ts`
- `cd pi-mom-fixture && npm run test`
- manual Slack fixture verification of `mom-direct-response` in-thread delivery