### PR TITLE
Update sandbox extension configuration instructions

### DIFF
--- a/packages/coding-agent/examples/extensions/sandbox/index.ts
+++ b/packages/coding-agent/examples/extensions/sandbox/index.ts
@@ -10,7 +10,7 @@
  * via `tool_call` input mutation without replacing the tool.
  *
  * Config files (merged, project takes precedence):
- * - ~/.pi/agent/sandbox.json (global)
+ * - ~/.pi/agent/extensions/sandbox.json (global)
  * - <cwd>/.pi/sandbox.json (project-local)
  *
  * Example .pi/sandbox.json:


### PR DESCRIPTION
The current sandbox extension instructions state the global configuration file must exist at `~/.pi/agent/sandbox.json` whereas it actually must exist at  `~/.pi/agent/extensions/sandbox.json` to be picked up.