### PR TITLE
feat(coding-agent): add working spinner override for extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 
 - Set `PI_CODING_AGENT=true` environment variable at startup so sub-processes can detect they are running inside the coding agent ([#2868](https://github.com/badlogic/pi-mono/issues/2868))
+- Extensions can now override the main working spinner via `ctx.ui.setWorkingSpinner({ frames, intervalMs })`, with `ctx.ui.setWorkingSpinner()` restoring the default braille spinner.
 
 ## [0.66.1] - 2026-04-08
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1959,6 +1959,10 @@ ctx.ui.setStatus("my-ext", undefined);  // Clear
 ctx.ui.setWorkingMessage("Thinking deeply...");
 ctx.ui.setWorkingMessage();  // Restore default
 
+// Working spinner (main streaming loader only)
+ctx.ui.setWorkingSpinner({ frames: ["◐", "◓", "◑", "◒"], intervalMs: 100 });
+ctx.ui.setWorkingSpinner();  // Restore default braille spinner
+
 // Widget above editor (default)
 ctx.ui.setWidget("my-widget", ["Line 1", "Line 2"]);
 // Widget below editor

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -964,7 +964,7 @@ If a dialog method includes a `timeout` field, the agent-side will auto-resolve 
 
 Some `ExtensionUIContext` methods are not supported or degraded in RPC mode because they require direct TUI access:
 - `custom()` returns `undefined`
-- `setWorkingMessage()`, `setFooter()`, `setHeader()`, `setEditorComponent()`, `setToolsExpanded()` are no-ops
+- `setWorkingMessage()`, `setWorkingSpinner()`, `setFooter()`, `setHeader()`, `setEditorComponent()`, `setToolsExpanded()` are no-ops
 - `getEditorText()` returns `""`
 - `getToolsExpanded()` returns `false`
 - `pasteToEditor()` delegates to `setEditorText()` (no paste/collapse handling)

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -178,6 +178,7 @@ const noOpUIContext: ExtensionUIContext = {
 	onTerminalInput: () => () => {},
 	setStatus: () => {},
 	setWorkingMessage: () => {},
+	setWorkingSpinner: () => {},
 	setHiddenThinkingLabel: () => {},
 	setWidget: () => {},
 	setFooter: () => {},

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -101,6 +101,11 @@ export interface ExtensionWidgetOptions {
 /** Raw terminal input listener for extensions. */
 export type TerminalInputHandler = (data: string) => { consume?: boolean; data?: string } | undefined;
 
+export interface ExtensionWorkingSpinner {
+	frames: string[];
+	intervalMs?: number;
+}
+
 /**
  * UI context for extensions to request interactive UI.
  * Each mode (interactive, RPC, print) provides its own implementation.
@@ -126,6 +131,9 @@ export interface ExtensionUIContext {
 
 	/** Set the working/loading message shown during streaming. Call with no argument to restore default. */
 	setWorkingMessage(message?: string): void;
+
+	/** Set the main working spinner frames/interval shown during streaming. Persists for future turns until reset. Call with no argument to restore default. */
+	setWorkingSpinner(spinner?: ExtensionWorkingSpinner): void;
 
 	/** Set the label shown for hidden thinking blocks. Call with no argument to restore default. */
 	setHiddenThinkingLabel(label?: string): void;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -174,6 +174,7 @@ export class InteractiveMode {
 	private onInputCallback?: (text: string) => void;
 	private loadingAnimation: Loader | undefined = undefined;
 	private pendingWorkingMessage: string | undefined = undefined;
+	private workingSpinnerOverride: { frames: string[]; intervalMs?: number } | undefined = undefined;
 	private readonly defaultWorkingMessage = "Working...";
 	private readonly defaultHiddenThinkingLabel = "Thinking...";
 	private hiddenThinkingLabel = this.defaultHiddenThinkingLabel;
@@ -1634,6 +1635,12 @@ export class InteractiveMode {
 					this.pendingWorkingMessage = message;
 				}
 			},
+			setWorkingSpinner: (spinner) => {
+				this.workingSpinnerOverride = spinner;
+				if (this.loadingAnimation) {
+					this.loadingAnimation.setFrames(spinner?.frames, spinner?.intervalMs);
+				}
+			},
 			setHiddenThinkingLabel: (label) => this.setHiddenThinkingLabel(label),
 			setWidget: (key, content, options) => this.setExtensionWidget(key, content, options),
 			setFooter: (factory) => this.setExtensionFooter(factory),
@@ -2324,6 +2331,12 @@ export class InteractiveMode {
 					(text) => theme.fg("muted", text),
 					this.defaultWorkingMessage,
 				);
+				if (this.workingSpinnerOverride !== undefined) {
+					this.loadingAnimation.setFrames(
+						this.workingSpinnerOverride.frames,
+						this.workingSpinnerOverride.intervalMs,
+					);
+				}
 				this.statusContainer.addChild(this.loadingAnimation);
 				// Apply any pending working message queued before loader existed
 				if (this.pendingWorkingMessage !== undefined) {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -169,6 +169,10 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 			// Working message not supported in RPC mode - requires TUI loader access
 		},
 
+		setWorkingSpinner(_spinner?: unknown): void {
+			// Working spinner override not supported in RPC mode - requires TUI loader access
+		},
+
 		setHiddenThinkingLabel(_label?: string): void {
 			// Hidden thinking label not supported in RPC mode - requires TUI message rendering access
 		},

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -108,6 +108,141 @@ describe("InteractiveMode.createExtensionUIContext setTheme", () => {
 	});
 });
 
+describe("InteractiveMode working spinner override", () => {
+	test("stores working spinner overrides when loader does not exist yet", () => {
+		initTheme("dark");
+
+		const fakeThis: any = {
+			session: { settingsManager: {} },
+			settingsManager: {},
+			ui: { requestRender: vi.fn(), terminal: { setTitle: vi.fn() } },
+			setExtensionStatus: vi.fn(),
+			setHiddenThinkingLabel: vi.fn(),
+			setExtensionWidget: vi.fn(),
+			setExtensionFooter: vi.fn(),
+			setExtensionHeader: vi.fn(),
+			showExtensionSelector: vi.fn(),
+			showExtensionConfirm: vi.fn(),
+			showExtensionInput: vi.fn(),
+			showExtensionNotify: vi.fn(),
+			addExtensionTerminalInputListener: vi.fn(),
+			showExtensionCustom: vi.fn(),
+			editor: {
+				handleInput: vi.fn(),
+				setText: vi.fn(),
+				getText: vi.fn(() => ""),
+				getExpandedText: vi.fn(() => ""),
+			},
+			setCustomEditorComponent: vi.fn(),
+			workingSpinnerOverride: undefined,
+			loadingAnimation: undefined,
+		};
+
+		const uiContext = (InteractiveMode as any).prototype.createExtensionUIContext.call(fakeThis);
+		uiContext.setWorkingSpinner({ frames: ["a", "b"], intervalMs: 120 });
+
+		expect(fakeThis.workingSpinnerOverride).toEqual({ frames: ["a", "b"], intervalMs: 120 });
+	});
+
+	test("applies working spinner override immediately when loader already exists", () => {
+		initTheme("dark");
+
+		const setFrames = vi.fn();
+		const fakeThis: any = {
+			session: { settingsManager: {} },
+			settingsManager: {},
+			ui: { requestRender: vi.fn(), terminal: { setTitle: vi.fn() } },
+			setExtensionStatus: vi.fn(),
+			setHiddenThinkingLabel: vi.fn(),
+			setExtensionWidget: vi.fn(),
+			setExtensionFooter: vi.fn(),
+			setExtensionHeader: vi.fn(),
+			showExtensionSelector: vi.fn(),
+			showExtensionConfirm: vi.fn(),
+			showExtensionInput: vi.fn(),
+			showExtensionNotify: vi.fn(),
+			addExtensionTerminalInputListener: vi.fn(),
+			showExtensionCustom: vi.fn(),
+			editor: {
+				handleInput: vi.fn(),
+				setText: vi.fn(),
+				getText: vi.fn(() => ""),
+				getExpandedText: vi.fn(() => ""),
+			},
+			setCustomEditorComponent: vi.fn(),
+			workingSpinnerOverride: undefined,
+			loadingAnimation: { setFrames },
+		};
+
+		const uiContext = (InteractiveMode as any).prototype.createExtensionUIContext.call(fakeThis);
+		uiContext.setWorkingSpinner({ frames: ["x", "y"], intervalMs: 100 });
+
+		expect(setFrames).toHaveBeenCalledWith(["x", "y"], 100);
+		expect(fakeThis.workingSpinnerOverride).toEqual({ frames: ["x", "y"], intervalMs: 100 });
+	});
+
+	test("clearing working spinner override resets current loader and future turns", () => {
+		initTheme("dark");
+
+		const setFrames = vi.fn();
+		const fakeThis: any = {
+			session: { settingsManager: {} },
+			settingsManager: {},
+			ui: { requestRender: vi.fn(), terminal: { setTitle: vi.fn() } },
+			setExtensionStatus: vi.fn(),
+			setHiddenThinkingLabel: vi.fn(),
+			setExtensionWidget: vi.fn(),
+			setExtensionFooter: vi.fn(),
+			setExtensionHeader: vi.fn(),
+			showExtensionSelector: vi.fn(),
+			showExtensionConfirm: vi.fn(),
+			showExtensionInput: vi.fn(),
+			showExtensionNotify: vi.fn(),
+			addExtensionTerminalInputListener: vi.fn(),
+			showExtensionCustom: vi.fn(),
+			editor: {
+				handleInput: vi.fn(),
+				setText: vi.fn(),
+				getText: vi.fn(() => ""),
+				getExpandedText: vi.fn(() => ""),
+			},
+			setCustomEditorComponent: vi.fn(),
+			workingSpinnerOverride: { frames: ["x"], intervalMs: 100 },
+			loadingAnimation: { setFrames },
+		};
+
+		const uiContext = (InteractiveMode as any).prototype.createExtensionUIContext.call(fakeThis);
+		uiContext.setWorkingSpinner();
+
+		expect(setFrames).toHaveBeenCalledWith(undefined, undefined);
+		expect(fakeThis.workingSpinnerOverride).toBeUndefined();
+	});
+
+	test("agent_start applies configured working spinner override to the main loader", async () => {
+		initTheme("dark");
+
+		const fakeThis: any = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			retryEscapeHandler: undefined,
+			retryLoader: undefined,
+			loadingAnimation: undefined,
+			statusContainer: new Container(),
+			ui: { requestRender: vi.fn() },
+			defaultWorkingMessage: "Working...",
+			pendingWorkingMessage: undefined,
+			workingSpinnerOverride: { frames: ["x", "y", "z"], intervalMs: 140 },
+		};
+
+		await (InteractiveMode as any).prototype.handleEvent.call(fakeThis, { type: "agent_start" });
+
+		expect(fakeThis.loadingAnimation).toBeDefined();
+		expect((fakeThis.loadingAnimation as any).frames).toEqual(["x", "y", "z"]);
+		expect((fakeThis.loadingAnimation as any).intervalMs).toBe(140);
+		expect(fakeThis.workingSpinnerOverride).toEqual({ frames: ["x", "y", "z"], intervalMs: 140 });
+	});
+});
+
 describe("InteractiveMode.showLoadedResources", () => {
 	beforeAll(() => {
 		initTheme("dark");

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -375,6 +375,8 @@ const loader = new Loader(
 );
 loader.start();
 loader.setMessage("Still loading...");
+loader.setFrames(["◐", "◓", "◑", "◒"], 100);
+loader.setFrames(); // restore default braille spinner
 loader.stop();
 ```
 

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -5,9 +5,11 @@ import { Text } from "./text.js";
  * Loader component that updates every 80ms with spinning animation
  */
 export class Loader extends Text {
-	private frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+	private defaultFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+	private frames = [...this.defaultFrames];
 	private currentFrame = 0;
 	private intervalId: NodeJS.Timeout | null = null;
+	private intervalMs = 80;
 	private ui: TUI | null = null;
 
 	constructor(
@@ -30,7 +32,7 @@ export class Loader extends Text {
 		this.intervalId = setInterval(() => {
 			this.currentFrame = (this.currentFrame + 1) % this.frames.length;
 			this.updateDisplay();
-		}, 80);
+		}, this.intervalMs);
 	}
 
 	stop() {
@@ -43,6 +45,14 @@ export class Loader extends Text {
 	setMessage(message: string) {
 		this.message = message;
 		this.updateDisplay();
+	}
+
+	setFrames(frames?: string[], intervalMs?: number) {
+		this.stop();
+		this.frames = frames && frames.length > 0 ? [...frames] : [...this.defaultFrames];
+		this.intervalMs = intervalMs && intervalMs > 0 ? intervalMs : 80;
+		this.currentFrame = 0;
+		this.start();
 	}
 
 	private updateDisplay() {

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { Loader } from "../src/components/loader.js";
+
+describe("Loader", () => {
+	test("setFrames replaces spinner frames and interval", () => {
+		const events: Array<{ type: string; ms?: number }> = [];
+		const originalSetInterval = globalThis.setInterval;
+		const originalClearInterval = globalThis.clearInterval;
+
+		globalThis.setInterval = ((fn: (...args: never[]) => void, ms?: number) => {
+			events.push({ type: "setInterval", ms: typeof ms === "number" ? ms : undefined });
+			return { fn, ms } as unknown as ReturnType<typeof setInterval>;
+		}) as typeof setInterval;
+		globalThis.clearInterval = ((_id?: ReturnType<typeof setInterval>) => {
+			events.push({ type: "clearInterval" });
+		}) as typeof clearInterval;
+
+		try {
+			const ui = { requestRender() {} } as any;
+			const loader = new Loader(
+				ui,
+				(s: string) => s,
+				(s: string) => s,
+				"Working...",
+			);
+			(loader as any).intervalId = { stale: true };
+			loader.setFrames(["a", "b", "c"], 120);
+
+			assert.deepEqual((loader as any).frames, ["a", "b", "c"]);
+			assert.equal((loader as any).currentFrame, 0);
+			assert.equal(events.at(-2)?.type, "clearInterval");
+			assert.equal(events.at(-1)?.type, "setInterval");
+			assert.equal(events.at(-1)?.ms, 120);
+		} finally {
+			globalThis.setInterval = originalSetInterval;
+			globalThis.clearInterval = originalClearInterval;
+		}
+	});
+
+	test("setFrames with undefined restores default frames and interval", () => {
+		const ui = { requestRender() {} } as any;
+		const loader = new Loader(
+			ui,
+			(s: string) => s,
+			(s: string) => s,
+			"Working...",
+		);
+		loader.setFrames(["x"], 120);
+		loader.setFrames(undefined);
+
+		assert.deepEqual((loader as any).frames, ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]);
+		assert.equal((loader as any).intervalMs, 80);
+	});
+});


### PR DESCRIPTION
## Summary

- add `ctx.ui.setWorkingSpinner(...)` so extensions can override the main streaming loader spinner
- add `Loader.setFrames(...)` in `@mariozechner/pi-tui` to support configurable spinner frames and interval
- keep scope intentionally narrow: this only affects the main working loader, not retry/compaction/summary loaders

## Why

Pi already exposes `ctx.ui.setWorkingMessage(...)`, but that only customizes the text beside the built-in braille spinner. There is currently no supported extension API for replacing the spinner itself.

This patch fills that gap with the smallest API I could find that fits the existing extension UI model.

## API

```ts
ctx.ui.setWorkingSpinner({
  frames: ["◐", "◓", "◑", "◒"],
  intervalMs: 100,
});

ctx.ui.setWorkingSpinner(); // restore default braille spinner
```

Behavior:
- persists across future turns until reset
- applies immediately if a working loader already exists
- otherwise is applied on the next `agent_start`
- RPC mode treats it as a no-op, matching other TUI-only extension UI methods

## Files changed

- `packages/tui/src/components/loader.ts`
  - add `setFrames(frames?, intervalMs?)`
- `packages/tui/test/loader.test.ts`
  - cover frame replacement and reset-to-default behavior
- `packages/coding-agent/src/core/extensions/types.ts`
  - add `ExtensionWorkingSpinner` and `setWorkingSpinner(...)`
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`
  - store/apply working spinner override for the main streaming loader
- `packages/coding-agent/src/modes/rpc/rpc-mode.ts`
  - no-op implementation for RPC mode
- `packages/coding-agent/src/core/extensions/runner.ts`
  - no-op UI context implementation updated
- `packages/coding-agent/test/interactive-mode-status.test.ts`
  - cover queued, immediate, reset, and agent_start application paths
- docs/changelog updates

## Notes for reviewers

- I intentionally did **not** generalize this to all loader instances.
- Retry, compaction, summary, and other loaders keep their current built-in braille spinner.
- This keeps the patch small and avoids changing unrelated UI behavior.

## Verification

Ran successfully:

- `cd packages/tui && node --test --import tsx test/loader.test.ts`
- `npm test -w @mariozechner/pi-coding-agent -- interactive-mode-status.test.ts`
- `npm test -w @mariozechner/pi-coding-agent`
- `npm run build -w @mariozechner/pi-tui -w @mariozechner/pi-coding-agent`
- `git diff --check`

## Related prior work

- `setWorkingMessage()` API: #625
- timing bug around `setWorkingMessage()` in `agent_start`: #935
