### PR TITLE
fix(model-registry): allow omitting apiKey when provider has stored auth

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -481,8 +481,18 @@ export class ModelRegistry {
 				if (!providerConfig.baseUrl) {
 					throw new Error(`Provider ${providerName}: "baseUrl" is required when defining custom models.`);
 				}
-				if (!providerConfig.apiKey) {
-					throw new Error(`Provider ${providerName}: "apiKey" is required when defining custom models.`);
+				// apiKey can be omitted when the provider is already authenticated via /login
+				// (credentials are stored in auth.json). At request time, getApiKeyAndHeaders()
+				// calls authStorage.getApiKey() first, so stored credentials are used
+				// automatically even if providerConfig.apiKey is absent.
+				const hasStoredAuth = this.authStorage.hasAuth(providerName);
+				if (!providerConfig.apiKey && !hasStoredAuth) {
+					throw new Error(
+						`Provider ${providerName}: "apiKey" is required when defining custom models. ` +
+							`Set it to an environment variable name, a literal key, or a shell command ("!cmd"). ` +
+							`Alternatively, authenticate via /login (if supported) then reload models — ` +
+							`stored credentials are used automatically.`,
+					);
 				}
 			}
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -455,6 +455,74 @@ describe("ModelRegistry", () => {
 			expect(anthropicModels.some((m) => m.id.includes("claude"))).toBe(true);
 		});
 
+		test("apiKey can be omitted when provider already has stored credentials", () => {
+			// Simulate the user having logged in via /login (credentials in auth.json)
+			authStorage.set("anthropic", { type: "api_key", key: "sk-stored-key" });
+
+			writeFileSync(
+				modelsJsonPath,
+				JSON.stringify({
+					providers: {
+						anthropic: {
+							baseUrl: "https://proxy.example.com/v1",
+							api: "anthropic-messages",
+							// apiKey intentionally omitted — auth comes from authStorage
+							models: [
+								{
+									id: "claude-custom",
+									name: "Claude Custom",
+									reasoning: false,
+									input: ["text"],
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+									contextWindow: 100000,
+									maxTokens: 8000,
+								},
+							],
+						},
+					},
+				}),
+			);
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			expect(registry.getError()).toBeUndefined();
+			expect(getModelsForProvider(registry, "anthropic").some((m) => m.id === "claude-custom")).toBe(true);
+		});
+
+		test("apiKey missing with no stored credentials produces actionable error", () => {
+			// No stored credentials, no apiKey in models.json
+			writeFileSync(
+				modelsJsonPath,
+				JSON.stringify({
+					providers: {
+						anthropic: {
+							baseUrl: "https://proxy.example.com/v1",
+							api: "anthropic-messages",
+							models: [
+								{
+									id: "claude-custom",
+									name: "Claude Custom",
+									reasoning: false,
+									input: ["text"],
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+									contextWindow: 100000,
+									maxTokens: 8000,
+								},
+							],
+						},
+					},
+				}),
+			);
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const error = registry.getError();
+			expect(error).toBeDefined();
+			// Error must mention apiKey and all actionable alternatives
+			expect(error).toContain("apiKey");
+			expect(error).toContain("!cmd"); // shell command hint
+			expect(error).toContain("/login"); // stored-auth alternative
+			expect(error).toContain("environment variable"); // env var hint
+		});
+
 		test("removing custom models from models.json keeps built-in provider models", () => {
 			writeModelsJson({
 				anthropic: providerConfig("https://proxy.example.com/v1", [{ id: "claude-custom" }]),


### PR DESCRIPTION
## Problem

When adding custom models to a built-in provider in `models.json`, pi throws:

```
Provider openrouter: "apiKey" is required when defining custom models.
```

This happens even when the user already authenticated via `/login` and their credentials are stored in `auth.json`. At request time, `getApiKeyAndHeaders()` reads from `authStorage` first — so the stored key would be used automatically. The validation check is redundant for already-authenticated providers.

The error message also gives no hint about the three ways to supply `apiKey` (env var, literal, `!cmd`) or that `/login` credentials can substitute.

## Fix

1. Skip the `apiKey` requirement when `authStorage.hasAuth(providerName)` returns true
2. When `apiKey` is required (no stored auth), emit an actionable error listing all options
