### PR TITLE
fix(coding-agent): prefer workspace src aliases in extension loader

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -60,26 +60,44 @@ function getAliases(): Record<string, string> {
 	if (_aliases) return _aliases;
 
 	const __dirname = path.dirname(fileURLToPath(import.meta.url));
-	const packageIndex = path.resolve(__dirname, "../..", "index.js");
+	const packageIndexJs = path.resolve(__dirname, "../..", "index.js");
+	const packageIndexTs = path.resolve(__dirname, "../..", "index.ts");
+	const packageIndex = fs.existsSync(packageIndexTs) ? packageIndexTs : packageIndexJs;
 
 	const typeboxEntry = require.resolve("@sinclair/typebox");
-	const typeboxRoot = typeboxEntry.replace(/[\\/]build[\\/]cjs[\\/]index\.js$/, "");
+	const typeboxRoot = typeboxEntry.replace(/[/\\]build[/\\]cjs[/\\]index\.js$/i, "");
 
 	const packagesRoot = path.resolve(__dirname, "../../../../");
-	const resolveWorkspaceOrImport = (workspaceRelativePath: string, specifier: string): string => {
-		const workspacePath = path.join(packagesRoot, workspaceRelativePath);
-		if (fs.existsSync(workspacePath)) {
-			return workspacePath;
+	const resolveWorkspaceOrImport = (
+		workspaceSrcRelativePath: string,
+		workspaceDistRelativePath: string,
+		specifier: string,
+	): string => {
+		const workspaceSrcPath = path.join(packagesRoot, workspaceSrcRelativePath);
+		if (fs.existsSync(workspaceSrcPath)) {
+			return workspaceSrcPath;
+		}
+		const workspaceDistPath = path.join(packagesRoot, workspaceDistRelativePath);
+		if (fs.existsSync(workspaceDistPath)) {
+			return workspaceDistPath;
 		}
 		return fileURLToPath(import.meta.resolve(specifier));
 	};
 
 	_aliases = {
 		"@mariozechner/pi-coding-agent": packageIndex,
-		"@mariozechner/pi-agent-core": resolveWorkspaceOrImport("agent/dist/index.js", "@mariozechner/pi-agent-core"),
-		"@mariozechner/pi-tui": resolveWorkspaceOrImport("tui/dist/index.js", "@mariozechner/pi-tui"),
-		"@mariozechner/pi-ai": resolveWorkspaceOrImport("ai/dist/index.js", "@mariozechner/pi-ai"),
-		"@mariozechner/pi-ai/oauth": resolveWorkspaceOrImport("ai/dist/oauth.js", "@mariozechner/pi-ai/oauth"),
+		"@mariozechner/pi-agent-core": resolveWorkspaceOrImport(
+			"agent/src/index.ts",
+			"agent/dist/index.js",
+			"@mariozechner/pi-agent-core",
+		),
+		"@mariozechner/pi-tui": resolveWorkspaceOrImport("tui/src/index.ts", "tui/dist/index.js", "@mariozechner/pi-tui"),
+		"@mariozechner/pi-ai": resolveWorkspaceOrImport("ai/src/index.ts", "ai/dist/index.js", "@mariozechner/pi-ai"),
+		"@mariozechner/pi-ai/oauth": resolveWorkspaceOrImport(
+			"ai/src/oauth.ts",
+			"ai/dist/oauth.js",
+			"@mariozechner/pi-ai/oauth",
+		),
 		"@sinclair/typebox": typeboxRoot,
 	};
 


### PR DESCRIPTION
## Summary
- Prefer workspace `src` entrypoints over `dist` in extension-loader aliases during source runs, with `dist` and package import as fallbacks.
- Resolve `@mariozechner/pi-coding-agent` alias to `index.ts` when present (fallback to `index.js`) so extension runtime matches the actual source graph.
- Normalize TypeBox root path stripping for Windows separator variants/casing to avoid alias path mismatches.
- This addresses the extension startup crash reported in #2875 (`Class extends value undefined is not a constructor or null`).

## Test plan
- [x] Reproduced crash path before fix via jiti alias import of `@mariozechner/pi-coding-agent` (`KeybindingsManager extends undefined`).
- [x] Re-ran same jiti import scenario after fix; import succeeds and extension module import succeeds.
- [x] Launched local source runner via `bash /d/cursor_projects/pi-agent/pi-agent-home/pi-local.sh -p "test"`; extension load errors no longer printed.
- [ ] Full monorepo/type-check run (currently fails in this workspace due pre-existing unrelated type errors).

Closes #2875.

Made with [Cursor](https://cursor.com)