### PR TITLE
coding-agent: make external skill loading tolerant of malformed frontmatter

### DIFF
--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -130,6 +130,97 @@ function validateDescription(description: string | undefined): string[] {
 	return errors;
 }
 
+function stripQuotes(value: string): string {
+	const trimmed = value.trim();
+	if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+function parseFallbackSkillFrontmatter(rawContent: string): { frontmatter: SkillFrontmatter; body: string } {
+	const normalized = rawContent.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+	if (!normalized.startsWith("---")) {
+		return { frontmatter: {}, body: normalized };
+	}
+	const endIndex = normalized.indexOf("\n---", 3);
+	if (endIndex === -1) {
+		return { frontmatter: {}, body: normalized };
+	}
+	const yamlString = normalized.slice(4, endIndex);
+	const body = normalized.slice(endIndex + 4).trim();
+	const frontmatter: SkillFrontmatter = {};
+	const lines = yamlString.split("\n");
+
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		const match = /^(?<key>[A-Za-z0-9_-]+):\s*(?<value>.*)$/.exec(line);
+		if (!match?.groups) {
+			continue;
+		}
+		const key = match.groups.key;
+		const value = match.groups.value ?? "";
+		if (value === "|" || value === ">") {
+			const block: string[] = [];
+			index += 1;
+			while (index < lines.length) {
+				const next = lines[index];
+				if (/^\s+/.test(next) || next === "") {
+					block.push(next.replace(/^\s{1,2}/, ""));
+					index += 1;
+					continue;
+				}
+				index -= 1;
+				break;
+			}
+			frontmatter[key] = block.join("\n").trim();
+			continue;
+		}
+		frontmatter[key] = stripQuotes(value);
+	}
+
+	return { frontmatter, body };
+}
+
+function inferDescriptionFromBody(body: string): string {
+	const normalized = body.replace(/\r\n/g, "\n").trim();
+	if (!normalized) {
+		return "";
+	}
+
+	const lines = normalized.split("\n");
+	let startIndex = 0;
+
+	if (lines[0]?.startsWith("#")) {
+		startIndex = 1;
+		while (startIndex < lines.length && !lines[startIndex].trim()) {
+			startIndex += 1;
+		}
+	}
+
+	const paragraph: string[] = [];
+	for (let index = startIndex; index < lines.length; index++) {
+		const line = lines[index].trim();
+		if (!line) {
+			if (paragraph.length > 0) break;
+			continue;
+		}
+		if (line.startsWith("#")) {
+			continue;
+		}
+		paragraph.push(line);
+		if (paragraph.join(" ").length >= MAX_DESCRIPTION_LENGTH) {
+			break;
+		}
+	}
+
+	return paragraph.join(" ").slice(0, MAX_DESCRIPTION_LENGTH).trim();
+}
+
+function getExpectedSkillName(filePath: string): string {
+	return basename(filePath) === "SKILL.md" ? basename(dirname(filePath)) : basename(filePath, ".md");
+}
+
 export interface LoadSkillsFromDirOptions {
 	/** Directory to scan for skills */
 	dir: string;
@@ -286,34 +377,42 @@ function loadSkillFromFile(
 
 	try {
 		const rawContent = readFileSync(filePath, "utf-8");
-		const { frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent);
+		let parsed: { frontmatter: SkillFrontmatter; body: string };
+		try {
+			parsed = parseFrontmatter<SkillFrontmatter>(rawContent);
+		} catch {
+			parsed = parseFallbackSkillFrontmatter(rawContent);
+		}
+
+		const { frontmatter, body } = parsed;
 		const skillDir = dirname(filePath);
-		const parentDirName = basename(skillDir);
+		const expectedName = getExpectedSkillName(filePath);
+		const description = frontmatter.description || inferDescriptionFromBody(body);
 
 		// Validate description
-		const descErrors = validateDescription(frontmatter.description);
+		const descErrors = validateDescription(description);
 		for (const error of descErrors) {
 			diagnostics.push({ type: "warning", message: error, path: filePath });
 		}
 
-		// Use name from frontmatter, or fall back to parent directory name
-		const name = frontmatter.name || parentDirName;
+		// Use name from frontmatter, or fall back to expected skill name
+		const name = frontmatter.name || expectedName;
 
 		// Validate name
-		const nameErrors = validateName(name, parentDirName);
+		const nameErrors = validateName(name, expectedName);
 		for (const error of nameErrors) {
 			diagnostics.push({ type: "warning", message: error, path: filePath });
 		}
 
 		// Still load the skill even with warnings (unless description is completely missing)
-		if (!frontmatter.description || frontmatter.description.trim() === "") {
+		if (!description || description.trim() === "") {
 			return { skill: null, diagnostics };
 		}
 
 		return {
 			skill: {
 				name,
-				description: frontmatter.description,
+				description,
 				filePath,
 				baseDir: skillDir,
 				sourceInfo: createSkillSourceInfo(filePath, skillDir, source),

--- a/packages/coding-agent/test/fixtures/skills/empty-description/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/empty-description/SKILL.md
@@ -1,0 +1,3 @@
+---
+name: empty-description
+---

--- a/packages/coding-agent/test/fixtures/skills/standalone-md/brain-dump.md
+++ b/packages/coding-agent/test/fixtures/skills/standalone-md/brain-dump.md
@@ -1,0 +1,9 @@
+---
+name: brain-dump
+description: Route unstructured personal notes to the right place.
+argument-hint: [note text] [@file]
+---
+
+# Brain Dump
+
+Route unstructured notes.

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -74,9 +74,20 @@ describe("skills", () => {
 			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("exceeds 64 characters"))).toBe(true);
 		});
 
-		it("should warn and skip skill when description is missing", () => {
+		it("should infer description from body when description is missing", () => {
 			const { skills, diagnostics } = loadSkillsFromDir({
 				dir: join(fixturesDir, "missing-description"),
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].description).toBe("This skill has no description field.");
+			expect(diagnostics).toHaveLength(0);
+		});
+
+		it("should still skip skill when no description can be inferred", () => {
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: join(fixturesDir, "empty-description"),
 				source: "test",
 			});
 
@@ -117,25 +128,28 @@ describe("skills", () => {
 			expect(diagnostics).toHaveLength(0);
 		});
 
-		it("should skip files without frontmatter", () => {
+		it("should infer description for files without frontmatter", () => {
 			const { skills, diagnostics } = loadSkillsFromDir({
 				dir: join(fixturesDir, "no-frontmatter"),
 				source: "test",
 			});
 
-			// no-frontmatter has no description, so it should be skipped
-			expect(skills).toHaveLength(0);
-			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("description is required"))).toBe(true);
+			expect(skills).toHaveLength(1);
+			expect(skills[0].name).toBe("no-frontmatter");
+			expect(skills[0].description).toBe("This skill has no YAML frontmatter at all.");
+			expect(diagnostics).toHaveLength(0);
 		});
 
-		it("should warn and skip skill when YAML frontmatter is invalid", () => {
+		it("should tolerate malformed skill frontmatter when key-value pairs are still recoverable", () => {
 			const { skills, diagnostics } = loadSkillsFromDir({
 				dir: join(fixturesDir, "invalid-yaml"),
 				source: "test",
 			});
 
-			expect(skills).toHaveLength(0);
-			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("at line"))).toBe(true);
+			expect(skills).toHaveLength(1);
+			expect(skills[0].name).toBe("invalid-yaml");
+			expect(skills[0].description).toBe("[unclosed bracket");
+			expect(diagnostics).toHaveLength(0);
 		});
 
 		it("should preserve multiline descriptions from YAML", () => {
@@ -160,16 +174,25 @@ describe("skills", () => {
 			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("consecutive hyphens"))).toBe(true);
 		});
 
+		it("should load standalone markdown skills using the file name as fallback name", () => {
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: join(fixturesDir, "standalone-md"),
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].name).toBe("brain-dump");
+			expect(skills[0].description).toBe("Route unstructured personal notes to the right place.");
+			expect(diagnostics).toHaveLength(0);
+		});
+
 		it("should load all skills from fixture directory", () => {
 			const { skills } = loadSkillsFromDir({
 				dir: fixturesDir,
 				source: "test",
 			});
 
-			// Should load all skills that have descriptions (even with warnings)
-			// valid-skill, name-mismatch, invalid-name-chars, long-name, unknown-field, nested/child-skill, consecutive-hyphens
-			// NOT: missing-description, no-frontmatter (both missing descriptions)
-			expect(skills.length).toBeGreaterThanOrEqual(6);
+			expect(skills.length).toBeGreaterThanOrEqual(9);
 		});
 
 		it("should return empty for non-existent directory", () => {
@@ -183,9 +206,6 @@ describe("skills", () => {
 		});
 
 		it("should use parent directory name when name not in frontmatter", () => {
-			// The no-frontmatter fixture has no name in frontmatter, so it should use "no-frontmatter"
-			// But it also has no description, so it won't load
-			// Let's test with a valid skill that relies on directory name
 			const { skills } = loadSkillsFromDir({
 				dir: join(fixturesDir, "valid-skill"),
 				source: "test",
@@ -204,7 +224,6 @@ describe("skills", () => {
 			expect(skills).toHaveLength(1);
 			expect(skills[0].name).toBe("disable-model-invocation");
 			expect(skills[0].disableModelInvocation).toBe(true);
-			// Should not warn about unknown field
 			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("unknown frontmatter field"))).toBe(
 				false,
 			);
@@ -388,7 +407,6 @@ describe("skills", () => {
 
 	describe("collision handling", () => {
 		it("should detect name collisions and keep first skill", () => {
-			// Load from first directory
 			const first = loadSkillsFromDir({
 				dir: join(collisionFixturesDir, "first"),
 				source: "first",
@@ -399,7 +417,6 @@ describe("skills", () => {
 				source: "second",
 			});
 
-			// Simulate the collision behavior from loadSkills()
 			const skillMap = new Map<string, Skill>();
 			const collisionWarnings: Array<{ skillPath: string; message: string }> = [];
 


### PR DESCRIPTION
## Summary

Pi supports loading skills from external harness directories like `~/.claude/skills`, but the current skill loader is too strict in two places:

1. malformed YAML-ish frontmatter causes skills to be dropped entirely
2. standalone `.md` skills are validated against the parent `skills/` directory name instead of the file name

This PR makes **skill loading** more tolerant without weakening the generic frontmatter parser.

## What changed

### Skill loader hardening
In `packages/coding-agent/src/core/skills.ts`:

- fall back to a lightweight key/value frontmatter parser when `parseFrontmatter()` throws for a skill file
- recover common external skill cases like:
  - `argument-hint: [action] [args]`
  - `argument-hint: [spec content, @file, ...]`
  - other non-YAML-but-obviously-human frontmatter lines
- infer `description` from the first body paragraph when the frontmatter omits it
- use the **file name** as the expected skill name for standalone `.md` skills
  - example: `brain-dump.md` → expected name `brain-dump`
- keep existing Agent Skills validation warnings for non-compliant names

### Tests
Updated `packages/coding-agent/test/skills.test.ts` to cover:

- missing description inferred from body
- still skipping skills when no description can be inferred
- no-frontmatter markdown skills
- malformed skill frontmatter that is still recoverable
- standalone `.md` skill fallback naming

Added fixtures for:

- `empty-description`
- `standalone-md/brain-dump.md`

## Why this approach

I intentionally did **not** make `parseFrontmatter()` lenient globally.

That parser is a general utility and should stay strict. The compatibility problem is specific to **external skill ingestion**, where pi claims support for loading skills from other harnesses. That means the loader should be defensive at the boundary.

In short:
- strict parser stays strict
- skill loader gets compatibility fallback logic

## Real-world issue fixed

This fixes cases like external Claude skills failing to load with warnings such as:

- `name "brain-dump" does not match parent directory "skills"`
- `description is required`
- YAML parse errors from bracketed `argument-hint` values
- YAML parse errors from unquoted `@file` values

## Testing

Ran:

```bash
bun test packages/coding-agent/test/frontmatter.test.ts packages/coding-agent/test/skills.test.ts
```

Result:

- 38 passing
- 0 failing

## Notes

This is a compatibility improvement for third-party/external skills. It preserves the current Agent Skills validation behavior while avoiding needless breakage on slightly malformed but recoverable skill metadata.
