### PR TITLE
fix(openai-codex): request API scopes in OAuth flow

### DIFF
--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -25,7 +25,7 @@ const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const REDIRECT_URI = "http://localhost:1455/auth/callback";
-const SCOPE = "openid profile email offline_access";
+const SCOPE = "openid profile email offline_access model.request api.responses.write";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 
 type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
@@ -120,6 +120,20 @@ async function exchangeAuthorizationCode(
 	if (!json.access_token || !json.refresh_token || typeof json.expires_in !== "number") {
 		console.error("[openai-codex] token response missing fields:", json);
 		return { type: "failed" };
+	}
+
+	// Validate that the granted token has the API scopes needed for model inference.
+	// Without these, all Responses API calls will fail with 401/500.
+	const REQUIRED_SCOPES = ["model.request", "api.responses.write"];
+	const jwt = decodeJwt(json.access_token);
+	const grantedScopes: string[] = Array.isArray(jwt?.scp) ? jwt.scp : [];
+	const missingScopes = REQUIRED_SCOPES.filter((s) => !grantedScopes.includes(s));
+	if (missingScopes.length > 0) {
+		console.error(
+			`[openai-codex] token is missing required API scopes: ${missingScopes.join(", ")}. ` +
+			`Granted scopes: ${grantedScopes.join(", ") || "(none)"}. ` +
+			`Model API calls will fail. Re-authenticate with 'codex login'.`,
+		);
 	}
 
 	return {


### PR DESCRIPTION
## Summary

The OpenAI Codex OAuth flow only requests identity scopes (`openid profile email offline_access`) but never requests the API scopes required for model inference via the Responses API.

This causes **every** downstream consumer (OpenClaw, Codex CLI gateway integrations) using `openai-codex/*` models with OAuth authentication to fail:
- HTTP: `401 Missing scopes: model.request`
- WebSocket (`wss://api.openai.com/v1/responses`): `500 Internal Server Error`

### Changes

- **`packages/ai/src/utils/oauth/openai-codex.ts` line 28**: Add `model.request` and `api.responses.write` to the `SCOPE` constant so the authorize URL requests the scopes needed for the Responses API
- **Lines 125-137**: After token exchange, validate that the granted token actually has the required API scopes and log a clear diagnostic error if they're missing — instead of failing silently at runtime

### Impact

This is a one-line fix (plus defensive validation) that unblocks all OpenClaw users on `openai-codex` OAuth. The token exchange and refresh paths don't need changes — they inherit scopes from the authorization grant.

### Related issues

- openclaw/openclaw#56658 — OpenAI Codex OAuth login requests missing scope `model.request`
- openclaw/openclaw#36660 — openai-codex OAuth completes but runs fail; token lacks `api.responses.write`
- openclaw/openclaw#29418 — openai-codex OAuth completes but saved token only has identity scopes

### Test plan

- [ ] Run `codex login`, verify the authorize URL contains `model.request` and `api.responses.write` in the `scope` parameter
- [ ] After login, decode the JWT access token and confirm `scp` includes `model.request` and `api.responses.write`
- [ ] Verify `wss://api.openai.com/v1/responses` connects successfully with the new token
- [ ] Verify HTTP `POST /v1/responses` returns 200 (not 401) with the new token