### PR TITLE
[codex] Improve OpenAI prompt cache affinity

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Bumped default Antigravity User-Agent version to `1.21.9` ([#2901](https://github.com/badlogic/pi-mono/pull/2901) by [@aadishv](https://github.com/aadishv))
 - Fixed thinking levels for Gemma 4 models to use `thinkingLevel` and map Pi reasoning levels to the model's supported thinking levels ([#2903](https://github.com/badlogic/pi-mono/pull/2903) by [@aadishv](https://github.com/aadishv))
+- Fixed direct OpenAI Responses requests to send session routing headers when `sessionId` is provided, improving prompt cache affinity for append-only sessions.
 
 ## [0.66.1] - 2026-04-08
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -88,7 +88,9 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 		try {
 			// Create OpenAI client
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-			const client = createClient(model, context, apiKey, options?.headers);
+			const cacheRetention = resolveCacheRetention(options?.cacheRetention);
+			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
+			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId);
 			let params = buildParams(model, context, options);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -151,6 +153,7 @@ function createClient(
 	context: Context,
 	apiKey?: string,
 	optionsHeaders?: Record<string, string>,
+	sessionId?: string,
 ) {
 	if (!apiKey) {
 		if (!process.env.OPENAI_API_KEY) {
@@ -169,6 +172,11 @@ function createClient(
 			hasImages,
 		});
 		Object.assign(headers, copilotHeaders);
+	}
+
+	if (sessionId && model.provider === "openai" && model.baseUrl.includes("api.openai.com")) {
+		headers.session_id = sessionId;
+		headers["x-client-request-id"] = sessionId;
 	}
 
 	// Merge options headers last so they can override defaults

--- a/packages/ai/test/openai-responses-copilot-provider.test.ts
+++ b/packages/ai/test/openai-responses-copilot-provider.test.ts
@@ -2,7 +2,54 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getModel } from "../src/models.js";
 import { streamOpenAIResponses } from "../src/providers/openai-responses.js";
 
-describe("openai-responses github-copilot defaults", () => {
+type CapturedHeaders = Headers | string[][] | Record<string, string | readonly string[]> | undefined;
+
+function getHeader(headers: CapturedHeaders, name: string): string | null {
+	if (!headers) return null;
+	if (headers instanceof Headers) return headers.get(name);
+
+	const lowerName = name.toLowerCase();
+	if (Array.isArray(headers)) {
+		const match = headers.find(([key]) => key?.toLowerCase() === lowerName);
+		return match?.[1] ?? null;
+	}
+
+	for (const [key, value] of Object.entries(headers)) {
+		if (key.toLowerCase() === lowerName) return typeof value === "string" ? value : value.join(", ");
+	}
+	return null;
+}
+
+async function captureOpenAIResponseHeaders(
+	options: Parameters<typeof streamOpenAIResponses>[2],
+): Promise<{ sessionId: string | null; clientRequestId: string | null }> {
+	const captured = { sessionId: null as string | null, clientRequestId: null as string | null };
+	vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+		captured.sessionId = getHeader(init?.headers, "session_id");
+		captured.clientRequestId = getHeader(init?.headers, "x-client-request-id");
+		return new Response("data: [DONE]\n\n", {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	});
+
+	const stream = streamOpenAIResponses(
+		getModel("openai", "gpt-5.4"),
+		{
+			systemPrompt: "sys",
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+		},
+		{ apiKey: "test-key", ...options },
+	);
+
+	for await (const event of stream) {
+		if (event.type === "done" || event.type === "error") break;
+	}
+
+	return captured;
+}
+
+describe("openai-responses provider defaults", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
@@ -40,5 +87,29 @@ describe("openai-responses github-copilot defaults", () => {
 		expect(capturedPayload).not.toMatchObject({
 			reasoning: expect.anything(),
 		});
+	});
+
+	it("sets cache-affinity headers for official OpenAI Responses requests with a sessionId", async () => {
+		const captured = await captureOpenAIResponseHeaders({ sessionId: "session-123" });
+
+		expect(captured).toEqual({ sessionId: "session-123", clientRequestId: "session-123" });
+	});
+
+	it("lets explicit headers override the default OpenAI cache-affinity headers", async () => {
+		const captured = await captureOpenAIResponseHeaders({
+			sessionId: "session-123",
+			headers: {
+				session_id: "override-session",
+				"x-client-request-id": "override-request",
+			},
+		});
+
+		expect(captured).toEqual({ sessionId: "override-session", clientRequestId: "override-request" });
+	});
+
+	it("omits OpenAI cache-affinity headers when cacheRetention is none", async () => {
+		const captured = await captureOpenAIResponseHeaders({ cacheRetention: "none", sessionId: "session-123" });
+
+		expect(captured).toEqual({ sessionId: null, clientRequestId: null });
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Updated `antigravity-image-gen.ts` example extension to use User-Agent version `1.21.9` ([#2901](https://github.com/badlogic/pi-mono/pull/2901) by [@aadishv](https://github.com/aadishv))
+- Fixed newly generated session IDs to use UUIDv7, improving time locality for session-based request routing.
 ### Added
 
 - Set `PI_CODING_AGENT=true` environment variable at startup so sub-processes can detect they are running inside the coding agent ([#2868](https://github.com/badlogic/pi-mono/issues/2868))

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent, Message, TextContent } from "@mariozechner/pi-ai";
-import { randomUUID } from "crypto";
+import { randomBytes, randomUUID } from "crypto";
 import {
 	appendFileSync,
 	closeSync,
@@ -196,6 +196,27 @@ export type ReadonlySessionManager = Pick<
 	| "getTree"
 	| "getSessionName"
 >;
+
+function byteToHex(byte: number): string {
+	return byte.toString(16).padStart(2, "0");
+}
+
+function createSessionId(): string {
+	const timestampHex = BigInt(Date.now()).toString(16).padStart(12, "0").slice(-12);
+	const random = randomBytes(10);
+	const byte = (index: number): number => random[index] ?? 0;
+	const randA = ((byte(0) << 8) | byte(1)) & 0x0fff;
+	const randB0 = (byte(2) & 0x3f) | 0x80;
+	const randB = [randB0, ...Array.from(random.subarray(3, 10))].map(byteToHex).join("");
+
+	return [
+		timestampHex.slice(0, 8),
+		timestampHex.slice(8, 12),
+		`7${randA.toString(16).padStart(3, "0")}`,
+		randB.slice(0, 4),
+		randB.slice(4, 16),
+	].join("-");
+}
 
 /** Generate a unique short ID (8 hex chars, collision-checked) */
 function generateId(byId: { has(id: string): boolean }): string {
@@ -707,7 +728,7 @@ export class SessionManager {
 			}
 
 			const header = this.fileEntries.find((e) => e.type === "session") as SessionHeader | undefined;
-			this.sessionId = header?.id ?? randomUUID();
+			this.sessionId = header?.id ?? createSessionId();
 
 			if (migrateToCurrentVersion(this.fileEntries)) {
 				this._rewriteFile();
@@ -723,7 +744,7 @@ export class SessionManager {
 	}
 
 	newSession(options?: NewSessionOptions): string | undefined {
-		this.sessionId = options?.id ?? randomUUID();
+		this.sessionId = options?.id ?? createSessionId();
 		const timestamp = new Date().toISOString();
 		const header: SessionHeader = {
 			type: "session",
@@ -1172,7 +1193,7 @@ export class SessionManager {
 		// Filter out LabelEntry from path - we'll recreate them from the resolved map
 		const pathWithoutLabels = path.filter((e) => e.type !== "label");
 
-		const newSessionId = randomUUID();
+		const newSessionId = createSessionId();
 		const timestamp = new Date().toISOString();
 		const fileTimestamp = timestamp.replace(/[:.]/g, "-");
 		const newSessionFile = join(this.getSessionDir(), `${fileTimestamp}_${newSessionId}.jsonl`);
@@ -1325,7 +1346,7 @@ export class SessionManager {
 		}
 
 		// Create new session file with new ID but forked content
-		const newSessionId = randomUUID();
+		const newSessionId = createSessionId();
 		const timestamp = new Date().toISOString();
 		const fileTimestamp = timestamp.replace(/[:.]/g, "-");
 		const newSessionFile = join(dir, `${fileTimestamp}_${newSessionId}.jsonl`);

--- a/packages/coding-agent/test/session-manager/custom-session-id.test.ts
+++ b/packages/coding-agent/test/session-manager/custom-session-id.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { SessionManager } from "../../src/core/session-manager.js";
 
+const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
 describe("SessionManager.newSession with custom id", () => {
 	it("uses the provided id instead of generating one", () => {
 		const session = SessionManager.inMemory();
@@ -14,6 +16,7 @@ describe("SessionManager.newSession with custom id", () => {
 		const id = session.getSessionId();
 		expect(id).toBeDefined();
 		expect(id).not.toBe("");
+		expect(id).toMatch(UUID_V7_RE);
 	});
 
 	it("generates a random id when options is provided without id", () => {
@@ -22,6 +25,7 @@ describe("SessionManager.newSession with custom id", () => {
 		const id = session.getSessionId();
 		expect(id).toBeDefined();
 		expect(id).not.toBe("");
+		expect(id).toMatch(UUID_V7_RE);
 	});
 
 	it("includes the custom id in the session header", () => {
@@ -31,5 +35,25 @@ describe("SessionManager.newSession with custom id", () => {
 		const header = session.getHeader();
 		expect(header).not.toBeNull();
 		expect(header!.id).toBe("header-test-id");
+	});
+
+	it("generates a UUIDv7 id when constructed without an explicit id", () => {
+		const session = SessionManager.inMemory();
+		expect(session.getSessionId()).toMatch(UUID_V7_RE);
+		expect(session.getHeader()!.id).toBe(session.getSessionId());
+	});
+
+	it("generates a UUIDv7 id when creating a branched session", () => {
+		const session = SessionManager.inMemory();
+		const firstId = session.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "hello" }],
+			timestamp: Date.now(),
+		});
+
+		session.createBranchedSession(firstId);
+
+		expect(session.getSessionId()).toMatch(UUID_V7_RE);
+		expect(session.getHeader()!.id).toBe(session.getSessionId());
 	});
 });


### PR DESCRIPTION
## Summary

- Align direct OpenAI Responses cache affinity with Codex by sending `prompt_cache_key`, `session_id`, and `x-client-request-id` from the same session id.
- Generate new Pi session ids as UUIDv7 while preserving explicit and resumed session ids.
- Add focused regressions for cache-affinity headers and UUIDv7 session ids.

## Why

Pavel pointed out that cache routing should use the same session id in both the prompt cache key and session header, and that UUIDv7 is preferred for session ids. Codex uses the same request pattern, including `x-client-request-id` for Responses HTTP requests.

## Validation

- `npx vitest --run test/openai-responses-copilot-provider.test.ts` from `packages/ai`
- `npx vitest --run test/session-manager/custom-session-id.test.ts` from `packages/coding-agent`

`npm run check` was attempted. It still reaches the pre-existing web-ui no-build type resolution failure where `packages/web-ui` cannot resolve sibling workspace packages without built `dist` declarations.
