### PR TITLE
feat: add stream idle timeout watchdog for all providers

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -106,6 +106,11 @@ export interface AgentOptions {
 	thinkingBudgets?: ThinkingBudgets;
 	transport?: Transport;
 	maxRetryDelayMs?: number;
+	/**
+	 * Maximum idle time in milliseconds to wait for a streaming chunk.
+	 * Passed through to the underlying pi-ai provider. Default: 0 (disabled).
+	 */
+	streamIdleTimeoutMs?: number;
 	toolExecution?: ToolExecutionMode;
 }
 
@@ -182,6 +187,8 @@ export class Agent {
 	public transport: Transport;
 	/** Optional cap for provider-requested retry delays. */
 	public maxRetryDelayMs?: number;
+	/** Maximum idle time (ms) before aborting a streaming connection. */
+	public streamIdleTimeoutMs?: number;
 	/** Tool execution strategy for assistant messages that contain multiple tool calls. */
 	public toolExecution: ToolExecutionMode;
 
@@ -200,6 +207,7 @@ export class Agent {
 		this.thinkingBudgets = options.thinkingBudgets;
 		this.transport = options.transport ?? "sse";
 		this.maxRetryDelayMs = options.maxRetryDelayMs;
+		this.streamIdleTimeoutMs = options.streamIdleTimeoutMs;
 		this.toolExecution = options.toolExecution ?? "parallel";
 	}
 
@@ -414,6 +422,7 @@ export class Agent {
 			transport: this.transport,
 			thinkingBudgets: this.thinkingBudgets,
 			maxRetryDelayMs: this.maxRetryDelayMs,
+			streamIdleTimeoutMs: this.streamIdleTimeoutMs,
 			toolExecution: this.toolExecution,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -31,5 +31,6 @@ export type {
 	OAuthProviderInterface,
 } from "./utils/oauth/types.js";
 export * from "./utils/overflow.js";
+export * from "./utils/stream-idle-timeout.js";
 export * from "./utils/typebox-helpers.js";
 export * from "./utils/validation.js";

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -43,6 +43,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.js";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -169,7 +170,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 
 			const response = await client.send(command, { abortSignal: options.signal });
 
-			for await (const item of response.stream!) {
+			for await (const item of withStreamIdleTimeout(response.stream!, options?.streamIdleTimeoutMs)) {
 				if (item.messageStart) {
 					if (item.messageStart.role !== ConversationRole.ASSISTANT) {
 						throw new Error("Unexpected assistant message start but got user message start instead");

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -28,6 +28,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
@@ -262,7 +263,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
 			const blocks = output.content as Block[];
 
-			for await (const event of anthropicStream) {
+			for await (const event of withStreamIdleTimeout(anthropicStream, options?.streamIdleTimeoutMs)) {
 				if (event.type === "message_start") {
 					output.responseId = event.message.id;
 					// Capture initial token usage from message_start event

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -12,6 +12,7 @@ import type {
 	StreamOptions,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
@@ -96,7 +97,12 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 			);
 			stream.push({ type: "start", partial: output });
 
-			await processResponsesStream(openaiStream, output, stream, model);
+			await processResponsesStream(
+				withStreamIdleTimeout(openaiStream, options?.streamIdleTimeoutMs),
+				output,
+				stream,
+				model,
+			);
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -6,6 +6,7 @@
 
 import type { Content, ThinkingConfig } from "@google/genai";
 import { calculateCost } from "../models.js";
+import { StreamIdleTimeoutError } from "../utils/stream-idle-timeout.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -525,7 +526,23 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 							throw new Error("Request was aborted");
 						}
 
-						const { done, value } = await reader.read();
+						let readResult: ReadableStreamReadResult<Uint8Array>;
+						if (options?.streamIdleTimeoutMs && options.streamIdleTimeoutMs > 0) {
+							let idleTimer: ReturnType<typeof setTimeout> | undefined;
+							readResult = await Promise.race([
+								reader.read(),
+								new Promise<never>((_, reject) => {
+									idleTimer = setTimeout(
+										() => reject(new StreamIdleTimeoutError(options.streamIdleTimeoutMs!)),
+										options.streamIdleTimeoutMs!,
+									);
+								}),
+							]);
+							clearTimeout(idleTimer);
+						} else {
+							readResult = await reader.read();
+						}
+						const { done, value } = readResult;
 						if (done) break;
 
 						buffer += decoder.decode(value, { stream: true });

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -526,10 +526,11 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 							throw new Error("Request was aborted");
 						}
 
-						let readResult: ReadableStreamReadResult<Uint8Array>;
+						let done: boolean;
+						let value: Uint8Array | undefined;
 						if (options?.streamIdleTimeoutMs && options.streamIdleTimeoutMs > 0) {
 							let idleTimer: ReturnType<typeof setTimeout> | undefined;
-							readResult = await Promise.race([
+							const readResult = await Promise.race([
 								reader.read(),
 								new Promise<never>((_, reject) => {
 									idleTimer = setTimeout(
@@ -539,10 +540,13 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 								}),
 							]);
 							clearTimeout(idleTimer);
+							done = readResult.done;
+							value = readResult.value;
 						} else {
-							readResult = await reader.read();
+							const readResult = await reader.read();
+							done = readResult.done;
+							value = readResult.value;
 						}
-						const { done, value } = readResult;
 						if (done) break;
 
 						buffer += decoder.decode(value, { stream: true });

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -22,6 +22,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.js";
 import type { GoogleThinkingLevel } from "./google-gemini-cli.js";
 import {
 	convertMessages,
@@ -100,7 +101,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 			let currentBlock: TextContent | ThinkingContent | null = null;
 			const blocks = output.content;
 			const blockIndex = () => blocks.length - 1;
-			for await (const chunk of googleStream) {
+			for await (const chunk of withStreamIdleTimeout(googleStream, options?.streamIdleTimeoutMs)) {
 				// Vertex uses the same @google/genai GenerateContentResponse type as Gemini.
 				// responseId is documented there as an output-only identifier for each response.
 				output.responseId ||= chunk.responseId;

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -22,6 +22,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.js";
 import type { GoogleThinkingLevel } from "./google-gemini-cli.js";
 import {
 	convertMessages,
@@ -85,7 +86,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 			let currentBlock: TextContent | ThinkingContent | null = null;
 			const blocks = output.content;
 			const blockIndex = () => blocks.length - 1;
-			for await (const chunk of googleStream) {
+			for await (const chunk of withStreamIdleTimeout(googleStream, options?.streamIdleTimeoutMs)) {
 				// @google/genai documents GenerateContentResponse.responseId as an output-only field
 				// used to identify each response. Keep the first non-empty one from the stream.
 				output.responseId ||= chunk.responseId;

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -27,6 +27,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -76,7 +77,12 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
 			}
 			const mistralStream = await mistral.chat.stream(payload, buildRequestOptions(model, options));
 			stream.push({ type: "start", partial: output });
-			await consumeChatStream(model, output, stream, mistralStream);
+			await consumeChatStream(
+				model,
+				output,
+				stream,
+				withStreamIdleTimeout(mistralStream, options?.streamIdleTimeoutMs),
+			);
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -27,6 +27,7 @@ import type {
 	StreamOptions,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
@@ -251,7 +252,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			}
 
 			stream.push({ type: "start", partial: output });
-			await processStream(response, output, stream, model);
+			await processStream(response, output, stream, model, options?.streamIdleTimeoutMs);
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
@@ -366,8 +367,14 @@ async function processStream(
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
 	model: Model<"openai-codex-responses">,
+	streamIdleTimeoutMs?: number,
 ): Promise<void> {
-	await processResponsesStream(mapCodexEvents(parseSSE(response)), output, stream, model);
+	await processResponsesStream(
+		withStreamIdleTimeout(mapCodexEvents(parseSSE(response)), streamIdleTimeoutMs),
+		output,
+		stream,
+		model,
+	);
 }
 
 async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): AsyncGenerator<ResponseStreamEvent> {
@@ -806,7 +813,12 @@ async function processWebSocketStream(
 		socket.send(JSON.stringify({ type: "response.create", ...body }));
 		onStart();
 		stream.push({ type: "start", partial: output });
-		await processResponsesStream(mapCodexEvents(parseWebSocket(socket, options?.signal)), output, stream, model);
+		await processResponsesStream(
+			withStreamIdleTimeout(mapCodexEvents(parseWebSocket(socket, options?.signal)), options?.streamIdleTimeoutMs),
+			output,
+			stream,
+			model,
+		);
 		if (options?.signal?.aborted) {
 			keepConnection = false;
 		}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -29,6 +29,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
@@ -126,7 +127,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				}
 			};
 
-			for await (const chunk of openaiStream) {
+			for await (const chunk of withStreamIdleTimeout(openaiStream, options?.streamIdleTimeoutMs)) {
 				if (!chunk || typeof chunk !== "object") continue;
 
 				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -14,6 +14,7 @@ import type {
 	Usage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
@@ -100,10 +101,16 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 			);
 			stream.push({ type: "start", partial: output });
 
-			await processResponsesStream(openaiStream, output, stream, model, {
-				serviceTier: options?.serviceTier,
-				applyServiceTierPricing,
-			});
+			await processResponsesStream(
+				withStreamIdleTimeout(openaiStream, options?.streamIdleTimeoutMs),
+				output,
+				stream,
+				model,
+				{
+					serviceTier: options?.serviceTier,
+					applyServiceTierPricing,
+				},
+			);
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -98,6 +98,15 @@ export interface StreamOptions {
 	 */
 	maxRetryDelayMs?: number;
 	/**
+	 * Maximum idle time in milliseconds to wait for a streaming chunk before
+	 * aborting. If no data arrives within this window, the stream is terminated
+	 * with a StreamIdleTimeoutError. This guards against silently dropped
+	 * connections where the server stops sending but the TCP socket stays open.
+	 *
+	 * Set to 0 or omit to disable (default). Recommended: 90000 (90 seconds).
+	 */
+	streamIdleTimeoutMs?: number;
+	/**
 	 * Optional metadata to include in API requests.
 	 * Providers extract the fields they understand and ignore the rest.
 	 * For example, Anthropic uses `user_id` for abuse tracking and rate limiting.

--- a/packages/ai/src/utils/stream-idle-timeout.ts
+++ b/packages/ai/src/utils/stream-idle-timeout.ts
@@ -1,0 +1,68 @@
+/**
+ * Error thrown when a streaming connection receives no data for longer than
+ * the configured idle timeout. Consumers can catch this specifically to
+ * distinguish idle timeouts from other errors.
+ */
+export class StreamIdleTimeoutError extends Error {
+	public readonly timeoutMs: number;
+
+	constructor(timeoutMs: number) {
+		super(`Stream idle timeout: no data received for ${timeoutMs / 1000}s`);
+		this.name = "StreamIdleTimeoutError";
+		this.timeoutMs = timeoutMs;
+	}
+}
+
+/**
+ * Wraps an async iterable with a per-chunk idle timeout watchdog.
+ *
+ * After each yielded chunk, a timer is reset. If no chunk arrives within
+ * `timeoutMs`, a {@link StreamIdleTimeoutError} is thrown. This guards
+ * against silently dropped HTTP/SSE connections where the server stops
+ * sending data but the TCP connection stays open.
+ *
+ * When `timeoutMs` is 0, undefined, or negative the source is yielded
+ * through without any timeout logic (zero overhead pass-through).
+ *
+ * @param source   - The upstream async iterable (e.g. SDK stream)
+ * @param timeoutMs - Maximum idle time in milliseconds before aborting
+ */
+export async function* withStreamIdleTimeout<T>(
+	source: AsyncIterable<T>,
+	timeoutMs: number | undefined,
+): AsyncGenerator<T> {
+	if (!timeoutMs || timeoutMs <= 0) {
+		yield* source;
+		return;
+	}
+
+	const iterator = source[Symbol.asyncIterator]();
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	try {
+		while (true) {
+			// Race: next chunk vs idle timeout
+			const result = await Promise.race([
+				iterator.next(),
+				new Promise<never>((_, reject) => {
+					timeoutId = setTimeout(() => reject(new StreamIdleTimeoutError(timeoutMs)), timeoutMs);
+				}),
+			]);
+
+			// Chunk arrived — clear the timeout
+			clearTimeout(timeoutId);
+			timeoutId = undefined;
+
+			if (result.done) break;
+			yield result.value;
+		}
+	} finally {
+		if (timeoutId !== undefined) clearTimeout(timeoutId);
+		// Signal the underlying iterator to release resources (close HTTP connection, etc.)
+		// Reason: we don't await return() because if the iterator is stuck in an
+		// unresolvable promise (the exact scenario this utility guards against),
+		// awaiting return() would hang forever. Fire-and-forget is safe here —
+		// the iterator will be GC'd along with any pending promises.
+		iterator.return?.(undefined);
+	}
+}

--- a/packages/ai/test/stream-idle-timeout.test.ts
+++ b/packages/ai/test/stream-idle-timeout.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { StreamIdleTimeoutError, withStreamIdleTimeout } from "../src/utils/stream-idle-timeout.js";
+
+/** Helper: create an async iterable that yields values with configurable delays */
+async function* delayedStream(items: { value: string; delayMs: number }[]): AsyncGenerator<string> {
+	for (const item of items) {
+		await new Promise((r) => setTimeout(r, item.delayMs));
+		yield item.value;
+	}
+}
+
+/** Helper: create an async iterable that never yields (hangs forever) */
+async function* hangingStream(): AsyncGenerator<string> {
+	await new Promise(() => {}); // never resolves
+	yield "unreachable";
+}
+
+describe("withStreamIdleTimeout", () => {
+	it("passes through all items when no timeout occurs", async () => {
+		const items = [
+			{ value: "a", delayMs: 10 },
+			{ value: "b", delayMs: 10 },
+			{ value: "c", delayMs: 10 },
+		];
+		const result: string[] = [];
+		for await (const item of withStreamIdleTimeout(delayedStream(items), 500)) {
+			result.push(item);
+		}
+		expect(result).toEqual(["a", "b", "c"]);
+	});
+
+	it("throws StreamIdleTimeoutError when stream hangs before first chunk", async () => {
+		await expect(async () => {
+			for await (const _item of withStreamIdleTimeout(hangingStream(), 100)) {
+				// should not reach here
+			}
+		}).rejects.toThrow(StreamIdleTimeoutError);
+	});
+
+	it("throws StreamIdleTimeoutError when gap between chunks exceeds timeout", async () => {
+		const items = [
+			{ value: "a", delayMs: 10 },
+			{ value: "b", delayMs: 300 }, // exceeds 100ms timeout
+		];
+		const result: string[] = [];
+		await expect(async () => {
+			for await (const item of withStreamIdleTimeout(delayedStream(items), 100)) {
+				result.push(item);
+			}
+		}).rejects.toThrow(StreamIdleTimeoutError);
+		expect(result).toEqual(["a"]); // only first item received before timeout
+	});
+
+	it("includes timeout duration in error message", async () => {
+		try {
+			for await (const _item of withStreamIdleTimeout(hangingStream(), 150)) {
+				// should not reach here
+			}
+		} catch (error) {
+			expect(error).toBeInstanceOf(StreamIdleTimeoutError);
+			expect((error as StreamIdleTimeoutError).message).toContain("0.15s");
+			expect((error as StreamIdleTimeoutError).timeoutMs).toBe(150);
+		}
+	});
+
+	it("passes through when timeoutMs is 0 (disabled)", async () => {
+		const items = [
+			{ value: "a", delayMs: 10 },
+			{ value: "b", delayMs: 10 },
+		];
+		const result: string[] = [];
+		for await (const item of withStreamIdleTimeout(delayedStream(items), 0)) {
+			result.push(item);
+		}
+		expect(result).toEqual(["a", "b"]);
+	});
+
+	it("passes through when timeoutMs is undefined", async () => {
+		const items = [
+			{ value: "a", delayMs: 10 },
+			{ value: "b", delayMs: 10 },
+		];
+		const result: string[] = [];
+		for await (const item of withStreamIdleTimeout(delayedStream(items), undefined)) {
+			result.push(item);
+		}
+		expect(result).toEqual(["a", "b"]);
+	});
+
+	it("cleans up timer on normal completion", async () => {
+		const items = [{ value: "done", delayMs: 10 }];
+		const result: string[] = [];
+		for await (const item of withStreamIdleTimeout(delayedStream(items), 5000)) {
+			result.push(item);
+		}
+		expect(result).toEqual(["done"]);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a per-chunk streaming idle timeout watchdog that detects and aborts hung API connections where the server stops sending data but the TCP socket stays open.

- New `withStreamIdleTimeout()` async generator utility that races each `iterator.next()` against a `setTimeout`
- New `streamIdleTimeoutMs` option on `StreamOptions` (default: disabled, recommended: `90000`)
- Applied to all 10 streaming providers
- Wired through `AgentOptions` in pi-agent-core so consumers can configure it per-agent

## Problem

When an LLM provider hangs mid-stream (accepts the HTTP request but sends zero streaming events), `agent.prompt()` blocks forever. We observed Gemini taking 385+ seconds for a first token with zero feedback — the connection was alive but silent. There is currently no mechanism to detect or abort this.

## Design

**Utility (`packages/ai/src/utils/stream-idle-timeout.ts`):**
- `StreamIdleTimeoutError` — custom error class with `timeoutMs` property
- `withStreamIdleTimeout(source, timeoutMs)` — wraps any `AsyncIterable` with a watchdog timer
- When `timeoutMs` is `0`, `undefined`, or negative → zero-overhead pass-through (disabled)
- When timeout fires → throws `StreamIdleTimeoutError`, caught by provider's existing error handler, surfaced as `stopReason: "error"`

**Provider integration:**
- 9 providers: one-line wrapper around `for await` loop
- `google-gemini-cli`: uses `reader.read()` directly, so timeout applied via `Promise.race` on each read

**Agent config (`packages/agent/src/agent.ts`):**
- `streamIdleTimeoutMs` added to `AgentOptions`
- Passed through `createLoopConfig()` → `streamSimple()` → provider

## Test plan

- [x] 7 unit tests covering: pass-through, first-chunk hang, mid-stream hang, error message content, disabled (0), disabled (undefined), cleanup
- [x] Existing `google-gemini-cli-empty-stream` test passes (watchdog disabled by default)
- [x] Existing `faux-provider` tests pass
- [x] All provider changes are no-ops when `streamIdleTimeoutMs` is not set