### PR TITLE
fix: use Promise.allSettled for parallel tool execution to prevent result loss

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -419,10 +419,14 @@ async function executeToolCallsParallel(
 		execution: executePreparedToolCall(prepared, signal, emit),
 	}));
 
-	for (const running of runningCalls) {
-		const executed = await running.execution;
-		results.push(
-			await finalizeExecutedToolCall(
+	// Use Promise.allSettled to ensure all parallel tool results are collected
+	// even if one tool's finalization throws. Sequential await would lose all
+	// results after the first failure, causing the agent loop to deadlock
+	// waiting for missing tool results that will never arrive.
+	const settled = await Promise.allSettled(
+		runningCalls.map(async (running) => {
+			const executed = await running.execution;
+			return finalizeExecutedToolCall(
 				currentContext,
 				assistantMessage,
 				running.prepared,
@@ -430,8 +434,28 @@ async function executeToolCallsParallel(
 				config,
 				signal,
 				emit,
-			),
-		);
+			);
+		}),
+	);
+
+	for (let i = 0; i < settled.length; i++) {
+		const outcome = settled[i];
+		if (outcome.status === "fulfilled") {
+			results.push(outcome.value);
+		} else {
+			// Emit an error tool result so the agent loop can continue.
+			const toolCall = runningCalls[i].prepared.toolCall;
+			results.push(
+				await emitToolCallOutcome(
+					toolCall,
+					createErrorToolResult(
+						outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason),
+					),
+					true,
+					emit,
+				),
+			);
+		}
 	}
 
 	return results;


### PR DESCRIPTION
## Bug

`executeToolCallsParallel` in `packages/agent/src/agent-loop.ts` uses a sequential `for...of` + `await` loop to collect results from parallel tool executions:

```typescript
for (const running of runningCalls) {
    const executed = await running.execution;
    results.push(await finalizeExecutedToolCall(...));
}
```

If `finalizeExecutedToolCall` throws (e.g. `afterToolCall` hook or `emit` throws), the loop exits immediately. All subsequent tool execution promises — which are already running in parallel — become orphaned. Their results are never collected, and the caller receives fewer `ToolResultMessage` entries than expected.

**Impact:** Consumers like OpenClaw that track pending tool call IDs will wait forever for the missing tool results, causing a permanent session deadlock. The only workaround is setting `parallelToolCalls=false` in config.

**Reproduction (confirmed on OpenClaw 2026.3.28, pi-agent-core 0.66.1):**
- 13 parallel `feishu_search_user` toolCalls dispatched
- Only 4 tool_execution_start events emitted, only 3 tool_execution_end events
- Remaining 9 toolCalls: no events, no exceptions, no results
- Session permanently stuck (independently reproduced on 2026-04-10 and 2026-04-11)

## Fix

Replace the sequential for-await loop with `Promise.allSettled` to ensure every parallel tool execution result is collected regardless of individual failures. For rejected promises, emit a synthetic error `ToolResultMessage` via `emitToolCallOutcome` so the agent loop can continue.

## Changes

`packages/agent/src/agent-loop.ts`: Rewrite the result collection in `executeToolCallsParallel` from sequential await to `Promise.allSettled` with error fallback.

## Impact

- **Normal case:** No behavior change; all promises fulfill and results are collected in order
- **Error case:** Failed tool finalizations produce error tool results instead of silently dropping all subsequent results
- Preserves existing parallel dispatch semantics (all executions start immediately)