### PR TITLE
Apply model switches to the next queued request

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -259,8 +259,14 @@ async function streamAssistantResponse(
 	};
 
 	const streamFunction = streamFn || streamSimple;
-	const requestModel = config.model;
-	const requestReasoning = config.reasoning;
+	const requestConfig = config.resolveRequestConfig
+		? config.resolveRequestConfig()
+		: {
+				model: config.model,
+				reasoning: config.reasoning,
+			};
+	const requestModel = requestConfig.model;
+	const requestReasoning = requestConfig.reasoning;
 
 	// Resolve API key (important for expiring tokens)
 	const resolvedApiKey =

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -259,14 +259,17 @@ async function streamAssistantResponse(
 	};
 
 	const streamFunction = streamFn || streamSimple;
+	const requestModel = config.model;
+	const requestReasoning = config.reasoning;
 
 	// Resolve API key (important for expiring tokens)
 	const resolvedApiKey =
-		(config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
+		(config.getApiKey ? await config.getApiKey(requestModel.provider) : undefined) || config.apiKey;
 
-	const response = await streamFunction(config.model, llmContext, {
+	const response = await streamFunction(requestModel, llmContext, {
 		...config,
 		apiKey: resolvedApiKey,
+		reasoning: requestReasoning,
 		signal,
 	});
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -405,15 +405,14 @@ export class Agent {
 	}
 
 	private createLoopConfig(options: { skipInitialSteeringPoll?: boolean } = {}): AgentLoopConfig {
-		const agent = this;
 		let skipInitialSteeringPoll = options.skipInitialSteeringPoll === true;
 		return {
-			get model() {
-				return agent._state.model;
-			},
-			get reasoning() {
-				return agent._state.thinkingLevel === "off" ? undefined : agent._state.thinkingLevel;
-			},
+			model: this._state.model,
+			reasoning: this._state.thinkingLevel === "off" ? undefined : this._state.thinkingLevel,
+			resolveRequestConfig: () => ({
+				model: this._state.model,
+				reasoning: this._state.thinkingLevel === "off" ? undefined : this._state.thinkingLevel,
+			}),
 			sessionId: this.sessionId,
 			onPayload: this.onPayload,
 			transport: this.transport,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -405,10 +405,15 @@ export class Agent {
 	}
 
 	private createLoopConfig(options: { skipInitialSteeringPoll?: boolean } = {}): AgentLoopConfig {
+		const agent = this;
 		let skipInitialSteeringPoll = options.skipInitialSteeringPoll === true;
 		return {
-			model: this._state.model,
-			reasoning: this._state.thinkingLevel === "off" ? undefined : this._state.thinkingLevel,
+			get model() {
+				return agent._state.model;
+			},
+			get reasoning() {
+				return agent._state.thinkingLevel === "off" ? undefined : agent._state.thinkingLevel;
+			},
 			sessionId: this.sessionId,
 			onPayload: this.onPayload,
 			transport: this.transport,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -93,8 +93,21 @@ export interface AfterToolCallContext {
 	context: AgentContext;
 }
 
+export interface AgentRequestConfig {
+	model: Model<any>;
+	reasoning: SimpleStreamOptions["reasoning"];
+}
+
 export interface AgentLoopConfig extends SimpleStreamOptions {
 	model: Model<any>;
+	/**
+	 * Resolves the model/reasoning snapshot for a specific provider request.
+	 *
+	 * This is invoked immediately before each model request starts, allowing
+	 * long-lived runs to pick up mid-run model or reasoning changes for future
+	 * turns while keeping the request already in flight stable.
+	 */
+	resolveRequestConfig?: () => AgentRequestConfig;
 
 	/**
 	 * Converts AgentMessage[] to LLM-compatible Message[] before each LLM call.

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -36,6 +36,29 @@ function createAssistantMessage(text: string): AssistantMessage {
 	};
 }
 
+function createAssistantMessageForModel(
+	text: string,
+	model: { api: AssistantMessage["api"]; provider: AssistantMessage["provider"]; id: string },
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
 function createDeferred(): {
 	promise: Promise<void>;
 	resolve: () => void;
@@ -433,6 +456,82 @@ describe("Agent", () => {
 		const recentMessages = agent.state.messages.slice(-4);
 		expect(recentMessages.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
 		expect(responseCount).toBe(2);
+	});
+
+	it("uses the latest model and reasoning for the next request after a mid-run switch", async () => {
+		const initialModel = getModel("openai", "gpt-4o-mini");
+		const switchedModel = getModel("google", "gemini-2.5-flash");
+		const firstRequestStarted = createDeferred();
+		const finishFirstRequest = createDeferred();
+		const requests: Array<{ provider: string; model: string; reasoning: string | undefined }> = [];
+		let requestCount = 0;
+
+		const agent = new Agent({
+			initialState: {
+				model: initialModel,
+				thinkingLevel: "high",
+			},
+			streamFn: (model, _context, options) => {
+				requestCount++;
+				requests.push({
+					provider: model.provider,
+					model: model.id,
+					reasoning: options?.reasoning,
+				});
+				const stream = new MockAssistantStream();
+
+				if (requestCount === 1) {
+					firstRequestStarted.resolve();
+					queueMicrotask(() => {
+						stream.push({ type: "start", partial: createAssistantMessageForModel("", model) });
+						void finishFirstRequest.promise.then(() => {
+							stream.push({
+								type: "done",
+								reason: "stop",
+								message: createAssistantMessageForModel("first", model),
+							});
+						});
+					});
+				} else {
+					queueMicrotask(() => {
+						stream.push({
+							type: "done",
+							reason: "stop",
+							message: createAssistantMessageForModel("second", model),
+						});
+					});
+				}
+
+				return stream;
+			},
+		});
+
+		const promptPromise = agent.prompt("hello");
+		await firstRequestStarted.promise;
+
+		agent.state.model = switchedModel;
+		agent.state.thinkingLevel = "medium";
+		agent.steer({
+			role: "user",
+			content: [{ type: "text", text: "queued while streaming" }],
+			timestamp: Date.now(),
+		});
+
+		finishFirstRequest.resolve();
+		await promptPromise;
+
+		expect(requests).toEqual([
+			{
+				provider: initialModel.provider,
+				model: initialModel.id,
+				reasoning: "high",
+			},
+			{
+				provider: switchedModel.provider,
+				model: switchedModel.id,
+				reasoning: "medium",
+			},
+		]);
 	});
 
 	it("forwards sessionId to streamFn options", async () => {


### PR DESCRIPTION
https://pi.dev/session/#2c1abd35bae7dc1d7c9c9ad3466daad5

## Summary
- resolve model/reasoning at request start instead of freezing them for the whole run
- keep the currently in-flight request on its original model
- make the next queued request after a mid-run model switch use the newly selected model
- add agent coverage for mid-run model + reasoning switches

## Why

repro: https://pi.dev/session/#f9b88fdc09a067fc3976b29d3cd8179c

There is a clean repro where:
- a run starts on `anthropic/claude-opus-4-6`
- the user switches to `openai-codex/gpt-5.4` while the first response is still streaming
- the user then enters another message, which is queued via `steer`
- when the first turn finishes, the queued message is consumed by the existing run
- the next provider request still goes to Anthropic

The problem is that the active run freezes `model` and `reasoning` when `createLoopConfig()` is called. Queued steering/follow-up messages are consumed later by that same run, so future requests in the run can still use stale request config even after live session state has switched.

This change makes `model` and `reasoning` live until request start, then snapshots them once per provider request. That keeps the request already in flight stable, while making the next request honor the latest selected model/thinking.

## Testing
- `cd packages/agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent.test.ts`
- `npm run check`

## Notes
This supersedes my earlier closed PR that targeted the extension hook layer.
