### PR TITLE
fix(coding-agent): avoid double-loading startup resource loader

### DIFF
--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -55,6 +55,11 @@ export interface CreateAgentSessionRuntimeOptions {
 	sessionManager?: SessionManager;
 	/** Optional session_start metadata to emit when the runtime binds extensions. */
 	sessionStartEvent?: SessionStartEvent;
+	/**
+	 * Optional preloaded resource loader to use directly for this runtime.
+	 * When provided, createAgentSessionRuntime will not call reload() again.
+	 */
+	resourceLoader?: ResourceLoader;
 }
 
 type AgentSessionRuntime = CreateAgentSessionResult & {
@@ -86,15 +91,18 @@ export async function createAgentSessionRuntime(
 	const settingsManager = SettingsManager.create(cwd, agentDir);
 	const modelRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
 	const resourceLoader =
-		typeof bootstrap.resourceLoader === "function"
+		options.resourceLoader ??
+		(typeof bootstrap.resourceLoader === "function"
 			? await bootstrap.resourceLoader(cwd, agentDir)
 			: new DefaultResourceLoader({
 					...(bootstrap.resourceLoader ?? {}),
 					cwd,
 					agentDir,
 					settingsManager,
-				});
-	await resourceLoader.reload();
+				}));
+	if (!options.resourceLoader) {
+		await resourceLoader.reload();
+	}
 
 	const extensionsResult = resourceLoader.getExtensions();
 	for (const { name, config } of extensionsResult.runtime.pendingProviderRegistrations) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -873,6 +873,7 @@ export async function main(args: string[]) {
 	const runtime = await createAgentSessionRuntime(runtimeBootstrap, {
 		cwd: sessionManager?.getCwd() ?? cwd,
 		sessionManager,
+		resourceLoader,
 	});
 	if (process.cwd() !== runtime.cwd) {
 		process.chdir(runtime.cwd);

--- a/packages/coding-agent/test/agent-session-runtime-resource-loader.test.ts
+++ b/packages/coding-agent/test/agent-session-runtime-resource-loader.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResourceLoader } from "../src/core/resource-loader.js";
+
+const mockState = vi.hoisted(() => ({
+	defaultLoaderReloads: 0,
+	defaultLoaderInstances: 0,
+	registerProvider: vi.fn(),
+	createAgentSession: vi.fn(
+		async (options: { sessionManager?: unknown; resourceLoader: unknown }) =>
+			({
+				session: {
+					sessionManager: options.sessionManager ?? ({ id: "session-manager" } as unknown),
+					dispose: vi.fn(),
+					extensionRunner: undefined,
+				},
+				modelFallbackMessage: undefined,
+			}) as const,
+	),
+}));
+
+vi.mock("../src/core/resource-loader.js", () => ({
+	DefaultResourceLoader: class {
+		constructor(_options: unknown) {
+			mockState.defaultLoaderInstances += 1;
+		}
+
+		async reload(): Promise<void> {
+			mockState.defaultLoaderReloads += 1;
+		}
+
+		getExtensions() {
+			return {
+				extensions: [],
+				errors: [],
+				runtime: {
+					pendingProviderRegistrations: [],
+					flagValues: new Map(),
+				},
+			};
+		}
+	},
+}));
+
+vi.mock("../src/core/model-registry.js", () => ({
+	ModelRegistry: {
+		create: () => ({
+			registerProvider: mockState.registerProvider,
+		}),
+	},
+}));
+
+vi.mock("../src/core/settings-manager.js", () => ({
+	SettingsManager: {
+		create: () => ({ id: "settings-manager" }),
+	},
+}));
+
+vi.mock("../src/core/auth-storage.js", () => ({
+	AuthStorage: {
+		create: () => ({ id: "auth-storage" }),
+	},
+}));
+
+vi.mock("../src/core/sdk.js", () => ({
+	createAgentSession: mockState.createAgentSession,
+}));
+
+import { createAgentSessionRuntime } from "../src/core/agent-session-runtime.js";
+
+describe("createAgentSessionRuntime resource loader lifecycle", () => {
+	beforeEach(() => {
+		mockState.defaultLoaderReloads = 0;
+		mockState.defaultLoaderInstances = 0;
+		mockState.registerProvider.mockReset();
+		mockState.createAgentSession.mockClear();
+	});
+
+	it("uses a provided preloaded resource loader without reloading it", async () => {
+		const providedReload = vi.fn(async () => {});
+		const providedLoader = {
+			reload: providedReload,
+			getExtensions: () => ({
+				extensions: [],
+				errors: [],
+				runtime: {
+					pendingProviderRegistrations: [],
+					flagValues: new Map(),
+				},
+			}),
+			getSkills: () => ({
+				skills: [],
+				diagnostics: [],
+			}),
+			getPrompts: () => ({
+				prompts: [],
+				diagnostics: [],
+			}),
+			getThemes: () => ({
+				themes: [],
+				diagnostics: [],
+			}),
+			getAgentsFiles: () => ({
+				agentsFiles: [],
+			}),
+			getSystemPrompt: () => undefined,
+			getAppendSystemPrompt: () => [],
+			extendResources: () => {},
+		} as unknown as ResourceLoader;
+
+		await createAgentSessionRuntime(
+			{
+				resourceLoader: {
+					noExtensions: true,
+				},
+			},
+			{
+				cwd: "/tmp/runtime-test",
+				resourceLoader: providedLoader,
+			},
+		);
+
+		expect(providedReload).not.toHaveBeenCalled();
+		expect(mockState.defaultLoaderReloads).toBe(0);
+		expect(mockState.defaultLoaderInstances).toBe(0);
+	});
+
+	it("creates and reloads a default resource loader when no preloaded loader is provided", async () => {
+		await createAgentSessionRuntime(
+			{
+				resourceLoader: {
+					noExtensions: true,
+				},
+			},
+			{
+				cwd: "/tmp/runtime-test",
+			},
+		);
+
+		expect(mockState.defaultLoaderInstances).toBe(1);
+		expect(mockState.defaultLoaderReloads).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary
- Reuse the startup `DefaultResourceLoader` instance when creating the initial runtime in `main.ts`.
- Extend `createAgentSessionRuntime` to accept an optional preloaded `resourceLoader` and skip reloading when provided.
- Add a regression test verifying preloaded loaders are not reloaded and default loaders are reloaded once.

## Testing
- npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-session-runtime-resource-loader.test.ts
- npm run check

fixes #2766
