### PR TITLE
feat(coding-agent): allow ctx.reload from all extension contexts

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -956,6 +956,9 @@ pi.registerCommand("switch", {
 
 Run the same reload flow as `/reload`.
 
+`ctx.reload()` is now available in both `ExtensionContext` and `ExtensionCommandContext`.
+Modes may defer the actual reload until the runtime becomes idle if the request arrives while streaming or compacting.
+
 ```typescript
 pi.registerCommand("reload-runtime", {
   description: "Reload extensions, skills, prompts, and themes",
@@ -976,7 +979,7 @@ Important behavior:
 
 For predictable behavior, treat reload as terminal for that handler (`await ctx.reload(); return;`).
 
-Tools run with `ExtensionContext`, so they cannot call `ctx.reload()` directly. Use a command as the reload entrypoint, then expose a tool that queues that command as a follow-up user message.
+Because tools now also receive `ExtensionContext`, they can call `ctx.reload()` directly when needed. If the mode cannot reload immediately, the request may be deferred until the session becomes idle.
 
 Example tool the LLM can call to trigger reload:
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2195,6 +2195,12 @@ export class AgentSession {
 					})();
 				},
 				getSystemPrompt: () => this.systemPrompt,
+				reload: async () => {
+					if (!this._extensionCommandContextActions) {
+						throw new Error("Reload is not available in this mode");
+					}
+					await this._extensionCommandContextActions.reload();
+				},
 			},
 			{
 				registerProvider: (name, config) => {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -274,6 +274,7 @@ export class ExtensionRunner {
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
+		this.reloadHandler = contextActions.reload;
 
 		// Flush provider registrations queued during extension loading
 		for (const { name, config, extensionPath } of this.runtime.pendingProviderRegistrations) {
@@ -551,6 +552,7 @@ export class ExtensionRunner {
 			getContextUsage: () => this.getContextUsageFn(),
 			compact: (options) => this.compactFn(options),
 			getSystemPrompt: () => this.getSystemPromptFn(),
+			reload: () => this.reloadHandler(),
 		};
 	}
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -291,6 +291,8 @@ export interface ExtensionContext {
 	compact(options?: CompactOptions): void;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
+	/** Request a runtime reload. Available in all contexts; modes may defer execution until safe. */
+	reload(): Promise<void>;
 }
 
 /**
@@ -1390,6 +1392,7 @@ export interface ExtensionContextActions {
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
 	getSystemPrompt: () => string;
+	reload: () => Promise<void>;
 }
 
 /**

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -218,6 +218,8 @@ export class InteractiveMode {
 
 	// Shutdown state
 	private shutdownRequested = false;
+	private pendingExtensionReload = false;
+	private extensionReloadInProgress = false;
 
 	// Extension UI state
 	private extensionSelector: ExtensionSelectorComponent | undefined = undefined;
@@ -1228,7 +1230,7 @@ export class InteractiveMode {
 					return { cancelled: false };
 				},
 				reload: async () => {
-					await this.handleReloadCommand();
+					await this.requestExtensionReload();
 				},
 			},
 			shutdownHandler: () => {
@@ -1344,6 +1346,7 @@ export class InteractiveMode {
 				})();
 			},
 			getSystemPrompt: () => this.session.systemPrompt,
+			reload: () => this.requestExtensionReload(),
 		});
 
 		// Set up the extension shortcut handler on the default editor
@@ -2567,6 +2570,8 @@ export class InteractiveMode {
 				break;
 			}
 		}
+
+		await this.maybeRunPendingExtensionReload();
 	}
 
 	/** Extract text content from a user message */
@@ -3987,6 +3992,29 @@ export class InteractiveMode {
 	// Command handlers
 	// =========================================================================
 
+	private async requestExtensionReload(): Promise<void> {
+		if (this.extensionReloadInProgress) {
+			return;
+		}
+		if (this.session.isStreaming || this.session.isCompacting) {
+			this.pendingExtensionReload = true;
+			this.showStatus("Reload scheduled for when the session becomes idle");
+			return;
+		}
+		await this.performReload();
+	}
+
+	private async maybeRunPendingExtensionReload(): Promise<void> {
+		if (!this.pendingExtensionReload || this.extensionReloadInProgress) {
+			return;
+		}
+		if (this.session.isStreaming || this.session.isCompacting) {
+			return;
+		}
+		this.pendingExtensionReload = false;
+		await this.performReload();
+	}
+
 	private async handleReloadCommand(): Promise<void> {
 		if (this.session.isStreaming) {
 			this.showWarning("Wait for the current response to finish before reloading.");
@@ -3996,7 +4024,11 @@ export class InteractiveMode {
 			this.showWarning("Wait for compaction to finish before reloading.");
 			return;
 		}
+		await this.performReload();
+	}
 
+	private async performReload(): Promise<void> {
+		this.extensionReloadInProgress = true;
 		this.resetExtensionUI();
 
 		const loader = new BorderedLoader(
@@ -4060,6 +4092,8 @@ export class InteractiveMode {
 		} catch (error) {
 			dismissLoader(previousEditor as Component);
 			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);
+		} finally {
+			this.extensionReloadInProgress = false;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -33,6 +33,24 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 	let exitCode = 0;
 	let session = runtimeHost.session;
 	let unsubscribe: (() => void) | undefined;
+	let pendingExtensionReload = false;
+	let extensionReloadInProgress = false;
+
+	const requestExtensionReload = async (): Promise<void> => {
+		if (extensionReloadInProgress) {
+			return;
+		}
+		if (session.isStreaming || session.isCompacting) {
+			pendingExtensionReload = true;
+			return;
+		}
+		extensionReloadInProgress = true;
+		try {
+			await session.reload();
+		} finally {
+			extensionReloadInProgress = false;
+		}
+	};
 
 	const rebindSession = async (): Promise<void> => {
 		session = runtimeHost.session;
@@ -70,7 +88,7 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 					return result;
 				},
 				reload: async () => {
-					await session.reload();
+					await requestExtensionReload();
 				},
 			},
 			onError: (err) => {
@@ -79,9 +97,13 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 		});
 
 		unsubscribe?.();
-		unsubscribe = session.subscribe((event) => {
+		unsubscribe = session.subscribe(async (event) => {
 			if (mode === "json") {
 				writeRawStdout(`${JSON.stringify(event)}\n`);
+			}
+			if (pendingExtensionReload && !extensionReloadInProgress && !session.isStreaming && !session.isCompacting) {
+				pendingExtensionReload = false;
+				await requestExtensionReload();
 			}
 		});
 	};

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -75,6 +75,8 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 
 	// Shutdown request flag
 	let shutdownRequested = false;
+	let pendingExtensionReload = false;
+	let extensionReloadInProgress = false;
 
 	/** Helper for dialog methods with signal/timeout support */
 	function createDialogPromise<T>(
@@ -282,6 +284,29 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		},
 	});
 
+	const requestExtensionReload = async (): Promise<void> => {
+		if (extensionReloadInProgress) {
+			return;
+		}
+		if (session.isStreaming || session.isCompacting) {
+			pendingExtensionReload = true;
+			output({
+				type: "extension_ui_request",
+				id: crypto.randomUUID(),
+				method: "notify",
+				message: "Reload scheduled for when the session becomes idle",
+				notifyType: "info",
+			} as RpcExtensionUIRequest);
+			return;
+		}
+		extensionReloadInProgress = true;
+		try {
+			await session.reload();
+		} finally {
+			extensionReloadInProgress = false;
+		}
+	};
+
 	const rebindSession = async (): Promise<void> => {
 		session = runtimeHost.session;
 		await session.bindExtensions({
@@ -319,7 +344,7 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 					return result;
 				},
 				reload: async () => {
-					await session.reload();
+					await requestExtensionReload();
 				},
 			},
 			shutdownHandler: () => {
@@ -331,8 +356,12 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		});
 
 		unsubscribe?.();
-		unsubscribe = session.subscribe((event) => {
+		unsubscribe = session.subscribe(async (event) => {
 			output(event);
+			if (pendingExtensionReload && !extensionReloadInProgress && !session.isStreaming && !session.isCompacting) {
+				pendingExtensionReload = false;
+				await requestExtensionReload();
+			}
 		});
 	};
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -78,6 +78,7 @@ describe("ExtensionRunner", () => {
 		getContextUsage: () => undefined,
 		compact: () => {},
 		getSystemPrompt: () => "",
+		reload: async () => {},
 	};
 
 	describe("shortcut conflicts", () => {
@@ -401,6 +402,21 @@ describe("ExtensionRunner", () => {
 	});
 
 	describe("context creation", () => {
+		it("exposes reload on ExtensionContext", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			const reload = vi.fn(async () => {});
+
+			runner.bindCore(extensionActions, {
+				...extensionContextActions,
+				reload,
+			});
+
+			const ctx = runner.createContext();
+			await ctx.reload();
+			expect(reload).toHaveBeenCalledTimes(1);
+		});
+
 		it("exposes the current abort signal on ExtensionContext", async () => {
 			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -18,6 +18,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		getContextUsage: () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 }),
 		compact,
 		getSystemPrompt: () => "",
+		reload: async () => {},
 	};
 }
 


### PR DESCRIPTION
## Summary

Promotes reload from a command-only capability to a general extension capability.

This makes `ctx.reload()` available from generic `ExtensionContext`, not only `ExtensionCommandContext`.

## Implementation

- adds `reload(): Promise<void>` to `ExtensionContext`
- wires it through `ExtensionContextActions` and `ExtensionRunner.createContext()`
- routes it through the mode-specific reload handlers
- interactive, RPC, and print modes now defer reload until safe if the request arrives while streaming or compacting
- updates docs and tests for the new semantics

## Why

Before this patch, tools, event handlers, and shortcut handlers could not request reload directly because only command context exposed `reload()`.

That forced downstream runtimes to bounce reload requests through command-only workarounds. This patch keeps reload safe while making it generally accessible.

## Validation

Ran:

- `cd packages/coding-agent && npm run build`
- `cd packages/coding-agent && npx vitest --run test/extensions-runner.test.ts test/trigger-compact-extension.test.ts`

Observed:

- build passed
- tests passed
- coverage verifies `ExtensionContext.reload()` is exposed and wired
