### PR TITLE
fix: use local timezone for system prompt date

### DIFF
--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -39,7 +39,13 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const resolvedCwd = cwd ?? process.cwd();
 	const promptCwd = resolvedCwd.replace(/\\/g, "/");
 
-	const date = new Date().toISOString().slice(0, 10);
+	// Format current date in local OS timezone as YYYY-MM-DD to preserve prompt caching.
+	// We avoid using toISOString() directly as it returns UTC, which causes "yesterday/tomorrow" hallucinations for users in other timezones.
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, "0");
+	const day = String(now.getDate()).padStart(2, "0");
+	const date = `${year}-${month}-${day}`;
 
 	const appendSection = appendSystemPrompt ? `\n\n${appendSystemPrompt}` : "";
 


### PR DESCRIPTION
Using `toISOString().slice(0, 10)` forces the date to UTC, causing 'yesterday/tomorrow' hallucinations for users in non-UTC timezones during certain hours of the day.

This fix constructs a `YYYY-MM-DD` string using the local OS timezone, which preserves 100% prompt cacheability (the original goal of #2131) while maintaining accurate local dates.

Fixes #2814