### PR TITLE
fix(coding-agent): use local timezone for system prompt date instead of UTC

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Bumped default Antigravity User-Agent version to `1.21.9` to fix "This version of Antigravity is no longer supported" errors from Google's API ([#2815](https://github.com/badlogic/pi-mono/issues/2815))
 - Fixed OpenAI-compatible completions streaming usage to preserve `prompt_tokens_details.cache_write_tokens` and normalize OpenRouter `cached_tokens` to previous-request cache hits only, preventing cache read/write double counting in `usage` and cost calculation ([#2802](https://github.com/badlogic/pi-mono/issues/2802))
 
 ## [0.65.0] - 2026-04-03

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -77,7 +77,7 @@ const GEMINI_CLI_HEADERS = {
 };
 
 // Headers for Antigravity (sandbox endpoint) - requires specific User-Agent
-const DEFAULT_ANTIGRAVITY_VERSION = "1.18.4";
+const DEFAULT_ANTIGRAVITY_VERSION = "1.21.9";
 
 function getAntigravityHeaders() {
 	const version = process.env.PI_AI_ANTIGRAVITY_VERSION || DEFAULT_ANTIGRAVITY_VERSION;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Bumped default Antigravity User-Agent version to `1.21.9` to fix "This version of Antigravity is no longer supported" errors from Google's API ([#2815](https://github.com/badlogic/pi-mono/issues/2815))
 - System prompt date now uses local timezone instead of UTC, fixing date hallucination for users far from UTC ([#2814](https://github.com/badlogic/pi-mono/issues/2814))
 - RpcClient now forwards subprocess stderr to parent process in real-time ([#2805](https://github.com/badlogic/pi-mono/issues/2805))
 - Theme file watcher now handles async `fs.watch` error events instead of crashing the process ([#2791](https://github.com/badlogic/pi-mono/issues/2791))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- System prompt date now uses local timezone instead of UTC, fixing date hallucination for users far from UTC
+- System prompt date now uses local timezone instead of UTC, fixing date hallucination for users far from UTC ([#2814](https://github.com/badlogic/pi-mono/issues/2814))
 - RpcClient now forwards subprocess stderr to parent process in real-time ([#2805](https://github.com/badlogic/pi-mono/issues/2805))
 - Theme file watcher now handles async `fs.watch` error events instead of crashing the process ([#2791](https://github.com/badlogic/pi-mono/issues/2791))
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- System prompt date now uses local timezone instead of UTC, fixing date hallucination for users far from UTC
 - RpcClient now forwards subprocess stderr to parent process in real-time ([#2805](https://github.com/badlogic/pi-mono/issues/2805))
 - Theme file watcher now handles async `fs.watch` error events instead of crashing the process ([#2791](https://github.com/badlogic/pi-mono/issues/2791))
 

--- a/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
+++ b/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
@@ -48,7 +48,7 @@ type SaveMode = (typeof SAVE_MODES)[number];
 
 const ANTIGRAVITY_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 
-const DEFAULT_ANTIGRAVITY_VERSION = "1.18.3";
+const DEFAULT_ANTIGRAVITY_VERSION = "1.21.9";
 
 const ANTIGRAVITY_HEADERS = {
 	"User-Agent": `antigravity/${process.env.PI_AI_ANTIGRAVITY_VERSION || DEFAULT_ANTIGRAVITY_VERSION} darwin/arm64`,

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -39,7 +39,11 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const resolvedCwd = cwd ?? process.cwd();
 	const promptCwd = resolvedCwd.replace(/\\/g, "/");
 
-	const date = new Date().toISOString().slice(0, 10);
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, "0");
+	const day = String(now.getDate()).padStart(2, "0");
+	const date = `${year}-${month}-${day}`;
 
 	const appendSection = appendSystemPrompt ? `\n\n${appendSystemPrompt}` : "";
 

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -45,6 +45,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const day = String(now.getDate()).padStart(2, "0");
 	const date = `${year}-${month}-${day}`;
 
+
 	const appendSection = appendSystemPrompt ? `\n\n${appendSystemPrompt}` : "";
 
 	const contextFiles = providedContextFiles ?? [];


### PR DESCRIPTION
The date injected into the system prompt was always in UTC because of `toISOString()`. For anyone living far from UTC, this means the agent sees the wrong date for a few hours every day; this causes stuff like changelog generation to hallucinate yesterday's date

Fix is straightforward. Build the date string from `getFullYear()`, `getMonth()`, `getDate()` instead, which respects the user's local timezone while keeping the same YYYY-MM-DD format

Fixes [#2814](https://github.com/badlogic/pi-mono/issues/2814)

----------------------------------------------------------
Fixes [Antigravity "no longer supported" error (#2815)](https://github.com/badlogic/pi-mono/issues/2815)

Google's Antigravity service has updated their API requirements and is rejecting requests with the old User-Agent version (1.18.4). This PR bumps the default version to 1.21.9 (latest stable release as of April 2026)

Changes:

- Updated `DEFAULT_ANTIGRAVITY_VERSION` from `1.18.4` to `1.21.9` in `packages/ai/src/providers/google-gemini-cli.ts`
- Updated `DEFAULT_ANTIGRAVITY_VERSION` from `1.18.3` to `1.21.9` in `packages/coding-agent/examples/extensions/antigravity-image-gen.ts`
- Updated CHANGELOGs for both packages

Users should verify that Antigravity models (gemini-3.1-pro, claude-sonnet-4-5, etc.) work without the "no longer supported" error after this change