### PR TITLE
fix(coding-agent): handle overlapping compactions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Updated `antigravity-image-gen.ts` example extension to use User-Agent version `1.21.9` ([#2901](https://github.com/badlogic/pi-mono/pull/2901) by [@aadishv](https://github.com/aadishv))
+- Fixed overlapping manual and auto compactions to share a stable cancel-all signal, preventing `Cannot read properties of undefined (reading 'signal')` crashes during concurrent compaction runs ([#3075](https://github.com/badlogic/pi-mono/pull/3075) by [@aliou](https://github.com/aliou))
+
 ### Added
 
 - Set `PI_CODING_AGENT=true` environment variable at startup so sub-processes can detect they are running inside the coding agent ([#2868](https://github.com/badlogic/pi-mono/issues/2868))

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -249,8 +249,8 @@ export class AgentSession {
 	private _pendingNextTurnMessages: CustomMessage[] = [];
 
 	// Compaction state
-	private _compactionAbortController: AbortController | undefined = undefined;
-	private _autoCompactionAbortController: AbortController | undefined = undefined;
+	private _compactionCancelController: AbortController | undefined = undefined;
+	private _activeCompactionControllers = new Set<AbortController>();
 	private _overflowRecoveryAttempted = false;
 
 	// Branch summarization state
@@ -802,11 +802,7 @@ export class AgentSession {
 
 	/** Whether compaction or branch summarization is currently running */
 	get isCompacting(): boolean {
-		return (
-			this._autoCompactionAbortController !== undefined ||
-			this._compactionAbortController !== undefined ||
-			this._branchSummaryAbortController !== undefined
-		);
+		return this._activeCompactionControllers.size > 0 || this._branchSummaryAbortController !== undefined;
 	}
 
 	/** All messages including custom types like BashExecutionMessage */
@@ -1584,7 +1580,12 @@ export class AgentSession {
 	async compact(customInstructions?: string): Promise<CompactionResult> {
 		this._disconnectFromAgent();
 		await this.abort();
-		this._compactionAbortController = new AbortController();
+		if (!this._compactionCancelController) {
+			this._compactionCancelController = new AbortController();
+		}
+		const controller = new AbortController();
+		this._activeCompactionControllers.add(controller);
+		const signal = AbortSignal.any([controller.signal, this._compactionCancelController.signal]);
 		this._emit({ type: "compaction_start", reason: "manual" });
 
 		try {
@@ -1616,7 +1617,7 @@ export class AgentSession {
 					preparation,
 					branchEntries: pathEntries,
 					customInstructions,
-					signal: this._compactionAbortController.signal,
+					signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (result?.cancel) {
@@ -1642,21 +1643,14 @@ export class AgentSession {
 				details = extensionCompaction.details;
 			} else {
 				// Generate compaction result
-				const result = await compact(
-					preparation,
-					this.model,
-					apiKey,
-					headers,
-					customInstructions,
-					this._compactionAbortController.signal,
-				);
+				const result = await compact(preparation, this.model, apiKey, headers, customInstructions, signal);
 				summary = result.summary;
 				firstKeptEntryId = result.firstKeptEntryId;
 				tokensBefore = result.tokensBefore;
 				details = result.details;
 			}
 
-			if (this._compactionAbortController.signal.aborted) {
+			if (signal.aborted) {
 				throw new Error("Compaction cancelled");
 			}
 
@@ -1705,7 +1699,10 @@ export class AgentSession {
 			});
 			throw error;
 		} finally {
-			this._compactionAbortController = undefined;
+			this._activeCompactionControllers.delete(controller);
+			if (this._activeCompactionControllers.size === 0) {
+				this._compactionCancelController = undefined;
+			}
 			this._reconnectToAgent();
 		}
 	}
@@ -1714,8 +1711,7 @@ export class AgentSession {
 	 * Cancel in-progress compaction (manual or auto).
 	 */
 	abortCompaction(): void {
-		this._compactionAbortController?.abort();
-		this._autoCompactionAbortController?.abort();
+		this._compactionCancelController?.abort();
 	}
 
 	/**
@@ -1821,9 +1817,17 @@ export class AgentSession {
 	 */
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<void> {
 		const settings = this.settingsManager.getCompactionSettings();
+		if (this._activeCompactionControllers.size > 0) {
+			return;
+		}
 
 		this._emit({ type: "compaction_start", reason });
-		this._autoCompactionAbortController = new AbortController();
+		if (!this._compactionCancelController) {
+			this._compactionCancelController = new AbortController();
+		}
+		const controller = new AbortController();
+		this._activeCompactionControllers.add(controller);
+		const signal = AbortSignal.any([controller.signal, this._compactionCancelController.signal]);
 
 		try {
 			if (!this.model) {
@@ -1873,7 +1877,7 @@ export class AgentSession {
 					preparation,
 					branchEntries: pathEntries,
 					customInstructions: undefined,
-					signal: this._autoCompactionAbortController.signal,
+					signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (extensionResult?.cancel) {
@@ -1906,21 +1910,14 @@ export class AgentSession {
 				details = extensionCompaction.details;
 			} else {
 				// Generate compaction result
-				const compactResult = await compact(
-					preparation,
-					this.model,
-					apiKey,
-					headers,
-					undefined,
-					this._autoCompactionAbortController.signal,
-				);
+				const compactResult = await compact(preparation, this.model, apiKey, headers, undefined, signal);
 				summary = compactResult.summary;
 				firstKeptEntryId = compactResult.firstKeptEntryId;
 				tokensBefore = compactResult.tokensBefore;
 				details = compactResult.details;
 			}
 
-			if (this._autoCompactionAbortController.signal.aborted) {
+			if (signal.aborted) {
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -1988,7 +1985,10 @@ export class AgentSession {
 						: `Auto-compaction failed: ${errorMessage}`,
 			});
 		} finally {
-			this._autoCompactionAbortController = undefined;
+			this._activeCompactionControllers.delete(controller);
+			if (this._activeCompactionControllers.size === 0) {
+				this._compactionCancelController = undefined;
+			}
 		}
 	}
 

--- a/packages/coding-agent/test/suite/regressions/2911-overlapping-compaction-signal.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2911-overlapping-compaction-signal.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Regression test for issue #2911
+ * Compaction can fail with "Cannot read properties of undefined (reading 'signal')"
+ * when compactions overlap.
+ *
+ * The bug: both compact() and _runAutoCompaction() stored their AbortController on
+ * shared instance fields. If two compactions of the same kind overlap, the second one
+ * replaces the shared field, and when the first one's finally block sets it to
+ * undefined, the second one reads undefined and crashes on .signal.
+ */
+
+import { fauxAssistantMessage } from "@mariozechner/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, type Harness } from "../harness.js";
+
+type SessionWithCompactionInternals = {
+	_compactionCancelController: AbortController | undefined;
+	_activeCompactionControllers: Set<AbortController>;
+	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+};
+
+/**
+ * Create a slow compaction extension that takes time to complete,
+ * allowing overlapping compactions to be triggered.
+ */
+function slowCompactionExtension(delayMs: number) {
+	return (pi: unknown) => {
+		const api = pi as {
+			on: (
+				event: string,
+				handler: (event: {
+					preparation: { firstKeptEntryId: string; tokensBefore: number };
+					signal: AbortSignal;
+				}) => Promise<unknown>,
+			) => void;
+		};
+		api.on("session_before_compact", async (event) => {
+			await new Promise<void>((resolve) => {
+				const timeout = setTimeout(resolve, delayMs);
+				event.signal.addEventListener("abort", () => {
+					clearTimeout(timeout);
+					resolve();
+				});
+			});
+			if (event.signal.aborted) return { cancel: true as const };
+			return {
+				compaction: {
+					summary: "slow extension compact",
+					firstKeptEntryId: event.preparation.firstKeptEntryId,
+					tokensBefore: event.preparation.tokensBefore,
+					details: { source: "slow-extension" },
+				},
+			};
+		});
+	};
+}
+
+describe("issue #2911 overlapping compaction signal", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("does not crash when two manual compactions overlap", async () => {
+		// Use a slow extension so the first compact() is still in-flight
+		// when we trigger a second compact().
+		const harness = await createHarness({
+			extensionFactories: [slowCompactionExtension(200)],
+		});
+		harnesses.push(harness);
+
+		await harness.session.prompt("one");
+		await harness.session.prompt("two");
+
+		// Start first compact - it will take 200ms due to slow extension
+		const firstCompact = harness.session.compact();
+
+		// Let the first compact get past the abort controller creation
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// The first compact is still running. Start a second compact.
+		// Both compactions should share the cancel-all signal and keep
+		// their own local controllers until they finish.
+		const secondCompact = harness.session.compact();
+
+		// Both should settle without "Cannot read properties of undefined (reading 'signal')"
+		const results = await Promise.allSettled([firstCompact, secondCompact]);
+
+		// At least one should succeed (the second one)
+		const successes = results.filter((r) => r.status === "fulfilled");
+		expect(successes.length).toBeGreaterThanOrEqual(1);
+
+		// Neither should fail with the signal bug
+		for (const result of results) {
+			if (result.status === "rejected") {
+				const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+				expect(message).not.toContain("Cannot read properties of undefined");
+			}
+		}
+
+		// After both settle, compaction state should be cleared
+		const internals = harness.session as unknown as SessionWithCompactionInternals;
+		expect(internals._compactionCancelController).toBeUndefined();
+		expect(internals._activeCompactionControllers.size).toBe(0);
+	});
+
+	it("does not crash when manual and auto compactions overlap", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [slowCompactionExtension(200)],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("first");
+		await harness.session.prompt("second");
+
+		// Trigger auto-compaction via the internal method
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const autoCompactPromise = sessionInternals._runAutoCompaction("threshold", false);
+
+		// Let it get started
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// Now also trigger a manual compact while auto is running
+		const manualCompactPromise = harness.session.compact();
+
+		// Both should settle
+		const results = await Promise.allSettled([autoCompactPromise, manualCompactPromise]);
+
+		for (const result of results) {
+			if (result.status === "rejected") {
+				const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+				expect(message).not.toContain("Cannot read properties of undefined");
+			}
+		}
+
+		// Shared compaction state should be cleared
+		expect(sessionInternals._compactionCancelController).toBeUndefined();
+		expect(sessionInternals._activeCompactionControllers.size).toBe(0);
+	});
+
+	it("skips second auto compaction when one is already running", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [slowCompactionExtension(200)],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("first");
+		await harness.session.prompt("second");
+
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		// Clear events so we only count from the two _runAutoCompaction calls
+		harness.events.length = 0;
+
+		// Start first auto-compaction
+		const first = sessionInternals._runAutoCompaction("threshold", false);
+
+		// Let it get past controller creation
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// Start second auto-compaction while first is still running.
+		// It should skip because one is already in progress.
+		const second = sessionInternals._runAutoCompaction("threshold", false);
+
+		// Both should settle
+		await Promise.allSettled([first, second]);
+
+		// The second auto-compaction should have been skipped —
+		// only one compaction_start event should have been emitted for this pair.
+		const startEvents = harness.eventsOfType("compaction_start");
+		expect(startEvents).toHaveLength(1);
+
+		// And only one compaction_end event
+		const endEvents = harness.eventsOfType("compaction_end");
+		expect(endEvents).toHaveLength(1);
+
+		// Shared compaction state should be cleared after both settle
+		expect(sessionInternals._compactionCancelController).toBeUndefined();
+		expect(sessionInternals._activeCompactionControllers.size).toBe(0);
+	});
+});


### PR DESCRIPTION
Hello! This is an attempt at fixing https://github.com/badlogic/pi-mono/issues/2911

Decided on the following:
- Prevent overlapping automated compacts. I don't think it's even possible, but now we just don't enter in this part of the code at all.
- Store one signal per compaction and cancel them all on `esc`. I think this is debatable; I personally don't think we should allow multiple compaction at once but since compaction can be entirely customised, there could be some use cases where it makes sense, so this handles that.

Sessions:
- Adding failing tests: https://pi.dev/session/#b8d21ceaa0cf42c356b324277f588f60
- Investigation: https://pi.dev/session/#ae5fc5951dce2432a144853a523ed173
- Implementation: https://pi.dev/session/#d7269bca253b527fe0d9c7a44928db2b

------

<details><summary>Summary by gpt-5.4:</summary>
<p>

## Summary

Fixes a crash in overlapping session compaction flows in `packages/coding-agent`.

## packages/coding-agent

### `packages/coding-agent/src/core/agent-session.ts`

- Replaced the separate shared compaction abort fields with:
  - `_compactionCancelController`
  - `_activeCompactionControllers`
- Manual `compact()` runs now create a local `AbortController` per run and combine it with the shared cancel-all signal via `AbortSignal.any(...)`.
- Auto compaction uses the same signal strategy, so overlapping compactions no longer read `.signal` from a cleared shared field.
- `abortCompaction()` now aborts the shared cancel-all controller, cancelling all active compactions at once.
- `isCompacting` now reflects active compaction controllers instead of the removed per-kind fields.
- `_runAutoCompaction()` now skips immediately if any compaction is already in progress, preventing overlapping auto-compaction runs.

Behavior change:
- overlapping manual compactions no longer race on shared controller state
- overlapping manual/auto compactions no longer crash with `Cannot read properties of undefined (reading 'signal')`
- a second auto compaction now skips while one is already running

### `packages/coding-agent/test/suite/regressions/2911-overlapping-compaction-signal.test.ts`

- Added regression coverage for:
  - overlapping manual compactions
  - overlapping manual + auto compactions
  - overlapping auto compactions skipping the second run
- Updated test internals to assert the new shared cancel-all controller and active-controller set cleanup.

### `packages/coding-agent/CHANGELOG.md`

- Added an Unreleased `### Fixed` entry for this PR.

## Verification

- `npm run check`
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/2911-overlapping-compaction-signal.test.ts`

</p>
</details>