### PR TITLE
fix(ai): correct thinking budget for 2.5-flash-lite models

### DIFF
--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -462,6 +462,16 @@ function getGoogleBudget(
 		return budgets[effort];
 	}
 
+	if (model.id.includes("2.5-flash-lite")) {
+		const budgets: Record<ClampedThinkingLevel, number> = {
+			minimal: 512,
+			low: 2048,
+			medium: 8192,
+			high: 24576,
+		};
+		return budgets[effort];
+	}
+
 	if (model.id.includes("2.5-flash")) {
 		const budgets: Record<ClampedThinkingLevel, number> = {
 			minimal: 128,


### PR DESCRIPTION
Fixes #2838

## Problem

`2.5-flash-lite` models match the `model.id.includes("2.5-flash")` case, which sets `minimal` thinking budget to 128. Per [Google docs](https://ai.google.dev/gemini-api/docs/thinking), flash-lite minimum is **512**, not 128.

This causes:
```
The thinking budget 128 is invalid. Please choose a value between 512 and 24576.
```

## Fix

Add a dedicated `2.5-flash-lite` case **before** the `2.5-flash` case so the more specific match takes priority:

- `2.5-flash-lite`: minimal = 512
- `2.5-flash`: minimal = 128 (unchanged)

## Testing

- Manual: `model.id.includes("2.5-flash-lite")` correctly matches before `model.id.includes("2.5-flash")`
- No existing tests for `getGoogleBudget`; behavior of other models unchanged