### PR TITLE
fix(coding-agent): remove inline osc 133 markers from user messages

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/user-message.ts
@@ -1,10 +1,6 @@
 import { Container, Markdown, type MarkdownTheme, Spacer } from "@mariozechner/pi-tui";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
 
-const OSC133_ZONE_START = "\x1b]133;A\x07";
-const OSC133_ZONE_END = "\x1b]133;B\x07";
-const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
-
 /**
  * Component that renders a user message
  */
@@ -18,16 +14,5 @@ export class UserMessageComponent extends Container {
 				color: (text: string) => theme.fg("userMessageText", text),
 			}),
 		);
-	}
-
-	override render(width: number): string[] {
-		const lines = super.render(width);
-		if (lines.length === 0) {
-			return lines;
-		}
-
-		lines[0] = OSC133_ZONE_START + lines[0];
-		lines[lines.length - 1] = lines[lines.length - 1] + OSC133_ZONE_END + OSC133_ZONE_FINAL;
-		return lines;
 	}
 }

--- a/packages/coding-agent/test/user-message.test.ts
+++ b/packages/coding-agent/test/user-message.test.ts
@@ -1,0 +1,31 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { UserMessageComponent } from "../src/modes/interactive/components/user-message.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+const OSC133_ZONE_START = "\x1b]133;A\x07";
+const OSC133_ZONE_END = "\x1b]133;B\x07";
+const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
+
+describe("UserMessageComponent", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	it("does not emit inline OSC 133 prompt markers", () => {
+		const component = new UserMessageComponent("hi there");
+		const rendered = component.render(40).join("\n");
+
+		expect(rendered).not.toContain(OSC133_ZONE_START);
+		expect(rendered).not.toContain(OSC133_ZONE_END);
+		expect(rendered).not.toContain(OSC133_ZONE_FINAL);
+	});
+
+	it("does not emit inline OSC 133 prompt markers for multi-line messages", () => {
+		const component = new UserMessageComponent("hello\nworld");
+		const rendered = component.render(40).join("\n");
+
+		expect(rendered).not.toContain(OSC133_ZONE_START);
+		expect(rendered).not.toContain(OSC133_ZONE_END);
+		expect(rendered).not.toContain(OSC133_ZONE_FINAL);
+	});
+});


### PR DESCRIPTION
i'm building a terminal-native rust app to manage ai agents that uses libghostty-vt for the terminal rendering part. and obviously i use pi most of the time. i am building extensions that uses overlay windows, [pi-ghost](https://github.com/ogulcancelik/pi-extensions/tree/main/packages/pi-ghost) which is like /btw and [pi-spar](https://github.com/ogulcancelik/pi-extensions/tree/main/packages/pi-spar) and both have re-render issues with libghostty-vt.

i'm not that knowledgeable with terminal rendering and character coding, i let both gpt 5.4 and opus 4.6 to discuss and both agreed that osc 133 markers should be removed from user messages. and after researching a bit about osc 133 i also agree.

here's their clanker reasoning:


> This was introduced intentionally to add OSC 133 semantic prompt markers around user messages. The problem is not the existence of OSC 133 itself, but that these markers were emitted inside rendered TUI component lines. OSC 133 is a terminal shell-integration protocol, not inline styling. Emitting OSC 133;A/B/C from UserMessageComponent made behavior depend on host-terminal tolerance. Terminals that strictly honor OSC 133 semantics can legitimately treat mid-line 133;A as a fresh prompt boundary, which corrupts layout. Removing these inline markers restores correct terminal-agnostic behavior.
