### PR TITLE
fix(coding-agent): preserve json mode for piped stdin

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - RpcClient now forwards subprocess stderr to parent process in real-time ([#2805](https://github.com/badlogic/pi-mono/issues/2805))
 - Theme file watcher now handles async `fs.watch` error events instead of crashing the process ([#2791](https://github.com/badlogic/pi-mono/issues/2791))
 - Fixed CLI extension paths like `git:gist.github.com/...` being incorrectly resolved against cwd instead of being passed through to the package manager ([#2845](https://github.com/badlogic/pi-mono/pull/2845) by [@aliou](https://github.com/aliou))
+- Fixed piped stdin runs with `--mode json` to preserve JSONL output instead of falling back to plain text ([#2848](https://github.com/badlogic/pi-mono/pull/2848) by [@aliou](https://github.com/aliou))
 
 ## [0.65.0] - 2026-04-03
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -578,7 +578,7 @@ export async function main(args: string[]) {
 	let stdinContent: string | undefined;
 	if (appMode !== "rpc") {
 		stdinContent = await readPipedStdin();
-		if (stdinContent !== undefined) {
+		if (stdinContent !== undefined && appMode === "interactive") {
 			appMode = "print";
 		}
 	}


### PR DESCRIPTION
Hello! As mentioned in the discord: when passing `--mode json` and `-p` and then giving the prompt via stdin,the json mode is ignored. 

------

<details><summary>Summary by gpt-5.4:</summary>
<p>

## Summary

Fixes `packages/coding-agent` non-interactive mode selection when the first user message is provided via stdin.

## What changed

### packages/coding-agent

- Fixed `packages/coding-agent/src/main.ts`
  - Preserves explicit `--mode json` when stdin is piped in.
  - Only auto-switches to internal `print` mode when the app was still in `interactive` mode.
  - This keeps JSONL output consistent between:
    - `pi --mode json -p "..."`
    - `echo "..." | pi --mode json -p`
    - `echo "..." | pi --mode json`

- Updated `packages/coding-agent/CHANGELOG.md`
  - Added an Unreleased `Fixed` entry for PR #2848.

## Root cause

`resolveAppMode()` initially resolved `--mode json` correctly, but after stdin was read, `main.ts` unconditionally overwrote the internal app mode to `"print"` whenever piped stdin was present. That erased the explicit JSON mode and caused text output.

## Behavior before

- `pi --mode json -p "say hello"` -> JSONL
- `echo "say hello" | pi --mode json -p` -> plain text
- `echo "say hello" | pi --mode json` -> plain text

## Behavior after

- `pi --mode json -p "say hello"` -> JSONL
- `echo "say hello" | pi --mode json -p` -> JSONL
- `echo "say hello" | pi --mode json` -> JSONL
- `echo "say hello" | pi` -> plain text

## Validation

- Ran repo checks:
  - `npm run check`

</p>
</details>