### PR TITLE
feat(coding-agent): support unregistering extension tools and commands

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1020,6 +1020,8 @@ Register a custom tool callable by the LLM. See [Custom Tools](#custom-tools) fo
 
 `pi.registerTool()` works both during extension load and after startup. You can call it inside `session_start`, command handlers, or other event handlers. New tools are refreshed immediately in the same session, so they appear in `pi.getAllTools()` and are callable by the LLM without `/reload`.
 
+Use `pi.unregisterTool(name)` to remove a previously registered tool from the current extension. The tool registry refreshes immediately in the same session.
+
 Use `pi.setActiveTools()` to enable or disable tools (including dynamically added tools) at runtime.
 
 Use `promptSnippet` to opt a custom tool into a one-line entry in `Available tools`, and `promptGuidelines` to append tool-specific bullets to the default `Guidelines` section when the tool is active.
@@ -1062,6 +1064,16 @@ pi.registerTool({
   renderResult(result, options, theme, context) { ... },
 });
 ```
+
+### pi.unregisterTool(name)
+
+Unregister a previously registered tool by name.
+
+```typescript
+pi.unregisterTool("my_tool");
+```
+
+If the tool is currently active, pi refreshes the runtime registry immediately so it disappears from `pi.getAllTools()` and from the active tool set.
 
 ### pi.sendMessage(message, options?)
 
@@ -1201,6 +1213,16 @@ pi.registerCommand("deploy", {
   },
 });
 ```
+
+### pi.unregisterCommand(name)
+
+Unregister a previously registered custom command by name.
+
+```typescript
+pi.unregisterCommand("stats");
+```
+
+Command lookups are resolved dynamically, so the command disappears immediately from `pi.getCommands()` and from slash-command resolution.
 
 ### pi.getCommands()
 

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -180,12 +180,22 @@ function createExtensionAPI(
 			runtime.refreshTools();
 		},
 
+		unregisterTool(name: string): void {
+			if (extension.tools.delete(name)) {
+				runtime.refreshTools();
+			}
+		},
+
 		registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">): void {
 			extension.commands.set(name, {
 				name,
 				sourceInfo: extension.sourceInfo,
 				...options,
 			});
+		},
+
+		unregisterCommand(name: string): void {
+			extension.commands.delete(name);
 		},
 
 		registerShortcut(

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1034,12 +1034,18 @@ export interface ExtensionAPI {
 		tool: ToolDefinition<TParams, TDetails, TState>,
 	): void;
 
+	/** Unregister a previously registered tool by name. */
+	unregisterTool(name: string): void;
+
 	// =========================================================================
 	// Command, Shortcut, Flag Registration
 	// =========================================================================
 
 	/** Register a custom command. */
 	registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">): void;
+
+	/** Unregister a previously registered custom command by name. */
+	unregisterCommand(name: string): void;
 
 	/** Register a keyboard shortcut. */
 	registerShortcut(

--- a/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
+++ b/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
@@ -179,4 +179,112 @@ describe("AgentSession dynamic tool registration", () => {
 
 		session.dispose();
 	});
+
+	it("removes tools from the active registry when unregistered at runtime", async () => {
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const sessionManager = SessionManager.inMemory();
+
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: tempDir,
+			agentDir,
+			settingsManager,
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", () => {
+						pi.registerTool({
+							name: "dynamic_tool",
+							label: "Dynamic Tool",
+							description: "Tool registered from session_start",
+							promptSnippet: "Run dynamic test behavior",
+							promptGuidelines: ["Use dynamic_tool when the user asks for dynamic behavior tests."],
+							parameters: Type.Object({}),
+							execute: async () => ({
+								content: [{ type: "text", text: "ok" }],
+								details: {},
+							}),
+						});
+					});
+					pi.registerCommand("drop-dynamic", {
+						description: "Remove the dynamic tool",
+						handler: async () => {
+							pi.unregisterTool("dynamic_tool");
+						},
+					});
+				},
+			],
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir,
+			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+		});
+
+		await session.bindExtensions({});
+		expect(session.getAllTools().map((tool) => tool.name)).toContain("dynamic_tool");
+		expect(session.getActiveToolNames()).toContain("dynamic_tool");
+		expect(session.systemPrompt).toContain("dynamic_tool");
+
+		await session.prompt("/drop-dynamic");
+
+		expect(session.getAllTools().map((tool) => tool.name)).not.toContain("dynamic_tool");
+		expect(session.getActiveToolNames()).not.toContain("dynamic_tool");
+		expect(session.systemPrompt).not.toContain("- dynamic_tool: Run dynamic test behavior");
+		expect(session.systemPrompt).not.toContain("Use dynamic_tool when the user asks for dynamic behavior tests.");
+
+		session.dispose();
+	});
+
+	it("removes commands when unregistered at runtime", async () => {
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const sessionManager = SessionManager.inMemory();
+		const commandRuns: string[] = [];
+
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: tempDir,
+			agentDir,
+			settingsManager,
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("target-cmd", {
+						description: "Target command",
+						handler: async () => {
+							commandRuns.push("target");
+						},
+					});
+					pi.registerCommand("remove-target-cmd", {
+						description: "Remove target command",
+						handler: async () => {
+							pi.unregisterCommand("target-cmd");
+						},
+					});
+				},
+			],
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir,
+			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+		});
+
+		await session.bindExtensions({});
+		expect(session.extensionRunner?.getCommand("target-cmd")).toBeDefined();
+
+		await session.prompt("/remove-target-cmd");
+
+		expect(session.extensionRunner?.getCommand("target-cmd")).toBeUndefined();
+		expect(session.extensionRunner?.getRegisteredCommands().map((command) => command.invocationName)).not.toContain("target-cmd");
+		expect(commandRuns).toEqual([]);
+
+		session.dispose();
+	});
 });

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -325,6 +325,29 @@ describe("ExtensionRunner", () => {
 			expect(tools).toHaveLength(1);
 			expect(tools[0]?.definition.description).toBe("first");
 		});
+
+		it("omits tools unregistered during extension load", async () => {
+			const extCode = `
+				import { Type } from "@sinclair/typebox";
+				export default function(pi) {
+					pi.registerTool({
+						name: "temp_tool",
+						label: "temp_tool",
+						description: "temporary",
+						parameters: Type.Object({}),
+						execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+					});
+					pi.unregisterTool("temp_tool");
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "temp-tool.ts"), extCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			const tools = runner.getAllRegisteredTools();
+
+			expect(tools).toHaveLength(0);
+		});
 	});
 
 	describe("command collection", () => {
@@ -397,6 +420,26 @@ describe("ExtensionRunner", () => {
 			expect(diagnostics).toEqual([]);
 			expect(runner.getCommand("shared-cmd:1")?.description).toBe("First command");
 			expect(runner.getCommand("shared-cmd:2")?.description).toBe("Second command");
+		});
+
+		it("omits commands unregistered during extension load", async () => {
+			const cmdCode = `
+				export default function(pi) {
+					pi.registerCommand("temp-cmd", {
+						description: "temporary",
+						handler: async () => {},
+					});
+					pi.unregisterCommand("temp-cmd");
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "cmd-temp.ts"), cmdCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			const commands = runner.getRegisteredCommands();
+
+			expect(commands).toHaveLength(0);
+			expect(runner.getCommand("temp-cmd")).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Adds public extension API support for:

- `pi.unregisterTool(name)`
- `pi.unregisterCommand(name)`

Pi already supports dynamic addition via `pi.registerTool()` and `pi.registerCommand()`, but it had no symmetric public removal API. This patch makes extension-owned runtime state reversible.

## Implementation

- adds `unregisterTool()` and `unregisterCommand()` to `ExtensionAPI`
- removes tools from the extension-owned tool map and refreshes the runtime registry immediately
- removes commands from the extension-owned command map so command lookup/listing updates immediately
- documents the new APIs in `docs/extensions.md`
- adds coverage for load-time and runtime unregister behavior

## Validation

Ran:

- `cd packages/coding-agent && npm run build`
- `cd packages/coding-agent && npx vitest --run test/extensions-runner.test.ts test/agent-session-dynamic-tools.test.ts`

Observed:

- build passed
- tests passed
- new cases verify:
  - tools unregistered during extension load are omitted
  - commands unregistered during extension load are omitted
  - runtime-unregistered tools disappear from the active registry/system prompt
  - runtime-unregistered commands disappear from command lookup/listing
