### PR TITLE
feat(coding-agent): Set PI_CODING_AGENT=true env variable at startup

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -7,6 +7,7 @@
  */
 process.title = "pi";
 process.emitWarning = (() => {}) as typeof process.emitWarning;
+process.env.PI_CODING_AGENT = "true";
 
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { main } from "./main.js";


### PR DESCRIPTION
Set process.env.PI_CODING_AGENT = "true" in the CLI entry point so that downstream code and subprocesses can detect when they are running as part of the pi coding agent. This propagates automatically to:
- Bash tool subprocesses via getShellEnv() which spreads process.env
- execCommand() subprocesses which inherit process.env by default