### PR TITLE
docs: update README with mise installation instructions

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -76,6 +76,8 @@ I regularly publish my own `pi-mono` work sessions here:
 
 ```bash
 npm install -g @mariozechner/pi-coding-agent
+# or via mise
+mise use -g npm:@mariozechner/pi-coding-agent
 ```
 
 Authenticate with an API key:


### PR DESCRIPTION
# Summary  
Adds [mise](https://mise.jdx.dev/) as an installation option in the README.  `mise` can install npm-based tools globally, providing a convenient alternative for users who already use `mise` as their tools manager.