### PR TITLE
fix(coding-agent): deliver extension followUp messages queued during agent_end

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1063,6 +1063,16 @@ export class AgentSession {
 
 		await this.agent.prompt(messages);
 		await this.waitForRetry();
+
+		// Extensions may queue follow-up messages during agent_end (e.g. commit reminders).
+		// The agent loop has finished, so the internal followUpQueue won't be drained automatically.
+		// Drain it here, mirroring what agent.continue() does for user-initiated follow-ups.
+		if (this.agent.hasQueuedMessages()) {
+			const queued = this._drainExtensionFollowUps();
+			if (queued.length > 0) {
+				await this._sendFollowUp(queued);
+			}
+		}
 	}
 
 	/**
@@ -1200,6 +1210,28 @@ export class AgentSession {
 			content,
 			timestamp: Date.now(),
 		});
+	}
+
+	/** Drain follow-up messages queued by extensions during agent_end. */
+	private _drainExtensionFollowUps(): string[] {
+		const followUps = [...this._followUpMessages];
+		this._followUpMessages = [];
+		this._emitQueueUpdate();
+		this.agent.clearFollowUpQueue();
+		return followUps;
+	}
+
+	/** Send drained follow-up messages as a new prompt, bypassing streaming checks. */
+	private async _sendFollowUp(messages: string[]): Promise<void> {
+		const combined = messages.join("\n\n");
+		const content: TextContent[] = [{ type: "text", text: combined }];
+		const userMessage: AgentMessage = {
+			role: "user",
+			content,
+			timestamp: Date.now(),
+		};
+		await this.agent.prompt(userMessage);
+		await this.waitForRetry();
 	}
 
 	/**

--- a/packages/coding-agent/test/suite/regressions/extension-followup-after-agent-end.test.ts
+++ b/packages/coding-agent/test/suite/regressions/extension-followup-after-agent-end.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression test for extension followUp messages queued during agent_end.
+ *
+ * Bug: Extensions calling sendUserMessage({ deliverAs: "followUp" }) during
+ * agent_end had their messages silently dropped. The agent loop had already
+ * finished, so the internal followUpQueue was never drained.
+ *
+ * Fix: After agent.prompt() resolves, drain any followUp messages queued by
+ * extensions during agent_end and send them as a new prompt.
+ */
+
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "../harness.js";
+
+async function createWaitingHarness(extensionFactories?: Array<(pi: ExtensionAPI) => void>): Promise<{
+	harness: Harness;
+	releaseToolExecution: () => void;
+	promptPromise: Promise<void>;
+	waitForToolStart: Promise<void>;
+}> {
+	let releaseToolExecution: (() => void) | undefined;
+	const toolRelease = new Promise<void>((resolve) => {
+		releaseToolExecution = resolve;
+	});
+	const waitTool: AgentTool = {
+		name: "wait",
+		label: "Wait",
+		description: "Wait for release",
+		parameters: Type.Object({}),
+		execute: async () => {
+			await toolRelease;
+			return {
+				content: [{ type: "text", text: "released" }],
+				details: {},
+			};
+		},
+	};
+	const harness = await createHarness({
+		tools: [waitTool],
+		extensionFactories,
+	});
+
+	const waitForToolStart = new Promise<void>((resolve) => {
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "tool_execution_start" && event.toolName === "wait") {
+				unsubscribe();
+				resolve();
+			}
+		});
+	});
+
+	return {
+		harness,
+		releaseToolExecution: () => releaseToolExecution?.(),
+		promptPromise: harness.session.prompt("start"),
+		waitForToolStart,
+	};
+}
+
+const harnesses: Harness[] = [];
+
+afterEach(() => {
+	while (harnesses.length > 0) {
+		harnesses.pop()?.cleanup();
+	}
+});
+
+describe("extension followUp after agent_end", () => {
+	it("delivers followUp queued by extension during agent_end", async () => {
+		let extensionApi: ExtensionAPI | undefined;
+
+		const waiting = await createWaitingHarness([
+			(pi) => {
+				extensionApi = pi;
+				pi.on("agent_end", () => {
+					extensionApi?.sendUserMessage("reminder from extension", {
+						deliverAs: "followUp",
+					});
+				});
+			},
+		]);
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("first turn done"),
+			fauxAssistantMessage("handled reminder"),
+		]);
+
+		await waitForToolStart;
+		releaseToolExecution();
+		await promptPromise;
+
+		expect(getUserTexts(harness)).toEqual(["start", "reminder from extension"]);
+		expect(getAssistantTexts(harness)).toEqual(["", "first turn done", "handled reminder"]);
+	});
+
+	it("does not deliver followUp when extension does not queue during agent_end", async () => {
+		const waiting = await createWaitingHarness();
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+
+		await waitForToolStart;
+		releaseToolExecution();
+		await promptPromise;
+
+		expect(getUserTexts(harness)).toEqual(["start"]);
+		expect(getAssistantTexts(harness)).toEqual(["", "done"]);
+	});
+});


### PR DESCRIPTION
## Problem

Extensions calling `sendUserMessage({ deliverAs: "followUp" })` during the `agent_end` event had their messages silently dropped. The agent loop had already exited, so the internal `followUpQueue` was never drained.

## Root Cause

The execution order in the agent loop is:
1. Agent loop emits `agent_end`
2. Extension handlers run (queue followUp via `this.agent.followUp()`)
3. `finishRun()` sets `isStreaming = false`
4. `agent.prompt()` promise resolves

After step 4, nobody calls `agent.continue()` to drain the followUpQueue — the messages are orphaned.

## Fix

After `agent.prompt()` resolves in `AgentSession.prompt()`, check if extensions queued followUp messages during `agent_end` and send them as a new prompt. This mirrors what `agent.continue()` does for user-initiated follow-ups.

## Test Plan

- Added regression test with two cases:
  - Extension queues followUp during agent_end → message is delivered
  - No followUp queued → no extra turn
- All 82 existing suite tests pass