### PR TITLE
Add local Ollama and LM Studio support

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -821,6 +821,10 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
 	const isGroq = provider === "groq" || baseUrl.includes("groq.com");
 
+	const isOllama = provider === "ollama" || baseUrl.includes(":11434");
+	const isLMStudio = provider === "lmstudio" || provider === "lm-studio" || baseUrl.includes(":1234");
+	const isLocalLLM = isOllama || isLMStudio;
+
 	const reasoningEffortMap =
 		isGroq && model.id === "qwen/qwen3-32b"
 			? {
@@ -832,12 +836,12 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 				}
 			: {};
 	return {
-		supportsStore: !isNonStandard,
-		supportsDeveloperRole: !isNonStandard,
-		supportsReasoningEffort: !isGrok && !isZai,
+		supportsStore: !isNonStandard && !isLocalLLM,
+		supportsDeveloperRole: !isNonStandard && !isLocalLLM,
+		supportsReasoningEffort: !isGrok && !isZai && !isLocalLLM,
 		reasoningEffortMap,
 		supportsUsageInStreaming: true,
-		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
+		maxTokensField: useMaxTokens || isLocalLLM ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: false,
 		requiresAssistantAfterToolResult: false,
 		requiresThinkingAsText: false,
@@ -849,7 +853,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		openRouterRouting: {},
 		vercelGatewayRouting: {},
 		zaiToolStream: false,
-		supportsStrictMode: true,
+		supportsStrictMode: !isLocalLLM,
 	};
 }
 

--- a/packages/web-ui/src/components/AgentInterface.ts
+++ b/packages/web-ui/src/components/AgentInterface.ts
@@ -13,8 +13,33 @@ import type { Attachment } from "../utils/attachment-utils.js";
 import { formatUsage } from "../utils/format.js";
 import { i18n } from "../utils/i18n.js";
 import { createStreamFn } from "../utils/proxy-utils.js";
+import type { CustomProviderType } from "../storage/stores/custom-providers-store.js";
 import type { UserMessageWithAttachments } from "./Messages.js";
 import type { StreamingMessageContainer } from "./StreamingMessageContainer.js";
+
+/**
+ * Resolve an API key for a custom provider stored in the custom-providers store.
+ * Returns the provider's configured key, or a type-appropriate placeholder for
+ * local servers (Ollama, LM Studio, etc.) that do not require real authentication.
+ * Returns null if the provider is not found in the custom-providers store.
+ */
+async function getCustomProviderApiKey(provider: string): Promise<string | null> {
+	try {
+		const customProviders = await getAppStorage().customProviders.getAll();
+		const cp = customProviders.find((p) => p.name === provider);
+		if (!cp) return null;
+		if (cp.apiKey) return cp.apiKey;
+		const placeholders: Partial<Record<CustomProviderType, string>> = {
+			ollama: "ollama",
+			"llama.cpp": "llamacpp",
+			vllm: "vllm",
+			lmstudio: "lmstudio",
+		};
+		return placeholders[cp.type] ?? null;
+	} catch {
+		return null;
+	}
+}
 
 @customElement("agent-interface")
 export class AgentInterface extends LitElement {
@@ -146,7 +171,9 @@ export class AgentInterface extends LitElement {
 		if (!this.session.getApiKey) {
 			this.session.getApiKey = async (provider: string) => {
 				const key = await getAppStorage().providerKeys.get(provider);
-				return key ?? undefined;
+				if (key) return key;
+				// Fall back to the custom provider's stored key or a type-appropriate placeholder
+				return (await getCustomProviderApiKey(provider)) ?? undefined;
 			};
 		}
 
@@ -220,10 +247,15 @@ export class AgentInterface extends LitElement {
 
 		// Check if API key exists for the provider (only needed in direct mode)
 		const provider = session.state.model.provider;
-		const apiKey = await getAppStorage().providerKeys.get(provider);
+		let effectiveApiKey = await getAppStorage().providerKeys.get(provider);
 
-		// If no API key, prompt for it
-		if (!apiKey) {
+		// Fall back to the custom provider's stored key or placeholder (covers Ollama, LM Studio, etc.)
+		if (!effectiveApiKey) {
+			effectiveApiKey = await getCustomProviderApiKey(provider);
+		}
+
+		// If still no API key, prompt for it
+		if (!effectiveApiKey) {
 			if (!this.onApiKeyRequired) {
 				console.error("No API key configured and no onApiKeyRequired handler set");
 				return;

--- a/packages/web-ui/src/utils/model-discovery.ts
+++ b/packages/web-ui/src/utils/model-discovery.ts
@@ -1,6 +1,20 @@
 import { LMStudioClient } from "@lmstudio/sdk";
-import type { Model } from "@mariozechner/pi-ai";
+import type { Model, OpenAICompletionsCompat } from "@mariozechner/pi-ai";
 import { Ollama } from "ollama/browser";
+
+/**
+ * Compat settings shared by local LLM servers (Ollama, LM Studio).
+ * These servers speak the OpenAI Completions API but do not support
+ * newer OpenAI-specific fields such as `store`, the `developer` role,
+ * `reasoning_effort`, `max_completion_tokens`, or strict tool schemas.
+ */
+const LOCAL_LLM_COMPAT: OpenAICompletionsCompat = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: false,
+	maxTokensField: "max_tokens",
+	supportsStrictMode: false,
+};
 
 /**
  * Discover models from an Ollama server.
@@ -59,6 +73,7 @@ export async function discoverOllamaModels(baseUrl: string, _apiKey?: string): P
 					},
 					contextWindow: contextWindow,
 					maxTokens: maxTokens,
+					compat: LOCAL_LLM_COMPAT,
 				};
 
 				return ollamaModel;
@@ -242,6 +257,7 @@ export async function discoverLMStudioModels(baseUrl: string, _apiKey?: string):
 					},
 					contextWindow: contextWindow,
 					maxTokens: maxTokens,
+					compat: LOCAL_LLM_COMPAT,
 				};
 
 				return lmStudioModel;


### PR DESCRIPTION
## Summary

Enables Ollama and LM Studio to work with pi out of the box.

## Changes

**Detection for local LLM providers**
The openai completions adapter now detects Ollama and LM Studio by provider name or baseUrl port (:11434, :1234) and applies correct compatibility settings. Local servers do not support `store`, `developer` role, `reasoning_effort`, `max_completion_tokens`, or strict tool schemas.

**API key handling for custom providers**
Custom providers store their API keys separately from the standard provider key store. Added fallback logic to retrieve keys from custom provider records and use placeholder values for servers that require no authentication.

**Model discovery**
Embedded compatibility settings directly on discovered models so they work correctly regardless of user chosen provider name.

## Testing

Tested with Ollama running llama3.1:8b and LM Studio running qwen2.5 coder:7b. Both providers work in interactive mode and complete multi turn coding tasks successfully.