### PR TITLE
fix: support AWS SDK auth (Bedrock via IMDS) in auth pre-flight checks

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -330,6 +330,11 @@ export class AgentSession {
 		apiKey: string;
 		headers?: Record<string, string>;
 	}> {
+		// Bedrock uses AWS SDK signing (SigV4), not API keys.
+		// The provider adapter handles auth at the HTTP layer.
+		if (model.provider === "amazon-bedrock") {
+			return { apiKey: undefined as any, headers: {} };
+		}
 		const result = await this._modelRegistry.getApiKeyAndHeaders(model);
 		if (!result.ok) {
 			throw new Error(result.error);

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -535,6 +535,12 @@ export class ModelRegistry {
 	 * Get API key for a model.
 	 */
 	hasConfiguredAuth(model: Model<Api>): boolean {
+		// Bedrock uses AWS SDK signing (SigV4) — credentials are resolved at
+		// request time via the default credential chain (env vars, IMDS, etc.).
+		// There is no API key to pre-check.
+		if (model.provider === "amazon-bedrock") {
+			return true;
+		}
 		return (
 			this.authStorage.hasAuth(model.provider) ||
 			this.providerRequestConfigs.get(model.provider)?.apiKey !== undefined


### PR DESCRIPTION
## Problem

`hasConfiguredAuth()` and `_getRequiredRequestAuth()` reject AWS SDK auth for Bedrock because they only check for API keys in authStorage or providerRequestConfigs. On EC2 instances with IAM roles, Bedrock credentials come from IMDS via the AWS SDK default credential chain — there's no API key to pre-check.

This causes `"No API key found for amazon-bedrock"` before any API request is made, even though the SDK would resolve credentials successfully at request time.

## Fix

- **`model-registry.ts`**: `hasConfiguredAuth()` returns `true` for `amazon-bedrock` provider since credentials are resolved at request time via SigV4.
- **`agent-session.ts`**: `_getRequiredRequestAuth()` early-returns for `amazon-bedrock`, skipping the API key requirement.

## Environment

- Amazon Linux 2023 on EC2 with IAM instance profile
- Auth method: Bedrock via IMDS (no API keys, no env vars)
- Config: `models.providers.amazon-bedrock.auth: "aws-sdk"`

## Related

A companion fix is being submitted to OpenClaw to propagate AWS SDK auth mode into pi's authStorage (the root cause), but these defensive checks are still valuable for standalone pi usage with Bedrock.