### PR TITLE
feat(grep): add multiline mode, pattern escaping, asymmetric context, and file type filter

### DIFF
--- a/packages/coding-agent/src/core/tools/grep.ts
+++ b/packages/coding-agent/src/core/tools/grep.ts
@@ -24,6 +24,12 @@ const grepSchema = Type.Object({
 	pattern: Type.String({ description: "Search pattern (regex or literal string)" }),
 	path: Type.Optional(Type.String({ description: "Directory or file to search (default: current directory)" })),
 	glob: Type.Optional(Type.String({ description: "Filter files by glob pattern, e.g. '*.ts' or '**/*.spec.ts'" })),
+	type: Type.Optional(
+		Type.String({
+			description:
+				"File type to search (rg --type), e.g. 'js', 'py', 'rust', 'go', 'java'. More efficient than glob for standard file types.",
+		}),
+	),
 	ignoreCase: Type.Optional(Type.Boolean({ description: "Case-insensitive search (default: false)" })),
 	literal: Type.Optional(
 		Type.Boolean({ description: "Treat pattern as literal string instead of regex (default: false)" }),
@@ -31,7 +37,23 @@ const grepSchema = Type.Object({
 	context: Type.Optional(
 		Type.Number({ description: "Number of lines to show before and after each match (default: 0)" }),
 	),
+	contextBefore: Type.Optional(
+		Type.Number({
+			description:
+				"Number of lines to show before each match (default: 0). Overrides context for before-match lines.",
+		}),
+	),
+	contextAfter: Type.Optional(
+		Type.Number({
+			description: "Number of lines to show after each match (default: 0). Overrides context for after-match lines.",
+		}),
+	),
 	limit: Type.Optional(Type.Number({ description: "Maximum number of matches to return (default: 100)" })),
+	multiline: Type.Optional(
+		Type.Boolean({
+			description: "Enable multiline mode where . matches newlines and patterns can span lines (default: false)",
+		}),
+	),
 });
 
 export type GrepToolInput = Static<typeof grepSchema>;
@@ -136,18 +158,26 @@ export function createGrepToolDefinition(
 				pattern,
 				path: searchDir,
 				glob,
+				type,
 				ignoreCase,
 				literal,
 				context,
+				contextBefore,
+				contextAfter,
 				limit,
+				multiline,
 			}: {
 				pattern: string;
 				path?: string;
 				glob?: string;
+				type?: string;
 				ignoreCase?: boolean;
 				literal?: boolean;
 				context?: number;
+				contextBefore?: number;
+				contextAfter?: number;
 				limit?: number;
+				multiline?: boolean;
 			},
 			signal?: AbortSignal,
 			_onUpdate?,
@@ -184,7 +214,8 @@ export function createGrepToolDefinition(
 							return;
 						}
 
-						const contextValue = context && context > 0 ? context : 0;
+						const ctxBefore = contextBefore ?? (context && context > 0 ? context : 0);
+						const ctxAfter = contextAfter ?? (context && context > 0 ? context : 0);
 						const effectiveLimit = Math.max(1, limit ?? DEFAULT_LIMIT);
 						const formatPath = (filePath: string): string => {
 							if (isDirectory) {
@@ -214,8 +245,14 @@ export function createGrepToolDefinition(
 						const args: string[] = ["--json", "--line-number", "--color=never", "--hidden"];
 						if (ignoreCase) args.push("--ignore-case");
 						if (literal) args.push("--fixed-strings");
+						if (multiline) args.push("-U", "--multiline-dotall");
 						if (glob) args.push("--glob", glob);
-						args.push(pattern, searchPath);
+						if (type) args.push("--type", type);
+						if (pattern.startsWith("-")) {
+							args.push("-e", pattern, searchPath);
+						} else {
+							args.push(pattern, searchPath);
+						}
 
 						const child = spawn(rgPath, args, { stdio: ["ignore", "pipe", "pipe"] });
 						const rl = createInterface({ input: child.stdout });
@@ -251,8 +288,8 @@ export function createGrepToolDefinition(
 							const lines = await getFileLines(filePath);
 							if (!lines.length) return [`${relativePath}:${lineNumber}: (unable to read file)`];
 							const block: string[] = [];
-							const start = contextValue > 0 ? Math.max(1, lineNumber - contextValue) : lineNumber;
-							const end = contextValue > 0 ? Math.min(lines.length, lineNumber + contextValue) : lineNumber;
+							const start = ctxBefore > 0 ? Math.max(1, lineNumber - ctxBefore) : lineNumber;
+							const end = ctxAfter > 0 ? Math.min(lines.length, lineNumber + ctxAfter) : lineNumber;
 							for (let current = start; current <= end; current++) {
 								const lineText = lines[current - 1] ?? "";
 								const sanitized = lineText.replace(/\r/g, "");

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -479,6 +479,70 @@ describe("Coding Agent Tools", () => {
 			// Ensure second match is not present
 			expect(output).not.toContain("match two");
 		});
+
+		it("should support multiline matching", async () => {
+			const testFile = join(testDir, "multi.txt");
+			writeFileSync(testFile, "no match here\nfunction foo() {\n  return 1;\n}\nlast line");
+			// Without multiline, a cross-line pattern should find no matches
+			const noMatch = await grepTool.execute("test-multiline-off", {
+				pattern: "foo.*return",
+				path: testFile,
+			});
+			expect(getTextOutput(noMatch)).toBe("No matches found");
+			// With multiline, the same cross-line pattern should find a match
+			const result = await grepTool.execute("test-multiline-on", {
+				pattern: "foo.*return",
+				path: testFile,
+				multiline: true,
+			});
+			const output = getTextOutput(result);
+			expect(output).toContain("foo");
+			expect(output).not.toBe("No matches found");
+		});
+
+		it("should escape patterns starting with dash", async () => {
+			const testFile = join(testDir, "dash.txt");
+			writeFileSync(testFile, "line one\n-TODO fix this\nline three");
+			const result = await grepTool.execute("test-dash", {
+				pattern: "-TODO",
+				path: testFile,
+				literal: true,
+			});
+			const output = getTextOutput(result);
+			expect(output).toContain("-TODO fix this");
+		});
+
+		it("should support separate contextBefore and contextAfter", async () => {
+			const testFile = join(testDir, "asymctx.txt");
+			writeFileSync(testFile, "a\nb\nc\nmatch\nd\ne\nf");
+			const result = await grepTool.execute("test-ctx-asym", {
+				pattern: "match",
+				path: testFile,
+				contextBefore: 1,
+				contextAfter: 2,
+			});
+			const output = getTextOutput(result);
+			expect(output).toContain("asymctx.txt-3- c");
+			expect(output).toContain("asymctx.txt:4: match");
+			expect(output).toContain("asymctx.txt-5- d");
+			expect(output).toContain("asymctx.txt-6- e");
+			expect(output).not.toContain("asymctx.txt-2-");
+			expect(output).not.toContain("asymctx.txt-7-");
+		});
+
+		it("should support --type file type filter", async () => {
+			mkdirSync(join(testDir, "typed"), { recursive: true });
+			writeFileSync(join(testDir, "typed", "code.ts"), "const x = 1;");
+			writeFileSync(join(testDir, "typed", "data.json"), '{"x": 1}');
+			const result = await grepTool.execute("test-type", {
+				pattern: "x",
+				path: join(testDir, "typed"),
+				type: "ts",
+			});
+			const output = getTextOutput(result);
+			expect(output).toContain("code.ts");
+			expect(output).not.toContain("data.json");
+		});
 	});
 
 	describe("find tool", () => {


### PR DESCRIPTION
## Summary

- Multiline mode: `multiline: true` → `-U --multiline-dotall` for cross-line pattern matching
- Pattern escaping: `-e` flag for patterns starting with `-` (prevents rg option interpretation)
- Asymmetric context: `contextBefore`/`contextAfter` params override symmetric `context` independently
- File type filter: `type` param passes `--type` to ripgrep for built-in type definitions

Closes #2771

## Test plan

- [x] All 58 existing tests pass (0 regressions)
- [x] New test: multiline matching finds cross-line patterns only when enabled
- [x] New test: dash-prefixed patterns (`-TODO`) search correctly with literal mode
- [x] New test: asymmetric context (contextBefore=1, contextAfter=2) shows correct line ranges
- [x] New test: `type: "ts"` filters to TypeScript files only, excludes JSON

```
Test Files  1 passed (1)
    Tests  58 passed (58)
```