### PR TITLE
fix(tui): replace spread push with concat in Container.render()

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -200,9 +200,12 @@ export class Container implements Component {
 	}
 
 	render(width: number): string[] {
-		const lines: string[] = [];
+		let lines: string[] = [];
 		for (const child of this.children) {
-			lines.push(...child.render(width));
+			const childLines = child.render(width);
+			if (childLines.length > 0) {
+				lines = lines.concat(childLines);
+			}
 		}
 		return lines;
 	}


### PR DESCRIPTION
Container.render() used lines.push(...child.render(width)) which converts each array element into a function argument. When a child produces tens of thousands of lines (e.g. large PDF tool results), this exceeds the JS engine's max call stack size and crashes with RangeError: Maximum call stack size exceeded.

Replace with Array.concat() which handles arrays of any size.

Resolves #2931 