### PR TITLE
fix(web-ui): ignore key events during IME composition

### DIFF
--- a/packages/web-ui/src/components/MessageEditor.ts
+++ b/packages/web-ui/src/components/MessageEditor.ts
@@ -60,6 +60,9 @@ export class MessageEditor extends LitElement {
 	};
 
 	private handleKeyDown = (e: KeyboardEvent) => {
+		// Ignore key events during IME composition (e.g. CJK input)
+		if (e.isComposing || e.key === "Process") return;
+
 		if (e.key === "Enter" && !e.shiftKey) {
 			e.preventDefault();
 			if (!this.isStreaming && !this.processingFiles && (this.value.trim() || this.attachments.length > 0)) {

--- a/packages/web-ui/src/dialogs/ModelSelector.ts
+++ b/packages/web-ui/src/dialogs/ModelSelector.ts
@@ -113,6 +113,9 @@ export class ModelSelector extends DialogBase {
 
 		// Add global keyboard handler for the dialog
 		this.addEventListener("keydown", (e: KeyboardEvent) => {
+			// Ignore key events during IME composition (e.g. CJK input)
+			if (e.isComposing || e.key === "Process") return;
+
 			// Get filtered models to know the bounds
 			const filteredModels = this.getFilteredModels();
 


### PR DESCRIPTION
This PR skips `keydown` handling during IME composition (e.g. CJK input) to prevent premature Enter submission.

test with chrome on macOS:

before:

https://github.com/user-attachments/assets/8515281b-05da-4bfa-89c1-9161100fbff1

after:

https://github.com/user-attachments/assets/7d24e631-e63d-4bd4-8af4-0af2a0044ffa