### PR TITLE
Fix overlapping compaction abort controller race

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1584,7 +1584,8 @@ export class AgentSession {
 	async compact(customInstructions?: string): Promise<CompactionResult> {
 		this._disconnectFromAgent();
 		await this.abort();
-		this._compactionAbortController = new AbortController();
+		const compactionAbortController = new AbortController();
+		this._compactionAbortController = compactionAbortController;
 		this._emit({ type: "compaction_start", reason: "manual" });
 
 		try {
@@ -1616,7 +1617,7 @@ export class AgentSession {
 					preparation,
 					branchEntries: pathEntries,
 					customInstructions,
-					signal: this._compactionAbortController.signal,
+					signal: compactionAbortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (result?.cancel) {
@@ -1648,7 +1649,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					customInstructions,
-					this._compactionAbortController.signal,
+					compactionAbortController.signal,
 				);
 				summary = result.summary;
 				firstKeptEntryId = result.firstKeptEntryId;
@@ -1656,7 +1657,7 @@ export class AgentSession {
 				details = result.details;
 			}
 
-			if (this._compactionAbortController.signal.aborted) {
+			if (compactionAbortController.signal.aborted) {
 				throw new Error("Compaction cancelled");
 			}
 
@@ -1705,7 +1706,9 @@ export class AgentSession {
 			});
 			throw error;
 		} finally {
-			this._compactionAbortController = undefined;
+			if (this._compactionAbortController === compactionAbortController) {
+				this._compactionAbortController = undefined;
+			}
 			this._reconnectToAgent();
 		}
 	}
@@ -1823,7 +1826,8 @@ export class AgentSession {
 		const settings = this.settingsManager.getCompactionSettings();
 
 		this._emit({ type: "compaction_start", reason });
-		this._autoCompactionAbortController = new AbortController();
+		const autoCompactionAbortController = new AbortController();
+		this._autoCompactionAbortController = autoCompactionAbortController;
 
 		try {
 			if (!this.model) {
@@ -1873,7 +1877,7 @@ export class AgentSession {
 					preparation,
 					branchEntries: pathEntries,
 					customInstructions: undefined,
-					signal: this._autoCompactionAbortController.signal,
+					signal: autoCompactionAbortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (extensionResult?.cancel) {
@@ -1912,7 +1916,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					undefined,
-					this._autoCompactionAbortController.signal,
+					autoCompactionAbortController.signal,
 				);
 				summary = compactResult.summary;
 				firstKeptEntryId = compactResult.firstKeptEntryId;
@@ -1920,7 +1924,7 @@ export class AgentSession {
 				details = compactResult.details;
 			}
 
-			if (this._autoCompactionAbortController.signal.aborted) {
+			if (autoCompactionAbortController.signal.aborted) {
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -1988,7 +1992,9 @@ export class AgentSession {
 						: `Auto-compaction failed: ${errorMessage}`,
 			});
 		} finally {
-			this._autoCompactionAbortController = undefined;
+			if (this._autoCompactionAbortController === autoCompactionAbortController) {
+				this._autoCompactionAbortController = undefined;
+			}
 		}
 	}
 

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1,11 +1,62 @@
 import { type AssistantMessage, fauxAssistantMessage, type Model } from "@mariozechner/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionBeforeCompactResult } from "../../src/core/extensions/index.js";
+import type { ExtensionFactory, SessionBeforeCompactEvent } from "../../src/index.js";
 import { createHarness, type Harness } from "./harness.js";
 
 type SessionWithCompactionInternals = {
 	_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
 	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
 };
+
+type DeferredCompaction = {
+	preparation: { firstKeptEntryId: string; tokensBefore: number };
+	resolve: (value: {
+		compaction: {
+			summary: string;
+			firstKeptEntryId: string;
+			tokensBefore: number;
+			details: Record<string, never>;
+		};
+	}) => void;
+};
+
+function createDeferredCompactionFactory(pending: DeferredCompaction[]): ExtensionFactory {
+	return (pi) => {
+		pi.on("session_before_compact", async (event: SessionBeforeCompactEvent) => {
+			return await new Promise<SessionBeforeCompactResult>((resolve) => {
+				pending.push({
+					preparation: {
+						firstKeptEntryId: event.preparation.firstKeptEntryId,
+						tokensBefore: event.preparation.tokensBefore,
+					},
+					resolve: resolve as DeferredCompaction["resolve"],
+				});
+			});
+		});
+	};
+}
+
+async function waitForPendingCompactions(pending: DeferredCompaction[], count: number): Promise<void> {
+	const deadline = Date.now() + 1000;
+	while (pending.length < count) {
+		if (Date.now() > deadline) {
+			throw new Error(`Timed out waiting for ${count} pending compactions`);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
+function resolveDeferredCompaction(deferred: DeferredCompaction, summary: string): void {
+	deferred.resolve({
+		compaction: {
+			summary,
+			firstKeptEntryId: deferred.preparation.firstKeptEntryId,
+			tokensBefore: deferred.preparation.tokensBefore,
+			details: {},
+		},
+	});
+}
 
 function createUsage(totalTokens: number) {
 	return {
@@ -117,6 +168,53 @@ describe("AgentSession compaction characterization", () => {
 		harness.session.abortCompaction();
 
 		await expect(compactPromise).rejects.toThrow("Compaction cancelled");
+	});
+
+	it("keeps overlapping manual compactions isolated to their own abort controllers", async () => {
+		const pending: DeferredCompaction[] = [];
+		const harness = await createHarness({
+			extensionFactories: [createDeferredCompactionFactory(pending)],
+		});
+		harnesses.push(harness);
+
+		await harness.session.prompt("one");
+		await harness.session.prompt("two");
+
+		const firstCompact = harness.session.compact();
+		await waitForPendingCompactions(pending, 1);
+		const secondCompact = harness.session.compact();
+		await waitForPendingCompactions(pending, 2);
+
+		resolveDeferredCompaction(pending[0]!, "manual compact 1");
+		await expect(firstCompact).resolves.toMatchObject({ summary: "manual compact 1" });
+		resolveDeferredCompaction(pending[1]!, "manual compact 2");
+		await expect(secondCompact).resolves.toMatchObject({ summary: "manual compact 2" });
+	});
+
+	it("keeps overlapping auto-compactions isolated to their own abort controllers", async () => {
+		const pending: DeferredCompaction[] = [];
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [createDeferredCompactionFactory(pending)],
+		});
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		await harness.session.prompt("one");
+		await harness.session.prompt("two");
+
+		const firstCompact = sessionInternals._runAutoCompaction("threshold", false);
+		await waitForPendingCompactions(pending, 1);
+		const secondCompact = sessionInternals._runAutoCompaction("threshold", false);
+		await waitForPendingCompactions(pending, 2);
+
+		resolveDeferredCompaction(pending[0]!, "auto compact 1");
+		await expect(firstCompact).resolves.toBeUndefined();
+		resolveDeferredCompaction(pending[1]!, "auto compact 2");
+		await expect(secondCompact).resolves.toBeUndefined();
+
+		const compactionErrors = harness.eventsOfType("compaction_end").filter((event) => event.errorMessage);
+		expect(compactionErrors).toHaveLength(0);
 	});
 
 	it("resumes after threshold compaction when only agent-level queued messages exist", async () => {


### PR DESCRIPTION
## Summary
- keep manual compaction bound to a per-run local abort controller instead of repeatedly reading the mutable session field
- do the same for auto-compaction and only clear the shared field if it still belongs to the finishing run
- add regression tests covering overlapping manual and auto compactions

## Testing
- npx vitest --run test/suite/agent-session-compaction.test.ts
- npm --prefix packages/coding-agent run build

## Notes
- the repo's pre-commit hook currently fails on unrelated existing `packages/web-ui` example type errors, so I validated the coding-agent package directly for this change.