### PR TITLE
Preserve cache write tokens in openai-completions streaming usage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed Anthropic context overflow detection to recognize HTTP 413 `request_too_large` errors, so callers can trigger compaction and retry instead of getting stuck on repeated oversized-image requests ([#2734](https://github.com/badlogic/pi-mono/issues/2734))
 - Fixed OpenAI Responses tool-call streaming to emit a `toolcall_delta` when function call arguments arrive only in `response.function_call_arguments.done`, and to emit only the missing suffix when `.done` extends earlier streamed arguments ([#2745](https://github.com/badlogic/pi-mono/issues/2745))
+- Fixed OpenAI-compatible streaming usage parsing to preserve `prompt_tokens_details.cache_write_tokens` as `usage.cacheWrite` instead of dropping cache write token counts from streamed responses.
 
 ## [0.64.0] - 2026-03-29
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -734,12 +734,13 @@ function parseChunkUsage(
 	rawUsage: {
 		prompt_tokens?: number;
 		completion_tokens?: number;
-		prompt_tokens_details?: { cached_tokens?: number };
+		prompt_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
 		completion_tokens_details?: { reasoning_tokens?: number };
 	},
 	model: Model<"openai-completions">,
 ): AssistantMessage["usage"] {
 	const cachedTokens = rawUsage.prompt_tokens_details?.cached_tokens || 0;
+	const cacheWriteTokens = rawUsage.prompt_tokens_details?.cache_write_tokens || 0;
 	const reasoningTokens = rawUsage.completion_tokens_details?.reasoning_tokens || 0;
 	// OpenAI includes cached tokens in prompt_tokens, so subtract to get non-cached input
 	const input = (rawUsage.prompt_tokens || 0) - cachedTokens;
@@ -750,8 +751,8 @@ function parseChunkUsage(
 		input,
 		output: outputTokens,
 		cacheRead: cachedTokens,
-		cacheWrite: 0,
-		totalTokens: input + outputTokens + cachedTokens,
+		cacheWrite: cacheWriteTokens,
+		totalTokens: input + outputTokens + cachedTokens + cacheWriteTokens,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 	calculateCost(model, usage);

--- a/packages/ai/test/openai-completions-cache-write-tokens.test.ts
+++ b/packages/ai/test/openai-completions-cache-write-tokens.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.js";
+import { streamSimple } from "../src/stream.js";
+
+const mockState = vi.hoisted(() => ({
+	lastParams: undefined as unknown,
+	chunks: undefined as
+		| Array<null | {
+				id?: string;
+				choices?: Array<{ delta: Record<string, unknown>; finish_reason: string | null; usage?: unknown }>;
+				usage?: {
+					prompt_tokens: number;
+					completion_tokens: number;
+					prompt_tokens_details: { cached_tokens: number; cache_write_tokens?: number };
+					completion_tokens_details: { reasoning_tokens: number };
+				};
+		  }>
+		| undefined,
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: async (params: unknown) => {
+					mockState.lastParams = params;
+					return {
+						async *[Symbol.asyncIterator]() {
+							const chunks = mockState.chunks ?? [
+								{
+									choices: [{ delta: {}, finish_reason: "stop" }],
+									usage: {
+										prompt_tokens: 1,
+										completion_tokens: 1,
+										prompt_tokens_details: { cached_tokens: 0 },
+										completion_tokens_details: { reasoning_tokens: 0 },
+									},
+								},
+							];
+							for (const chunk of chunks) {
+								yield chunk;
+							}
+						},
+					};
+				},
+			},
+		};
+	}
+
+	return { default: FakeOpenAI };
+});
+
+describe("openai-completions cache write token parsing", () => {
+	beforeEach(() => {
+		mockState.lastParams = undefined;
+		mockState.chunks = undefined;
+	});
+
+	it("maps cache_write_tokens from prompt_tokens_details into usage.cacheWrite", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-cache-write",
+				choices: [{ delta: { content: "READY" }, finish_reason: null }],
+			},
+			{
+				id: "chatcmpl-cache-write",
+				choices: [{ delta: {}, finish_reason: "stop" }],
+				usage: {
+					prompt_tokens: 100,
+					completion_tokens: 5,
+					prompt_tokens_details: { cached_tokens: 80, cache_write_tokens: 20 },
+					completion_tokens_details: { reasoning_tokens: 0 },
+				},
+			},
+		];
+
+		const model = getModel("openrouter", "google/gemini-3-flash-preview")!;
+		const response = await streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Reply with READY",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		expect(response.stopReason).toBe("stop");
+		expect(response.usage.input).toBe(20);
+		expect(response.usage.output).toBe(5);
+		expect(response.usage.cacheRead).toBe(80);
+		expect(response.usage.cacheWrite).toBe(20);
+		expect(response.usage.totalTokens).toBe(125);
+	});
+});


### PR DESCRIPTION
## Summary
- preserve `prompt_tokens_details.cache_write_tokens` in openai-completions streamed usage parsing
- expose cache write token counts through `usage.cacheWrite` and `totalTokens`
- add a focused regression test covering the mapping

## Testing
- `cd packages/ai && ../../node_modules/.bin/vitest --run test/openai-completions-cache-write-tokens.test.ts`
- `cd packages/ai && ../../node_modules/.bin/tsgo --noEmit -p tsconfig.build.json`
- `npm run check`

## Context
OpenAI-compatible streamed responses can include `prompt_tokens_details.cache_write_tokens`, but pi-ai currently drops that field and reports `usage.cacheWrite = 0`. This makes prompt-cache creation invisible to downstream consumers even when prompt caching is working.
