### PR TITLE
fix(model-registry): models.json custom models survive registerProvider()

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -288,6 +288,13 @@ export const clearApiKeyCache = clearConfigValueCache;
  */
 export class ModelRegistry {
 	private models: Model<Api>[] = [];
+	/**
+	 * Custom models loaded from models.json.
+	 * Kept as a separate field so they can be re-merged after registerProvider() full
+	 * replacements — which otherwise wipe all existing models for a provider.
+	 * Updated in loadModels() (constructor and refresh()). Read-only in applyProviderConfig().
+	 */
+	private customModelsFromJson: Model<Api>[] = [];
 	private providerRequestConfigs: Map<string, ProviderRequestConfig> = new Map();
 	private modelRequestHeaders: Map<string, Record<string, string>> = new Map();
 	private registeredProviders: Map<string, ProviderConfigInput> = new Map();
@@ -314,6 +321,7 @@ export class ModelRegistry {
 	refresh(): void {
 		this.providerRequestConfigs.clear();
 		this.modelRequestHeaders.clear();
+		this.customModelsFromJson = [];
 		this.loadError = undefined;
 
 		// Ensure dynamic API/OAuth registrations are rebuilt from current provider state.
@@ -348,6 +356,7 @@ export class ModelRegistry {
 			// Keep built-in models even if custom models failed to load
 		}
 
+		this.customModelsFromJson = customModels;
 		const builtInModels = this.loadBuiltInModels(overrides, modelOverrides);
 		let combined = this.mergeCustomModels(builtInModels, customModels);
 
@@ -772,6 +781,14 @@ export class ModelRegistry {
 					headers: undefined,
 					compat: modelDef.compat,
 				} as Model<Api>);
+			}
+
+			// Re-merge any models.json custom models for this provider that were
+			// wiped by the full replacement above. Custom entries win on id conflicts.
+			// O(n) filter is acceptable for expected scale (dozens of custom models).
+			const customForProvider = this.customModelsFromJson.filter((m) => m.provider === providerName);
+			if (customForProvider.length > 0) {
+				this.models = this.mergeCustomModels(this.models, customForProvider);
 			}
 
 			// Apply OAuth modifyModels if credentials exist (e.g., to update baseUrl)

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -716,6 +716,145 @@ describe("ModelRegistry", () => {
 	});
 
 	describe("dynamic provider lifecycle", () => {
+		function kilocodeCustomModel() {
+			return {
+				id: "qwen/qwen3.6-plus",
+				name: "Qwen3.6 Plus",
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 0.325, output: 1.95, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1000000,
+				maxTokens: 65536,
+			};
+		}
+
+		function kilocodeProviderJson(extraModels: unknown[] = []) {
+			return {
+				baseUrl: "https://api.kilo.ai/api/openrouter",
+				apiKey: "TEST_KEY",
+				api: "openai-completions",
+				models: [kilocodeCustomModel(), ...extraModels],
+			};
+		}
+
+		test("registerProvider full replacement re-merges models.json custom entries", () => {
+			writeRawModelsJson({ kilocode: kilocodeProviderJson() });
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			expect(getModelsForProvider(registry, "kilocode").some((m) => m.id === "qwen/qwen3.6-plus")).toBe(true);
+
+			// Simulate kilocode extension calling registerProvider (full replacement with different models)
+			registry.registerProvider("kilocode", {
+				baseUrl: "https://api.kilo.ai/api/openrouter",
+				apiKey: "TEST_KEY",
+				api: "openai-completions",
+				models: [
+					{
+						id: "anthropic/claude-sonnet-4",
+						name: "Claude Sonnet 4 (Kilo)",
+						reasoning: false,
+						input: ["text", "image"],
+						cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+						contextWindow: 200000,
+						maxTokens: 8192,
+					},
+				],
+			});
+
+			const kilocodeModels = getModelsForProvider(registry, "kilocode");
+			expect(kilocodeModels).toHaveLength(2); // no duplicates
+			expect(kilocodeModels.some((m) => m.id === "anthropic/claude-sonnet-4")).toBe(true);
+			expect(kilocodeModels.some((m) => m.id === "qwen/qwen3.6-plus")).toBe(true);
+		});
+
+		test("models.json custom model wins on id conflict with registerProvider model", () => {
+			writeRawModelsJson({
+				kilocode: {
+					baseUrl: "https://api.kilo.ai/api/openrouter",
+					apiKey: "TEST_KEY",
+					api: "openai-completions",
+					models: [
+						{
+							id: "shared-model",
+							name: "Custom Name from models.json",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 100000,
+							maxTokens: 8000,
+						},
+					],
+				},
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			registry.registerProvider("kilocode", {
+				baseUrl: "https://api.kilo.ai/api/openrouter",
+				apiKey: "TEST_KEY",
+				api: "openai-completions",
+				models: [
+					{
+						id: "shared-model",
+						name: "Name from registerProvider",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 100000,
+						maxTokens: 8000,
+					},
+				],
+			});
+
+			const model = getModelsForProvider(registry, "kilocode").find((m) => m.id === "shared-model");
+			expect(model).toBeDefined();
+			expect(model?.name).toBe("Custom Name from models.json"); // models.json wins
+		});
+
+		test("re-merge only affects the targeted provider, not others", () => {
+			writeRawModelsJson({
+				kilocode: kilocodeProviderJson(),
+				anthropic: {
+					baseUrl: "https://proxy.example.com/v1",
+					apiKey: "TEST_KEY",
+					api: "anthropic-messages",
+					models: [
+						{
+							id: "claude-custom",
+							name: "Claude Custom",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 100000,
+							maxTokens: 8000,
+						},
+					],
+				},
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			expect(getModelsForProvider(registry, "anthropic").some((m) => m.id === "claude-custom")).toBe(true);
+
+			// Replacing kilocode should not disturb anthropic custom models
+			registry.registerProvider("kilocode", {
+				baseUrl: "https://api.kilo.ai/api/openrouter",
+				apiKey: "TEST_KEY",
+				api: "openai-completions",
+				models: [
+					{
+						id: "some-model",
+						name: "Some",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 100000,
+						maxTokens: 8000,
+					},
+				],
+			});
+
+			expect(getModelsForProvider(registry, "anthropic").some((m) => m.id === "claude-custom")).toBe(true);
+			expect(getModelsForProvider(registry, "kilocode").some((m) => m.id === "qwen/qwen3.6-plus")).toBe(true);
+		});
+
 		test("failed registerProvider does not persist invalid streamSimple config", () => {
 			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
 


### PR DESCRIPTION
Closes #2956

Extension providers (e.g. `kilocode`) call `registerProvider()` which does a full model replacement, silently wiping any `models.json` custom entries for that provider.

Changes:
- Store custom models from `models.json` in `customModelsFromJson` field
- After every full replacement in `applyProviderConfig()`, re-merge `models.json` custom models for that provider
- Custom entries win on ID conflicts — consistent with existing built-in vs custom merge semantics
- Field is reset explicitly in `refresh()` and repopulated by `loadModels()`

52/52 tests passing.
