### PR TITLE
fix(google-vertex): add thinking budgets and maxOutputTokens fallback for Gemini 3.x

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -411,6 +411,11 @@ function buildParams(
 	}
 	if (options.maxTokens !== undefined) {
 		generationConfig.maxOutputTokens = options.maxTokens;
+	} else if (
+		isGemini3ProModel(model as unknown as Model<"google-generative-ai">) ||
+		isGemini3FlashModel(model as unknown as Model<"google-generative-ai">)
+	) {
+		generationConfig.maxOutputTokens = 16384;
 	}
 
 	const config: GenerateContentConfig = {
@@ -531,6 +536,26 @@ function getGoogleBudget(
 	if (model.id.includes("2.5-flash")) {
 		const budgets: Record<ClampedThinkingLevel, number> = {
 			minimal: 128,
+			low: 2048,
+			medium: 8192,
+			high: 24576,
+		};
+		return budgets[effort];
+	}
+
+	if (isGemini3ProModel(model)) {
+		const budgets: Record<ClampedThinkingLevel, number> = {
+			minimal: 1024,
+			low: 4096,
+			medium: 16384,
+			high: 32768,
+		};
+		return budgets[effort];
+	}
+
+	if (isGemini3FlashModel(model)) {
+		const budgets: Record<ClampedThinkingLevel, number> = {
+			minimal: 512,
 			low: 2048,
 			medium: 8192,
 			high: 24576,


### PR DESCRIPTION
## Summary

Gemini 3.x models via direct google-vertex produce empty visible output intermittently because `getGoogleBudget()` returns `-1` (unlimited thinking budget) for them, causing all context to be consumed by hidden thinking.

## Root Cause

In `getGoogleBudget()`, only `2.5-pro` and `2.5-flash` models have defined budgets. All other models (including Gemini 3.x) fall through to `return -1`, which means unlimited thinking. With unlimited thinking, Gemini 3.x consumes the entire context window for hidden thinking, leaving no room for visible output.

Additionally, `buildParams()` did not set a default `maxOutputTokens` for Gemini 3.x models, so Vertex AI could not reserve capacity for visible output.

## Fix

1. **Patch 1**: Add thinking budgets for Gemini 3.x models in `getGoogleBudget()`:
   - `gemini-3-pro`: minimal=1024, low=4096, medium=16384, high=32768
   - `gemini-3-flash`: minimal=512, low=2048, medium=8192, high=24576

2. **Patch 2**: Add a `maxOutputTokens` fallback of 16384 for Gemini 3.x models in `buildParams()` when `options.maxTokens` is not explicitly set.

## Impact

- **Affected models**: All Gemini 3.x (pro and flash) via direct `google-vertex` provider
- **Not affected**: Gemini 2.5.x models (already have explicit budgets), models routed through external proxies
- **Workaround**: Use an external proxy (like 9router) that handles thinking configuration separately

## Testing

Build passes and all existing tests pass (101 passed).
