### PR TITLE
feat(coding-agent): add resume scope to /settings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 
 - Set `PI_CODING_AGENT=true` environment variable at startup so sub-processes can detect they are running inside the coding agent ([#2868](https://github.com/badlogic/pi-mono/issues/2868))
+- Added `resumeScope` setting (`"current"` | `"all"`) to control which tab opens by default in the session resume picker
 
 ## [0.66.1] - 2026-04-08
 

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -13,6 +13,7 @@ type SessionsLoader = (onProgress?: SessionListProgress) => Promise<SessionInfo[
 export async function selectSession(
 	currentSessionsLoader: SessionsLoader,
 	allSessionsLoader: SessionsLoader,
+	initialScope: "current" | "all" = "current",
 ): Promise<string | null> {
 	return new Promise((resolve) => {
 		const ui = new TUI(new ProcessTerminal());
@@ -42,7 +43,7 @@ export async function selectSession(
 				process.exit(0);
 			},
 			() => ui.requestRender(),
-			{ showRenameHint: false, keybindings },
+			{ showRenameHint: false, keybindings, initialScope },
 		);
 
 		ui.addChild(selector);

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -95,6 +95,7 @@ export interface Settings {
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
 	sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
+	resumeScope?: "current" | "all"; // default: "current" - scope shown by default in the session resume picker
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -955,5 +956,15 @@ export class SettingsManager {
 
 	getCodeBlockIndent(): string {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
+	}
+
+	getResumeScope(): "current" | "all" {
+		return this.settings.resumeScope ?? "current";
+	}
+
+	setResumeScope(scope: "current" | "all"): void {
+		this.globalSettings.resumeScope = scope;
+		this.markModified("resumeScope");
+		this.save();
 	}
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -265,6 +265,7 @@ async function createSessionManager(
 			const selectedPath = await selectSession(
 				(onProgress) => SessionManager.list(cwd, sessionDir, onProgress),
 				SessionManager.listAll,
+				settingsManager.getResumeScope(),
 			);
 			if (!selectedPath) {
 				console.log(chalk.dim("No session selected"));

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -731,11 +731,13 @@ export class SessionSelectorComponent extends Container implements Focusable {
 			renameSession?: (sessionPath: string, currentName: string | undefined) => Promise<void>;
 			showRenameHint?: boolean;
 			keybindings?: KeybindingsManager;
+			initialScope?: SessionScope;
 		},
 		currentSessionFilePath?: string,
 	) {
 		super();
 		this.keybindings = options?.keybindings ?? KeybindingsManager.create();
+		this.scope = options?.initialScope ?? "current";
 		this.currentSessionsLoader = currentSessionsLoader;
 		this.allSessionsLoader = allSessionsLoader;
 		this.onCancel = onCancel;
@@ -830,12 +832,8 @@ export class SessionSelectorComponent extends Container implements Focusable {
 			this.requestRender();
 		};
 
-		// Start loading current sessions immediately
-		this.loadCurrentSessions();
-	}
-
-	private loadCurrentSessions(): void {
-		void this.loadScope("current", "initial");
+		// Start loading the initial scope immediately
+		void this.loadScope(this.scope, "initial");
 	}
 
 	private enterRenameMode(sessionPath: string, currentName: string | undefined): void {

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -50,6 +50,7 @@ export interface SettingsConfig {
 	autocompleteMaxVisible: number;
 	quietStartup: boolean;
 	clearOnShrink: boolean;
+	resumeScope: "current" | "all";
 }
 
 export interface SettingsCallbacks {
@@ -73,6 +74,7 @@ export interface SettingsCallbacks {
 	onAutocompleteMaxVisibleChange: (maxVisible: number) => void;
 	onQuietStartupChange: (enabled: boolean) => void;
 	onClearOnShrinkChange: (enabled: boolean) => void;
+	onResumeScopeChange: (scope: "current" | "all") => void;
 	onCancel: () => void;
 }
 
@@ -354,6 +356,16 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
+		// Resume scope toggle (insert after clear-on-shrink)
+		const clearOnShrinkIndex = items.findIndex((item) => item.id === "clear-on-shrink");
+		items.splice(clearOnShrinkIndex + 1, 0, {
+			id: "resume-scope",
+			label: "Resume scope",
+			description: "Default scope shown when opening the session resume picker",
+			currentValue: config.resumeScope,
+			values: ["current", "all"],
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -415,6 +427,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "clear-on-shrink":
 						callbacks.onClearOnShrinkChange(newValue === "true");
+						break;
+					case "resume-scope":
+						callbacks.onResumeScopeChange(newValue as "current" | "all");
 						break;
 				}
 			},

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3358,6 +3358,7 @@ export class InteractiveMode {
 					autocompleteMaxVisible: this.settingsManager.getAutocompleteMaxVisible(),
 					quietStartup: this.settingsManager.getQuietStartup(),
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
+					resumeScope: this.settingsManager.getResumeScope(),
 				},
 				{
 					onAutoCompactChange: (enabled) => {
@@ -3456,6 +3457,9 @@ export class InteractiveMode {
 					onClearOnShrinkChange: (enabled) => {
 						this.settingsManager.setClearOnShrink(enabled);
 						this.ui.setClearOnShrink(enabled);
+					},
+					onResumeScopeChange: (scope) => {
+						this.settingsManager.setResumeScope(scope);
 					},
 					onCancel: () => {
 						done();
@@ -3883,6 +3887,7 @@ export class InteractiveMode {
 					},
 					showRenameHint: true,
 					keybindings: this.keybindings,
+					initialScope: this.settingsManager.getResumeScope(),
 				},
 
 				this.sessionManager.getSessionFile(),


### PR DESCRIPTION
I commonly like to have an "pi -r" alias but I would like it to be easy to jump around to multiple workspaces / folders and this makes that possible more easily.