### PR TITLE
fix: cap in-memory `fileEntries` array to prevent unbounded heap growth

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -661,6 +661,13 @@ async function listSessionsFromDir(
  * Use buildSessionContext() to get the resolved message list for the LLM, which
  * handles compaction summaries and follows the path from root to current leaf.
  */
+/**
+ * Default cap for the in-memory fileEntries array. Entries beyond this limit
+ * are pruned from the front (oldest first, header always preserved).
+ * The on-disk JSONL transcript is append-only and retains full history.
+ */
+export const DEFAULT_MAX_FILE_ENTRIES = 1000;
+
 export class SessionManager {
 	private sessionId: string = "";
 	private sessionFile: string | undefined;
@@ -673,11 +680,13 @@ export class SessionManager {
 	private labelsById: Map<string, string> = new Map();
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
+	private maxFileEntries: number;
 
-	private constructor(cwd: string, sessionDir: string, sessionFile: string | undefined, persist: boolean) {
+	private constructor(cwd: string, sessionDir: string, sessionFile: string | undefined, persist: boolean, maxFileEntries?: number) {
 		this.cwd = cwd;
 		this.sessionDir = sessionDir;
 		this.persist = persist;
+		this.maxFileEntries = maxFileEntries ?? DEFAULT_MAX_FILE_ENTRIES;
 		if (persist && sessionDir && !existsSync(sessionDir)) {
 			mkdirSync(sessionDir, { recursive: true });
 		}
@@ -714,6 +723,7 @@ export class SessionManager {
 			}
 
 			this._buildIndex();
+			this._pruneIfNeeded();
 			this.flushed = true;
 		} else {
 			const explicitPath = this.sessionFile;
@@ -818,6 +828,47 @@ export class SessionManager {
 		this.byId.set(entry.id, entry);
 		this.leafId = entry.id;
 		this._persist(entry);
+		this._pruneIfNeeded();
+	}
+
+	/**
+	 * Cap the in-memory fileEntries array. Removes oldest entries (after the
+	 * header at index 0) when length exceeds maxFileEntries. Also evicts
+	 * pruned entries from byId, labelsById, and labelTimestampsById.
+	 *
+	 * The on-disk JSONL transcript is append-only, so full history is
+	 * preserved on disk even after in-memory pruning.
+	 */
+	private _pruneIfNeeded(): void {
+		// +1 for the header at index 0
+		const limit = this.maxFileEntries + 1;
+		if (this.fileEntries.length <= limit) return;
+
+		const excess = this.fileEntries.length - limit;
+		// Remove entries after the header (index 1) through index `excess`
+		const pruned = this.fileEntries.splice(1, excess);
+
+		for (const entry of pruned) {
+			if (entry.type === "session") continue;
+			this.byId.delete(entry.id);
+			this.labelsById.delete(entry.id);
+			this.labelTimestampsById.delete(entry.id);
+			if (entry.type === "label") {
+				// Only remove the label mapping if it hasn't been superseded
+				// by a newer label entry that's still in the kept set
+				const currentLabel = this.labelsById.get(entry.targetId);
+				if (currentLabel === entry.label) {
+					// Check if there's a newer label entry for this target
+					const hasNewerLabel = this.fileEntries.some(
+						(e) => e.type !== "session" && e.type === "label" && e.targetId === entry.targetId,
+					);
+					if (!hasNewerLabel) {
+						this.labelsById.delete(entry.targetId);
+						this.labelTimestampsById.delete(entry.targetId);
+					}
+				}
+			}
+		}
 	}
 
 	/** Append a message as child of current leaf, then advance leaf. Returns entry id.
@@ -1260,44 +1311,47 @@ export class SessionManager {
 	 * Create a new session.
 	 * @param cwd Working directory (stored in session header)
 	 * @param sessionDir Optional session directory. If omitted, uses default (~/.pi/agent/sessions/<encoded-cwd>/).
+	 * @param maxFileEntries Optional cap on in-memory entries. Defaults to DEFAULT_MAX_FILE_ENTRIES.
 	 */
-	static create(cwd: string, sessionDir?: string): SessionManager {
+	static create(cwd: string, sessionDir?: string, maxFileEntries?: number): SessionManager {
 		const dir = sessionDir ?? getDefaultSessionDir(cwd);
-		return new SessionManager(cwd, dir, undefined, true);
+		return new SessionManager(cwd, dir, undefined, true, maxFileEntries);
 	}
 
 	/**
 	 * Open a specific session file.
 	 * @param path Path to session file
 	 * @param sessionDir Optional session directory for /new or /branch. If omitted, derives from file's parent.
+	 * @param maxFileEntries Optional cap on in-memory entries. Defaults to DEFAULT_MAX_FILE_ENTRIES.
 	 */
-	static open(path: string, sessionDir?: string): SessionManager {
+	static open(path: string, sessionDir?: string, maxFileEntries?: number): SessionManager {
 		// Extract cwd from session header if possible, otherwise use process.cwd()
 		const entries = loadEntriesFromFile(path);
 		const header = entries.find((e) => e.type === "session") as SessionHeader | undefined;
 		const cwd = header?.cwd ?? process.cwd();
 		// If no sessionDir provided, derive from file's parent directory
 		const dir = sessionDir ?? resolve(path, "..");
-		return new SessionManager(cwd, dir, path, true);
+		return new SessionManager(cwd, dir, path, true, maxFileEntries);
 	}
 
 	/**
 	 * Continue the most recent session, or create new if none.
 	 * @param cwd Working directory
 	 * @param sessionDir Optional session directory. If omitted, uses default (~/.pi/agent/sessions/<encoded-cwd>/).
+	 * @param maxFileEntries Optional cap on in-memory entries. Defaults to DEFAULT_MAX_FILE_ENTRIES.
 	 */
-	static continueRecent(cwd: string, sessionDir?: string): SessionManager {
+	static continueRecent(cwd: string, sessionDir?: string, maxFileEntries?: number): SessionManager {
 		const dir = sessionDir ?? getDefaultSessionDir(cwd);
 		const mostRecent = findMostRecentSession(dir);
 		if (mostRecent) {
-			return new SessionManager(cwd, dir, mostRecent, true);
+			return new SessionManager(cwd, dir, mostRecent, true, maxFileEntries);
 		}
-		return new SessionManager(cwd, dir, undefined, true);
+		return new SessionManager(cwd, dir, undefined, true, maxFileEntries);
 	}
 
 	/** Create an in-memory session (no file persistence) */
-	static inMemory(cwd: string = process.cwd()): SessionManager {
-		return new SessionManager(cwd, "", undefined, false);
+	static inMemory(cwd: string = process.cwd(), maxFileEntries?: number): SessionManager {
+		return new SessionManager(cwd, "", undefined, false, maxFileEntries);
 	}
 
 	/**
@@ -1306,8 +1360,9 @@ export class SessionManager {
 	 * @param sourcePath Path to the source session file
 	 * @param targetCwd Target working directory (where the new session will be stored)
 	 * @param sessionDir Optional session directory. If omitted, uses default for targetCwd.
+	 * @param maxFileEntries Optional cap on in-memory entries. Defaults to DEFAULT_MAX_FILE_ENTRIES.
 	 */
-	static forkFrom(sourcePath: string, targetCwd: string, sessionDir?: string): SessionManager {
+	static forkFrom(sourcePath: string, targetCwd: string, sessionDir?: string, maxFileEntries?: number): SessionManager {
 		const sourceEntries = loadEntriesFromFile(sourcePath);
 		if (sourceEntries.length === 0) {
 			throw new Error(`Cannot fork: source session file is empty or invalid: ${sourcePath}`);
@@ -1347,7 +1402,7 @@ export class SessionManager {
 			}
 		}
 
-		return new SessionManager(targetCwd, dir, newSessionFile, true);
+		return new SessionManager(targetCwd, dir, newSessionFile, true, maxFileEntries);
 	}
 
 	/**

--- a/packages/coding-agent/test/session-manager-pruning.test.ts
+++ b/packages/coding-agent/test/session-manager-pruning.test.ts
@@ -1,0 +1,254 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Message } from "@mariozechner/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	DEFAULT_MAX_FILE_ENTRIES,
+	SessionManager,
+	loadEntriesFromFile,
+} from "../src/core/session-manager.js";
+
+function userMsg(text: string): Message {
+	return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function assistantMsg(text: string): Message {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		model: "test-model",
+		provider: "test",
+		usage: { input: 10, output: 10, cacheRead: 0, cacheWrite: 0, totalTokens: 20, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+	} as Message;
+}
+
+describe("SessionManager fileEntries pruning", () => {
+	let tempDir: string;
+	let sessionDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-prune-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		sessionDir = join(tempDir, "sessions");
+		mkdirSync(sessionDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("exports DEFAULT_MAX_FILE_ENTRIES as 1000", () => {
+		expect(DEFAULT_MAX_FILE_ENTRIES).toBe(1000);
+	});
+
+	it("does not prune when below the cap", () => {
+		const sm = SessionManager.inMemory("/tmp", 10);
+		// Append 5 user+assistant pairs = 10 entries, at cap
+		for (let i = 0; i < 5; i++) {
+			sm.appendMessage(userMsg(`user ${i}`));
+			sm.appendMessage(assistantMsg(`assistant ${i}`));
+		}
+		const entries = sm.getEntries();
+		expect(entries.length).toBe(10);
+	});
+
+	it("prunes entries beyond the cap, preserving the header", () => {
+		const cap = 5;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		// Append 10 entries (5 pairs) — should prune to 5 entries + header
+		for (let i = 0; i < 5; i++) {
+			sm.appendMessage(userMsg(`user ${i}`));
+			sm.appendMessage(assistantMsg(`assistant ${i}`));
+		}
+		const entries = sm.getEntries();
+		expect(entries.length).toBe(cap);
+
+		// Header must still be accessible
+		const header = sm.getHeader();
+		expect(header).not.toBeNull();
+		expect(header!.type).toBe("session");
+	});
+
+	it("preserves the most recent entries after pruning", () => {
+		const cap = 4;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		for (let i = 0; i < 5; i++) {
+			sm.appendMessage(userMsg(`user ${i}`));
+			sm.appendMessage(assistantMsg(`assistant ${i}`));
+		}
+		const entries = sm.getEntries();
+		expect(entries.length).toBe(cap);
+
+		// The last entries should be the most recent ones
+		const lastEntry = entries[entries.length - 1];
+		expect(lastEntry.type).toBe("message");
+		expect((lastEntry as any).message.content[0].text).toBe("assistant 4");
+	});
+
+	it("removes pruned entries from byId (getEntry returns undefined)", () => {
+		const cap = 4;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		const firstId = sm.appendMessage(userMsg("first"));
+		for (let i = 0; i < 5; i++) {
+			sm.appendMessage(userMsg(`user ${i}`));
+			sm.appendMessage(assistantMsg(`assistant ${i}`));
+		}
+		// The first entry should have been pruned
+		expect(sm.getEntry(firstId)).toBeUndefined();
+	});
+
+	it("leaf entry is always accessible after pruning", () => {
+		const cap = 3;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		for (let i = 0; i < 10; i++) {
+			sm.appendMessage(userMsg(`msg ${i}`));
+		}
+		const leaf = sm.getLeafEntry();
+		expect(leaf).toBeDefined();
+		expect(leaf!.type).toBe("message");
+		expect((leaf as any).message.content).toBe("msg 9");
+	});
+
+	it("newSession() resets fileEntries regardless of cap", () => {
+		const cap = 5;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		for (let i = 0; i < 10; i++) {
+			sm.appendMessage(userMsg(`msg ${i}`));
+		}
+		sm.newSession();
+		const entries = sm.getEntries();
+		expect(entries.length).toBe(0);
+		expect(sm.getHeader()).not.toBeNull();
+	});
+
+	it("appendCompaction works within a capped session", () => {
+		const cap = 6;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		const id1 = sm.appendMessage(userMsg("user 1"));
+		sm.appendMessage(assistantMsg("assistant 1"));
+		const id3 = sm.appendMessage(userMsg("user 2"));
+		sm.appendMessage(assistantMsg("assistant 2"));
+
+		// Append compaction referencing id3 as firstKeptEntryId
+		sm.appendCompaction("Summary of earlier conversation", id3, 5000);
+
+		sm.appendMessage(userMsg("user 3"));
+		sm.appendMessage(assistantMsg("assistant 3"));
+
+		const entries = sm.getEntries();
+		// Should be capped at 6
+		expect(entries.length).toBe(cap);
+
+		// Compaction entry should still be present (it's recent enough)
+		const compactionEntry = entries.find((e) => e.type === "compaction");
+		// It may or may not be pruned depending on count — what matters is no crash
+		expect(sm.getHeader()).not.toBeNull();
+		expect(sm.getLeafEntry()).toBeDefined();
+	});
+
+	it("createBranchedSession works after pruning", () => {
+		const cap = 6;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		for (let i = 0; i < 4; i++) {
+			sm.appendMessage(userMsg(`user ${i}`));
+			sm.appendMessage(assistantMsg(`assistant ${i}`));
+		}
+		// Leaf should be the last entry
+		const leafId = sm.getLeafId();
+		expect(leafId).not.toBeNull();
+
+		// createBranchedSession should not throw
+		const result = sm.createBranchedSession(leafId!);
+		// In-memory mode returns undefined
+		expect(result).toBeUndefined();
+		// Session should still be valid
+		expect(sm.getHeader()).not.toBeNull();
+		expect(sm.getEntries().length).toBeGreaterThan(0);
+	});
+
+	it("default cap is applied when no maxFileEntries is provided", () => {
+		const sm = SessionManager.inMemory("/tmp");
+		// Default should be DEFAULT_MAX_FILE_ENTRIES (1000)
+		// We can't easily test this without appending 1001 entries,
+		// but we can verify the session works normally
+		for (let i = 0; i < 10; i++) {
+			sm.appendMessage(userMsg(`msg ${i}`));
+		}
+		expect(sm.getEntries().length).toBe(10);
+	});
+
+	it("persisted session prunes in memory but preserves full JSONL on disk", () => {
+		const cap = 4;
+		const sm = SessionManager.create("/tmp", sessionDir, cap);
+
+		// Need at least one assistant message to trigger file flush
+		sm.appendMessage(userMsg("user 0"));
+		sm.appendMessage(assistantMsg("assistant 0"));
+		sm.appendMessage(userMsg("user 1"));
+		sm.appendMessage(assistantMsg("assistant 1"));
+		sm.appendMessage(userMsg("user 2"));
+		sm.appendMessage(assistantMsg("assistant 2"));
+
+		// In-memory: should be capped
+		const entries = sm.getEntries();
+		expect(entries.length).toBe(cap);
+
+		// On disk: should have full history (header + 6 entries = 7 lines)
+		const sessionFile = sm.getSessionFile()!;
+		expect(existsSync(sessionFile)).toBe(true);
+		const diskEntries = loadEntriesFromFile(sessionFile);
+		expect(diskEntries.length).toBe(7); // header + 6 entries
+	});
+
+	it("getBranch returns entries within the window", () => {
+		const cap = 6;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		for (let i = 0; i < 5; i++) {
+			sm.appendMessage(userMsg(`user ${i}`));
+			sm.appendMessage(assistantMsg(`assistant ${i}`));
+		}
+		const leafId = sm.getLeafId()!;
+		const branch = sm.getBranch(leafId);
+		// Branch may be shorter than expected if ancestors were pruned
+		// but should not throw and should contain the leaf
+		expect(branch.length).toBeGreaterThan(0);
+		expect(branch[branch.length - 1].id).toBe(leafId);
+	});
+
+	it("getTree does not throw after pruning", () => {
+		const cap = 4;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		for (let i = 0; i < 10; i++) {
+			sm.appendMessage(userMsg(`msg ${i}`));
+		}
+		// Should not throw
+		const tree = sm.getTree();
+		expect(tree.length).toBeGreaterThan(0);
+	});
+
+	it("buildSessionContext works after pruning", () => {
+		const cap = 6;
+		const sm = SessionManager.inMemory("/tmp", cap);
+		for (let i = 0; i < 5; i++) {
+			sm.appendMessage(userMsg(`user ${i}`));
+			sm.appendMessage(assistantMsg(`assistant ${i}`));
+		}
+		const ctx = sm.buildSessionContext();
+		// Should return messages without throwing
+		expect(ctx.messages.length).toBeGreaterThan(0);
+	});
+
+	it("handles cap of 1 (minimum useful)", () => {
+		const sm = SessionManager.inMemory("/tmp", 1);
+		sm.appendMessage(userMsg("first"));
+		sm.appendMessage(userMsg("second"));
+		sm.appendMessage(userMsg("third"));
+
+		const entries = sm.getEntries();
+		expect(entries.length).toBe(1);
+		expect((entries[0] as any).message.content).toBe("third");
+		expect(sm.getHeader()).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Problem

`SessionManager.fileEntries` is a `private FileEntry[]` that mirrors every JSONL session entry in memory. It grows via `push()` in `_appendEntry()` and is never pruned. In long-running gateway sessions (9+ hours of normal use), this array silently accumulates thousands of entries containing full message bodies, tool results, and metadata, causing heap growth of 1GB+ with no upper bound.

The on-disk JSONL transcript is append-only and that's correct. But the in-memory mirror has no reason to retain the full history. Most read paths either use the `byId` Map for tree traversal or only need recent entries. Compaction summarizes older context for the LLM but never touches `fileEntries`. Two layers of session state, only one with a ceiling.

Heap snapshot analysis of a production session showed 99.5% of 250K+ retained `message` objects tracing back through `fileEntries` -> `SessionManager` -> `AgentSession`.

Full investigation with V8 heap snapshots, retainer analysis, and related issue survey: openclaw/openclaw#58802

## Fix

Add a configurable sliding window cap (`maxFileEntries`, default 1000) on the in-memory `fileEntries` array. After each `_appendEntry()` and after `setSessionFile()` bulk loads, if the array exceeds the limit, the oldest entries (after the header at index 0) are spliced out and evicted from `byId`, `labelsById`, and `labelTimestampsById`.

The on-disk JSONL file is append-only and unaffected. Full session history is preserved on disk. Only the in-memory representation is bounded.

### What changes

- New `_pruneIfNeeded()` private method, called after `_appendEntry()` and after `setSessionFile()` loads entries from disk
- New `maxFileEntries` private field, set via constructor (default: `DEFAULT_MAX_FILE_ENTRIES = 1000`)
- Static factory methods (`create`, `open`, `continueRecent`, `inMemory`, `forkFrom`) accept optional `maxFileEntries` parameter
- `DEFAULT_MAX_FILE_ENTRIES` exported for downstream configuration

### What does NOT change

- On-disk JSONL format and append-only persistence behavior
- `newSession()` and `createBranchedSession()` (they replace `fileEntries` entirely)
- Public API shape (`getEntries()`, `getHeader()`, `getBranch()`, `buildSessionContext()`, etc.)
- All existing test behavior (876 tests pass, 0 failures)

## Why 1000 as the default

- A typical interactive turn produces 2-4 entries (user message, assistant message, optional tool calls). 1000 entries covers ~250-500 turns, well beyond what any single LLM context window can hold.
- Compaction typically fires at 50K-200K tokens, which maps to ~100-400 entries. 1000 provides generous headroom above the compaction window.
- OpenClaw's `session.maintenance.maxEntries` defaults to 500 for the session index file, so 1000 for the in-memory transcript mirror is consistent.
- At ~1-10KB per entry, 1000 entries = 1-10MB of retained heap. Compared to unbounded growth toward 1GB+, that's a hard ceiling that stays invisible.

## Trade-offs

- **Branch navigation to very old entries**: If an entry has been pruned from memory, `getEntry(id)` returns `undefined` and `getBranch(id)` produces a truncated path. This only affects TUI users navigating to entries older than the window. The JSONL file on disk retains full history. Callers that need old entries can reload via `loadEntriesFromFile()`.
- **`getTree()` shows fewer branches**: Only entries within the window appear in the tree view. Disk has full history.
- **External access**: OpenClaw's `session-manager-init.ts` accesses `sm.fileEntries` directly (bypassing TypeScript `private`). The array is still a plain `FileEntry[]` with the same shape, just bounded. OpenClaw's existing pattern of resetting `sm.fileEntries = [header]` continues to work.

## Related issues

- openclaw/openclaw#13758: Gateway accumulates memory over long sessions (1.9GB RSS after 13h). Comment by echoVic identifies SessionManager caching as likely primary cause.
- openclaw/openclaw#6190: Session log growing and bot hanging up (master issue for session bloat).
- openclaw/openclaw#4948: Multiple in-memory caches grow unbounded (same class of bug, fixed).
- openclaw/openclaw#17820: Cron runs never clean up agent-events Maps (same pattern, ~68MB/hr growth).
- openclaw/openclaw#51031: Tool calls hang after compaction; shows `sessionManager.appendMessage` and `pendingState` map divergence.
- openclaw/openclaw#24800: Auto-compaction not triggered during tool-use loops.
- openclaw/openclaw#33553: Feature request for configurable sliding window to cap conversation history.

## Testing

- 15 new tests in `test/session-manager-pruning.test.ts` covering:
  - Cap enforcement and header preservation
  - Most-recent-entries retention
  - Pruned entry eviction from byId
  - Leaf accessibility after pruning
  - newSession/createBranchedSession after pruning
  - Compaction within capped sessions
  - Persisted sessions (in-memory pruned, disk retains full JSONL)
  - getBranch, getTree, buildSessionContext after pruning
  - Minimum cap (1 entry)
  - Default cap applied when unspecified
- All 876 existing tests pass with zero changes