### PR TITLE
fix(tui): validate slash command argument completions

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -333,7 +333,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			}
 
 			const argumentSuggestions = command.getArgumentCompletions(argumentText);
-			if (!argumentSuggestions || argumentSuggestions.length === 0) {
+			if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
 				return null;
 			}
 


### PR DESCRIPTION
## Summary

Extensions that declare  as  return a Promise, which was not handled, causing a TypeError when passed to SelectList.

This PR adds validation using  to ensure the return value is an array before passing it to SelectList.

## Changes

- Use  to validate  return value

## Testing

- Manual: Install an extension with async  and verify pi no longer crashes

Fixes #2719