### PR TITLE
feat(ai): add Gemma 4 thinking support

### DIFF
--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -293,12 +293,12 @@ export const streamSimpleGoogle: StreamFunction<"google-generative-ai", SimpleSt
 	const effort = clampReasoning(options.reasoning)!;
 	const googleModel = model as Model<"google-generative-ai">;
 
-	if (isGemini3ProModel(googleModel) || isGemini3FlashModel(googleModel)) {
+	if (isGemini3ProModel(googleModel) || isGemini3FlashModel(googleModel) || isGemma4Model(googleModel)) {
 		return streamGoogle(model, context, {
 			...base,
 			thinking: {
 				enabled: true,
-				level: getGemini3ThinkingLevel(effort, googleModel),
+				level: getThinkingLevel(effort, googleModel),
 			},
 		} satisfies GoogleOptions);
 	}
@@ -402,6 +402,11 @@ function isGemini3FlashModel(model: Model<"google-generative-ai">): boolean {
 	return /gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
 }
 
+function isGemma4Model(model: Model<"google-generative-ai">): boolean {
+	// Gemma 4 models use thinkingLevel (like Gemini 3), not thinkingBudget.
+	return /gemma-?4/.test(model.id.toLowerCase());
+}
+
 function getDisabledThinkingConfig(model: Model<"google-generative-ai">): ThinkingConfig {
 	// Google docs: Gemini 3.1 Pro cannot disable thinking, and Gemini 3 Flash / Flash-Lite
 	// do not support full thinking-off either. For Gemini 3 models, use the lowest supported
@@ -417,15 +422,23 @@ function getDisabledThinkingConfig(model: Model<"google-generative-ai">): Thinki
 	return { thinkingBudget: 0 };
 }
 
-function getGemini3ThinkingLevel(
-	effort: ClampedThinkingLevel,
-	model: Model<"google-generative-ai">,
-): GoogleThinkingLevel {
+function getThinkingLevel(effort: ClampedThinkingLevel, model: Model<"google-generative-ai">): GoogleThinkingLevel {
 	if (isGemini3ProModel(model)) {
 		switch (effort) {
 			case "minimal":
 			case "low":
 				return "LOW";
+			case "medium":
+			case "high":
+				return "HIGH";
+		}
+	}
+	// Gemma 4 only supports MINIMAL and HIGH thinking levels.
+	if (isGemma4Model(model)) {
+		switch (effort) {
+			case "minimal":
+			case "low":
+				return "MINIMAL";
 			case "medium":
 			case "high":
 				return "HIGH";

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -90,6 +90,33 @@ Override defaults when you need specific values:
 
 The file reloads each time you open `/model`. Edit during session; no restart needed.
 
+## Google AI Studio Example
+
+Use `google-generative-ai` with a `baseUrl` to add models from Google AI Studio (e.g., Gemma 4):
+
+```json
+{
+  "providers": {
+    "my-google": {
+      "baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+      "api": "google-generative-ai",
+      "apiKey": "GEMINI_API_KEY",
+      "models": [
+        {
+          "id": "gemma-4-31b-it",
+          "name": "Gemma 4 31B",
+          "input": ["text", "image"],
+          "contextWindow": 262144,
+          "reasoning": true
+        }
+      ]
+    }
+  }
+}
+```
+
+The `baseUrl` is required when adding custom models to the `google-generative-ai` API type.
+
 ## Supported APIs
 
 | API | Description |


### PR DESCRIPTION
## Summary

- Adds Gemma 4 extended thinking support to the Google provider
- Gemma 4 uses `thinkingLevel` (like Gemini 3) instead of `thinkingBudget`, and only supports `MINIMAL` and `HIGH` levels — `LOW` and `MEDIUM` return 400 errors from the API
- Documents how to add Google AI Studio models (like Gemma 4) to `models.json` with the required `baseUrl`

## Changes

**`packages/ai/src/providers/google.ts`**
- `isGemma4Model()` — detects Gemma 4 via `/gemma-?4/` regex
- `streamSimpleGoogle` — routes Gemma 4 through `thinkingLevel` path
- `getGemini3ThinkingLevel` → `getThinkingLevel` — adds Gemma 4 level mapping (`MINIMAL`/`HIGH` only)

**`packages/coding-agent/docs/models.md`**
- Added "Google AI Studio Example" section showing `baseUrl` + `google-generative-ai` config for Gemma 4

## Test plan

- [ ] Verify Gemma 4 31B works with thinking enabled via `models.json` config
- [ ] Verify thinking output includes both thinking trace and answer
- [ ] Verify Gemma 4 works with thinking disabled (`reasoning: false`)
- [ ] Verify no regression for Gemini 2.x models (still use `thinkingBudget`)
- [ ] Verify no regression for Gemini 3.x models (still use `thinkingLevel`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)