### PR TITLE
Add configurable sourceInfoStyle setting for autocomplete tags

### DIFF
--- a/packages/coding-agent/src/core/format-source-tag.ts
+++ b/packages/coding-agent/src/core/format-source-tag.ts
@@ -1,57 +1,90 @@
-import type { SourceInfo } from "./source-info.js";
 import { parseGitUrl } from "../utils/git.js";
+import type { SourceInfo } from "./source-info.js";
 
 export type SourceInfoStyle = "full" | "short" | "tiny" | "name-only" | "minimal" | "none";
 
-export function formatSourceTag(sourceInfo: SourceInfo, style: SourceInfoStyle): string | undefined {
-	if (style === "none") {
-		return undefined;
-	}
+interface NpmSource {
+	type: "npm";
+	name: string;
+}
 
-	const scopePrefix = sourceInfo.scope === "user" ? "u" : sourceInfo.scope === "project" ? "p" : "t";
+interface GitSource {
+	type: "git";
+	host: string;
+	path: string;
+	repo: string;
+	ref: string;
+}
 
-	if (style === "minimal") {
-		return scopePrefix;
-	}
+type ParsedSource = { type: "local" } | NpmSource | GitSource;
 
-	const source = sourceInfo.source.trim();
+const scopePrefixes: Record<SourceInfo["scope"], string> = {
+	user: "u",
+	project: "p",
+	temporary: "t",
+};
 
-	if (source === "auto" || source === "local" || source === "cli") {
-		return scopePrefix;
-	}
+const localFormatters: Record<SourceInfoStyle, () => string | undefined> = {
+	none: () => undefined,
+	minimal: () => "",
+	"name-only": () => "",
+	tiny: () => "",
+	short: () => "",
+	full: () => "",
+};
+
+const npmFormatters: Record<SourceInfoStyle, (s: NpmSource) => string | undefined> = {
+	none: () => undefined,
+	minimal: () => "",
+	"name-only": (s) => s.name.split("/").pop()!,
+	tiny: (s) => s.name,
+	short: (s) => `npm:${s.name}`,
+	full: (s) => `npm:${s.name}`,
+};
+
+const gitFormatters: Record<SourceInfoStyle, (s: GitSource) => string | undefined> = {
+	none: () => undefined,
+	minimal: () => "",
+	"name-only": (s) => `${s.repo}${s.ref}`,
+	tiny: (s) => `${s.path}${s.ref}`,
+	short: (s) => `git:${s.path}${s.ref}`,
+	full: (s) => `git:${s.host}/${s.path}${s.ref}`,
+};
+
+function parseSource(raw: string): ParsedSource {
+	const source = raw.trim();
 
 	if (source.startsWith("npm:")) {
-		const npmName = source.slice(4);
-		switch (style) {
-			case "name-only":
-				return `${scopePrefix}:${npmName.split("/").pop()}`;
-			case "tiny":
-				return `${scopePrefix}:${npmName}`;
-			case "short":
-			case "full":
-			default:
-				return `${scopePrefix}:${source}`;
-		}
+		return { type: "npm", name: source.slice(4) };
 	}
 
 	const gitSource = parseGitUrl(source);
 	if (gitSource) {
-		const ref = gitSource.ref ? `@${gitSource.ref}` : "";
-		const repoName = gitSource.path.split("/").pop() ?? gitSource.path;
-		switch (style) {
-			case "name-only":
-				return `${scopePrefix}:${repoName}${ref}`;
-			case "tiny":
-				return `${scopePrefix}:${gitSource.path}${ref}`;
-			case "short":
-				return `${scopePrefix}:git:${gitSource.path}${ref}`;
-			case "full":
-			default:
-				return `${scopePrefix}:git:${gitSource.host}/${gitSource.path}${ref}`;
-		}
+		return {
+			type: "git",
+			host: gitSource.host,
+			path: gitSource.path,
+			repo: gitSource.path.split("/").pop() ?? gitSource.path,
+			ref: gitSource.ref ? `@${gitSource.ref}` : "",
+		};
 	}
 
-	return scopePrefix;
+	return { type: "local" };
+}
+
+export function formatSourceTag(sourceInfo: SourceInfo, style: SourceInfoStyle): string | undefined {
+	const prefix = scopePrefixes[sourceInfo.scope];
+	const parsed = parseSource(sourceInfo.source);
+
+	const detail =
+		parsed.type === "npm"
+			? npmFormatters[style](parsed)
+			: parsed.type === "git"
+				? gitFormatters[style](parsed)
+				: localFormatters[style]();
+
+	if (detail === undefined) return undefined;
+	return detail ? `${prefix}:${detail}` : prefix;
 }
 
 export function prefixAutocompleteDescription(

--- a/packages/coding-agent/src/core/format-source-tag.ts
+++ b/packages/coding-agent/src/core/format-source-tag.ts
@@ -1,0 +1,70 @@
+import type { SourceInfo } from "./source-info.js";
+import { parseGitUrl } from "../utils/git.js";
+
+export type SourceInfoStyle = "full" | "short" | "tiny" | "name-only" | "minimal" | "none";
+
+export function formatSourceTag(sourceInfo: SourceInfo, style: SourceInfoStyle): string | undefined {
+	if (style === "none") {
+		return undefined;
+	}
+
+	const scopePrefix = sourceInfo.scope === "user" ? "u" : sourceInfo.scope === "project" ? "p" : "t";
+
+	if (style === "minimal") {
+		return scopePrefix;
+	}
+
+	const source = sourceInfo.source.trim();
+
+	if (source === "auto" || source === "local" || source === "cli") {
+		return scopePrefix;
+	}
+
+	if (source.startsWith("npm:")) {
+		const npmName = source.slice(4);
+		switch (style) {
+			case "name-only":
+				return `${scopePrefix}:${npmName.split("/").pop()}`;
+			case "tiny":
+				return `${scopePrefix}:${npmName}`;
+			case "short":
+			case "full":
+			default:
+				return `${scopePrefix}:${source}`;
+		}
+	}
+
+	const gitSource = parseGitUrl(source);
+	if (gitSource) {
+		const ref = gitSource.ref ? `@${gitSource.ref}` : "";
+		const repoName = gitSource.path.split("/").pop() ?? gitSource.path;
+		switch (style) {
+			case "name-only":
+				return `${scopePrefix}:${repoName}${ref}`;
+			case "tiny":
+				return `${scopePrefix}:${gitSource.path}${ref}`;
+			case "short":
+				return `${scopePrefix}:git:${gitSource.path}${ref}`;
+			case "full":
+			default:
+				return `${scopePrefix}:git:${gitSource.host}/${gitSource.path}${ref}`;
+		}
+	}
+
+	return scopePrefix;
+}
+
+export function prefixAutocompleteDescription(
+	description: string | undefined,
+	sourceInfo: SourceInfo | undefined,
+	style: SourceInfoStyle,
+): string | undefined {
+	if (!sourceInfo) {
+		return description;
+	}
+	const sourceTag = formatSourceTag(sourceInfo, style);
+	if (!sourceTag) {
+		return description;
+	}
+	return description ? `[${sourceTag}] ${description}` : `[${sourceTag}]`;
+}

--- a/packages/coding-agent/src/core/format-source-tag.ts
+++ b/packages/coding-agent/src/core/format-source-tag.ts
@@ -37,12 +37,12 @@ const localFormatters = withDefault<() => string | undefined>({ none: () => unde
 const npmFull = (s: NpmSource): string => `npm:${s.name}`;
 const npmFormatters = withDefault<(s: NpmSource) => string | undefined>(
 	{
-		none: () => undefined,
-		minimal: () => "",
-		"name-only": (s) => s.name.split("/").pop()!,
-		tiny: (s) => s.name,
-		short: npmFull,
 		full: npmFull,
+		short: npmFull,
+		tiny: (s) => s.name,
+		"name-only": (s) => s.name.split("/").pop()!,
+		minimal: () => "",
+		none: () => undefined,
 	},
 	npmFull,
 );
@@ -50,12 +50,12 @@ const npmFormatters = withDefault<(s: NpmSource) => string | undefined>(
 const gitFull = (s: GitSource): string => `git:${s.host}/${s.path}${s.ref}`;
 const gitFormatters = withDefault<(s: GitSource) => string | undefined>(
 	{
-		none: () => undefined,
-		minimal: () => "",
-		"name-only": (s) => `${s.repo}${s.ref}`,
-		tiny: (s) => `${s.path}${s.ref}`,
-		short: (s) => `git:${s.path}${s.ref}`,
 		full: gitFull,
+		short: (s) => `git:${s.path}${s.ref}`,
+		tiny: (s) => `${s.path}${s.ref}`,
+		"name-only": (s) => `${s.repo}${s.ref}`,
+		minimal: () => "",
+		none: () => undefined,
 	},
 	gitFull,
 );

--- a/packages/coding-agent/src/core/format-source-tag.ts
+++ b/packages/coding-agent/src/core/format-source-tag.ts
@@ -24,32 +24,47 @@ const scopePrefixes: Record<SourceInfo["scope"], string> = {
 	temporary: "t",
 };
 
-const localFormatters: Record<SourceInfoStyle, () => string | undefined> = {
-	none: () => undefined,
-	minimal: () => "",
-	"name-only": () => "",
-	tiny: () => "",
-	short: () => "",
-	full: () => "",
-};
+function withDefault<T>(overrides: Partial<Record<SourceInfoStyle, T>>, fallback: T): Record<SourceInfoStyle, T> {
+	return new Proxy({} as Record<SourceInfoStyle, T>, {
+		get(_target, prop: string) {
+			return overrides[prop as SourceInfoStyle] ?? fallback;
+		},
+	});
+}
 
-const npmFormatters: Record<SourceInfoStyle, (s: NpmSource) => string | undefined> = {
-	none: () => undefined,
-	minimal: () => "",
-	"name-only": (s) => s.name.split("/").pop()!,
-	tiny: (s) => s.name,
-	short: (s) => `npm:${s.name}`,
-	full: (s) => `npm:${s.name}`,
-};
+const localFormatters = withDefault<() => string | undefined>({ none: () => undefined }, () => "");
 
-const gitFormatters: Record<SourceInfoStyle, (s: GitSource) => string | undefined> = {
-	none: () => undefined,
-	minimal: () => "",
-	"name-only": (s) => `${s.repo}${s.ref}`,
-	tiny: (s) => `${s.path}${s.ref}`,
-	short: (s) => `git:${s.path}${s.ref}`,
-	full: (s) => `git:${s.host}/${s.path}${s.ref}`,
-};
+const npmFull = (s: NpmSource): string => `npm:${s.name}`;
+const npmFormatters = withDefault<(s: NpmSource) => string | undefined>(
+	{
+		none: () => undefined,
+		minimal: () => "",
+		"name-only": (s) => s.name.split("/").pop()!,
+		tiny: (s) => s.name,
+		short: npmFull,
+		full: npmFull,
+	},
+	npmFull,
+);
+
+const gitFull = (s: GitSource): string => `git:${s.host}/${s.path}${s.ref}`;
+const gitFormatters = withDefault<(s: GitSource) => string | undefined>(
+	{
+		none: () => undefined,
+		minimal: () => "",
+		"name-only": (s) => `${s.repo}${s.ref}`,
+		tiny: (s) => `${s.path}${s.ref}`,
+		short: (s) => `git:${s.path}${s.ref}`,
+		full: gitFull,
+	},
+	gitFull,
+);
+
+const sourceFormatters = {
+	local: localFormatters,
+	npm: npmFormatters,
+	git: gitFormatters,
+} as Record<ParsedSource["type"], Record<SourceInfoStyle, (s: ParsedSource) => string | undefined>>;
 
 function parseSource(raw: string): ParsedSource {
 	const source = raw.trim();
@@ -75,13 +90,7 @@ function parseSource(raw: string): ParsedSource {
 export function formatSourceTag(sourceInfo: SourceInfo, style: SourceInfoStyle): string | undefined {
 	const prefix = scopePrefixes[sourceInfo.scope];
 	const parsed = parseSource(sourceInfo.source);
-
-	const detail =
-		parsed.type === "npm"
-			? npmFormatters[style](parsed)
-			: parsed.type === "git"
-				? gitFormatters[style](parsed)
-				: localFormatters[style]();
+	const detail = sourceFormatters[parsed.type][style](parsed);
 
 	if (detail === undefined) return undefined;
 	return detail ? `${prefix}:${detail}` : prefix;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -95,6 +95,7 @@ export interface Settings {
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
 	sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
+	sourceInfoStyle?: "full" | "short" | "tiny" | "name-only" | "minimal" | "none"; // Display style for source info tags in autocomplete (default: "full")
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -955,5 +956,15 @@ export class SettingsManager {
 
 	getCodeBlockIndent(): string {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
+	}
+
+	getSourceInfoStyle(): "full" | "short" | "tiny" | "name-only" | "minimal" | "none" {
+		return this.settings.sourceInfoStyle ?? "full";
+	}
+
+	setSourceInfoStyle(style: "full" | "short" | "tiny" | "name-only" | "minimal" | "none"): void {
+		this.globalSettings.sourceInfoStyle = style;
+		this.markModified("sourceInfoStyle");
+		this.save();
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -64,12 +64,12 @@ import type { ResourceDiagnostic } from "../../core/resource-loader.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
 import { type SessionContext, SessionManager } from "../../core/session-manager.js";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
+import { prefixAutocompleteDescription } from "../../core/format-source-tag.js";
 import type { SourceInfo } from "../../core/source-info.js";
 import type { TruncationResult } from "../../core/tools/truncate.js";
 import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/changelog.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.js";
-import { parseGitUrl } from "../../utils/git.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
@@ -305,37 +305,8 @@ export class InteractiveMode {
 		initTheme(this.settingsManager.getTheme(), true);
 	}
 
-	private getAutocompleteSourceTag(sourceInfo?: SourceInfo): string | undefined {
-		if (!sourceInfo) {
-			return undefined;
-		}
-
-		const scopePrefix = sourceInfo.scope === "user" ? "u" : sourceInfo.scope === "project" ? "p" : "t";
-		const source = sourceInfo.source.trim();
-
-		if (source === "auto" || source === "local" || source === "cli") {
-			return scopePrefix;
-		}
-
-		if (source.startsWith("npm:")) {
-			return `${scopePrefix}:${source}`;
-		}
-
-		const gitSource = parseGitUrl(source);
-		if (gitSource) {
-			const ref = gitSource.ref ? `@${gitSource.ref}` : "";
-			return `${scopePrefix}:git:${gitSource.host}/${gitSource.path}${ref}`;
-		}
-
-		return scopePrefix;
-	}
-
 	private prefixAutocompleteDescription(description: string | undefined, sourceInfo?: SourceInfo): string | undefined {
-		const sourceTag = this.getAutocompleteSourceTag(sourceInfo);
-		if (!sourceTag) {
-			return description;
-		}
-		return description ? `[${sourceTag}] ${description}` : `[${sourceTag}]`;
+		return prefixAutocompleteDescription(description, sourceInfo, this.settingsManager.getSourceInfoStyle());
 	}
 
 	private getBuiltInCommandConflictDiagnostics(extensionRunner: ExtensionRunner | undefined): ResourceDiagnostic[] {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -56,6 +56,7 @@ import type {
 	ExtensionWidgetOptions,
 } from "../../core/extensions/index.js";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.js";
+import { prefixAutocompleteDescription } from "../../core/format-source-tag.js";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
 import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScope } from "../../core/model-resolver.js";
@@ -64,7 +65,6 @@ import type { ResourceDiagnostic } from "../../core/resource-loader.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
 import { type SessionContext, SessionManager } from "../../core/session-manager.js";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
-import { prefixAutocompleteDescription } from "../../core/format-source-tag.js";
 import type { SourceInfo } from "../../core/source-info.js";
 import type { TruncationResult } from "../../core/tools/truncate.js";
 import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/changelog.js";

--- a/packages/coding-agent/test/format-source-tag.test.ts
+++ b/packages/coding-agent/test/format-source-tag.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { formatSourceTag, prefixAutocompleteDescription, type SourceInfoStyle } from "../src/core/format-source-tag.js";
+import type { SourceInfo } from "../src/core/source-info.js";
+
+function makeSourceInfo(overrides: Partial<SourceInfo> = {}): SourceInfo {
+	return {
+		path: "/some/path",
+		source: overrides.source ?? "auto",
+		scope: overrides.scope ?? "user",
+		origin: overrides.origin ?? "top-level",
+	};
+}
+
+describe("formatSourceTag", () => {
+	describe("none style", () => {
+		it("hides source info completely", () => {
+			const info = makeSourceInfo({ source: "git:https://github.com/jvortmann/pi-claude-commands" });
+			expect(formatSourceTag(info, "none")).toBeUndefined();
+		});
+	});
+
+	describe("minimal style", () => {
+		it("shows only scope prefix for user scope", () => {
+			const info = makeSourceInfo({ scope: "user", source: "git:https://github.com/jvortmann/pi-claude-commands" });
+			expect(formatSourceTag(info, "minimal")).toBe("u");
+		});
+
+		it("shows only scope prefix for project scope", () => {
+			const info = makeSourceInfo({ scope: "project", source: "git:https://github.com/jvortmann/pi-claude-commands" });
+			expect(formatSourceTag(info, "minimal")).toBe("p");
+		});
+
+		it("shows only scope prefix for temporary scope", () => {
+			const info = makeSourceInfo({ scope: "temporary", source: "git:https://github.com/jvortmann/pi-claude-commands" });
+			expect(formatSourceTag(info, "minimal")).toBe("t");
+		});
+	});
+
+	describe("git sources", () => {
+		const gitSource = "git:https://github.com/jvortmann/pi-claude-commands";
+
+		it("full — shows host and path", () => {
+			const info = makeSourceInfo({ source: gitSource });
+			expect(formatSourceTag(info, "full")).toBe("u:git:github.com/jvortmann/pi-claude-commands");
+		});
+
+		it("short — shows git prefix and path without host", () => {
+			const info = makeSourceInfo({ source: gitSource });
+			expect(formatSourceTag(info, "short")).toBe("u:git:jvortmann/pi-claude-commands");
+		});
+
+		it("tiny — shows path without git prefix or host", () => {
+			const info = makeSourceInfo({ source: gitSource });
+			expect(formatSourceTag(info, "tiny")).toBe("u:jvortmann/pi-claude-commands");
+		});
+
+		it("name-only — shows only repo name", () => {
+			const info = makeSourceInfo({ source: gitSource });
+			expect(formatSourceTag(info, "name-only")).toBe("u:pi-claude-commands");
+		});
+
+		it("preserves ref across all styles", () => {
+			const info = makeSourceInfo({ source: "git:https://github.com/jvortmann/pi-claude-commands#main" });
+			expect(formatSourceTag(info, "full")).toBe("u:git:github.com/jvortmann/pi-claude-commands@main");
+			expect(formatSourceTag(info, "short")).toBe("u:git:jvortmann/pi-claude-commands@main");
+			expect(formatSourceTag(info, "tiny")).toBe("u:jvortmann/pi-claude-commands@main");
+			expect(formatSourceTag(info, "name-only")).toBe("u:pi-claude-commands@main");
+		});
+	});
+
+	describe("npm sources", () => {
+		const npmSource = "npm:@scope/my-package";
+
+		it("full and short — show full npm: prefix", () => {
+			const info = makeSourceInfo({ source: npmSource });
+			expect(formatSourceTag(info, "full")).toBe("u:npm:@scope/my-package");
+			expect(formatSourceTag(info, "short")).toBe("u:npm:@scope/my-package");
+		});
+
+		it("tiny — shows scoped name without npm: prefix", () => {
+			const info = makeSourceInfo({ source: npmSource });
+			expect(formatSourceTag(info, "tiny")).toBe("u:@scope/my-package");
+		});
+
+		it("name-only — shows only package name", () => {
+			const info = makeSourceInfo({ source: npmSource });
+			expect(formatSourceTag(info, "name-only")).toBe("u:my-package");
+		});
+	});
+
+	describe("local sources", () => {
+		it.each(["auto", "local", "cli"])("%s — shows only scope prefix regardless of style", (source) => {
+			const info = makeSourceInfo({ source });
+			const styles: SourceInfoStyle[] = ["full", "short", "tiny", "name-only"];
+			for (const style of styles) {
+				expect(formatSourceTag(info, style)).toBe("u");
+			}
+		});
+	});
+});
+
+describe("prefixAutocompleteDescription", () => {
+	it("prepends source tag to description", () => {
+		const info = makeSourceInfo({ source: "git:https://github.com/jvortmann/pi-claude-commands" });
+		expect(prefixAutocompleteDescription("Some command", info, "full")).toBe(
+			"[u:git:github.com/jvortmann/pi-claude-commands] Some command",
+		);
+	});
+
+	it("shows only tag when description is undefined", () => {
+		const info = makeSourceInfo({ source: "auto" });
+		expect(prefixAutocompleteDescription(undefined, info, "full")).toBe("[u]");
+	});
+
+	it("passes description through when sourceInfo is undefined", () => {
+		expect(prefixAutocompleteDescription("Some command", undefined, "full")).toBe("Some command");
+	});
+
+	it("passes description through when style is none", () => {
+		const info = makeSourceInfo({ source: "git:https://github.com/jvortmann/pi-claude-commands" });
+		expect(prefixAutocompleteDescription("Some command", info, "none")).toBe("Some command");
+	});
+});

--- a/packages/coding-agent/test/format-source-tag.test.ts
+++ b/packages/coding-agent/test/format-source-tag.test.ts
@@ -26,12 +26,18 @@ describe("formatSourceTag", () => {
 		});
 
 		it("shows only scope prefix for project scope", () => {
-			const info = makeSourceInfo({ scope: "project", source: "git:https://github.com/jvortmann/pi-claude-commands" });
+			const info = makeSourceInfo({
+				scope: "project",
+				source: "git:https://github.com/jvortmann/pi-claude-commands",
+			});
 			expect(formatSourceTag(info, "minimal")).toBe("p");
 		});
 
 		it("shows only scope prefix for temporary scope", () => {
-			const info = makeSourceInfo({ scope: "temporary", source: "git:https://github.com/jvortmann/pi-claude-commands" });
+			const info = makeSourceInfo({
+				scope: "temporary",
+				source: "git:https://github.com/jvortmann/pi-claude-commands",
+			});
 			expect(formatSourceTag(info, "minimal")).toBe("t");
 		});
 	});


### PR DESCRIPTION
Closes #3052

## Summary

Source info tags in autocomplete (e.g. `[u:git:github.com/user/repo-name]`) can consume significant horizontal space, leaving less room for the actual command description. This adds a `sourceInfoStyle` setting that gives users full control over how verbose those tags are.

## Details

Six display levels, from most to least verbose:

| Style | Git source | npm source |
|---|---|---|
| `full` (default) | `[u:git:github.com/jvortmann/pi-claude-commands]` | `[u:npm:@scope/my-package]` |
| `short` | `[u:git:jvortmann/pi-claude-commands]` | `[u:npm:@scope/my-package]` |
| `tiny` | `[u:jvortmann/pi-claude-commands]` | `[u:@scope/my-package]` |
| `name-only` | `[u:pi-claude-commands]` | `[u:my-package]` |
| `minimal` | `[u]` | `[u]` |
| `none` | *(hidden)* | *(hidden)* |

The scope prefix (`u`/`p`/`t`) is preserved in all levels except `none`.

The formatting logic was extracted from `InteractiveMode` into a standalone pure function (`formatSourceTag`) with data-driven formatter lookup tables — one per source type (local, npm, git). Each table maps every style to its formatter, with a `Proxy`-based default fallback for unexpected styles. This makes it straightforward to test and extend with new source types or styles.

Configured via `settings.json`:

```json
{
  "sourceInfoStyle": "short"
}
```

Default is `full`, preserving current behavior.
