### PR TITLE
fix(ai): use messages.create instead of messages.stream to avoid uncaught partialParse throw

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -256,7 +256,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			if (nextParams !== undefined) {
 				params = nextParams as MessageCreateParamsStreaming;
 			}
-			const anthropicStream = client.messages.stream({ ...params, stream: true }, { signal: options?.signal });
+			const anthropicStream = await client.messages.create({ ...params, stream: true }, { signal: options?.signal });
 			stream.push({ type: "start", partial: output });
 
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };


### PR DESCRIPTION
## Problem

`pi-ai`'s `anthropic.ts` uses `client.messages.stream()`, which internally uses the SDK's `MessageStream`. On every `input_json_delta` SSE event, `MessageStream._accumulateMessage` calls:

```js
// @anthropic-ai/sdk/_vendor/partial-json-parser/parser.js
newContent.input = partialParse(jsonBuf);
// where: partialParse = (input) => JSON.parse(generate(unstrip(strip(tokenize(input)))))
```

There is **no try-catch** around this `JSON.parse`. When the model emits a string value containing an unescaught double-quote in a tool call argument (e.g. `"newText": "    x = " foo " + y"`), `tokenize` mis-splits the input, `generate` produces invalid JSON, and `JSON.parse` throws:

```
SyntaxError: Expected ',' or '}' after property value in JSON at position N
```

This propagates through `MessageStream._run`'s rejection handler (`_handleError`), which emits an `'error'` event that rejects the async iterator — killing the entire streaming turn. The user sees `Error: Expected ',' or '}' after property value in JSON at position N` in the UI.

## Root cause is ironic

`pi-ai` **already accumulates `input_json_delta` fragments itself** with its own `parseStreamingJson` that has proper try-catch:

```ts
block.partialJson += event.delta.partial_json;
block.arguments = parseStreamingJson(block.partialJson); // catches all errors, returns {}
```

The SDK's internal `partialParse` is entirely redundant to pi's own processing — and it's the only one without error handling.

## Fix

Replace `client.messages.stream()` with `await client.messages.create({ stream: true })`.

`messages.create({ stream: true })` returns a raw `Stream<RawMessageStreamEvent>` that emits the same SSE events, but **bypasses `MessageStream` entirely** — so `_accumulateMessage` and its unguarded `partialParse` are never called.

## Change

```diff
- const anthropicStream = client.messages.stream({ ...params, stream: true }, { signal: options?.signal });
+ const anthropicStream = await client.messages.create({ ...params, stream: true }, { signal: options?.signal });
```

One line.