### PR TITLE
fix(tui): defensive Box.addChild validation + render error handling

### DIFF
--- a/packages/tui/src/components/box.ts
+++ b/packages/tui/src/components/box.ts
@@ -27,6 +27,9 @@ export class Box implements Component {
 	}
 
 	addChild(component: Component): void {
+		if (!component || typeof component.render !== "function") {
+			return;
+		}
 		this.children.push(component);
 		this.invalidateCache();
 	}
@@ -82,9 +85,14 @@ export class Box implements Component {
 		// Render all children
 		const childLines: string[] = [];
 		for (const child of this.children) {
-			const lines = child.render(contentWidth);
-			for (const line of lines) {
-				childLines.push(leftPad + line);
+			try {
+				const lines = child.render(contentWidth);
+				for (const line of lines) {
+					childLines.push(leftPad + line);
+				}
+			} catch {
+				// Skip children that fail to render rather than crashing the entire TUI
+				childLines.push(`${leftPad}[render error]`);
 			}
 		}
 


### PR DESCRIPTION
## Problem

`Box.render()` crashes with `TypeError: child.render is not a function` when a custom tool renderer returns `null`, `undefined`, or a non-Component value via `addChild()`. This kills the entire TUI session, losing all progress.

## Fix

1. **`addChild()` validation** — Checks that the component exists and has a `render()` method before adding to children array. Invalid components are silently dropped.

2. **`render()` try/catch** — Wraps each `child.render()` call. A failing child shows `[render error]` instead of crashing the TUI.

## Testing

- Build passes
- Manual verification: TUI no longer crashes when extensions return invalid components

## Related

This was reported by a user running pi-subagents where the Markdown component's theme lookup failed mid-render.