### PR TITLE
fix: explicitly set enable_thinking for Qwen/Qwen-chat-template model…

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -409,10 +409,14 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 
 	if (compat.thinkingFormat === "zai" && model.reasoning) {
 		(params as any).enable_thinking = !!options?.reasoningEffort;
-	} else if (compat.thinkingFormat === "qwen" && model.reasoning) {
-		(params as any).enable_thinking = !!options?.reasoningEffort;
-	} else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
-		(params as any).chat_template_kwargs = { enable_thinking: !!options?.reasoningEffort };
+	} else if (compat.thinkingFormat === "qwen") {
+		// Qwen models default to thinking enabled, so we must always explicitly set
+		// enable_thinking — both to turn it on (when reasoning is requested) and to
+		// turn it off (when model.reasoning is false or no reasoningEffort is given).
+		(params as any).enable_thinking = model.reasoning && !!options?.reasoningEffort;
+	} else if (compat.thinkingFormat === "qwen-chat-template") {
+		// Same rationale as "qwen": always explicitly set to avoid model defaults.
+		(params as any).chat_template_kwargs = { enable_thinking: model.reasoning && !!options?.reasoningEffort };
 	} else if (compat.thinkingFormat === "openrouter" && model.reasoning) {
 		// OpenRouter normalizes reasoning across providers via a nested reasoning object.
 		const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };


### PR DESCRIPTION
## Summary

- Qwen 3.5+ series models (qwen3.5-plus, qwen3.5-flash, qwen3.6-plus, etc.) have thinking mode **enabled by default**. When `enable_thinking` is not explicitly sent in the request, these models will still produce thinking/reasoning output.
- Previously, the `"qwen"` and `"qwen-chat-template"` thinking format branches were gated behind `model.reasoning === true`. When a model had `reasoning: false`, the branch was skipped entirely and no `enable_thinking` parameter was sent — causing Qwen models with default-on thinking to still return thinking content unexpectedly.
- This fix removes the `model.reasoning` guard from the branch condition so that `enable_thinking` is **always explicitly set** for Qwen-format models: `enable_thinking = model.reasoning && !!options?.reasoningEffort`.

## Context

Qwen models fall into two categories regarding thinking mode defaults:

**Default thinking ON:**
- Commercial: qwen3.6-plus, qwen3.5-plus, qwen3.5-flash
- Open-source: qwen3.5-397b-a17b, qwen3.5-122b-a10b, qwen3.5-27b, qwen3.5-35b-a3b, qwen3-235b-a22b, qwen3-32b, qwen3-30b-a3b, qwen3-14b, qwen3-8b, qwen3-4b, qwen3-1.7b, qwen3-0.6b

**Default thinking OFF:**
- Commercial: qwen3-max, qwen-plus, qwen-flash, qwen-turbo

Without explicit `enable_thinking: false`, models in the first category produce thinking output even when the caller does not want it (e.g., simple title generation tasks with `model.reasoning: false`).

## Changes

`packages/ai/src/providers/openai-completions.ts`:
- `thinkingFormat === "qwen"`: removed `&& model.reasoning` guard, now always enters branch and explicitly sends `enable_thinking`
- `thinkingFormat === "qwen-chat-template"`: same change for consistency

## Behavior matrix

| `model.reasoning` | `options.reasoning` | `enable_thinking` sent |
|---|---|---|
| `true` | `"minimal"` / `"low"` / `"medium"` / `"high"` | `true` |
| `true` | `undefined` | `false` |
| `false` | any | `false` |