### PR TITLE
fix(coding-agent): make edit preview args edits-only

### DIFF
--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -107,8 +107,6 @@ type RenderableEditArgs = {
 	path?: string;
 	file_path?: string;
 	edits?: Edit[];
-	oldText?: string;
-	newText?: string;
 };
 
 function formatEditCall(


### PR DESCRIPTION
## Summary

- remove legacy top-level `oldText` / `newText` from `RenderableEditArgs` in the built-in `edit` tool

## Why

The public `edit` schema is already `edits[]`-only.

However, the render-facing `RenderableEditArgs` type still includes legacy top-level `oldText` / `newText`, which keeps an outdated input shape visible in code even though it is no longer part of the intended public contract.

This change keeps the render-facing type surface aligned with the current `edits[]`-only direction and avoids treating the legacy shape as first-class outside the internal compatibility path.

## Scope

This is a cleanup-only change:
- no public schema changes
- no execution behavior changes
- no compatibility-path changes
