### PR TITLE
feat(mom): gracefully handle missing Slack scopes on startup

### DIFF
--- a/packages/mom/src/slack.ts
+++ b/packages/mom/src/slack.ts
@@ -154,10 +154,29 @@ export class SlackBot {
 		const auth = await this.webClient.auth.test();
 		this.botUserId = auth.user_id as string;
 
-		await Promise.all([this.fetchUsers(), this.fetchChannels()]);
+		try {
+			await this.fetchUsers();
+		} catch (err) {
+			log.logWarning(`Failed to fetch users (missing scope?): ${err instanceof Error ? err.message : String(err)}`);
+		}
+
+		try {
+			await this.fetchChannels();
+		} catch (err) {
+			log.logWarning(
+				`Failed to fetch channels (missing scope?): ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+
 		log.logInfo(`Loaded ${this.channels.size} channels, ${this.users.size} users`);
 
-		await this.backfillAllChannels();
+		try {
+			await this.backfillAllChannels();
+		} catch (err) {
+			log.logWarning(
+				`Failed to backfill channels (missing scope?): ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
 
 		this.setupEventHandlers();
 		await this.socketClient.start();


### PR DESCRIPTION
Wrap fetchUsers, fetchChannels, and backfillAllChannels in try/catch so MOM starts with minimal scopes (app_mentions:read, chat:write, files:read, files:write) instead of crashing with missing_scope error.

None of the extra scopes are required for MOM to function. They're just used for:

- User name resolution (cosmetic)
- Channel listing (prompt enrichment)
- Message backfill (history catch-up)

<img width="504" height="261" alt="Screenshot 2026-04-02 at 8 28 56 AM" src="https://github.com/user-attachments/assets/810e899a-8a7d-45a0-9d0e-35ceeec74cfb" />
