### PR TITLE
fix: quote variables in doom build script (shellcheck SC2086)

### DIFF
--- a/packages/coding-agent/examples/extensions/doom-overlay/doom/build.sh
+++ b/packages/coding-agent/examples/extensions/doom-overlay/doom/build.sh
@@ -60,8 +60,8 @@ emcc -O2 \
     -s FORCE_FILESYSTEM=1 \
     -s EXIT_RUNTIME=0 \
     -s NO_EXIT_RUNTIME=1 \
-    -DDOOMGENERIC_RESX=$RESX \
-    -DDOOMGENERIC_RESY=$RESY \
+    -DDOOMGENERIC_RESX="$RESX" \
+    -DDOOMGENERIC_RESY="$RESY" \
     -I. \
     am_map.c \
     d_event.c \


### PR DESCRIPTION
Hi! This is a minor fix addressing shellcheck SC2086 (double quote to prevent globbing and word splitting).

Quotes `$RESX` and `$RESY` in the doom overlay build script to avoid potential issues with word splitting or globbing.