### PR TITLE
fix(ai): sanitize tool schemas for Cloud Code Assist compatibility

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -240,12 +240,68 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 }
 
 /**
+ * Sanitize a JSON Schema for OpenAPI 3.03 compatibility.
+ *
+ * Cloud Code Assist's `parameters` field expects OpenAPI 3.03 Schema, which doesn't
+ * support JSON Schema constructs like `anyOf`, `oneOf`, or `const`. This function
+ * recursively transforms:
+ * - `anyOf` arrays containing `const` values → `enum` array (e.g., TypeBox unions of literals)
+ * - Standalone `const` → single-value `enum`
+ */
+function sanitizeSchemaForOpenApi(schema: Record<string, unknown>): Record<string, unknown> {
+	if (typeof schema !== "object" || schema === null) {
+		return schema;
+	}
+
+	const result: Record<string, unknown> = {};
+
+	for (const [key, value] of Object.entries(schema)) {
+		if (key === "anyOf" && Array.isArray(value)) {
+			const constValues = value
+				.filter(
+					(item): item is Record<string, unknown> => typeof item === "object" && item !== null && "const" in item,
+				)
+				.map((item) => item.const);
+
+			if (constValues.length === value.length && constValues.length > 0) {
+				result.type = "string";
+				result.enum = constValues;
+				continue;
+			}
+		}
+
+		if (key === "const") {
+			result.type = "string";
+			result.enum = [value];
+			continue;
+		}
+
+		if (Array.isArray(value)) {
+			result[key] = value.map((item) =>
+				typeof item === "object" && item !== null
+					? sanitizeSchemaForOpenApi(item as Record<string, unknown>)
+					: item,
+			);
+		} else if (typeof value === "object" && value !== null) {
+			result[key] = sanitizeSchemaForOpenApi(value as Record<string, unknown>);
+		} else {
+			result[key] = value;
+		}
+	}
+
+	return result;
+}
+
+/**
  * Convert tools to Gemini function declarations format.
  *
  * By default uses `parametersJsonSchema` which supports full JSON Schema (including
  * anyOf, oneOf, const, etc.). Set `useParameters` to true to use the legacy `parameters`
  * field instead (OpenAPI 3.03 Schema). This is needed for Cloud Code Assist with Claude
  * models, where the API translates `parameters` into Anthropic's `input_schema`.
+ *
+ * When `useParameters` is true, schemas are sanitized to convert JSON Schema constructs
+ * (anyOf, const) to OpenAPI 3.03-compatible equivalents (enum).
  */
 export function convertTools(
 	tools: Tool[],
@@ -257,7 +313,9 @@ export function convertTools(
 			functionDeclarations: tools.map((tool) => ({
 				name: tool.name,
 				description: tool.description,
-				...(useParameters ? { parameters: tool.parameters } : { parametersJsonSchema: tool.parameters }),
+				...(useParameters
+					? { parameters: sanitizeSchemaForOpenApi(tool.parameters as Record<string, unknown>) }
+					: { parametersJsonSchema: tool.parameters }),
 			})),
 		},
 	];

--- a/packages/ai/test/google-shared-schema-sanitization.test.ts
+++ b/packages/ai/test/google-shared-schema-sanitization.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { convertTools } from "../src/providers/google-shared.js";
+import type { Tool } from "../src/types.js";
+
+// Helper to create test tools with plain object schemas (simulating runtime behavior)
+function createTestTools(
+	tools: Array<{ name: string; description: string; parameters: Record<string, unknown> }>,
+): Tool[] {
+	return tools as unknown as Tool[];
+}
+
+describe("google-shared convertTools — schema sanitization for OpenAPI 3.03", () => {
+	it("converts anyOf with const values to enum when useParameters=true", () => {
+		const tools = createTestTools([
+			{
+				name: "test_tool",
+				description: "A test tool",
+				parameters: {
+					type: "object",
+					properties: {
+						type: {
+							anyOf: [{ const: "fact" }, { const: "lesson" }],
+						},
+					},
+					required: ["type"],
+				},
+			},
+		]);
+
+		const result = convertTools(tools, true);
+
+		expect(result).toBeTruthy();
+		const funcDecl = result![0].functionDeclarations[0];
+		expect(funcDecl.name).toBe("test_tool");
+
+		const params = funcDecl.parameters as Record<string, unknown>;
+		const props = params.properties as Record<string, unknown>;
+		const typeSchema = props.type as Record<string, unknown>;
+
+		// Should be converted to enum, not anyOf
+		expect(typeSchema.anyOf).toBeUndefined();
+		expect(typeSchema.type).toBe("string");
+		expect(typeSchema.enum).toEqual(["fact", "lesson"]);
+	});
+
+	it("converts standalone const to single-value enum when useParameters=true", () => {
+		const tools = createTestTools([
+			{
+				name: "test_tool",
+				description: "A test tool",
+				parameters: {
+					type: "object",
+					properties: {
+						mode: { const: "strict" },
+					},
+				},
+			},
+		]);
+
+		const result = convertTools(tools, true);
+
+		const funcDecl = result![0].functionDeclarations[0];
+		const params = funcDecl.parameters as Record<string, unknown>;
+		const props = params.properties as Record<string, unknown>;
+		const modeSchema = props.mode as Record<string, unknown>;
+
+		expect(modeSchema.const).toBeUndefined();
+		expect(modeSchema.type).toBe("string");
+		expect(modeSchema.enum).toEqual(["strict"]);
+	});
+
+	it("preserves original schema when useParameters=false", () => {
+		const tools = createTestTools([
+			{
+				name: "test_tool",
+				description: "A test tool",
+				parameters: {
+					type: "object",
+					properties: {
+						type: {
+							anyOf: [{ const: "fact" }, { const: "lesson" }],
+						},
+					},
+				},
+			},
+		]);
+
+		const result = convertTools(tools, false);
+
+		const funcDecl = result![0].functionDeclarations[0];
+		// When useParameters=false, parametersJsonSchema is used (not parameters)
+		const schema = funcDecl.parametersJsonSchema as Record<string, unknown>;
+		const props = schema.properties as Record<string, unknown>;
+		const typeSchema = props.type as Record<string, unknown>;
+
+		// Should preserve anyOf with const
+		expect(typeSchema.anyOf).toEqual([{ const: "fact" }, { const: "lesson" }]);
+	});
+
+	it("handles nested objects with anyOf+const", () => {
+		const tools = createTestTools([
+			{
+				name: "nested_tool",
+				description: "A tool with nested schema",
+				parameters: {
+					type: "object",
+					properties: {
+						config: {
+							type: "object",
+							properties: {
+								level: {
+									anyOf: [{ const: "low" }, { const: "medium" }, { const: "high" }],
+								},
+							},
+						},
+					},
+				},
+			},
+		]);
+
+		const result = convertTools(tools, true);
+
+		const funcDecl = result![0].functionDeclarations[0];
+		const params = funcDecl.parameters as Record<string, unknown>;
+		const props = params.properties as Record<string, unknown>;
+		const config = props.config as Record<string, unknown>;
+		const configProps = config.properties as Record<string, unknown>;
+		const level = configProps.level as Record<string, unknown>;
+
+		expect(level.anyOf).toBeUndefined();
+		expect(level.type).toBe("string");
+		expect(level.enum).toEqual(["low", "medium", "high"]);
+	});
+
+	it("preserves mixed anyOf (not all const)", () => {
+		const tools = createTestTools([
+			{
+				name: "mixed_tool",
+				description: "A tool with mixed anyOf",
+				parameters: {
+					type: "object",
+					properties: {
+						value: {
+							anyOf: [{ type: "string" }, { type: "number" }],
+						},
+					},
+				},
+			},
+		]);
+
+		const result = convertTools(tools, true);
+
+		const funcDecl = result![0].functionDeclarations[0];
+		const params = funcDecl.parameters as Record<string, unknown>;
+		const props = params.properties as Record<string, unknown>;
+		const valueSchema = props.value as Record<string, unknown>;
+
+		// Should preserve anyOf since items are not all const
+		expect(valueSchema.anyOf).toEqual([{ type: "string" }, { type: "number" }]);
+		expect(valueSchema.enum).toBeUndefined();
+	});
+});


### PR DESCRIPTION
When using Claude models via Google Cloud Code Assist (Antigravity), tool schemas fail with "Unknown name 'const'" because the `parameters` field only supports OpenAPI 3.0.3, which lacks `anyOf` and `const`.

This adds `sanitizeSchemaForOpenApi()` to transform incompatible patterns:
- `{ anyOf: [{ const: "a" }, { const: "b" }] }` → `{ type: "string", enum: ["a", "b"] }`
- `{ const: "value" }` → `{ type: "string", enum: ["value"] }`

Only applied when `useParameters=true` (Claude models via Cloud Code Assist). Native Google models using `parametersJsonSchema` are unaffected.