### PR TITLE
fix(coding-agent): kill detached child processes on SIGHUP/SIGTERM to prevent orphan leaks

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -11,6 +11,19 @@ process.emitWarning = (() => {}) as typeof process.emitWarning;
 
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { main } from "./main.js";
+import { killAllTrackedChildren } from "./utils/shell.js";
+
+// When the controlling terminal closes it sends SIGHUP to the foreground
+// process group.  Child processes spawned with `detached: true` live in their
+// own process groups and never receive this signal, so they would keep running
+// as orphans (reparented to PID 1) forever.  Explicitly kill them before exit.
+// SIGTERM is handled for the same reason (e.g. `kill <pid>`, system shutdown).
+for (const sig of ["SIGHUP", "SIGTERM"] as const) {
+	process.on(sig, () => {
+		killAllTrackedChildren();
+		process.exit(0);
+	});
+}
 
 setGlobalDispatcher(new EnvHttpProxyAgent());
 

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -10,7 +10,7 @@ import { keyHint } from "../../modes/interactive/components/keybinding-hints.js"
 import { truncateToVisualLines } from "../../modes/interactive/components/visual-truncate.js";
 import { theme } from "../../modes/interactive/theme/theme.js";
 import { waitForChildProcess } from "../../utils/child-process.js";
-import { getShellConfig, getShellEnv, killProcessTree } from "../../utils/shell.js";
+import { getShellConfig, getShellEnv, killProcessTree, trackChildPid, untrackChildPid } from "../../utils/shell.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import { getTextOutput, invalidArgText, str } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
@@ -81,6 +81,7 @@ export function createLocalBashOperations(): BashOperations {
 					env: env ?? getShellEnv(),
 					stdio: ["ignore", "pipe", "pipe"],
 				});
+				if (child.pid) trackChildPid(child.pid);
 				let timedOut = false;
 				let timeoutHandle: NodeJS.Timeout | undefined;
 				// Set timeout if provided.
@@ -105,6 +106,7 @@ export function createLocalBashOperations(): BashOperations {
 				// on inherited stdio handles held by detached descendants.
 				waitForChildProcess(child)
 					.then((code) => {
+						if (child.pid) untrackChildPid(child.pid);
 						if (timeoutHandle) clearTimeout(timeoutHandle);
 						if (signal) signal.removeEventListener("abort", onAbort);
 						if (signal?.aborted) {
@@ -118,6 +120,7 @@ export function createLocalBashOperations(): BashOperations {
 						resolve({ exitCode: code });
 					})
 					.catch((err) => {
+						if (child.pid) untrackChildPid(child.pid);
 						if (timeoutHandle) clearTimeout(timeoutHandle);
 						if (signal) signal.removeEventListener("abort", onAbort);
 						reject(err);

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -173,6 +173,35 @@ export function sanitizeBinaryOutput(str: string): string {
 }
 
 /**
+ * Registry of actively running detached child process PIDs.
+ *
+ * Because child processes are spawned with `detached: true` (to enable
+ * process-group kills), they live in their own process groups and do NOT
+ * receive SIGHUP when the controlling terminal closes. If the parent pi
+ * process is killed by SIGHUP without explicitly cleaning these up, the
+ * children become orphans (reparented to PID 1) and run forever.
+ *
+ * Call `trackChildPid` / `untrackChildPid` around every detached spawn,
+ * and `killAllTrackedChildren` from signal handlers to prevent leaks.
+ */
+const trackedChildPids = new Set<number>();
+
+export function trackChildPid(pid: number): void {
+	trackedChildPids.add(pid);
+}
+
+export function untrackChildPid(pid: number): void {
+	trackedChildPids.delete(pid);
+}
+
+export function killAllTrackedChildren(): void {
+	for (const pid of trackedChildPids) {
+		killProcessTree(pid);
+	}
+	trackedChildPids.clear();
+}
+
+/**
  * Kill a process and all its children (cross-platform)
  */
 export function killProcessTree(pid: number): void {


### PR DESCRIPTION
## Problem

When closing a terminal, the OS sends `SIGHUP` to the foreground process group. The bash tool spawns child processes with `detached: true` (in `createLocalBashOperations()`), placing them in their own process groups. These children **never receive SIGHUP** and become orphans reparented to PID 1 (launchd on macOS, init on Linux), running indefinitely.

This is amplified when the AI model spawns sub-agent `pi` instances via the bash tool — each can spawn more, creating deep recursive chains. On terminal close, the entire tree leaks. I observed **811 orphaned `pi` processes** consuming ~90GB of RAM after a single session.

### Root cause

1. `bash.ts:80` — `spawn()` with `detached: true` (needed for `killProcessTree()` to work via `process.kill(-pid)`)
2. `cli.ts` — no `SIGHUP` or `SIGTERM` handler to propagate termination to detached children
3. Recursive self-invocation (AI spawning `pi` via bash) multiplies the leak

### Steps to reproduce

1. Run `pi` in a terminal
2. Let the AI execute a few bash commands (or spawn sub-agents)
3. Close the terminal window (not Ctrl+C — close the tab/window)
4. Run `pgrep -x pi | wc -l` — orphaned processes remain

## Fix

- **`shell.ts`**: Add a `trackedChildPids` registry with `trackChildPid()`, `untrackChildPid()`, and `killAllTrackedChildren()`
- **`bash.ts`**: Track each detached child PID on spawn, untrack on exit
- **`cli.ts`**: Install `SIGHUP` and `SIGTERM` handlers that call `killAllTrackedChildren()` before `process.exit()`

This preserves the existing `detached: true` + `killProcessTree()` pattern (which is correct for active cleanup) while adding the missing passive cleanup path.

## Test plan

- [ ] Start `pi`, run a few bash commands, close the terminal — verify no orphaned `pi` processes remain (`pgrep -x pi`)
- [ ] Start `pi`, run a long-running bash command, press Ctrl+C — verify the command is still killed properly (existing behavior preserved)
- [ ] Start `pi`, run `kill <pid>` from another terminal — verify child processes are cleaned up