### PR TITLE
fix(coding-agent): update visible custom messages from hidden follow-ups

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed bash output truncation by line count to always persist full output to a temp file, preventing data loss when output exceeds 2000 lines but stays under the byte threshold ([#2852](https://github.com/badlogic/pi-mono/issues/2852))
+- Interactive custom messages now update existing visible cards when extensions send hidden follow-up updates, so placeholder cards no longer stay stale in the TUI ([#2843](https://github.com/badlogic/pi-mono/issues/2843))
 - RpcClient now forwards subprocess stderr to parent process in real-time ([#2805](https://github.com/badlogic/pi-mono/issues/2805))
 - Theme file watcher now handles async `fs.watch` error events instead of crashing the process ([#2791](https://github.com/badlogic/pi-mono/issues/2791))
 - Fixed stored session cwd handling so resuming or importing a session whose original working directory no longer exists now prompts interactive users to continue in the current cwd, while non-interactive modes fail with a clear error.

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -122,7 +122,7 @@ export interface SessionInfoEntry extends SessionEntryBase {
  * Use details for extension-specific metadata (not sent to LLM).
  *
  * display controls TUI rendering:
- * - false: hidden entirely
+ * - false: not rendered as a new chat entry; can be used to update an existing visible custom message
  * - true: rendered with distinct styling (different from user messages)
  */
 export interface CustomMessageEntry<T = unknown> extends SessionEntryBase {
@@ -933,7 +933,7 @@ export class SessionManager {
 	 * Append a custom message entry (for extensions) that participates in LLM context.
 	 * @param customType Extension identifier for filtering on reload
 	 * @param content Message content (string or TextContent/ImageContent array)
-	 * @param display Whether to show in TUI (true = styled display, false = hidden)
+	 * @param display Whether to render as a new TUI entry (true = styled display, false = hidden entry/update-only)
 	 * @param details Optional extension-specific metadata (not sent to LLM)
 	 * @returns Entry id
 	 */

--- a/packages/coding-agent/src/modes/interactive/components/custom-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-message.ts
@@ -42,6 +42,24 @@ export class CustomMessageComponent extends Container {
 		}
 	}
 
+	getCustomType(): string {
+		return this.message.customType;
+	}
+
+	getRequestId(): string | undefined {
+		const details = this.message.details;
+		if (typeof details !== "object" || details === null || !("requestId" in details)) {
+			return undefined;
+		}
+		const requestId = (details as { requestId?: unknown }).requestId;
+		return typeof requestId === "string" && requestId.length > 0 ? requestId : undefined;
+	}
+
+	updateMessage(message: CustomMessage<unknown>): void {
+		this.message = message;
+		this.invalidate();
+	}
+
 	override invalidate(): void {
 		super.invalidate();
 		this.rebuild();
@@ -66,7 +84,7 @@ export class CustomMessageComponent extends Container {
 					return;
 				}
 			} catch {
-				// Fall through to default rendering
+				// Broken extension renderers fall back to the built-in custom-message UI.
 			}
 		}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2636,6 +2636,35 @@ export class InteractiveMode {
 					const component = new CustomMessageComponent(message, renderer, this.getMarkdownThemeWithSettings());
 					component.setExpanded(this.toolOutputExpanded);
 					this.chatContainer.addChild(component);
+				} else {
+					const details = message.details;
+					const requestId =
+						typeof details === "object" && details !== null && "requestId" in details
+							? (details as { requestId?: unknown }).requestId
+							: undefined;
+
+					if (typeof requestId === "string" && requestId.length > 0) {
+						for (let i = this.chatContainer.children.length - 1; i >= 0; i--) {
+							const child = this.chatContainer.children[i];
+							if (
+								child instanceof CustomMessageComponent &&
+								child.getCustomType() === message.customType &&
+								child.getRequestId() === requestId
+							) {
+								child.updateMessage(message);
+								break;
+							}
+						}
+						break;
+					}
+
+					for (let i = this.chatContainer.children.length - 1; i >= 0; i--) {
+						const child = this.chatContainer.children[i];
+						if (child instanceof CustomMessageComponent && child.getCustomType() === message.customType) {
+							child.updateMessage(message);
+							break;
+						}
+					}
 				}
 				break;
 			}

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@mariozechner/pi-tui";
+import { Container, Text } from "@mariozechner/pi-tui";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
@@ -11,6 +11,31 @@ function renderLastLine(container: Container, width = 120): string {
 
 function renderAll(container: Container, width = 120): string {
 	return container.children.flatMap((child) => child.render(width)).join("\n");
+}
+
+function createCustomMessageContext(renderer?: (message: { details?: unknown }) => Text) {
+	return {
+		chatContainer: new Container(),
+		session: {
+			extensionRunner: renderer ? { getMessageRenderer: () => renderer } : undefined,
+		},
+		toolOutputExpanded: false,
+		getMarkdownThemeWithSettings: () => undefined,
+	};
+}
+
+function addCustomMessage(
+	context: ReturnType<typeof createCustomMessageContext>,
+	message: {
+		role: "custom";
+		customType: string;
+		content: string;
+		display: boolean;
+		details?: unknown;
+		timestamp: number;
+	},
+): void {
+	(InteractiveMode as any).prototype.addMessageToChat.call(context, message);
 }
 
 describe("InteractiveMode.showStatus", () => {
@@ -57,6 +82,157 @@ describe("InteractiveMode.showStatus", () => {
 		// adds spacer + text
 		expect(fakeThis.chatContainer.children).toHaveLength(5);
 		expect(renderLastLine(fakeThis.chatContainer)).toContain("STATUS_TWO");
+	});
+});
+
+describe("InteractiveMode.addMessageToChat custom messages", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("updates the last visible custom message when a hidden update arrives", () => {
+		const context = createCustomMessageContext();
+
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "placeholder",
+			display: true,
+			timestamp: 1,
+		});
+
+		expect(context.chatContainer.children).toHaveLength(1);
+
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "final",
+			display: false,
+			timestamp: 2,
+		});
+
+		expect(context.chatContainer.children).toHaveLength(1);
+		const output = renderAll(context.chatContainer);
+		expect(output).toContain("final");
+		expect(output).not.toContain("placeholder");
+	});
+
+	test("matches by requestId when multiple visible custom messages share the same type", () => {
+		const context = createCustomMessageContext((message) => {
+			const details = (message.details as { requestId?: string; state?: string } | undefined) ?? {};
+			return new Text(`id:${details.requestId ?? "none"} state:${details.state ?? "none"}`, 0, 0);
+		});
+
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "placeholder-a",
+			display: true,
+			details: { requestId: "req-a", state: "running" },
+			timestamp: 1,
+		});
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "placeholder-b",
+			display: true,
+			details: { requestId: "req-b", state: "running" },
+			timestamp: 2,
+		});
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "final-a",
+			display: false,
+			details: { requestId: "req-a", state: "done" },
+			timestamp: 3,
+		});
+
+		const output = renderAll(context.chatContainer);
+		expect(output).toContain("id:req-a state:done");
+		expect(output).toContain("id:req-b state:running");
+		expect(output).not.toContain("id:req-a state:running");
+	});
+
+	test("does not fall back to type-only matching when hidden update has unmatched requestId", () => {
+		const context = createCustomMessageContext((message) => {
+			const details = (message.details as { requestId?: string; state?: string } | undefined) ?? {};
+			return new Text(`id:${details.requestId ?? "none"} state:${details.state ?? "none"}`, 0, 0);
+		});
+
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "placeholder-a",
+			display: true,
+			details: { requestId: "req-a", state: "running" },
+			timestamp: 1,
+		});
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "placeholder-b",
+			display: true,
+			details: { requestId: "req-b", state: "running" },
+			timestamp: 2,
+		});
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "final-c",
+			display: false,
+			details: { requestId: "req-c", state: "done" },
+			timestamp: 3,
+		});
+
+		const output = renderAll(context.chatContainer);
+		expect(output).toContain("id:req-a state:running");
+		expect(output).toContain("id:req-b state:running");
+		expect(output).not.toContain("id:req-a state:done");
+		expect(output).not.toContain("id:req-b state:done");
+		expect(output).not.toContain("id:req-c state:done");
+	});
+
+	test("updates custom-rendered message details when hidden update arrives", () => {
+		const context = createCustomMessageContext((message) => {
+			const details = (message.details as { state?: string } | undefined) ?? {};
+			return new Text(`state:${details.state ?? "none"}`, 0, 0);
+		});
+
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "placeholder",
+			display: true,
+			details: { state: "running" },
+			timestamp: 1,
+		});
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "final",
+			display: false,
+			details: { state: "done" },
+			timestamp: 2,
+		});
+
+		const output = renderAll(context.chatContainer);
+		expect(output).toContain("state:done");
+		expect(output).not.toContain("state:running");
+	});
+
+	test("ignores hidden custom messages when no visible component exists", () => {
+		const context = createCustomMessageContext();
+
+		addCustomMessage(context, {
+			role: "custom",
+			customType: "subagent-slash-result",
+			content: "hidden",
+			display: false,
+			timestamp: 1,
+		});
+
+		expect(context.chatContainer.children).toHaveLength(0);
 	});
 });
 


### PR DESCRIPTION
This addresses #2843.

I was able to repro by creating a an extension with a `/repro-hidden-update` command that sends a visible `state:running content:placeholder` message, waits a second, then sends a hidden `state:done content:final` update. On installed `pi 0.65.0`, the card stayed stuck on the `state:running content:placeholder` message. On the local source build with the fixes in place, the same command updated the visible card to `state:done content:final` instead of leaving it stuck on the placeholder.

The issue was that `InteractiveMode` just ignored `display: false` custom messages in the interactive TUI. That meant extensions doing the “show a placeholder first, then send a hidden final update” pattern didn’t have a real update path in the UI, so the visible card could get stuck.

This changes that behavior so a hidden follow-up updates the existing visible `CustomMessageComponent` instead of being dropped. If `details.requestId` is there, it uses that first so multiple cards of the same `customType` don’t step on each other. If not, it falls back to the most recent visible message with that `customType`.

I added regression coverage for the main update path, `requestId` matching, unmatched `requestId` behavior, custom renderer refreshes, and the no-visible-message case. I also updated the `session-manager.ts` comments since they still described `display: false` as fully hidden, which wasn’t a good description anymore once the TUI supported update-only messages.

I also sanity-checked the real `pi-subagents` slash flow afterward and that looked good too: placeholder cards updated to final results, `/reload` kept the final state around, and multiple result cards in the same session didn’t stomp each other.
