### PR TITLE
fix(tui): prevent overlay padding from inflating scrollback on terminal widen

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -722,9 +722,10 @@ export class TUI extends Container {
 			minLinesNeeded = Math.max(minLinesNeeded, row + overlayLines.length);
 		}
 
-		// Ensure result covers the terminal working area to keep overlay positioning stable across resizes.
-		// maxLinesRendered can exceed current content length after a shrink; pad to keep viewportStart consistent.
-		const workingHeight = Math.max(this.maxLinesRendered, minLinesNeeded);
+		// Pad to at least terminal height so overlays have screen-relative positions.
+		// Excludes maxLinesRendered: the historical high-water mark caused self-reinforcing
+		// inflation that pushed content into scrollback on terminal widen.
+		const workingHeight = Math.max(result.length, termHeight, minLinesNeeded);
 
 		// Extend result with empty lines if content is too short for overlay placement or working area
 		while (result.length < workingHeight) {


### PR DESCRIPTION
Fixes #2760
Related: #2759

## Change

One-line fix in `compositeOverlays` (`packages/tui/src/tui.ts`):

```typescript
// Before:
const workingHeight = Math.max(this.maxLinesRendered, minLinesNeeded);

// After:
const workingHeight = Math.max(result.length, termHeight, minLinesNeeded);
```

See issue #2760 for full root cause analysis and reproduction steps.

## Testing

Verified with 5 concurrent nonCapturing overlays at various anchor positions (screen-anchored and relatively-positioned). Repeated terminal widen/narrow cycles no longer corrupt the viewport.