### PR TITLE
fix(coding-agent): guard interactive rendering against huge output

### DIFF
--- a/packages/coding-agent/src/core/tools/render-utils.ts
+++ b/packages/coding-agent/src/core/tools/render-utils.ts
@@ -4,6 +4,9 @@ import { getCapabilities, getImageDimensions, imageFallback } from "@mariozechne
 import stripAnsi from "strip-ansi";
 import { sanitizeBinaryOutput } from "../../utils/shell.js";
 
+const MAX_RENDER_OUTPUT_CHARS = 200_000;
+const DISPLAY_OUTPUT_TRUNCATED_TEXT = "[display output truncated: too large]";
+
 export function shortenPath(path: unknown): string {
 	if (typeof path !== "string") return "";
 	const home = os.homedir();
@@ -36,7 +39,31 @@ export function getTextOutput(
 	const textBlocks = result.content.filter((c) => c.type === "text");
 	const imageBlocks = result.content.filter((c) => c.type === "image");
 
-	let output = textBlocks.map((c) => sanitizeBinaryOutput(stripAnsi(c.text || "")).replace(/\r/g, "")).join("\n");
+	const outputParts: string[] = [];
+	let remainingChars = MAX_RENDER_OUTPUT_CHARS;
+	let outputTruncated = false;
+
+	for (const block of textBlocks) {
+		if (remainingChars <= 0) {
+			outputTruncated = true;
+			break;
+		}
+
+		const rawText = stripAnsi(block.text || "");
+		const rawSlice = rawText.slice(0, remainingChars);
+		outputParts.push(sanitizeBinaryOutput(rawSlice).replace(/\r/g, ""));
+		remainingChars -= rawSlice.length;
+
+		if (rawSlice.length < rawText.length) {
+			outputTruncated = true;
+			break;
+		}
+	}
+
+	let output = outputParts.join("\n");
+	if (outputTruncated) {
+		output = output ? `${output}\n${DISPLAY_OUTPUT_TRUNCATED_TEXT}` : DISPLAY_OUTPUT_TRUNCATED_TEXT;
+	}
 
 	const caps = getCapabilities();
 	if (imageBlocks.length > 0 && (!caps.images || !showImages)) {

--- a/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
@@ -20,7 +20,8 @@ const PREVIEW_LINES = 20;
 
 export class BashExecutionComponent extends Container {
 	private command: string;
-	private outputLines: string[] = [];
+	private outputText = "";
+	private readonly maxBufferedBytes = DEFAULT_MAX_BYTES * 2;
 	private status: "running" | "complete" | "cancelled" | "error" = "running";
 	private exitCode: number | undefined = undefined;
 	private loader: Loader;
@@ -82,14 +83,13 @@ export class BashExecutionComponent extends Container {
 		// Note: binary data is already sanitized in tui-renderer.ts executeBashCommand
 		const clean = stripAnsi(chunk).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 
-		// Append to output lines
-		const newLines = clean.split("\n");
-		if (this.outputLines.length > 0 && newLines.length > 0) {
-			// Append first chunk to last line (incomplete line continuation)
-			this.outputLines[this.outputLines.length - 1] += newLines[0];
-			this.outputLines.push(...newLines.slice(1));
-		} else {
-			this.outputLines.push(...newLines);
+		this.outputText += clean;
+		const bufferTruncation = truncateTail(this.outputText, {
+			maxLines: Number.MAX_SAFE_INTEGER,
+			maxBytes: this.maxBufferedBytes,
+		});
+		if (bufferTruncation.truncated) {
+			this.outputText = bufferTruncation.content;
 		}
 
 		this.updateDisplay();
@@ -118,7 +118,7 @@ export class BashExecutionComponent extends Container {
 
 	private updateDisplay(): void {
 		// Apply truncation for LLM context limits (same limits as bash tool)
-		const fullOutput = this.outputLines.join("\n");
+		const fullOutput = this.outputText;
 		const contextTruncation = truncateTail(fullOutput, {
 			maxLines: DEFAULT_MAX_LINES,
 			maxBytes: DEFAULT_MAX_BYTES,
@@ -206,7 +206,7 @@ export class BashExecutionComponent extends Container {
 	 * Get the raw output for creating BashExecutionMessage.
 	 */
 	getOutput(): string {
-		return this.outputLines.join("\n");
+		return this.outputText;
 	}
 
 	/**

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -141,35 +141,39 @@ export function getShellEnv(): NodeJS.ProcessEnv {
  * - Characters with undefined code points
  */
 export function sanitizeBinaryOutput(str: string): string {
-	// Use Array.from to properly iterate over code points (not code units)
-	// This handles surrogate pairs correctly and catches edge cases where
-	// codePointAt() might return undefined
-	return Array.from(str)
-		.filter((char) => {
-			// Filter out characters that cause string-width to crash
-			// This includes:
-			// - Unicode format characters
-			// - Lone surrogates (already filtered by Array.from)
-			// - Control chars except \t \n \r
-			// - Characters with undefined code points
+	let sanitized = "";
 
-			const code = char.codePointAt(0);
+	for (const char of str) {
+		// Filter out characters that cause string-width to crash
+		// This includes:
+		// - Unicode format characters
+		// - Lone surrogates
+		// - Control chars except \t \n \r
+		// - Characters with undefined code points
+		const code = char.codePointAt(0);
 
-			// Skip if code point is undefined (edge case with invalid strings)
-			if (code === undefined) return false;
+		// Skip if code point is undefined (edge case with invalid strings)
+		if (code === undefined) continue;
 
-			// Allow tab, newline, carriage return
-			if (code === 0x09 || code === 0x0a || code === 0x0d) return true;
+		// Allow tab, newline, carriage return
+		if (code === 0x09 || code === 0x0a || code === 0x0d) {
+			sanitized += char;
+			continue;
+		}
 
-			// Filter out control characters (0x00-0x1F, except 0x09, 0x0a, 0x0x0d)
-			if (code <= 0x1f) return false;
+		// Filter out control characters (0x00-0x1F, except 0x09, 0x0a, 0x0x0d)
+		if (code <= 0x1f) continue;
 
-			// Filter out Unicode format characters
-			if (code >= 0xfff9 && code <= 0xfffb) return false;
+		// Filter out lone surrogate code units
+		if (code >= 0xd800 && code <= 0xdfff) continue;
 
-			return true;
-		})
-		.join("");
+		// Filter out Unicode format characters
+		if (code >= 0xfff9 && code <= 0xfffb) continue;
+
+		sanitized += char;
+	}
+
+	return sanitized;
 }
 
 /**

--- a/packages/coding-agent/test/large-output-guards.test.ts
+++ b/packages/coding-agent/test/large-output-guards.test.ts
@@ -1,0 +1,56 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { getTextOutput } from "../src/core/tools/render-utils.js";
+import { DEFAULT_MAX_BYTES } from "../src/core/tools/truncate.js";
+import { BashExecutionComponent } from "../src/modes/interactive/components/bash-execution.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import { sanitizeBinaryOutput } from "../src/utils/shell.js";
+
+function createTuiStub(): any {
+	return {
+		terminal: {
+			columns: 120,
+			rows: 24,
+		},
+		addInterval: (_cb: () => void, _ms: number) => ({ dispose: () => {} }),
+		removeInterval: () => {},
+		requestRender: () => {},
+	};
+}
+
+describe("large output guards", () => {
+	beforeAll(() => {
+		initTheme(undefined, false);
+	});
+
+	it("sanitizeBinaryOutput removes control, format, and lone surrogate characters", () => {
+		const input = `a\u0000b\tc\nd\r🙂\uFFF9\uD800z`;
+
+		expect(sanitizeBinaryOutput(input)).toBe("ab\tc\nd\r🙂z");
+	});
+
+	it("getTextOutput truncates oversized text for display", () => {
+		const hugeText = "x".repeat(210_000);
+		const output = getTextOutput(
+			{
+				content: [{ type: "text", text: hugeText }],
+			},
+			false,
+		);
+
+		expect(output).toContain("[display output truncated: too large]");
+		expect(output.length).toBeLessThan(205_000);
+		expect(output.startsWith("x")).toBe(true);
+	});
+
+	it("BashExecutionComponent keeps only a bounded streaming buffer", () => {
+		const component = new BashExecutionComponent("printf test", createTuiStub());
+		const largeChunk = `${"prefix-".repeat(20_000)}TAIL_MARKER`;
+
+		component.appendOutput(largeChunk);
+		component.setComplete(0, false);
+
+		expect(component.getOutput()).toContain("TAIL_MARKER");
+		expect(Buffer.byteLength(component.getOutput(), "utf-8")).toBeLessThanOrEqual(DEFAULT_MAX_BYTES * 2);
+		expect(component.render(80).length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
Superseded. I’ll open an issue first and resubmit after approval per CONTRIBUTING.md.