### PR TITLE
fix(coding-agent): prevent `/reload` command causing constant CPU use

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/bordered-loader.ts
+++ b/packages/coding-agent/src/modes/interactive/components/bordered-loader.ts
@@ -62,5 +62,8 @@ export class BorderedLoader extends Container {
 		if ("dispose" in this.loader && typeof this.loader.dispose === "function") {
 			this.loader.dispose();
 		}
+		if ("stop" in this.loader && typeof this.loader.stop === "function") {
+			this.loader.stop();
+		}
 	}
 }

--- a/packages/coding-agent/test/bordered-loader.test.ts
+++ b/packages/coding-agent/test/bordered-loader.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { BorderedLoader } from "../src/modes/interactive/components/bordered-loader.js";
+
+describe("BorderedLoader", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test("dispose stops the spinner for non-cancellable loaders", () => {
+		vi.useFakeTimers();
+
+		const ui = { requestRender: vi.fn() } as any;
+		const theme = { fg: (_key: string, str: string) => str } as any;
+
+		const loader = new BorderedLoader(ui, theme, "Reloading keybindings, extensions, skills, prompts, themes...", {
+			cancellable: false,
+		});
+
+		expect(ui.requestRender).toHaveBeenCalledTimes(1);
+
+		loader.dispose();
+		vi.advanceTimersByTime(250);
+
+		expect(ui.requestRender).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/badlogic/pi-mono/issues/3093

Ensure `BorderedLoader` with `cancellable: false`, which wraps a plain `Loader`, is cleaning up properly. Make `BorderedLoader.dispose()` falls back to `stop()` when `dispose()` doesn't exist, which is the case for `Loader`.

Includes a simple test case for this, which fails without the fix.