### PR TITLE
fix(tui): await async getArgumentCompletions in slash command completions

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -332,8 +332,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				return null;
 			}
 
-			const argumentSuggestions = command.getArgumentCompletions(argumentText);
-			if (!argumentSuggestions || argumentSuggestions.length === 0) {
+			const rawSuggestions = command.getArgumentCompletions(argumentText);
+			const argumentSuggestions = rawSuggestions instanceof Promise ? await rawSuggestions : rawSuggestions;
+			if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
 				return null;
 			}
 


### PR DESCRIPTION
## Summary

After validating that `getArgumentCompletions` returns an array, this PR adds support for async completions by awaiting the result if it's a Promise.

## Changes

- Await `getArgumentCompletions` result if it's a Promise
- Sync completions are handled without overhead

## Testing

- Manual: Install an extension with async `getArgumentCompletions` and verify completions work correctly

Fixes #2719
