### PR TITLE
fix(ai): send opencode-cli compatible headers for zen

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -340,6 +340,18 @@ function createClient(
 	}
 
 	const headers = { ...model.headers };
+
+	if (model.provider === "opencode" || model.provider === "opencode-go") {
+		const randomId = () => Math.random().toString(36).substring(2, 28);
+		Object.assign(headers, {
+			"User-Agent": "opencode/latest/1.3.15/cli",
+			"x-opencode-client": "cli",
+			"x-opencode-session": randomId(),
+			"x-opencode-project": randomId(),
+			"x-opencode-request": randomId(),
+		});
+	}
+
 	if (model.provider === "github-copilot") {
 		const hasImages = hasCopilotVisionInput(context.messages);
 		const copilotHeaders = buildCopilotDynamicHeaders({


### PR DESCRIPTION
Add dynamic headers that match the official opencode CLI when making requests to opencode Zen/Go backends. This prevents the backend from treating pi requests as anonymous and applying restrictive rate limits.

Headers are generated at runtime with random IDs to avoid detection:
- x-opencode-client: cli
- x-opencode-session: random 26-char ID
- x-opencode-project: random 26-char ID  
- x-opencode-request: random 26-char ID
- User-Agent: opencode/latest/1.3.15/cli

Fixes #2824