### PR TITLE
fix: improve TLS interception error guidance and fallback prompt

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -24,6 +24,43 @@ import type {
 
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
 
+const FETCH_FAILED_PATTERN = /^fetch failed(?::.*)?$/i;
+const CERTIFICATE_ERROR_PATTERN =
+	/certificate|self[\s-]?signed|unable to verify|unable to get (local )?issuer|cert[_\s-]?|SSL interception/i;
+const HAS_CERT_SETUP_GUIDANCE_PATTERN = /NODE_EXTRA_CA_CERTS|npm config set cafile|NODE_TLS_REJECT_UNAUTHORIZED/i;
+
+function enhanceAssistantErrorMessage(errorMessage: string | undefined): string | undefined {
+	if (!errorMessage) return errorMessage;
+
+	const trimmed = errorMessage.trim();
+	if (!trimmed) return errorMessage;
+	if (HAS_CERT_SETUP_GUIDANCE_PATTERN.test(trimmed)) return trimmed;
+
+	const shouldAddGuidance = FETCH_FAILED_PATTERN.test(trimmed) || CERTIFICATE_ERROR_PATTERN.test(trimmed);
+	if (!shouldAddGuidance) return trimmed;
+
+	return [
+		trimmed,
+		"",
+		"Potential SSL interception / corporate TLS proxy detected.",
+		"Recommended trust-store setup:",
+		"  export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem",
+		"  npm config set cafile /path/to/corporate-ca.pem",
+		"Temporary workaround (insecure):",
+		"  NODE_TLS_REJECT_UNAUTHORIZED=0",
+	].join("\n");
+}
+
+function enhanceAssistantError(message: AssistantMessage): AssistantMessage {
+	if (message.stopReason !== "error") return message;
+	const nextError = enhanceAssistantErrorMessage(message.errorMessage);
+	if (nextError === message.errorMessage) return message;
+	return {
+		...message,
+		errorMessage: nextError,
+	};
+}
+
 /**
  * Start an agent loop with a new prompt message.
  * The prompt is added to the context and events are emitted for it.
@@ -304,7 +341,7 @@ async function streamAssistantResponse(
 
 			case "done":
 			case "error": {
-				const finalMessage = await response.result();
+				const finalMessage = enhanceAssistantError(await response.result());
 				if (addedPartial) {
 					context.messages[context.messages.length - 1] = finalMessage;
 				} else {
@@ -319,7 +356,7 @@ async function streamAssistantResponse(
 		}
 	}
 
-	const finalMessage = await response.result();
+	const finalMessage = enhanceAssistantError(await response.result());
 	if (addedPartial) {
 		context.messages[context.messages.length - 1] = finalMessage;
 	} else {

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -11,6 +11,7 @@ import {
 	type ToolResultMessage,
 	validateToolArguments,
 } from "@mariozechner/pi-ai";
+import { appendNodeErrorCodes, extractNodeErrorCodesFromMessage, isNodeTlsCertificateErrorCode } from "./node-error.js";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -24,23 +25,27 @@ import type {
 
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
 
-const FETCH_FAILED_PATTERN = /^fetch failed(?::.*)?$/i;
-const CERTIFICATE_ERROR_PATTERN =
-	/certificate|self[\s-]?signed|unable to verify|unable to get (local )?issuer|cert[_\s-]?|SSL interception/i;
-const HAS_CERT_SETUP_GUIDANCE_PATTERN = /NODE_EXTRA_CA_CERTS|npm config set cafile|NODE_TLS_REJECT_UNAUTHORIZED/i;
-
 function enhanceAssistantErrorMessage(errorMessage: string | undefined): string | undefined {
 	if (!errorMessage) return errorMessage;
 
 	const trimmed = errorMessage.trim();
 	if (!trimmed) return errorMessage;
-	if (HAS_CERT_SETUP_GUIDANCE_PATTERN.test(trimmed)) return trimmed;
+	if (
+		trimmed.includes("NODE_EXTRA_CA_CERTS") ||
+		trimmed.includes("npm config set cafile") ||
+		trimmed.includes("NODE_TLS_REJECT_UNAUTHORIZED")
+	) {
+		return trimmed;
+	}
 
-	const shouldAddGuidance = FETCH_FAILED_PATTERN.test(trimmed) || CERTIFICATE_ERROR_PATTERN.test(trimmed);
-	if (!shouldAddGuidance) return trimmed;
+	const codes = extractNodeErrorCodesFromMessage(trimmed);
+	if (!codes.some((code) => isNodeTlsCertificateErrorCode(code))) {
+		return trimmed;
+	}
 
+	const withNodeCodes = appendNodeErrorCodes(trimmed, codes);
 	return [
-		trimmed,
+		withNodeCodes,
 		"",
 		"Potential SSL interception / corporate TLS proxy detected.",
 		"Recommended trust-store setup:",

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -9,6 +9,7 @@ import {
 	type Transport,
 } from "@mariozechner/pi-ai";
 import { runAgentLoop, runAgentLoopContinue } from "./agent-loop.js";
+import { appendNodeErrorCodes, collectNodeErrorCodes, isNodeTlsCertificateErrorCode } from "./node-error.js";
 import type {
 	AfterToolCallContext,
 	AfterToolCallResult,
@@ -30,11 +31,6 @@ function defaultConvertToLlm(messages: AgentMessage[]): Message[] {
 	);
 }
 
-const FETCH_FAILED_PATTERN = /^fetch failed(?::.*)?$/i;
-const CERTIFICATE_ERROR_PATTERN =
-	/certificate|self[\s-]?signed|unable to verify|unable to get (local )?issuer|cert[_\s-]?/i;
-const HAS_CERT_SETUP_GUIDANCE_PATTERN = /NODE_EXTRA_CA_CERTS|npm config set cafile/i;
-
 function toErrorMessage(error: unknown): string {
 	if (error instanceof Error) {
 		if (error.message === "fetch failed" && error.cause instanceof Error && error.cause.message) {
@@ -45,13 +41,14 @@ function toErrorMessage(error: unknown): string {
 	return String(error);
 }
 
-function addCertificateTrustStoreGuidance(errorMessage: string): string {
+function addCertificateTrustStoreGuidance(errorMessage: string, codes: readonly string[]): string {
 	const trimmed = errorMessage.trim();
 	if (!trimmed) return "Unknown error";
-	if (HAS_CERT_SETUP_GUIDANCE_PATTERN.test(trimmed)) return trimmed;
+	if (trimmed.includes("NODE_EXTRA_CA_CERTS") || trimmed.includes("npm config set cafile")) return trimmed;
 
-	const shouldAddGuidance = FETCH_FAILED_PATTERN.test(trimmed) || CERTIFICATE_ERROR_PATTERN.test(trimmed);
-	if (!shouldAddGuidance) return trimmed;
+	if (!codes.some((code) => isNodeTlsCertificateErrorCode(code))) {
+		return trimmed;
+	}
 
 	return [
 		trimmed,
@@ -63,7 +60,10 @@ function addCertificateTrustStoreGuidance(errorMessage: string): string {
 }
 
 function formatAgentErrorMessage(error: unknown): string {
-	return addCertificateTrustStoreGuidance(toErrorMessage(error));
+	const baseMessage = toErrorMessage(error).trim() || "Unknown error";
+	const codes = collectNodeErrorCodes(error);
+	const messageWithCodes = appendNodeErrorCodes(baseMessage, codes);
+	return addCertificateTrustStoreGuidance(messageWithCodes, codes);
 }
 
 const EMPTY_USAGE = {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -30,6 +30,42 @@ function defaultConvertToLlm(messages: AgentMessage[]): Message[] {
 	);
 }
 
+const FETCH_FAILED_PATTERN = /^fetch failed(?::.*)?$/i;
+const CERTIFICATE_ERROR_PATTERN =
+	/certificate|self[\s-]?signed|unable to verify|unable to get (local )?issuer|cert[_\s-]?/i;
+const HAS_CERT_SETUP_GUIDANCE_PATTERN = /NODE_EXTRA_CA_CERTS|npm config set cafile/i;
+
+function toErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		if (error.message === "fetch failed" && error.cause instanceof Error && error.cause.message) {
+			return `fetch failed: ${error.cause.message}`;
+		}
+		return error.message;
+	}
+	return String(error);
+}
+
+function addCertificateTrustStoreGuidance(errorMessage: string): string {
+	const trimmed = errorMessage.trim();
+	if (!trimmed) return "Unknown error";
+	if (HAS_CERT_SETUP_GUIDANCE_PATTERN.test(trimmed)) return trimmed;
+
+	const shouldAddGuidance = FETCH_FAILED_PATTERN.test(trimmed) || CERTIFICATE_ERROR_PATTERN.test(trimmed);
+	if (!shouldAddGuidance) return trimmed;
+
+	return [
+		trimmed,
+		"",
+		"If this is caused by a corporate TLS proxy (e.g. Zscaler), configure Node/npm trust:",
+		"  export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem",
+		"  npm config set cafile /path/to/corporate-ca.pem",
+	].join("\n");
+}
+
+function formatAgentErrorMessage(error: unknown): string {
+	return addCertificateTrustStoreGuidance(toErrorMessage(error));
+}
+
 const EMPTY_USAGE = {
 	input: 0,
 	output: 0,
@@ -465,7 +501,7 @@ export class Agent {
 			model: this._state.model.id,
 			usage: EMPTY_USAGE,
 			stopReason: aborted ? "aborted" : "error",
-			errorMessage: error instanceof Error ? error.message : String(error),
+			errorMessage: formatAgentErrorMessage(error),
 			timestamp: Date.now(),
 		} satisfies AgentMessage;
 		this._state.messages.push(failureMessage);

--- a/packages/agent/src/node-error.ts
+++ b/packages/agent/src/node-error.ts
@@ -1,0 +1,118 @@
+const NODE_TLS_CERTIFICATE_ERROR_CODES = new Set<string>([
+	"CERT_CHAIN_TOO_LONG",
+	"CERT_HAS_EXPIRED",
+	"CERT_NOT_YET_VALID",
+	"CERT_REJECTED",
+	"CERT_SIGNATURE_FAILURE",
+	"CERT_UNTRUSTED",
+	"CRL_HAS_EXPIRED",
+	"CRL_NOT_YET_VALID",
+	"CRL_SIGNATURE_FAILURE",
+	"DEPTH_ZERO_SELF_SIGNED_CERT",
+	"ERR_TLS_CERT_ALTNAME_INVALID",
+	"HOSTNAME_MISMATCH",
+	"INVALID_CA",
+	"INVALID_PURPOSE",
+	"PATH_LENGTH_EXCEEDED",
+	"SELF_SIGNED_CERT_IN_CHAIN",
+	"UNABLE_TO_GET_ISSUER_CERT",
+	"UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+	"UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+]);
+
+interface ErrorLike {
+	message?: unknown;
+	code?: unknown;
+	cause?: unknown;
+	errors?: unknown;
+}
+
+function asErrorLike(value: unknown): ErrorLike | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	return value as ErrorLike;
+}
+
+function parseNodeErrorCodesList(raw: string): string[] {
+	const codes: string[] = [];
+	for (const part of raw.split(",")) {
+		const code = part.trim();
+		if (code.length > 0 && !codes.includes(code)) {
+			codes.push(code);
+		}
+	}
+	return codes;
+}
+
+export function collectNodeErrorCodes(error: unknown): string[] {
+	const queue: unknown[] = [error];
+	const seen = new Set<unknown>();
+	const codes: string[] = [];
+
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (current === undefined || seen.has(current)) continue;
+		seen.add(current);
+
+		const entry = asErrorLike(current);
+		if (!entry) continue;
+
+		if (typeof entry.code === "string" && entry.code.length > 0 && !codes.includes(entry.code)) {
+			codes.push(entry.code);
+		}
+
+		if (entry.cause !== undefined) {
+			queue.push(entry.cause);
+		}
+		if (Array.isArray(entry.errors)) {
+			for (const nested of entry.errors) {
+				queue.push(nested);
+			}
+		}
+	}
+
+	return codes;
+}
+
+export function extractNodeErrorCodesFromMessage(message: string | undefined): string[] {
+	if (!message) return [];
+
+	const parsedCodes: string[] = [];
+	for (const line of message.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.startsWith("Node.js error code: ")) {
+			const code = trimmed.slice("Node.js error code: ".length).trim();
+			if (code.length > 0 && !parsedCodes.includes(code)) {
+				parsedCodes.push(code);
+			}
+			continue;
+		}
+		if (trimmed.startsWith("Node.js error codes: ")) {
+			for (const code of parseNodeErrorCodesList(trimmed.slice("Node.js error codes: ".length))) {
+				if (!parsedCodes.includes(code)) {
+					parsedCodes.push(code);
+				}
+			}
+		}
+	}
+
+	for (const knownCode of NODE_TLS_CERTIFICATE_ERROR_CODES) {
+		if (message.includes(knownCode) && !parsedCodes.includes(knownCode)) {
+			parsedCodes.push(knownCode);
+		}
+	}
+
+	return parsedCodes;
+}
+
+export function appendNodeErrorCodes(message: string, codes: readonly string[]): string {
+	if (codes.length === 0) return message;
+	if (message.includes("Node.js error code:") || message.includes("Node.js error codes:")) {
+		return message;
+	}
+	const label = codes.length === 1 ? "Node.js error code" : "Node.js error codes";
+	return `${message}\n${label}: ${codes.join(", ")}`;
+}
+
+export function isNodeTlsCertificateErrorCode(code: string): boolean {
+	return NODE_TLS_CERTIFICATE_ERROR_CODES.has(code);
+}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -26,6 +26,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { formatProviderError } from "../utils/node-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
@@ -431,7 +432,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 		} catch (error) {
 			for (const block of output.content) delete (block as any).index;
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -12,6 +12,7 @@ import type {
 	StreamOptions,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatProviderError } from "../utils/node-error.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
@@ -111,7 +112,7 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 		} catch (error) {
 			for (const block of output.content) delete (block as { index?: number }).index;
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -21,6 +21,7 @@ import type {
 	ToolCall,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatProviderError } from "../utils/node-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
 	convertMessages,
@@ -454,11 +455,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 							throw new Error("Request was aborted");
 						}
 					}
-					// Extract detailed error message from fetch errors (Node includes cause)
 					lastError = error instanceof Error ? error : new Error(String(error));
-					if (lastError.message === "fetch failed" && lastError.cause instanceof Error) {
-						lastError = new Error(`Network error: ${lastError.cause.message}`);
-					}
 					// Network errors are retryable
 					if (attempt < MAX_RETRIES) {
 						const delayMs = BASE_DELAY_MS * 2 ** attempt;
@@ -796,7 +793,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 				}
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -21,6 +21,7 @@ import type {
 	ToolCall,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatProviderError } from "../utils/node-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import type { GoogleThinkingLevel } from "./google-gemini-cli.js";
 import {
@@ -280,7 +281,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 				}
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -21,6 +21,7 @@ import type {
 	ToolCall,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatProviderError } from "../utils/node-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import type { GoogleThinkingLevel } from "./google-gemini-cli.js";
 import {
@@ -266,7 +267,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 				}
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -33,6 +33,7 @@ import type {
 	Usage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatProviderError } from "../utils/node-error.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
@@ -269,7 +270,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			stream.end();
 		} catch (error) {
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : String(error);
+			output.errorMessage = formatProviderError(error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -28,6 +28,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { formatProviderError } from "../utils/node-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
@@ -291,7 +292,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 		} catch (error) {
 			for (const block of output.content) delete (block as any).index;
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error);
 			// Some providers via OpenRouter give additional information in this field.
 			const rawMetadata = (error as any)?.error?.metadata?.raw;
 			if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -14,6 +14,7 @@ import type {
 	Usage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatProviderError } from "../utils/node-error.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
@@ -118,7 +119,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 		} catch (error) {
 			for (const block of output.content) delete (block as { index?: number }).index;
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/utils/node-error.ts
+++ b/packages/ai/src/utils/node-error.ts
@@ -1,0 +1,108 @@
+const NODE_TLS_CERTIFICATE_ERROR_CODES = new Set<string>([
+	"CERT_CHAIN_TOO_LONG",
+	"CERT_HAS_EXPIRED",
+	"CERT_NOT_YET_VALID",
+	"CERT_REJECTED",
+	"CERT_SIGNATURE_FAILURE",
+	"CERT_UNTRUSTED",
+	"CRL_HAS_EXPIRED",
+	"CRL_NOT_YET_VALID",
+	"CRL_SIGNATURE_FAILURE",
+	"DEPTH_ZERO_SELF_SIGNED_CERT",
+	"ERR_TLS_CERT_ALTNAME_INVALID",
+	"HOSTNAME_MISMATCH",
+	"INVALID_CA",
+	"INVALID_PURPOSE",
+	"PATH_LENGTH_EXCEEDED",
+	"SELF_SIGNED_CERT_IN_CHAIN",
+	"UNABLE_TO_GET_ISSUER_CERT",
+	"UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+	"UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+]);
+
+interface ErrorLike {
+	message?: unknown;
+	code?: unknown;
+	cause?: unknown;
+	errors?: unknown;
+}
+
+function asErrorLike(value: unknown): ErrorLike | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	return value as ErrorLike;
+}
+
+function getErrorMessage(value: unknown): string {
+	if (value instanceof Error) {
+		return value.message;
+	}
+	if (typeof value === "string") {
+		return value;
+	}
+	if (typeof value === "object" && value !== null) {
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return String(value);
+		}
+	}
+	return String(value);
+}
+
+function getRootMessage(error: unknown): string {
+	if (!(error instanceof Error)) {
+		return getErrorMessage(error);
+	}
+
+	const cause = asErrorLike(error.cause);
+	const causeMessage = typeof cause?.message === "string" ? cause.message : undefined;
+	if (error.message === "fetch failed" && causeMessage) {
+		return `fetch failed: ${causeMessage}`;
+	}
+
+	return error.message;
+}
+
+export function collectNodeErrorCodes(error: unknown): string[] {
+	const queue: unknown[] = [error];
+	const seen = new Set<unknown>();
+	const codes: string[] = [];
+
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (current === undefined || seen.has(current)) continue;
+		seen.add(current);
+
+		const entry = asErrorLike(current);
+		if (!entry) continue;
+
+		if (typeof entry.code === "string" && entry.code.length > 0 && !codes.includes(entry.code)) {
+			codes.push(entry.code);
+		}
+		if (entry.cause !== undefined) {
+			queue.push(entry.cause);
+		}
+		if (Array.isArray(entry.errors)) {
+			for (const nested of entry.errors) {
+				queue.push(nested);
+			}
+		}
+	}
+
+	return codes;
+}
+
+export function isNodeTlsCertificateErrorCode(code: string): boolean {
+	return NODE_TLS_CERTIFICATE_ERROR_CODES.has(code);
+}
+
+export function formatProviderError(error: unknown): string {
+	const rootMessage = getRootMessage(error).trim() || "Unknown error";
+	const codes = collectNodeErrorCodes(error);
+	if (codes.length === 0) {
+		return rootMessage;
+	}
+
+	const label = codes.length === 1 ? "Node.js error code" : "Node.js error codes";
+	return `${rootMessage}\n${label}: ${codes.join(", ")}`;
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -131,8 +131,59 @@ type CompactionQueuedMessage = {
 
 const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
 	"Anthropic subscription auth is active. Third-party usage now draws from extra usage and is billed per token, not your Claude plan limits. Manage extra usage at https://claude.ai/settings/usage.";
-const SSL_INTERCEPTION_ERROR_PATTERN =
-	/Potential SSL interception|corporate TLS proxy|NODE_EXTRA_CA_CERTS|npm config set cafile|fetch failed|certificate|self[\s-]?signed|unable to verify|unable to get (local )?issuer|cert[_\s-]?/i;
+
+const NODE_TLS_CERTIFICATE_ERROR_CODES = new Set<string>([
+	"CERT_CHAIN_TOO_LONG",
+	"CERT_HAS_EXPIRED",
+	"CERT_NOT_YET_VALID",
+	"CERT_REJECTED",
+	"CERT_SIGNATURE_FAILURE",
+	"CERT_UNTRUSTED",
+	"CRL_HAS_EXPIRED",
+	"CRL_NOT_YET_VALID",
+	"CRL_SIGNATURE_FAILURE",
+	"DEPTH_ZERO_SELF_SIGNED_CERT",
+	"ERR_TLS_CERT_ALTNAME_INVALID",
+	"HOSTNAME_MISMATCH",
+	"INVALID_CA",
+	"INVALID_PURPOSE",
+	"PATH_LENGTH_EXCEEDED",
+	"SELF_SIGNED_CERT_IN_CHAIN",
+	"UNABLE_TO_GET_ISSUER_CERT",
+	"UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+	"UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+]);
+
+function extractNodeErrorCodes(errorMessage: string): string[] {
+	const codes: string[] = [];
+
+	for (const line of errorMessage.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.startsWith("Node.js error code: ")) {
+			const code = trimmed.slice("Node.js error code: ".length).trim();
+			if (code.length > 0 && !codes.includes(code)) {
+				codes.push(code);
+			}
+			continue;
+		}
+		if (trimmed.startsWith("Node.js error codes: ")) {
+			for (const codePart of trimmed.slice("Node.js error codes: ".length).split(",")) {
+				const code = codePart.trim();
+				if (code.length > 0 && !codes.includes(code)) {
+					codes.push(code);
+				}
+			}
+		}
+	}
+
+	for (const knownCode of NODE_TLS_CERTIFICATE_ERROR_CODES) {
+		if (errorMessage.includes(knownCode) && !codes.includes(knownCode)) {
+			codes.push(knownCode);
+		}
+	}
+
+	return codes;
+}
 
 function isAnthropicSubscriptionAuthKey(apiKey: string | undefined): boolean {
 	return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
@@ -3128,7 +3179,9 @@ export class InteractiveMode {
 		if (!errorMessage) return false;
 		if (this.insecureTlsFallbackPromptShown) return false;
 		if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === "0") return false;
-		return SSL_INTERCEPTION_ERROR_PATTERN.test(errorMessage);
+
+		const codes = extractNodeErrorCodes(errorMessage);
+		return codes.some((code) => NODE_TLS_CERTIFICATE_ERROR_CODES.has(code));
 	}
 
 	private async maybeOfferInsecureTlsFallback(errorMessage: string | undefined): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -131,6 +131,8 @@ type CompactionQueuedMessage = {
 
 const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
 	"Anthropic subscription auth is active. Third-party usage now draws from extra usage and is billed per token, not your Claude plan limits. Manage extra usage at https://claude.ai/settings/usage.";
+const SSL_INTERCEPTION_ERROR_PATTERN =
+	/Potential SSL interception|corporate TLS proxy|NODE_EXTRA_CA_CERTS|npm config set cafile|fetch failed|certificate|self[\s-]?signed|unable to verify|unable to get (local )?issuer|cert[_\s-]?/i;
 
 function isAnthropicSubscriptionAuthKey(apiKey: string | undefined): boolean {
 	return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
@@ -188,6 +190,7 @@ export class InteractiveMode {
 	private changelogMarkdown: string | undefined = undefined;
 	private startupNoticesShown = false;
 	private anthropicSubscriptionWarningShown = false;
+	private insecureTlsFallbackPromptShown = false;
 
 	// Status line tracking (for mutating immediately-sequential status updates)
 	private lastStatusSpacer: Spacer | undefined = undefined;
@@ -2458,6 +2461,9 @@ export class InteractiveMode {
 					this.streamingComponent = undefined;
 					this.streamingMessage = undefined;
 					this.footer.invalidate();
+					if (event.message.stopReason === "error") {
+						await this.maybeOfferInsecureTlsFallback(errorMessage);
+					}
 				}
 				this.ui.requestRender();
 				break;
@@ -3116,6 +3122,31 @@ export class InteractiveMode {
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
 		this.ui.requestRender();
+	}
+
+	private shouldOfferInsecureTlsFallback(errorMessage: string | undefined): boolean {
+		if (!errorMessage) return false;
+		if (this.insecureTlsFallbackPromptShown) return false;
+		if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === "0") return false;
+		return SSL_INTERCEPTION_ERROR_PATTERN.test(errorMessage);
+	}
+
+	private async maybeOfferInsecureTlsFallback(errorMessage: string | undefined): Promise<void> {
+		if (!this.shouldOfferInsecureTlsFallback(errorMessage)) return;
+		this.insecureTlsFallbackPromptShown = true;
+
+		const confirmed = await this.showExtensionConfirm(
+			"SSL interception detected",
+			"Network TLS/certificate failure detected. Enable insecure TLS fallback for this pi process (NODE_TLS_REJECT_UNAUTHORIZED=0)? This disables certificate verification.",
+		);
+		if (!confirmed) {
+			return;
+		}
+
+		process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+		this.showWarning(
+			"Enabled insecure TLS fallback for this process. Retry your prompt. Prefer NODE_EXTRA_CA_CERTS for a secure fix.",
+		);
 	}
 
 	showNewVersionNotification(newVersion: string): void {


### PR DESCRIPTION
## Summary
- Improve provider/network failure messaging when requests fail with generic `fetch failed` and certificate-related errors.
- Add actionable TLS trust-store guidance (`NODE_EXTRA_CA_CERTS`, `npm config set cafile`).
- In interactive mode, detect likely SSL interception failures and ask whether to enable an insecure per-process fallback (`NODE_TLS_REJECT_UNAUTHORIZED=0`).

## Notes
- this is slop
- will review!

## Why
Corporate TLS interception/proxy setups (e.g. Zscaler) currently surface as unhelpful errors. This change gives users explicit next steps and an opt-in escape hatch.