### PR TITLE
fix(coding-agent): do not inject bunfs script path into subagent prompts

### DIFF
--- a/packages/coding-agent/examples/extensions/subagent/index.ts
+++ b/packages/coding-agent/examples/extensions/subagent/index.ts
@@ -219,7 +219,8 @@ async function writePromptToTempFile(agentName: string, prompt: string): Promise
 
 function getPiInvocation(args: string[]): { command: string; args: string[] } {
 	const currentScript = process.argv[1];
-	if (currentScript && fs.existsSync(currentScript)) {
+	const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");
+	if (currentScript && !isBunVirtualScript && fs.existsSync(currentScript)) {
 		return { command: process.execPath, args: [currentScript, ...args] };
 	}
 


### PR DESCRIPTION
The presence of `process.argv[1]` in the current invocation does not imply that the current `pi` process is being invoked as a script. Specifically, in the case of a bun compiled binary, `process.argv[1]` will be the virtual path `/$bunfs/root/pi`, which is not a real file on the filesystem.  This causes the subagent extension to inject this path into the child `pi` invocation, which is interpreted as part of the prompt, which confuses the subagent.

e.g.
```
pi /$bunfs/root/pi --tools 'Bash,Read,Edit,Write' @/tmp/subagent-...
```

This change uses the script only if it is not a bunfs virtual script.