### PR TITLE
fix(coding-agent): preserve diff alignment highlighting

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -19,43 +19,46 @@ function replaceTabs(text: string): string {
 }
 
 /**
+ * Split changed segments into edge whitespace and the substantive content so
+ * alignment padding is not highlighted together with changed identifiers.
+ */
+function splitEdgeWhitespace(value: string): { leadingWhitespace: string; core: string; trailingWhitespace: string } {
+	const leadingWhitespace = value.match(/^(\s*)/)?.[1] || "";
+	const trailingWhitespace = value.match(/(\s*)$/)?.[1] || "";
+	const start = leadingWhitespace.length;
+	const end = value.length - trailingWhitespace.length;
+	return {
+		leadingWhitespace,
+		core: value.slice(start, end < start ? start : end),
+		trailingWhitespace,
+	};
+}
+
+function renderChangedSegment(value: string): string {
+	if (!value) return "";
+	const { leadingWhitespace, core, trailingWhitespace } = splitEdgeWhitespace(value);
+	if (!core) {
+		return theme.inverse(value);
+	}
+	return `${leadingWhitespace}${theme.inverse(core)}${trailingWhitespace}`;
+}
+
+/**
  * Compute word-level diff and render with inverse on changed parts.
- * Uses diffWords which groups whitespace with adjacent words for cleaner highlighting.
- * Strips leading whitespace from inverse to avoid highlighting indentation.
+ * Uses diffWordsWithSpace so whitespace-only changes stay visible, while edge
+ * whitespace is still kept outside the inverse highlight.
  */
 function renderIntraLineDiff(oldContent: string, newContent: string): { removedLine: string; addedLine: string } {
-	const wordDiff = Diff.diffWords(oldContent, newContent);
+	const wordDiff = Diff.diffWordsWithSpace(oldContent, newContent);
 
 	let removedLine = "";
 	let addedLine = "";
-	let isFirstRemoved = true;
-	let isFirstAdded = true;
 
 	for (const part of wordDiff) {
 		if (part.removed) {
-			let value = part.value;
-			// Strip leading whitespace from the first removed part
-			if (isFirstRemoved) {
-				const leadingWs = value.match(/^(\s*)/)?.[1] || "";
-				value = value.slice(leadingWs.length);
-				removedLine += leadingWs;
-				isFirstRemoved = false;
-			}
-			if (value) {
-				removedLine += theme.inverse(value);
-			}
+			removedLine += renderChangedSegment(part.value);
 		} else if (part.added) {
-			let value = part.value;
-			// Strip leading whitespace from the first added part
-			if (isFirstAdded) {
-				const leadingWs = value.match(/^(\s*)/)?.[1] || "";
-				value = value.slice(leadingWs.length);
-				addedLine += leadingWs;
-				isFirstAdded = false;
-			}
-			if (value) {
-				addedLine += theme.inverse(value);
-			}
+			addedLine += renderChangedSegment(part.value);
 		} else {
 			removedLine += part.value;
 			addedLine += part.value;

--- a/packages/coding-agent/test/diff-renderer.test.ts
+++ b/packages/coding-agent/test/diff-renderer.test.ts
@@ -1,0 +1,31 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { renderDiff } from "../src/modes/interactive/components/diff.js";
+import { setThemeInstance } from "../src/modes/interactive/theme/theme.js";
+
+describe("renderDiff", () => {
+	beforeAll(() => {
+		setThemeInstance({
+			fg: (_name: string, text: string) => text,
+			inverse: (text: string) => `<inv>${text}</inv>`,
+		} as never);
+	});
+
+	test("does not start inverse highlighting before the changed identifier in aligned replacements", () => {
+		const rendered = renderDiff('-240 "content":             content,\n+239 "text":                text,');
+		const lines = rendered.split("\n");
+
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toBe('-240 "<inv>content</inv>":             <inv>content</inv>,');
+		expect(lines[1]).toBe('+239 "<inv>text</inv>":                <inv>text</inv>,');
+		expect(lines[1]).not.toMatch(/<inv>\s+text<\/inv>/);
+	});
+
+	test("keeps whitespace-only changes visible", () => {
+		const rendered = renderDiff("-10 \tindented\n+10   indented");
+		const lines = rendered.split("\n");
+
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toBe("-10 <inv>   </inv>indented");
+		expect(lines[1]).toBe("+10 <inv>  </inv>indented");
+	});
+});


### PR DESCRIPTION
## Summary

Fix inline diff highlighting in `renderDiff()` so aligned replacements do not start inverse highlighting on leading whitespace.

The public `renderDiff(diffText)` API and the existing diff text format are unchanged. This only adjusts the internal intra-line rendering logic.

## What changed

- switched the intra-line renderer from `Diff.diffWords()` to `Diff.diffWordsWithSpace()`
- added a helper that keeps edge whitespace outside the inverse-highlighted core
- added regression tests for:
  - aligned replacements such as `"content" -> "text"`
  - whitespace-only indentation changes

## Why

With the previous implementation, a modified line like:

```text
-240 "content":             content,
+239 "text":                text,
```

could render the added-side inverse highlight as `<inv>   text</inv>`, which makes the visual diff look shifted even though the diff rows themselves are correct.

## Testing

- `npm test -- diff-renderer.test.ts`
- `npm test`

Notes on full test run in this environment:

- the new `diff-renderer.test.ts` passes
- the full `packages/coding-agent` suite still has pre-existing unrelated failures:
  - `test/stdout-cleanliness.test.ts`
  - `test/footer-data-provider.test.ts`
  - `test/package-manager.test.ts`
  - unhandled `EMFILE` watcher errors during footer-data-provider tests

## Issue

Fixes #2723
