### PR TITLE
fix: skip npm reinstall when package is already at latest version

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -947,20 +947,39 @@ export class DefaultPackageManager implements PackageManager {
 	}
 
 	async update(source?: string): Promise<void> {
+		if (isOfflineModeEnabled()) {
+			return;
+		}
+
+		// Check for available updates first
+		const updates = await this.checkForAvailableUpdates();
+		if (updates.length === 0) {
+			return;
+		}
+
 		const globalSettings = this.settingsManager.getGlobalSettings();
 		const projectSettings = this.settingsManager.getProjectSettings();
 		const identity = source ? this.getPackageIdentity(source) : undefined;
 		let matched = false;
 
+		// Filter updates by source if specified
+		const updateSources = new Set(
+			updates
+				.filter(u => !identity || this.getPackageIdentity(u.source, "user") === identity || this.getPackageIdentity(u.source, "project") === identity)
+				.map(u => u.source)
+		);
+
 		for (const pkg of globalSettings.packages ?? []) {
 			const sourceStr = typeof pkg === "string" ? pkg : pkg.source;
 			if (identity && this.getPackageIdentity(sourceStr, "user") !== identity) continue;
+			if (!updateSources.has(sourceStr)) continue;
 			matched = true;
 			await this.updateSourceForScope(sourceStr, "user");
 		}
 		for (const pkg of projectSettings.packages ?? []) {
 			const sourceStr = typeof pkg === "string" ? pkg : pkg.source;
 			if (identity && this.getPackageIdentity(sourceStr, "project") !== identity) continue;
+			if (!updateSources.has(sourceStr)) continue;
 			matched = true;
 			await this.updateSourceForScope(sourceStr, "project");
 		}


### PR DESCRIPTION
**Summary**
Before running updates, check if updates are actually available using the existing \`checkForAvailableUpdates()\` method. If no updates exist, return early instead of blindly running \`npm install @latest\`.

**The Problem**
The \`update()\` method was iterating through all packages and running \`npm install <pkg>@latest\` regardless of whether a newer version existed. This caused 259+ packages to be reinstalled on every \`pi update\` call, even when nothing needed updating.

**The Fix**
1. Call \`checkForAvailableUpdates()\` at the start of \`update()\`
2. Build a set of package sources that have available updates
3. Only update packages that are in this set
4. Return early if no updates are available

This mirrors the fix in [#2503](https://github.com/badlogic/pi-mono/issues/2503) which added HEAD comparison for git packages.

**Testing**
- \`pi update\` on already-up-to-date packages now does nothing
- \`pi update\` still correctly updates packages when newer versions exist
- \`pi update <specific-package>\` still works with the filter applied

**Related Issue**
Fixes #3000