### PR TITLE
feat: add PI_SKIP_TMUX_WARNING env var to suppress tmux warning

### DIFF
--- a/packages/coding-agent/docs/tmux.md
+++ b/packages/coding-agent/docs/tmux.md
@@ -55,6 +55,16 @@ Without tmux extended keys, modified Enter keys collapse to legacy sequences:
 
 This affects the default keybindings (`Enter` to submit, `Shift+Enter` for newline) and any custom keybindings using modified Enter.
 
+## Suppressing the Warning
+
+If you intentionally run tmux without extended keys and want to suppress the startup warning, set the `PI_SKIP_TMUX_WARNING` environment variable:
+
+```bash
+export PI_SKIP_TMUX_WARNING=1
+```
+
+This skips the tmux keyboard check entirely. Modified Enter keys (Shift+Enter, Ctrl+Enter, etc.) may still not work as expected.
+
 ## Requirements
 
 - tmux 3.2 or later (run `tmux -V` to check)

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -707,6 +707,7 @@ export class InteractiveMode {
 
 	private async checkTmuxKeyboardSetup(): Promise<string | undefined> {
 		if (!process.env.TMUX) return undefined;
+		if (process.env.PI_SKIP_TMUX_WARNING) return undefined;
 
 		const runTmuxShow = (option: string): Promise<string | undefined> => {
 			return new Promise((resolve) => {


### PR DESCRIPTION
## Problem

When running pi inside tmux without `extended-keys on`, a warning is shown on every startup:

> tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

There is currently no way to suppress this warning. Some users intentionally run tmux without extended keys (e.g. shared servers, minimal configs) and the warning adds noise on every launch.

## Solution

Add a `PI_SKIP_TMUX_WARNING` environment variable. When set (to any value), the tmux keyboard check is skipped entirely and no warning is shown.

```bash
export PI_SKIP_TMUX_WARNING=1
```

This follows the same pattern as existing env vars like `PI_SKIP_VERSION_CHECK`, `PI_OFFLINE`, and `PI_HARDWARE_CURSOR`.

## Changes

- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` — early return in `checkTmuxKeyboardSetup()` when `PI_SKIP_TMUX_WARNING` is set
- `packages/coding-agent/docs/tmux.md` — document the new env var with a "Suppressing the Warning" section