### PR TITLE
Add Morph compaction extension

### DIFF
--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -87,6 +87,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `pirate.ts` | Demonstrates `systemPromptAppend` to dynamically modify system prompt |
 | `claude-rules.ts` | Scans `.claude/rules/` folder and lists rules in system prompt |
 | `custom-compaction.ts` | Custom compaction that summarizes entire conversation |
+| `morph-compaction.ts` | Routes compaction through Morph's compaction API for fast context compression |
 | `trigger-compact.ts` | Triggers compaction when context usage exceeds 100k tokens and adds `/trigger-compact` command |
 
 ### System Integration

--- a/packages/coding-agent/examples/extensions/morph-compaction.ts
+++ b/packages/coding-agent/examples/extensions/morph-compaction.ts
@@ -1,0 +1,140 @@
+/**
+ * Morph Compaction Extension
+ *
+ * Replaces the default compaction with Morph's compaction service.
+ * Uses the OpenAI-compatible endpoint at api.morphllm.com with the
+ * "morph-compactor" model for fast, high-quality context compression.
+ *
+ * API key resolution (in order):
+ *   1. MORPH_API_KEY environment variable
+ *   2. ~/.claude/morph/.env file
+ *
+ * Usage:
+ *   pi --extension examples/extensions/morph-compaction.ts
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { convertToLlm, serializeConversation } from "@mariozechner/pi-coding-agent";
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+const MORPH_API_URL = "https://api.morphllm.com/v1/chat/completions";
+const MORPH_MODEL = "morph-compactor";
+
+function loadApiKey(): string | undefined {
+	// 1. Environment variable
+	const envKey = process.env.MORPH_API_KEY;
+	if (envKey) return envKey;
+
+	// 2. ~/.claude/morph/.env file
+	try {
+		const envFile = join(homedir(), ".claude", "morph", ".env");
+		const text = readFileSync(envFile, "utf-8");
+		for (const line of text.split("\n")) {
+			const match = line.match(/^MORPH_API_KEY=(.+)$/);
+			if (match) return match[1].trim();
+		}
+	} catch {
+		// File doesn't exist or isn't readable
+	}
+
+	return undefined;
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.on("session_before_compact", async (event, ctx) => {
+		const apiKey = loadApiKey();
+		if (!apiKey) {
+			ctx.ui.notify(
+				"MORPH_API_KEY not found. Set it as an environment variable or in ~/.claude/morph/.env. Falling back to default compaction.",
+				"warning",
+			);
+			return;
+		}
+
+		const { preparation, signal } = event;
+		const { messagesToSummarize, turnPrefixMessages, tokensBefore, firstKeptEntryId, previousSummary } = preparation;
+
+		const allMessages = [...messagesToSummarize, ...turnPrefixMessages];
+		if (allMessages.length === 0) {
+			return;
+		}
+
+		const inputChars = allMessages.reduce((n, m) => {
+			if ("content" in m && typeof m.content === "string") return n + m.content.length;
+			if ("content" in m && Array.isArray(m.content)) {
+				return n + m.content.reduce((acc: number, c: any) => acc + (c.text?.length || 0), 0);
+			}
+			return n;
+		}, 0);
+
+		ctx.ui.notify(
+			`Morph compaction: compressing ${allMessages.length} messages (${tokensBefore.toLocaleString()} tokens, ${inputChars.toLocaleString()} chars)...`,
+			"info",
+		);
+
+		// Serialize conversation to text
+		const conversationText = serializeConversation(convertToLlm(allMessages));
+
+		// Include previous summary if available (for iterative compaction)
+		const content = previousSummary
+			? `Previous summary:\n${previousSummary}\n\nNew conversation to compress:\n${conversationText}`
+			: conversationText;
+
+		const startTime = performance.now();
+
+		try {
+			const response = await fetch(MORPH_API_URL, {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					model: MORPH_MODEL,
+					messages: [{ role: "user", content }],
+				}),
+				signal,
+			});
+
+			if (!response.ok) {
+				const errorText = await response.text();
+				throw new Error(`Morph API returned ${response.status}: ${errorText}`);
+			}
+
+			const data = (await response.json()) as {
+				choices: Array<{ message: { content: string } }>;
+			};
+
+			const summary = data.choices?.[0]?.message?.content;
+			if (!summary?.trim()) {
+				if (!signal.aborted) {
+					ctx.ui.notify("Morph returned empty summary, falling back to default compaction", "warning");
+				}
+				return;
+			}
+
+			const durationMs = Math.round(performance.now() - startTime);
+			const ratio = inputChars > 0 ? ((summary.length / inputChars) * 100).toFixed(1) : "N/A";
+
+			ctx.ui.notify(
+				`Morph compaction complete: ${inputChars.toLocaleString()} → ${summary.length.toLocaleString()} chars (${ratio}%) in ${durationMs}ms`,
+				"info",
+			);
+
+			return {
+				compaction: {
+					summary,
+					firstKeptEntryId,
+					tokensBefore,
+				},
+			};
+		} catch (error) {
+			if (signal.aborted) return;
+			const message = error instanceof Error ? error.message : String(error);
+			ctx.ui.notify(`Morph compaction failed: ${message}. Falling back to default.`, "error");
+			return;
+		}
+	});
+}


### PR DESCRIPTION
## Why

The built-in compaction uses the active LLM to summarize older turns, which works but can be slow and expensive — especially on larger context windows. [Morph](https://morphllm.com) offers a dedicated compaction API (`morph-compactor` model) that's designed specifically for context compression and is significantly faster.

There's already a `custom-compaction.ts` example showing how to swap in a different model (Gemini Flash), but there's no example for using an external, non-LLM compaction service via a simple REST call.

## What

A new example extension `morph-compaction.ts` that hooks into `session_before_compact` and routes compaction through Morph's OpenAI-compatible API at `api.morphllm.com/v1/chat/completions`.

- Sends serialized conversation to the `morph-compactor` model
- Returns compressed context (Morph filters redundant lines rather than producing a traditional summary)
- Falls back to default compaction if no API key is found or if the API call fails
- API key is read from `MORPH_API_KEY` env var or `~/.claude/morph/.env`

Also adds a line to the examples README.

## How to use

```bash
# Set your Morph API key
export MORPH_API_KEY=sk-...

# Load the extension
pi --extension examples/extensions/morph-compaction.ts

# Compaction will now use Morph automatically
# You can also trigger it manually with /compact
```

Or copy it to `~/.pi/agent/extensions/` for auto-discovery.