### PR TITLE
feat: terminal multiplexer with split panes, tabs, and PTY support

### DIFF
--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -80,6 +80,11 @@ export class AgentSessionRuntime {
 		return this._modelFallbackMessage;
 	}
 
+	/** Expose the runtime factory for creating independent sessions (e.g., split panes). */
+	get runtimeFactory(): CreateAgentSessionRuntimeFactory {
+		return this.createRuntime;
+	}
+
 	private async emitBeforeSwitch(
 		reason: "new" | "resume",
 		targetSessionFile?: string,

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -39,6 +39,19 @@ export interface AppKeybindings {
 	"app.session.rename": true;
 	"app.session.delete": true;
 	"app.session.deleteNoninvasive": true;
+	// Pane management
+	"app.pane.splitH": true;
+	"app.pane.splitV": true;
+	"app.pane.close": true;
+	"app.pane.focusLeft": true;
+	"app.pane.focusRight": true;
+	"app.pane.focusUp": true;
+	"app.pane.focusDown": true;
+	// Tab management
+	"app.tab.new": true;
+	"app.tab.close": true;
+	"app.tab.next": true;
+	"app.tab.prev": true;
 }
 
 export type AppKeybinding = keyof AppKeybindings;
@@ -130,6 +143,52 @@ export const KEYBINDINGS = {
 	"app.session.deleteNoninvasive": {
 		defaultKeys: "ctrl+backspace",
 		description: "Delete session when query is empty",
+	},
+	// Pane management (alt+letter works reliably in legacy terminals on Windows)
+	"app.pane.splitH": {
+		defaultKeys: "alt+h",
+		description: "Split pane horizontally",
+	},
+	"app.pane.splitV": {
+		defaultKeys: "alt+s",
+		description: "Split pane vertically",
+	},
+	"app.pane.close": {
+		defaultKeys: "alt+w",
+		description: "Close current pane",
+	},
+	"app.pane.focusLeft": {
+		defaultKeys: "alt+a",
+		description: "Focus pane left",
+	},
+	"app.pane.focusRight": {
+		defaultKeys: "alt+d",
+		description: "Focus pane right",
+	},
+	"app.pane.focusUp": {
+		defaultKeys: "alt+e",
+		description: "Focus pane up",
+	},
+	"app.pane.focusDown": {
+		defaultKeys: "alt+x",
+		description: "Focus pane down",
+	},
+	// Tab management (alt+letter works reliably in legacy terminals on Windows)
+	"app.tab.new": {
+		defaultKeys: "alt+t",
+		description: "New tab",
+	},
+	"app.tab.close": {
+		defaultKeys: "alt+q",
+		description: "Close tab",
+	},
+	"app.tab.next": {
+		defaultKeys: "alt+n",
+		description: "Next tab",
+	},
+	"app.tab.prev": {
+		defaultKeys: "alt+b",
+		description: "Previous tab",
 	},
 } as const satisfies KeybindingDefinitions;
 

--- a/packages/coding-agent/src/modes/interactive/components/tab-bar.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tab-bar.ts
@@ -1,0 +1,59 @@
+/**
+ * Tab bar component — renders a single-line strip of tab labels.
+ *
+ * Active tab is highlighted. Clicking (future: mouse support) or keyboard
+ * shortcuts switch between tabs.
+ */
+
+import { type Component, visibleWidth } from "@mariozechner/pi-tui";
+import type { Tab } from "../tab-manager.js";
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+const ACTIVE_PREFIX = "\x1b[1;36m"; // bold cyan
+const INACTIVE_PREFIX = "\x1b[90m"; // gray
+const RESET = "\x1b[0m";
+const SEPARATOR = " │ ";
+
+// ---------------------------------------------------------------------------
+// TabBar
+// ---------------------------------------------------------------------------
+
+export class TabBar implements Component {
+	private tabs: readonly Tab[] = [];
+	private activeIndex = 0;
+	setTabs(tabs: readonly Tab[], activeIndex: number): void {
+		this.tabs = tabs;
+		this.activeIndex = activeIndex;
+	}
+
+	render(width: number): string[] {
+		if (this.tabs.length <= 1) {
+			// Single tab — no bar needed
+			return [];
+		}
+
+		const parts: string[] = [];
+		for (let i = 0; i < this.tabs.length; i++) {
+			const tab = this.tabs[i];
+			const label = tab.label || `Tab ${i + 1}`;
+			if (i === this.activeIndex) {
+				parts.push(`${ACTIVE_PREFIX}[ ${label} ]${RESET}`);
+			} else {
+				parts.push(`${INACTIVE_PREFIX}  ${label}  ${RESET}`);
+			}
+		}
+
+		const line = parts.join(SEPARATOR);
+		// Pad to width
+		const vis = visibleWidth(line);
+		const padded = vis < width ? line + " ".repeat(width - vis) : line;
+		return [padded];
+	}
+
+	invalidate(): void {
+		// No-op: render() recomputes from tabs/activeIndex each time
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -23,11 +23,13 @@ import type {
 import {
 	CombinedAutocompleteProvider,
 	type Component,
+	computeLayout,
 	Container,
 	fuzzyFilter,
 	Loader,
 	Markdown,
 	matchesKey,
+	PaneContainer,
 	ProcessTerminal,
 	Spacer,
 	setKeybindings,
@@ -94,10 +96,13 @@ import { ScopedModelsSelectorComponent } from "./components/scoped-models-select
 import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.js";
+import { TabBar } from "./components/tab-bar.js";
 import { ToolExecutionComponent } from "./components/tool-execution.js";
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
+import { InteractivePane } from "./interactive-pane.js";
+import { TabManager } from "./tab-manager.js";
 import {
 	getAvailableThemes,
 	getAvailableThemesWithPaths,
@@ -254,6 +259,12 @@ export class InteractiveMode {
 	// Custom header from extension (undefined = use built-in header)
 	private customHeader: (Component & { dispose?(): void }) | undefined = undefined;
 
+	// ── Multiplexer state ───────────────────────────────────────────────────
+	private tabManager: TabManager;
+	private paneContainer!: PaneContainer;
+	private tabBar: TabBar;
+	private primaryPane!: InteractivePane;
+
 	// Convenience accessors
 	private get session(): AgentSession {
 		return this.runtimeHost.session;
@@ -299,6 +310,10 @@ export class InteractiveMode {
 
 		// Load hide thinking block setting
 		this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
+
+		// Initialize multiplexer
+		this.tabManager = new TabManager();
+		this.tabBar = new TabBar();
 
 		// Register themes from resource loader and initialize
 		setRegisteredThemes(this.session.resourceLoader.getThemes().themes);
@@ -478,14 +493,10 @@ export class InteractiveMode {
 		const [fdPath] = await Promise.all([ensureTool("fd"), ensureTool("rg")]);
 		this.fdPath = fdPath;
 
-		// Add header container as first child
-		this.ui.addChild(this.headerContainer);
-
-		// Add header with keybindings from config (unless silenced)
+		// Build header content
 		if (this.options.verbose || !this.settingsManager.getQuietStartup()) {
 			const logo = theme.bold(theme.fg("accent", APP_NAME)) + theme.fg("dim", ` v${this.version}`);
 
-			// Build startup instructions using keybinding hint helpers
 			const hint = (keybinding: AppKeybinding, description: string) => keyHint(keybinding, description);
 
 			const instructions = [
@@ -515,24 +526,37 @@ export class InteractiveMode {
 			);
 			this.builtInHeader = new Text(`${logo}\n${instructions}\n\n${onboarding}`, 1, 0);
 
-			// Setup UI layout
 			this.headerContainer.addChild(new Spacer(1));
 			this.headerContainer.addChild(this.builtInHeader);
 			this.headerContainer.addChild(new Spacer(1));
 		} else {
-			// Minimal header when silenced
 			this.builtInHeader = new Text("", 0, 0);
 			this.headerContainer.addChild(this.builtInHeader);
 		}
 
-		this.ui.addChild(this.chatContainer);
-		this.ui.addChild(this.pendingMessagesContainer);
-		this.ui.addChild(this.statusContainer);
-		this.renderWidgets(); // Initialize with default spacer
-		this.ui.addChild(this.widgetContainerAbove);
-		this.ui.addChild(this.editorContainer);
-		this.ui.addChild(this.widgetContainerBelow);
-		this.ui.addChild(this.footer);
+		// Create primary pane — everything inside the pane (header to footer)
+		const { paneId } = this.tabManager.createTab("Session");
+		this.primaryPane = new InteractivePane(paneId);
+		this.primaryPane.addChild(this.headerContainer);
+		this.primaryPane.addChild(this.chatContainer);
+		this.primaryPane.addChild(this.pendingMessagesContainer);
+		this.primaryPane.addChild(this.statusContainer);
+		this.renderWidgets();
+		this.primaryPane.addChild(this.widgetContainerAbove);
+		this.primaryPane.addChild(this.editorContainer);
+		this.primaryPane.addChild(this.widgetContainerBelow);
+		this.primaryPane.addChild(this.footer);
+
+		// Set up PaneContainer with the primary pane
+		this.paneContainer = new PaneContainer(paneId, this.primaryPane);
+		this.paneContainer.siblingRows = 0;
+
+		// TabBar (hidden for single tab, shown when >1)
+		this.ui.addChild(this.tabBar as Component);
+
+		// PaneContainer is the only child of TUI — all content lives inside panes
+		this.ui.addChild(this.paneContainer as Component);
+
 		this.ui.setFocus(this.editor);
 
 		this.setupKeyHandlers();
@@ -540,6 +564,10 @@ export class InteractiveMode {
 
 		// Start the UI before initializing extensions so session_start handlers can use interactive dialogs
 		this.ui.start();
+
+		// Enable mouse click-to-focus for pane switching
+		this.enableMousePaneFocus();
+
 		this.isInitialized = true;
 
 		// Initialize extensions first so resources are shown before messages
@@ -2078,6 +2106,21 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.session.fork", () => this.showUserMessageSelector());
 		this.defaultEditor.onAction("app.session.resume", () => this.showSessionSelector());
 
+		// Pane management
+		this.defaultEditor.onAction("app.pane.splitH", () => this.handleSplitPane("horizontal"));
+		this.defaultEditor.onAction("app.pane.splitV", () => this.handleSplitPane("vertical"));
+		this.defaultEditor.onAction("app.pane.close", () => this.handleClosePane());
+		this.defaultEditor.onAction("app.pane.focusLeft", () => this.handleFocusPane("left"));
+		this.defaultEditor.onAction("app.pane.focusRight", () => this.handleFocusPane("right"));
+		this.defaultEditor.onAction("app.pane.focusUp", () => this.handleFocusPane("up"));
+		this.defaultEditor.onAction("app.pane.focusDown", () => this.handleFocusPane("down"));
+
+		// Tab management
+		this.defaultEditor.onAction("app.tab.new", () => this.handleNewTab());
+		this.defaultEditor.onAction("app.tab.close", () => this.handleCloseTab());
+		this.defaultEditor.onAction("app.tab.next", () => this.handleSwitchTab("next"));
+		this.defaultEditor.onAction("app.tab.prev", () => this.handleSwitchTab("prev"));
+
 		this.defaultEditor.onChange = (text: string) => {
 			const wasBashMode = this.isBashMode;
 			this.isBashMode = text.trimStart().startsWith("!");
@@ -2173,6 +2216,11 @@ export class InteractiveMode {
 			}
 			if (text === "/hotkeys") {
 				this.handleHotkeysCommand();
+				this.editor.setText("");
+				return;
+			}
+			if (text === "/keys") {
+				this.handleKeysCommand();
 				this.editor.setText("");
 				return;
 			}
@@ -4426,6 +4474,63 @@ export class InteractiveMode {
 		return this.capitalizeKey(keyText(action));
 	}
 
+	private handleKeysCommand(): void {
+		const k = (action: AppKeybinding) => this.getAppKeyDisplay(action);
+		const sections = [
+			theme.bold(theme.fg("accent", "── Multiplexer ──")),
+			"",
+			theme.bold("  Pane Management"),
+			`  ${theme.fg("accent", k("app.pane.splitH").padEnd(14))} Split pane horizontally`,
+			`  ${theme.fg("accent", k("app.pane.splitV").padEnd(14))} Split pane vertically`,
+			`  ${theme.fg("accent", k("app.pane.close").padEnd(14))} Close current pane`,
+			`  ${theme.fg("accent", "Click".padEnd(14))} Click to focus pane`,
+			"",
+			theme.bold("  Pane Focus"),
+			`  ${theme.fg("accent", k("app.pane.focusLeft").padEnd(14))} Focus pane left`,
+			`  ${theme.fg("accent", k("app.pane.focusRight").padEnd(14))} Focus pane right`,
+			`  ${theme.fg("accent", k("app.pane.focusUp").padEnd(14))} Focus pane up`,
+			`  ${theme.fg("accent", k("app.pane.focusDown").padEnd(14))} Focus pane down`,
+			"",
+			theme.bold("  Tab Management"),
+			`  ${theme.fg("accent", k("app.tab.new").padEnd(14))} New tab`,
+			`  ${theme.fg("accent", k("app.tab.close").padEnd(14))} Close tab`,
+			`  ${theme.fg("accent", k("app.tab.next").padEnd(14))} Next tab`,
+			`  ${theme.fg("accent", k("app.tab.prev").padEnd(14))} Previous tab`,
+			"",
+			theme.bold(theme.fg("accent", "── General ──")),
+			"",
+			theme.bold("  Session"),
+			`  ${theme.fg("accent", k("app.interrupt").padEnd(14))} Cancel / abort`,
+			`  ${theme.fg("accent", k("app.clear").padEnd(14))} Clear editor`,
+			`  ${theme.fg("accent", (k("app.clear") + " x2").padEnd(14))} Exit`,
+			`  ${theme.fg("accent", k("app.exit").padEnd(14))} Exit (empty editor)`,
+			`  ${theme.fg("accent", k("app.suspend").padEnd(14))} Suspend to background`,
+			"",
+			theme.bold("  Model & Thinking"),
+			`  ${theme.fg("accent", k("app.thinking.cycle").padEnd(14))} Cycle thinking level`,
+			`  ${theme.fg("accent", k("app.model.cycleForward").padEnd(14))} Next model`,
+			`  ${theme.fg("accent", k("app.model.cycleBackward").padEnd(14))} Previous model`,
+			`  ${theme.fg("accent", k("app.model.select").padEnd(14))} Model selector`,
+			"",
+			theme.bold("  Tools & Display"),
+			`  ${theme.fg("accent", k("app.tools.expand").padEnd(14))} Toggle tool output`,
+			`  ${theme.fg("accent", k("app.thinking.toggle").padEnd(14))} Toggle thinking blocks`,
+			`  ${theme.fg("accent", k("app.editor.external").padEnd(14))} External editor`,
+			"",
+			theme.bold("  Messages"),
+			`  ${theme.fg("accent", k("app.message.followUp").padEnd(14))} Queue follow-up`,
+			`  ${theme.fg("accent", k("app.message.dequeue").padEnd(14))} Edit queued messages`,
+			`  ${theme.fg("accent", k("app.clipboard.pasteImage").padEnd(14))} Paste image`,
+			`  ${theme.fg("accent", "/".padEnd(14))} Slash commands`,
+			`  ${theme.fg("accent", "!".padEnd(14))} Run bash`,
+		];
+		const msg = new Text(sections.join("\n"), 1, 1);
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(msg);
+		this.chatContainer.addChild(new Spacer(1));
+		this.ui.requestRender();
+	}
+
 	private handleHotkeysCommand(): void {
 		// Navigation keybindings
 		const cursorUp = this.getEditorKeyDisplay("tui.editor.cursorUp");
@@ -4732,7 +4837,165 @@ export class InteractiveMode {
 		}
 	}
 
+	// ── Multiplexer handlers ────────────────────────────────────────────────
+
+	/**
+	 * Atomically sync PaneContainer + TabBar from TabManager state.
+	 * Every multiplexer handler calls this instead of manually updating
+	 * setRoot/setActivePaneId/updateTabBar/requestRender individually.
+	 */
+	private syncMultiplexerState(): void {
+		const tab = this.tabManager.activeTab;
+		if (!tab) return;
+		this.paneContainer.setRoot(tab.splitRoot);
+		this.paneContainer.setActivePaneId(tab.activePaneId);
+		this.tabBar.setTabs(this.tabManager.getAllTabs(), this.tabManager.activeIndex);
+
+		// Set TUI keyboard focus to the active pane's editor
+		if (tab.activePaneId === this.primaryPane.paneId) {
+			// Primary pane uses InteractiveMode's own editor
+			this.ui.setFocus(this.editor);
+		} else {
+			const activePane = this.paneContainer.getPane(tab.activePaneId);
+			if (activePane && activePane instanceof InteractivePane) {
+				const editor = activePane.getEditor();
+				if (editor) {
+					this.ui.setFocus(editor);
+				}
+			}
+		}
+
+		this.ui.requestRender();
+	}
+
+	private handleSplitPane(direction: "horizontal" | "vertical"): void {
+		const newPaneId = this.tabManager.splitCurrentPane(direction);
+		if (!newPaneId) return;
+
+		const newPane = new InteractivePane(newPaneId);
+		this.paneContainer.setPane(newPaneId, newPane);
+		this.syncMultiplexerState();
+
+		// Initialize a live session asynchronously
+		this.initPaneSession(newPane).catch((err) => {
+			newPane.addChild(new Text(`\x1b[31m  Session error: ${err}\x1b[0m`, 1, 0) as Component);
+			this.ui.requestRender();
+		});
+	}
+
+	private handleClosePane(): void {
+		const tab = this.tabManager.activeTab;
+		if (!tab) return;
+		const closingPaneId = tab.activePaneId;
+		// removePane calls dispose() on PtyPane/disposable components
+		this.paneContainer.removePane(closingPaneId);
+		this.tabManager.closePane(closingPaneId);
+		this.syncMultiplexerState();
+	}
+
+	private handleFocusPane(direction: "up" | "down" | "left" | "right"): void {
+		this.tabManager.focusDirection(direction);
+		this.syncMultiplexerState();
+	}
+
+	private handleNewTab(): void {
+		const { paneId } = this.tabManager.createTab();
+		const newPane = new InteractivePane(paneId);
+		this.paneContainer.setPane(paneId, newPane);
+		this.syncMultiplexerState();
+
+		// Initialize a live session asynchronously
+		this.initPaneSession(newPane).catch((err) => {
+			newPane.addChild(new Text(`\x1b[31m  Session error: ${err}\x1b[0m`, 1, 0) as Component);
+			this.ui.requestRender();
+		});
+	}
+
+	private handleCloseTab(): void {
+		const tab = this.tabManager.activeTab;
+		if (!tab) return;
+		// closeTab returns the closed tab's pane IDs for cleanup
+		const closedPaneIds = this.tabManager.closeTab(tab.id);
+		if (closedPaneIds) {
+			for (const paneId of closedPaneIds) {
+				this.paneContainer.removePane(paneId); // calls dispose() on disposable components
+			}
+			this.syncMultiplexerState();
+		}
+	}
+
+	private enableMousePaneFocus(): void {
+		// Enable SGR mouse button reporting
+		process.stdout.write("\x1b[?1000h\x1b[?1006h");
+
+		// Register input listener to intercept mouse click events
+		this.ui.addInputListener((data: string) => {
+			// SGR mouse format: ESC[<btn;col;row M (press) or m (release)
+			const match = data.match(/^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/);
+			if (!match) return undefined;
+
+			const btn = Number.parseInt(match[1], 10);
+			const col = Number.parseInt(match[2], 10) - 1; // 1-based → 0-based
+			const row = Number.parseInt(match[3], 10) - 1;
+			const isPress = match[4] === "M";
+
+			// Only handle left-button press (btn 0)
+			if (btn !== 0 || !isPress) return { consume: true };
+
+			// Map click coordinates to a pane using the layout
+			const tab = this.tabManager.activeTab;
+			if (!tab) return { consume: true };
+
+			const termWidth = process.stdout.columns || 80;
+			const termHeight = process.stdout.rows || 24;
+			// Account for tab bar (1 row if >1 tab) and footer (2 rows)
+			const tabBarHeight = this.tabManager.tabCount > 1 ? 1 : 0;
+			const footerHeight = 2;
+			const paneAreaHeight = termHeight - tabBarHeight - footerHeight;
+			const paneAreaTop = tabBarHeight;
+
+			// Adjust row to pane-relative coordinates
+			const paneRow = row - paneAreaTop;
+			if (paneRow < 0 || paneRow >= paneAreaHeight) return { consume: true };
+
+			// Compute layout and find which pane was clicked
+			const layout = computeLayout(tab.splitRoot, { x: 0, y: 0, width: termWidth, height: paneAreaHeight });
+			for (const pl of layout.panes) {
+				if (
+					col >= pl.rect.x &&
+					col < pl.rect.x + pl.rect.width &&
+					paneRow >= pl.rect.y &&
+					paneRow < pl.rect.y + pl.rect.height
+				) {
+					if (pl.paneId !== tab.activePaneId) {
+						this.tabManager.setActivePaneId(pl.paneId);
+						this.syncMultiplexerState();
+					}
+					return { consume: true };
+				}
+			}
+
+			return { consume: true };
+		});
+	}
+
+	private async initPaneSession(pane: InteractivePane): Promise<void> {
+		const factory = this.runtimeHost.runtimeFactory;
+		const cwd = this.sessionManager.getCwd();
+		const agentDir = this.runtimeHost.services.agentDir;
+		const sessionDir = this.sessionManager.getSessionDir();
+		await pane.initSession(factory, cwd, agentDir, sessionDir, this.ui, this.keybindings);
+	}
+
+	private handleSwitchTab(direction: "next" | "prev"): void {
+		if (direction === "next") this.tabManager.nextTab();
+		else this.tabManager.prevTab();
+		this.syncMultiplexerState();
+	}
+
 	stop(): void {
+		// Disable mouse reporting
+		process.stdout.write("\x1b[?1000l\x1b[?1006l");
 		if (this.loadingAnimation) {
 			this.loadingAnimation.stop();
 			this.loadingAnimation = undefined;

--- a/packages/coding-agent/src/modes/interactive/interactive-pane.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-pane.ts
@@ -1,0 +1,402 @@
+/**
+ * Interactive pane — a complete, self-contained agent session for the multiplexer.
+ *
+ * Each pane is a full replica of InteractiveMode's UI: header, chat, editor,
+ * footer with model/cwd/tokens. Like tmux — each pane is an independent instance.
+ */
+
+import {
+	type BoundsAwareComponent,
+	type Component,
+	Container,
+	Loader,
+	Spacer,
+	Text,
+	TUI,
+} from "@mariozechner/pi-tui";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import type { AgentSession, AgentSessionEvent } from "../../core/agent-session.js";
+import {
+	type AgentSessionRuntime,
+	type CreateAgentSessionRuntimeFactory,
+	createAgentSessionRuntime,
+} from "../../core/agent-session-runtime.js";
+import { FooterDataProvider } from "../../core/footer-data-provider.js";
+import { SessionManager } from "../../core/session-manager.js";
+import type { KeybindingsManager } from "../../core/keybindings.js";
+import { AssistantMessageComponent } from "./components/assistant-message.js";
+import { CustomEditor } from "./components/custom-editor.js";
+import { FooterComponent } from "./components/footer.js";
+import { ToolExecutionComponent } from "./components/tool-execution.js";
+import { UserMessageComponent } from "./components/user-message.js";
+import { getEditorTheme, getMarkdownTheme, theme } from "./theme/theme.js";
+
+// ---------------------------------------------------------------------------
+// InteractivePane
+// ---------------------------------------------------------------------------
+
+export class InteractivePane implements BoundsAwareComponent {
+	readonly paneId: string;
+	readonly rootContainer: Container;
+
+	// Session
+	private runtimeHost: AgentSessionRuntime | undefined;
+	private unsubscribe?: () => void;
+
+	// UI containers (full instance — header to footer)
+	private headerContainer: Container;
+	private chatContainer: Container;
+	private statusContainer: Container;
+	private widgetContainerAbove: Container;
+	private editorContainer: Container;
+	private widgetContainerBelow: Container;
+	private footer: FooterComponent | undefined;
+	private footerDataProvider: FooterDataProvider | undefined;
+	private editor: CustomEditor | undefined;
+
+	// Streaming state
+	private streamingComponent: AssistantMessageComponent | undefined;
+	private streamingMessage: AssistantMessage | undefined;
+	private pendingTools = new Map<string, ToolExecutionComponent>();
+	private toolOutputExpanded = false;
+	private loadingAnimation: Loader | undefined;
+
+	// References
+	private tui: TUI | undefined;
+	private initialized = false;
+
+	constructor(paneId: string) {
+		this.paneId = paneId;
+
+		// Build full instance layout: header → chat → status → widgets → editor → widgets → footer
+		this.rootContainer = new Container();
+		this.headerContainer = new Container();
+		this.chatContainer = new Container();
+		this.statusContainer = new Container();
+		this.widgetContainerAbove = new Container();
+		this.editorContainer = new Container();
+		this.widgetContainerBelow = new Container();
+
+		this.rootContainer.addChild(this.headerContainer);
+		this.rootContainer.addChild(this.chatContainer);
+		this.rootContainer.addChild(this.statusContainer);
+		this.rootContainer.addChild(this.widgetContainerAbove);
+		this.rootContainer.addChild(this.editorContainer);
+		this.rootContainer.addChild(this.widgetContainerBelow);
+		// Footer added after session init (needs session reference)
+	}
+
+	/**
+	 * Initialize the pane with a live agent session.
+	 * Creates a complete Pi instance: header, chat, editor, footer.
+	 */
+	async initSession(
+		factory: CreateAgentSessionRuntimeFactory,
+		cwd: string,
+		agentDir: string,
+		sessionDir: string,
+		tui: TUI,
+		keybindings: KeybindingsManager,
+	): Promise<void> {
+		if (this.initialized) return;
+		this.initialized = true;
+		this.tui = tui;
+
+		// Create independent session
+		const sessionManager = SessionManager.create(cwd, sessionDir);
+		this.runtimeHost = await createAgentSessionRuntime(factory, {
+			cwd,
+			agentDir,
+			sessionManager,
+			sessionStartEvent: { type: "session_start", reason: "new" },
+		});
+
+		const session = this.runtimeHost.session;
+
+		// ── Header ──────────────────────────────────────────────────────────
+		const headerText = [
+			theme.bold(theme.fg("accent", "pi")) + theme.fg("dim", ` ${this.paneId}`),
+			theme.fg("dim", `cwd: ${cwd}`),
+		].join("\n");
+		this.headerContainer.addChild(new Spacer(1));
+		this.headerContainer.addChild(new Text(headerText, 1, 0));
+		this.headerContainer.addChild(new Spacer(1));
+
+		// ── Editor ──────────────────────────────────────────────────────────
+		this.editor = new CustomEditor(tui, getEditorTheme(), keybindings, { paddingX: 1 });
+		this.editorContainer.addChild(this.editor as Component);
+
+		// Widget spacers (default)
+		this.widgetContainerAbove.addChild(new Spacer(0));
+		this.widgetContainerBelow.addChild(new Spacer(0));
+
+		// ── Footer ──────────────────────────────────────────────────────────
+		this.footerDataProvider = new FooterDataProvider(cwd);
+		this.footer = new FooterComponent(session, this.footerDataProvider);
+		this.footer.setAutoCompactEnabled(session.autoCompactionEnabled);
+		this.rootContainer.addChild(this.footer);
+
+		// ── Editor submit handler ───────────────────────────────────────────
+		this.editor.onSubmit = async (text: string) => {
+			const trimmed = text.trim();
+			if (!trimmed || !this.runtimeHost) return;
+			this.editor?.setText("");
+			this.editor?.addToHistory?.(trimmed);
+
+			// Handle bash commands
+			if (trimmed.startsWith("!")) {
+				const cmd = trimmed.startsWith("!!") ? trimmed.slice(2).trim() : trimmed.slice(1).trim();
+				if (cmd) {
+					try {
+						await this.runtimeHost.session.prompt(trimmed);
+					} catch (err) {
+						this.showStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+					}
+				}
+				return;
+			}
+
+			// Normal prompt
+			try {
+				if (this.runtimeHost.session.isStreaming) {
+					// Queue as steer if agent is busy
+					await this.runtimeHost.session.steer(trimmed);
+				} else {
+					await this.runtimeHost.session.prompt(trimmed);
+				}
+			} catch (err) {
+				this.showStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		};
+
+		// ── Escape handler ──────────────────────────────────────────────────
+		this.editor.onEscape = () => {
+			if (this.loadingAnimation && this.runtimeHost) {
+				this.runtimeHost.session.abort();
+			}
+		};
+
+		// ── Subscribe to agent events ───────────────────────────────────────
+		this.unsubscribe = session.subscribe(async (event) => {
+			await this.handleEvent(event);
+		});
+
+		tui.requestRender();
+	}
+
+	/**
+	 * Add a child component directly (for primary pane backward compat).
+	 */
+	addChild(child: Component): void {
+		this.rootContainer.addChild(child);
+	}
+
+	removeChild(child: Component): void {
+		this.rootContainer.removeChild(child);
+	}
+
+	clear(): void {
+		this.rootContainer.clear();
+	}
+
+	getEditor(): Component | undefined {
+		return this.editor as Component | undefined;
+	}
+
+	// ── Event handling ───────────────────────────────────────────────────────
+
+	private async handleEvent(event: AgentSessionEvent): Promise<void> {
+		switch (event.type) {
+			case "agent_start":
+				this.statusContainer.clear();
+				if (this.tui) {
+					this.loadingAnimation = new Loader(
+						this.tui,
+						(spinner) => theme.fg("accent", spinner),
+						(text) => theme.fg("muted", text),
+						"Working...",
+					);
+					this.statusContainer.addChild(this.loadingAnimation);
+				}
+				this.tui?.requestRender();
+				break;
+
+			case "message_start":
+				if (event.message.role === "user") {
+					const content =
+						typeof event.message.content === "string"
+							? event.message.content
+							: event.message.content
+									.filter((c: any) => c.type === "text")
+									.map((c: any) => c.text)
+									.join("");
+					this.chatContainer.addChild(
+						new UserMessageComponent(content, getMarkdownTheme()),
+					);
+					this.tui?.requestRender();
+				} else if (event.message.role === "assistant") {
+					this.streamingComponent = new AssistantMessageComponent(
+						undefined,
+						false,
+						getMarkdownTheme(),
+					);
+					this.streamingMessage = event.message as AssistantMessage;
+					this.chatContainer.addChild(this.streamingComponent);
+					this.streamingComponent.updateContent(this.streamingMessage);
+					this.tui?.requestRender();
+				}
+				break;
+
+			case "message_update":
+				if (this.streamingComponent && event.message.role === "assistant") {
+					this.streamingMessage = event.message as AssistantMessage;
+					this.streamingComponent.updateContent(this.streamingMessage);
+
+					for (const content of this.streamingMessage.content) {
+						if (content.type === "toolCall" && !this.pendingTools.has(content.id)) {
+							const component = new ToolExecutionComponent(
+								content.name,
+								content.id,
+								content.arguments,
+								{ showImages: false },
+								undefined,
+								this.tui!,
+								this.runtimeHost?.session.sessionManager.getCwd() ?? ".",
+							);
+							component.setExpanded(this.toolOutputExpanded);
+							this.chatContainer.addChild(component);
+							this.pendingTools.set(content.id, component);
+						}
+					}
+					this.tui?.requestRender();
+				}
+				break;
+
+			case "message_end":
+				if (this.streamingComponent && event.message.role === "assistant") {
+					this.streamingMessage = event.message as AssistantMessage;
+					this.streamingComponent.updateContent(this.streamingMessage);
+					for (const [, component] of this.pendingTools) {
+						component.setArgsComplete();
+					}
+					this.streamingComponent = undefined;
+					this.streamingMessage = undefined;
+				}
+				this.footer?.invalidate();
+				this.tui?.requestRender();
+				break;
+
+			case "tool_execution_start": {
+				let component = this.pendingTools.get(event.toolCallId);
+				if (!component && this.tui) {
+					component = new ToolExecutionComponent(
+						event.toolName,
+						event.toolCallId,
+						event.args,
+						{ showImages: false },
+						undefined,
+						this.tui,
+						this.runtimeHost?.session.sessionManager.getCwd() ?? ".",
+					);
+					component.setExpanded(this.toolOutputExpanded);
+					this.chatContainer.addChild(component);
+					this.pendingTools.set(event.toolCallId, component);
+				}
+				component?.markExecutionStarted();
+				this.tui?.requestRender();
+				break;
+			}
+
+			case "tool_execution_update": {
+				const component = this.pendingTools.get(event.toolCallId);
+				if (component) {
+					component.updateResult({ ...event.partialResult, isError: false }, true);
+					this.tui?.requestRender();
+				}
+				break;
+			}
+
+			case "tool_execution_end": {
+				const component = this.pendingTools.get(event.toolCallId);
+				if (component) {
+					component.updateResult({ ...event.result, isError: event.isError });
+					this.pendingTools.delete(event.toolCallId);
+					this.tui?.requestRender();
+				}
+				break;
+			}
+
+			case "agent_end":
+				if (this.loadingAnimation) {
+					this.loadingAnimation.stop();
+					this.loadingAnimation = undefined;
+					this.statusContainer.clear();
+				}
+				if (this.streamingComponent) {
+					this.chatContainer.removeChild(this.streamingComponent);
+					this.streamingComponent = undefined;
+					this.streamingMessage = undefined;
+				}
+				this.pendingTools.clear();
+				this.footer?.invalidate();
+				this.tui?.requestRender();
+				break;
+
+			case "queue_update":
+				this.footer?.invalidate();
+				this.tui?.requestRender();
+				break;
+		}
+	}
+
+	private showStatus(message: string): void {
+		this.statusContainer.clear();
+		this.statusContainer.addChild(new Text(`\x1b[33m  ${message}\x1b[0m`, 1, 0));
+		this.tui?.requestRender();
+	}
+
+	// ── BoundsAwareComponent ─────────────────────────────────────────────────
+
+	/**
+	 * Render into a bounded region. Keeps the BOTTOM portion when content
+	 * exceeds height (most recent chat messages stay visible).
+	 */
+	renderBounded(width: number, height: number): string[] {
+		const lines = this.rootContainer.render(width);
+		if (lines.length > height) {
+			return lines.slice(lines.length - height);
+		}
+		while (lines.length < height) {
+			lines.push(" ".repeat(width));
+		}
+		return lines;
+	}
+
+	render(width: number): string[] {
+		return this.rootContainer.render(width);
+	}
+
+	invalidate(): void {
+		this.rootContainer.invalidate();
+	}
+
+	// ── Cleanup ──────────────────────────────────────────────────────────────
+
+	dispose(): void {
+		if (this.unsubscribe) {
+			this.unsubscribe();
+			this.unsubscribe = undefined;
+		}
+		if (this.loadingAnimation) {
+			this.loadingAnimation.stop();
+			this.loadingAnimation = undefined;
+		}
+		if (this.footer) {
+			this.footer.dispose();
+		}
+		if (this.footerDataProvider) {
+			this.footerDataProvider.dispose();
+		}
+		this.runtimeHost = undefined;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/layout-persistence.ts
+++ b/packages/coding-agent/src/modes/interactive/layout-persistence.ts
@@ -1,0 +1,105 @@
+/**
+ * Layout persistence — save/restore tab and pane layout across sessions.
+ *
+ * Serializes the TabManager's tab structure (split trees + pane metadata)
+ * to a JSON file. Instance-scoped debounce timer avoids both module-level
+ * singleton issues and thrashing on rapid layout changes.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { SplitNode } from "@mariozechner/pi-tui";
+import type { Tab } from "./tab-manager.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SerializedTab {
+	id: string;
+	label: string;
+	splitRoot: SplitNode;
+	activePaneId: string;
+}
+
+export interface SerializedLayout {
+	version: 1;
+	activeTabIndex: number;
+	tabs: SerializedTab[];
+}
+
+// ---------------------------------------------------------------------------
+// LayoutPersistence
+// ---------------------------------------------------------------------------
+
+const DEBOUNCE_MS = 2000;
+
+export class LayoutPersistence {
+	private readonly agentDir: string;
+	private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+	constructor(agentDir: string) {
+		this.agentDir = agentDir;
+	}
+
+	private getLayoutPath(): string {
+		return path.join(this.agentDir, "layout.json");
+	}
+
+	/**
+	 * Save layout to disk (debounced 2s).
+	 */
+	save(tabs: readonly Tab[], activeTabIndex: number): void {
+		if (this.debounceTimer) clearTimeout(this.debounceTimer);
+
+		this.debounceTimer = setTimeout(() => {
+			const layout: SerializedLayout = {
+				version: 1,
+				activeTabIndex,
+				tabs: tabs.map((t) => ({
+					id: t.id,
+					label: t.label,
+					splitRoot: t.splitRoot,
+					activePaneId: t.activePaneId,
+				})),
+			};
+
+			try {
+				const layoutPath = this.getLayoutPath();
+				fs.mkdirSync(path.dirname(layoutPath), { recursive: true });
+				fs.writeFileSync(layoutPath, JSON.stringify(layout, null, 2), "utf-8");
+			} catch {
+				// Non-fatal — layout persistence is best-effort
+			}
+		}, DEBOUNCE_MS);
+	}
+
+	/**
+	 * Restore layout from disk.
+	 * Returns undefined if no saved layout exists or it's corrupt.
+	 */
+	restore(): SerializedLayout | undefined {
+		try {
+			const layoutPath = this.getLayoutPath();
+			if (!fs.existsSync(layoutPath)) return undefined;
+			const raw = fs.readFileSync(layoutPath, "utf-8");
+			const parsed = JSON.parse(raw) as SerializedLayout;
+			if (parsed.version !== 1 || !Array.isArray(parsed.tabs) || parsed.tabs.length === 0) {
+				return undefined;
+			}
+			return parsed;
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
+	 * Cancel any pending debounced write and clean up.
+	 */
+	dispose(): void {
+		if (this.debounceTimer) {
+			clearTimeout(this.debounceTimer);
+			this.debounceTimer = undefined;
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/pty-pane.ts
+++ b/packages/coding-agent/src/modes/interactive/pty-pane.ts
@@ -1,0 +1,190 @@
+/**
+ * PTY shell pane — wraps node-pty + @xterm/headless for terminal emulation.
+ *
+ * Renders a real shell inside a split pane. Lazily spawns the PTY on first
+ * render to avoid overhead when the pane hasn't been laid out yet.
+ *
+ * Implements BoundsAwareComponent so PaneContainer can allocate a rectangular
+ * region and read the screen buffer from xterm.
+ */
+
+import type { BoundsAwareComponent } from "@mariozechner/pi-tui";
+
+// Lazy-loaded deps (node-pty may not be installed)
+// biome-ignore lint: dynamic imports for optional deps
+let pty: any;
+// biome-ignore lint: dynamic imports for optional deps
+let xtermLib: any;
+
+// Use a variable to prevent TypeScript from resolving the optional dependency at compile time
+const NODE_PTY_MODULE = "node-pty";
+
+async function loadPty() {
+	if (!pty) {
+		try {
+			pty = await import(NODE_PTY_MODULE);
+		} catch {
+			throw new Error("node-pty is not installed. Install it with: pnpm add node-pty");
+		}
+	}
+	return pty;
+}
+
+async function loadXterm() {
+	if (!xtermLib) {
+		try {
+			xtermLib = await import("@xterm/headless");
+		} catch {
+			throw new Error("@xterm/headless is not installed.");
+		}
+	}
+	return xtermLib;
+}
+
+// ---------------------------------------------------------------------------
+// PtyPane
+// ---------------------------------------------------------------------------
+
+export class PtyPane implements BoundsAwareComponent {
+	private cwd: string;
+	private shell: string;
+	private ptyProcess: any | undefined;
+	private terminal: any | undefined;
+	/** True after spawn() has been called (regardless of success/failure). No automatic retry. */
+	private spawnAttempted = false;
+	private spawnError: string | undefined;
+	private lastWidth = 80;
+	private lastHeight = 24;
+
+	constructor(cwd: string, shell?: string) {
+		this.cwd = cwd;
+		this.shell = shell || (process.platform === "win32" ? "powershell.exe" : process.env.SHELL || "/bin/bash");
+	}
+
+	/**
+	 * Spawn the PTY process. Called lazily on first render.
+	 */
+	async spawn(cols: number, rows: number): Promise<void> {
+		if (this.spawnAttempted) return;
+		this.spawnAttempted = true;
+
+		try {
+			const ptyMod = await loadPty();
+			const xtermMod = await loadXterm();
+
+			// Create headless xterm terminal for screen state
+			this.terminal = new xtermMod.Terminal({
+				cols,
+				rows,
+				scrollback: 1000,
+				allowProposedApi: true,
+			});
+
+			// Spawn PTY
+			this.ptyProcess = ptyMod.spawn(this.shell, [], {
+				name: "xterm-256color",
+				cols,
+				rows,
+				cwd: this.cwd,
+				env: process.env as Record<string, string>,
+			});
+
+			// Pipe PTY output to xterm
+			this.ptyProcess.onData((data: string) => {
+				this.terminal.write(data);
+			});
+
+			this.ptyProcess.onExit(() => {
+				this.ptyProcess = undefined;
+			});
+
+			// Apply any dimensions that arrived during the async spawn window
+			this.resize(this.lastWidth, this.lastHeight);
+		} catch (err) {
+			this.spawnError = err instanceof Error ? err.message : String(err);
+		}
+	}
+
+	/**
+	 * Forward keyboard input to the PTY process.
+	 */
+	handleInput(data: string): void {
+		if (this.ptyProcess) {
+			this.ptyProcess.write(data);
+		}
+	}
+
+	/**
+	 * Resize the PTY to match the new pane dimensions.
+	 */
+	resize(cols: number, rows: number): void {
+		this.lastWidth = cols;
+		this.lastHeight = rows;
+		if (this.ptyProcess) {
+			this.ptyProcess.resize(cols, rows);
+		}
+		if (this.terminal) {
+			this.terminal.resize(cols, rows);
+		}
+	}
+
+	// ── BoundsAwareComponent ─────────────────────────────────────────────────
+
+	renderBounded(width: number, height: number): string[] {
+		// Lazily spawn on first render
+		if (!this.spawnAttempted) {
+			this.spawn(width, height).catch(() => {});
+		}
+
+		this.resize(width, height);
+
+		if (this.spawnError) {
+			const lines: string[] = [];
+			lines.push(`\x1b[31m  Shell error: ${this.spawnError}\x1b[0m`);
+			while (lines.length < height) lines.push(" ".repeat(width));
+			return lines;
+		}
+
+		if (!this.terminal) {
+			const lines: string[] = [];
+			lines.push("\x1b[90m  Starting shell...\x1b[0m");
+			while (lines.length < height) lines.push(" ".repeat(width));
+			return lines;
+		}
+
+		// Read screen buffer from xterm
+		const lines: string[] = [];
+		const buffer = this.terminal.buffer.active;
+		for (let row = 0; row < height; row++) {
+			const line = buffer.getLine(row);
+			if (line) {
+				lines.push(line.translateToString(true));
+			} else {
+				lines.push("");
+			}
+		}
+
+		return lines;
+	}
+
+	render(width: number): string[] {
+		return this.renderBounded(width, this.lastHeight);
+	}
+
+	invalidate(): void {
+		// Terminal buffer is always fresh — no caching needed
+	}
+
+	// ── Cleanup ──────────────────────────────────────────────────────────────
+
+	dispose(): void {
+		if (this.ptyProcess) {
+			this.ptyProcess.kill();
+			this.ptyProcess = undefined;
+		}
+		if (this.terminal) {
+			this.terminal.dispose();
+			this.terminal = undefined;
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/tab-manager.ts
+++ b/packages/coding-agent/src/modes/interactive/tab-manager.ts
@@ -1,0 +1,174 @@
+/**
+ * Tab manager — coordinates tabs and split panes for the terminal multiplexer.
+ *
+ * Each tab owns a split tree (SplitNode) and a set of panes. The active tab's
+ * tree is rendered by PaneContainer in the TUI.
+ */
+
+import type { SplitDirection, SplitNode } from "@mariozechner/pi-tui";
+import { adjacentPane, allPanes, newLeaf, paneCount, removePane, splitPane as splitTree } from "@mariozechner/pi-tui";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Tab {
+	id: string;
+	label: string;
+	splitRoot: SplitNode;
+	activePaneId: string;
+}
+
+// ---------------------------------------------------------------------------
+// TabManager
+// ---------------------------------------------------------------------------
+
+export class TabManager {
+	private tabs: Tab[] = [];
+	private activeTabIndex = 0;
+	private nextTabId = 1;
+	private nextPaneId = 1;
+
+	private generateTabId(): string {
+		return `tab-${this.nextTabId++}`;
+	}
+
+	private generatePaneId(): string {
+		return `pane-${this.nextPaneId++}`;
+	}
+
+	/**
+	 * Create a new tab with a single pane.
+	 * Returns the tab and the pane ID of the initial pane.
+	 */
+	createTab(label?: string): { tab: Tab; paneId: string } {
+		const tabId = this.generateTabId();
+		const paneId = this.generatePaneId();
+		const tab: Tab = {
+			id: tabId,
+			label: label || `Tab ${this.tabs.length + 1}`,
+			splitRoot: newLeaf(paneId),
+			activePaneId: paneId,
+		};
+		this.tabs.push(tab);
+		this.activeTabIndex = this.tabs.length - 1;
+		return { tab, paneId };
+	}
+
+	/**
+	 * Close a tab by ID. Returns the closed tab's pane IDs for cleanup,
+	 * or undefined if the tab cannot be closed (last tab).
+	 */
+	closeTab(tabId: string): string[] | undefined {
+		if (this.tabs.length <= 1) return undefined;
+		const idx = this.tabs.findIndex((t) => t.id === tabId);
+		if (idx < 0) return undefined;
+		const closedTab = this.tabs[idx];
+		const closedPaneIds = allPanes(closedTab.splitRoot);
+		this.tabs.splice(idx, 1);
+		if (this.activeTabIndex >= this.tabs.length) {
+			this.activeTabIndex = this.tabs.length - 1;
+		}
+		return closedPaneIds;
+	}
+
+	/**
+	 * Switch to a tab by index.
+	 */
+	switchTab(index: number): void {
+		if (index >= 0 && index < this.tabs.length) {
+			this.activeTabIndex = index;
+		}
+	}
+
+	nextTab(): void {
+		this.switchTab((this.activeTabIndex + 1) % this.tabs.length);
+	}
+
+	prevTab(): void {
+		this.switchTab((this.activeTabIndex - 1 + this.tabs.length) % this.tabs.length);
+	}
+
+	/**
+	 * Split the current pane in the active tab.
+	 * Returns the new pane ID, or undefined if the split failed.
+	 */
+	splitCurrentPane(direction: SplitDirection): string | undefined {
+		const tab = this.activeTab;
+		if (!tab) return undefined;
+		const newPaneId = this.generatePaneId();
+		const newRoot = splitTree(tab.splitRoot, tab.activePaneId, direction, newPaneId);
+		// Verify the split actually produced a new pane (guards against stale activePaneId)
+		if (newRoot === tab.splitRoot || !allPanes(newRoot).includes(newPaneId)) {
+			return undefined;
+		}
+		tab.splitRoot = newRoot;
+		tab.activePaneId = newPaneId;
+		return newPaneId;
+	}
+
+	/**
+	 * Close a pane in the active tab. If it's the last pane, close the tab instead.
+	 * Returns false if nothing was closed (last tab, last pane).
+	 */
+	closePane(paneId: string): boolean {
+		const tab = this.activeTab;
+		if (!tab) return false;
+		if (paneCount(tab.splitRoot) <= 1) {
+			return this.closeTab(tab.id) !== undefined;
+		}
+		const newRoot = removePane(tab.splitRoot, paneId);
+		if (!newRoot) return false;
+		tab.splitRoot = newRoot;
+		if (tab.activePaneId === paneId) {
+			tab.activePaneId = this.getFirstPaneId(newRoot);
+		}
+		return true;
+	}
+
+	/**
+	 * Move focus to an adjacent pane in the given direction.
+	 */
+	focusDirection(direction: "up" | "down" | "left" | "right"): void {
+		const tab = this.activeTab;
+		if (!tab) return;
+		const neighbor = adjacentPane(tab.splitRoot, tab.activePaneId, direction);
+		if (neighbor) {
+			tab.activePaneId = neighbor;
+		}
+	}
+
+	// ── Getters ─────────────────────────────────────────────────────────────
+
+	get activeTab(): Tab | undefined {
+		return this.tabs[this.activeTabIndex];
+	}
+
+	get activePaneId(): string | undefined {
+		return this.activeTab?.activePaneId;
+	}
+
+	get tabCount(): number {
+		return this.tabs.length;
+	}
+
+	get activeIndex(): number {
+		return this.activeTabIndex;
+	}
+
+	getAllTabs(): readonly Tab[] {
+		return this.tabs;
+	}
+
+	setActivePaneId(paneId: string): void {
+		const tab = this.activeTab;
+		if (tab) tab.activePaneId = paneId;
+	}
+
+	// ── Helpers ──────────────────────────────────────────────────────────────
+
+	private getFirstPaneId(node: SplitNode): string {
+		if (node.type === "leaf") return node.paneId;
+		return this.getFirstPaneId(node.a);
+	}
+}

--- a/packages/coding-agent/test/tab-manager.test.ts
+++ b/packages/coding-agent/test/tab-manager.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for TabManager — tab and split-pane coordination.
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { allPanes } from "@mariozechner/pi-tui";
+import { TabManager } from "../src/modes/interactive/tab-manager.js";
+
+describe("TabManager", () => {
+	let tm: TabManager;
+
+	beforeEach(() => {
+		tm = new TabManager();
+	});
+
+	describe("createTab", () => {
+		it("creates a tab with a single pane", () => {
+			const { tab, paneId } = tm.createTab("Test");
+			expect(tab.label).toBe("Test");
+			expect(tab.splitRoot.type).toBe("leaf");
+			expect(tab.activePaneId).toBe(paneId);
+			expect(tm.tabCount).toBe(1);
+			expect(tm.activeIndex).toBe(0);
+		});
+
+		it("auto-generates label if none provided", () => {
+			const { tab } = tm.createTab();
+			expect(tab.label).toBe("Tab 1");
+		});
+
+		it("switches to the new tab", () => {
+			tm.createTab("First");
+			tm.createTab("Second");
+			expect(tm.activeIndex).toBe(1);
+			expect(tm.activeTab?.label).toBe("Second");
+		});
+
+		it("assigns unique pane IDs per instance", () => {
+			const { paneId: p1 } = tm.createTab();
+			const { paneId: p2 } = tm.createTab();
+			expect(p1).not.toBe(p2);
+		});
+
+		it("different TabManager instances have independent ID counters", () => {
+			const tm2 = new TabManager();
+			const { paneId: a } = tm.createTab();
+			const { paneId: b } = tm2.createTab();
+			// Both start from 1 independently
+			expect(a).toMatch(/^pane-/);
+			expect(b).toMatch(/^pane-/);
+		});
+	});
+
+	describe("closeTab", () => {
+		it("returns undefined when closing the last tab", () => {
+			tm.createTab();
+			expect(tm.closeTab(tm.activeTab!.id)).toBeUndefined();
+			expect(tm.tabCount).toBe(1);
+		});
+
+		it("closes a tab and returns its pane IDs", () => {
+			const { tab: first } = tm.createTab("First");
+			tm.createTab("Second");
+			const closed = tm.closeTab(first.id);
+			expect(closed).toBeDefined();
+			expect(closed!.length).toBeGreaterThan(0);
+			expect(tm.tabCount).toBe(1);
+		});
+
+		it("adjusts activeTabIndex when closing before it", () => {
+			tm.createTab("A");
+			tm.createTab("B");
+			tm.createTab("C");
+			// Active is C (index 2)
+			tm.switchTab(2);
+			tm.closeTab(tm.getAllTabs()[0].id); // Close A
+			expect(tm.activeTab?.label).toBe("C");
+		});
+	});
+
+	describe("switchTab / nextTab / prevTab", () => {
+		it("switches to a valid index", () => {
+			tm.createTab("A");
+			tm.createTab("B");
+			tm.switchTab(0);
+			expect(tm.activeTab?.label).toBe("A");
+		});
+
+		it("ignores invalid index", () => {
+			tm.createTab("A");
+			tm.switchTab(99);
+			expect(tm.activeIndex).toBe(0);
+		});
+
+		it("nextTab wraps around", () => {
+			tm.createTab("A");
+			tm.createTab("B");
+			tm.switchTab(1);
+			tm.nextTab();
+			expect(tm.activeIndex).toBe(0);
+		});
+
+		it("prevTab wraps around", () => {
+			tm.createTab("A");
+			tm.createTab("B");
+			tm.switchTab(0);
+			tm.prevTab();
+			expect(tm.activeIndex).toBe(1);
+		});
+	});
+
+	describe("splitCurrentPane", () => {
+		it("splits and returns new pane ID", () => {
+			tm.createTab();
+			const newId = tm.splitCurrentPane("horizontal");
+			expect(newId).toBeDefined();
+			expect(tm.activeTab?.splitRoot.type).toBe("split");
+			expect(tm.activeTab?.activePaneId).toBe(newId);
+		});
+
+		it("returns undefined with no active tab", () => {
+			expect(tm.splitCurrentPane("horizontal")).toBeUndefined();
+		});
+
+		it("validates new pane appears in tree", () => {
+			tm.createTab();
+			const newId = tm.splitCurrentPane("vertical");
+			expect(newId).toBeDefined();
+			const panes = allPanes(tm.activeTab!.splitRoot);
+			expect(panes).toContain(newId);
+		});
+	});
+
+	describe("closePane", () => {
+		it("closes a pane in a multi-pane tab", () => {
+			const { paneId: original } = tm.createTab();
+			const newId = tm.splitCurrentPane("horizontal")!;
+			expect(tm.closePane(newId)).toBe(true);
+			expect(tm.activeTab?.activePaneId).toBe(original);
+		});
+
+		it("closes the tab when last pane is closed", () => {
+			tm.createTab("A");
+			tm.createTab("B");
+			const paneId = tm.activeTab!.activePaneId;
+			// This is the only pane in tab B, so closing it closes the tab
+			expect(tm.closePane(paneId)).toBe(true);
+			expect(tm.tabCount).toBe(1);
+		});
+
+		it("returns false when nothing can be closed", () => {
+			tm.createTab();
+			// Only one tab with one pane — can't close
+			expect(tm.closePane(tm.activeTab!.activePaneId)).toBe(false);
+		});
+	});
+
+	describe("focusDirection", () => {
+		it("moves focus to adjacent pane", () => {
+			const { paneId: left } = tm.createTab();
+			const right = tm.splitCurrentPane("horizontal")!;
+			// Active is now 'right'
+			expect(tm.activePaneId).toBe(right);
+			tm.focusDirection("left");
+			expect(tm.activePaneId).toBe(left);
+		});
+
+		it("does nothing when no neighbor exists", () => {
+			const { paneId } = tm.createTab();
+			tm.focusDirection("right");
+			expect(tm.activePaneId).toBe(paneId);
+		});
+	});
+});

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -57,6 +57,24 @@ export {
 	parseKey,
 	setKittyProtocolActive,
 } from "./keys.js";
+export { type BoundsAwareComponent, PaneContainer } from "./pane-container.js";
+// Split tree and pane container
+export {
+	adjacentPane,
+	allPanes,
+	computeLayout,
+	type Divider,
+	type LayoutResult,
+	newLeaf,
+	type PaneLayout,
+	paneCount,
+	type Rect,
+	removePane,
+	type SplitDirection,
+	type SplitNode,
+	setRatio,
+	splitPane,
+} from "./split-tree.js";
 // Input buffering for batch splitting
 export { StdinBuffer, type StdinBufferEventMap, type StdinBufferOptions } from "./stdin-buffer.js";
 // Terminal interface and implementations

--- a/packages/tui/src/pane-container.ts
+++ b/packages/tui/src/pane-container.ts
@@ -1,0 +1,243 @@
+/**
+ * Pane container — composites multiple components into a split-tree layout.
+ *
+ * Holds a split-tree root supplier and a map of pane ID → Component. On render,
+ * computes the layout, renders each component into its allocated rect,
+ * and draws dividers between them.
+ *
+ * Divider.direction naming: "horizontal" means "produced by a horizontal split"
+ * which renders as a vertical line (│). "vertical" means "produced by a vertical
+ * split" which renders as a horizontal line (─). This matches the split-tree
+ * convention, not the visual direction of the drawn character.
+ */
+
+import type { Rect, SplitNode } from "./split-tree.js";
+import { computeLayout } from "./split-tree.js";
+import type { Component } from "./tui.js";
+import { sliceByColumn, visibleWidth } from "./utils.js";
+
+// ---------------------------------------------------------------------------
+// BoundsAwareComponent
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional interface for components that can render to bounded regions.
+ * PaneContainer calls renderBounded if available, otherwise falls back
+ * to render(width) and truncates to height.
+ */
+export interface BoundsAwareComponent extends Component {
+	renderBounded(width: number, height: number): string[];
+}
+
+function isBoundsAware(c: Component): c is BoundsAwareComponent {
+	return "renderBounded" in c && typeof (c as any).renderBounded === "function";
+}
+
+/** Optional cleanup interface for disposable pane components. */
+interface Disposable {
+	dispose(): void;
+}
+
+function isDisposable(c: Component): c is Component & Disposable {
+	return "dispose" in c && typeof (c as any).dispose === "function";
+}
+
+// ---------------------------------------------------------------------------
+// PaneContainer
+// ---------------------------------------------------------------------------
+
+export class PaneContainer implements BoundsAwareComponent {
+	private rootSupplier: () => SplitNode;
+	private panes: Map<string, Component> = new Map();
+	private activePaneId: string;
+
+	constructor(rootPaneId: string, rootComponent: Component) {
+		const initialRoot: SplitNode = { type: "leaf", paneId: rootPaneId };
+		this.rootSupplier = () => initialRoot;
+		this.panes.set(rootPaneId, rootComponent);
+		this.activePaneId = rootPaneId;
+	}
+
+	// --- Split tree access ---
+
+	/**
+	 * Set a supplier function that returns the current split tree root.
+	 * This avoids caching a copy — the PaneContainer always reads fresh state.
+	 */
+	setRootSupplier(supplier: () => SplitNode): void {
+		this.rootSupplier = supplier;
+	}
+
+	/**
+	 * Set the root directly (convenience for simple cases).
+	 */
+	setRoot(root: SplitNode): void {
+		this.rootSupplier = () => root;
+	}
+
+	getActivePaneId(): string {
+		return this.activePaneId;
+	}
+
+	setActivePaneId(id: string): void {
+		this.activePaneId = id;
+	}
+
+	// --- Pane management ---
+
+	setPane(paneId: string, component: Component): void {
+		this.panes.set(paneId, component);
+	}
+
+	getPane(paneId: string): Component | undefined {
+		return this.panes.get(paneId);
+	}
+
+	/**
+	 * Remove a pane. Calls dispose() on the component if available
+	 * (e.g., PtyPane cleanup of shell processes).
+	 */
+	removePane(paneId: string): void {
+		const component = this.panes.get(paneId);
+		if (component && isDisposable(component)) {
+			component.dispose();
+		}
+		this.panes.delete(paneId);
+	}
+
+	// --- Rendering ---
+
+	/**
+	 * Render using the full available terminal height minus the rows consumed
+	 * by sibling components (tab bar, etc.). Reads process.stdout.rows for
+	 * the current terminal dimensions so the layout recomputes on resize.
+	 */
+	render(width: number): string[] {
+		// Use terminal height minus a small margin for siblings (tab bar)
+		const termHeight = process.stdout.rows || 24;
+		// Subtract rows for the tab bar (rendered as a sibling before us)
+		const height = Math.max(4, termHeight - this.siblingRows);
+		return this.renderBounded(width, height);
+	}
+
+	/** Number of rows consumed by sibling components outside PaneContainer. */
+	siblingRows = 0;
+
+	renderBounded(width: number, height: number): string[] {
+		const root = this.rootSupplier();
+		const bounds: Rect = { x: 0, y: 0, width, height };
+		const layout = computeLayout(root, bounds);
+
+		// Initialize output grid with spaces
+		const lines: string[] = Array.from({ length: height }, () => " ".repeat(width));
+
+		// Render each pane into its rect
+		for (const pl of layout.panes) {
+			const component = this.panes.get(pl.paneId);
+			if (!component) continue;
+
+			let paneLines: string[];
+			if (isBoundsAware(component)) {
+				paneLines = component.renderBounded(pl.rect.width, pl.rect.height);
+			} else {
+				paneLines = component.render(pl.rect.width);
+			}
+
+			// Truncate/pad to pane height
+			while (paneLines.length < pl.rect.height) paneLines.push("");
+			if (paneLines.length > pl.rect.height) paneLines = paneLines.slice(0, pl.rect.height);
+
+			// Splice each pane line into the output grid at the correct column offset
+			for (let row = 0; row < pl.rect.height; row++) {
+				const outputRow = pl.rect.y + row;
+				if (outputRow >= height) break;
+
+				const paneLine = paneLines[row] || "";
+				lines[outputRow] = spliceLine(lines[outputRow]!, pl.rect.x, pl.rect.width, paneLine);
+			}
+		}
+
+		// Draw dividers (highlighted when adjacent to active pane)
+		const ACTIVE_COLOR = "\x1b[36m"; // cyan
+		const DIM_COLOR = "\x1b[90m"; // gray
+		const RESET = "\x1b[0m";
+
+		// Find active pane rect for adjacency highlighting
+		const activeRect = layout.panes.find((p) => p.paneId === this.activePaneId)?.rect;
+
+		for (const div of layout.dividers) {
+			// Check if this divider borders the active pane
+			const isAdjacentToActive = activeRect && isDividerAdjacentToRect(div, activeRect);
+			const color = isAdjacentToActive ? ACTIVE_COLOR : DIM_COLOR;
+
+			if (div.direction === "horizontal") {
+				// Vertical line (│) at column div.x — from a horizontal split
+				const divChar = `${color}│${RESET}`;
+				for (let row = 0; row < div.length; row++) {
+					const outputRow = div.y + row;
+					if (outputRow >= height) break;
+					lines[outputRow] = spliceLine(lines[outputRow]!, div.x, 1, divChar);
+				}
+			} else {
+				// Horizontal line (─) at row div.y — from a vertical split
+				const divLine = `${color}${"─".repeat(div.length)}${RESET}`;
+				if (div.y < height) {
+					lines[div.y] = spliceLine(lines[div.y]!, div.x, div.length, divLine);
+				}
+			}
+		}
+
+		return lines;
+	}
+
+	invalidate(): void {
+		for (const component of this.panes.values()) {
+			component.invalidate();
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a divider is adjacent to a rectangle (touches its border).
+ */
+function isDividerAdjacentToRect(
+	div: { direction: string; x: number; y: number; length: number },
+	rect: Rect,
+): boolean {
+	if (div.direction === "horizontal") {
+		// Vertical divider — check if it's at the left or right edge of the rect
+		return (
+			(div.x === rect.x - 1 || div.x === rect.x + rect.width) &&
+			div.y < rect.y + rect.height &&
+			div.y + div.length > rect.y
+		);
+	}
+	// Horizontal divider — check if it's at the top or bottom edge
+	return (
+		(div.y === rect.y - 1 || div.y === rect.y + rect.height) &&
+		div.x < rect.x + rect.width &&
+		div.x + div.length > rect.x
+	);
+}
+
+/**
+ * Splice `insert` into `line` at column `col` for `width` columns.
+ *
+ * Uses sliceByColumn from utils for ANSI-aware column extraction so
+ * that escape codes in the background line and the inserted content
+ * don't corrupt each other.
+ */
+function spliceLine(line: string, col: number, width: number, insert: string): string {
+	const before = col > 0 ? sliceByColumn(line, 0, col) : "";
+	const after = sliceByColumn(line, col + width, Math.max(0, visibleWidth(line) - col - width));
+
+	// Pad insert to exact width so pane boundaries stay aligned
+	const vw = visibleWidth(insert);
+	const padded = vw < width ? insert + " ".repeat(width - vw) : sliceByColumn(insert, 0, width);
+
+	return before + padded + after;
+}

--- a/packages/tui/src/split-tree.ts
+++ b/packages/tui/src/split-tree.ts
@@ -1,0 +1,382 @@
+/**
+ * Split tree — pure data structure for TUI multiplexer pane layout.
+ *
+ * A binary tree where leaves are panes and internal nodes are horizontal/vertical
+ * splits with a ratio controlling how space is divided between children.
+ *
+ * All functions are pure: they return new trees, never mutate input.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SplitDirection = "horizontal" | "vertical";
+
+export type SplitNode =
+	| { type: "leaf"; paneId: string }
+	| { type: "split"; direction: SplitDirection; ratio: number; a: SplitNode; b: SplitNode };
+
+/** Axis-aligned rectangle in terminal columns/rows. */
+export interface Rect {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+/** A single pane's computed position inside the layout. */
+export interface PaneLayout {
+	paneId: string;
+	rect: Rect;
+}
+
+/**
+ * A divider line between two panes.
+ *
+ * The `direction` field indicates the **split type** that produced this divider,
+ * NOT the visual direction of the drawn line:
+ * - `"horizontal"` split → produces a **vertical** divider line (`│`)
+ * - `"vertical"` split → produces a **horizontal** divider line (`─`)
+ */
+export interface Divider {
+	direction: SplitDirection;
+	x: number;
+	y: number;
+	length: number;
+}
+
+/** Output of computeLayout — every pane rect + every divider. */
+export interface LayoutResult {
+	panes: PaneLayout[];
+	dividers: Divider[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MIN_PANE_COLS = 10;
+const MIN_PANE_ROWS = 3;
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+/** Create a new leaf node. */
+export function newLeaf(paneId: string): SplitNode {
+	return { type: "leaf", paneId };
+}
+
+// ---------------------------------------------------------------------------
+// Layout computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively compute pane rectangles and dividers for the entire tree.
+ *
+ * - Leaf nodes produce a single PaneLayout filling the entire bounds.
+ * - Horizontal splits divide width: child A gets the left portion, child B the right,
+ *   with a 1-column divider between them.
+ * - Vertical splits divide height: child A gets the top portion, child B the bottom,
+ *   with a 1-row divider between them.
+ * - Neither child may shrink below 10 cols x 3 rows.
+ */
+export function computeLayout(root: SplitNode, bounds: Rect): LayoutResult {
+	const panes: PaneLayout[] = [];
+	const dividers: Divider[] = [];
+	computeLayoutRec(root, bounds, panes, dividers);
+	return { panes, dividers };
+}
+
+function computeLayoutRec(node: SplitNode, bounds: Rect, panes: PaneLayout[], dividers: Divider[]): void {
+	if (node.type === "leaf") {
+		panes.push({ paneId: node.paneId, rect: { ...bounds } });
+		return;
+	}
+
+	if (node.direction === "horizontal") {
+		// Horizontal split: divide width. 1 column for the divider.
+		const available = bounds.width - 1; // 1 col for divider
+		if (available < MIN_PANE_COLS * 2) {
+			// Not enough room to split — treat as single pane showing child A
+			computeLayoutRec(node.a, bounds, panes, dividers);
+			return;
+		}
+
+		let aWidth = Math.round(available * node.ratio);
+		let bWidth = available - aWidth;
+
+		// Clamp minimums
+		if (aWidth < MIN_PANE_COLS) {
+			aWidth = MIN_PANE_COLS;
+			bWidth = available - aWidth;
+		}
+		if (bWidth < MIN_PANE_COLS) {
+			bWidth = MIN_PANE_COLS;
+			aWidth = available - bWidth;
+		}
+
+		const divX = bounds.x + aWidth;
+
+		computeLayoutRec(node.a, { x: bounds.x, y: bounds.y, width: aWidth, height: bounds.height }, panes, dividers);
+
+		dividers.push({
+			direction: "horizontal",
+			x: divX,
+			y: bounds.y,
+			length: bounds.height,
+		});
+
+		computeLayoutRec(node.b, { x: divX + 1, y: bounds.y, width: bWidth, height: bounds.height }, panes, dividers);
+	} else {
+		// Vertical split: divide height. 1 row for the divider.
+		const available = bounds.height - 1; // 1 row for divider
+		if (available < MIN_PANE_ROWS * 2) {
+			computeLayoutRec(node.a, bounds, panes, dividers);
+			return;
+		}
+
+		let aHeight = Math.round(available * node.ratio);
+		let bHeight = available - aHeight;
+
+		if (aHeight < MIN_PANE_ROWS) {
+			aHeight = MIN_PANE_ROWS;
+			bHeight = available - aHeight;
+		}
+		if (bHeight < MIN_PANE_ROWS) {
+			bHeight = MIN_PANE_ROWS;
+			aHeight = available - bHeight;
+		}
+
+		const divY = bounds.y + aHeight;
+
+		computeLayoutRec(node.a, { x: bounds.x, y: bounds.y, width: bounds.width, height: aHeight }, panes, dividers);
+
+		dividers.push({
+			direction: "vertical",
+			x: bounds.x,
+			y: divY,
+			length: bounds.width,
+		});
+
+		computeLayoutRec(node.b, { x: bounds.x, y: divY + 1, width: bounds.width, height: bHeight }, panes, dividers);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tree manipulation
+// ---------------------------------------------------------------------------
+
+/**
+ * Split the leaf identified by `paneId` into two panes.
+ *
+ * The original pane becomes child A (left/top) and a new leaf with `newPaneId`
+ * becomes child B (right/bottom). Returns a new tree — the original is not mutated.
+ *
+ * @param ratio - Space fraction allocated to child A. Default 0.5.
+ */
+export function splitPane(
+	root: SplitNode,
+	paneId: string,
+	direction: SplitDirection,
+	newPaneId: string,
+	ratio = 0.5,
+): SplitNode {
+	return mapLeaf(root, paneId, (leaf) => ({
+		type: "split",
+		direction,
+		ratio,
+		a: leaf,
+		b: newLeaf(newPaneId),
+	}));
+}
+
+/**
+ * Remove a leaf from the tree, promoting its sibling to take the parent split's place.
+ *
+ * Returns `null` if the removed pane was the root (tree is now empty).
+ */
+export function removePane(root: SplitNode, paneId: string): SplitNode | null {
+	if (root.type === "leaf") {
+		return root.paneId === paneId ? null : root;
+	}
+
+	// Check if the target is an immediate child of this split
+	if (root.a.type === "leaf" && root.a.paneId === paneId) {
+		return root.b;
+	}
+	if (root.b.type === "leaf" && root.b.paneId === paneId) {
+		return root.a;
+	}
+
+	// Recurse into children
+	const newA = removePane(root.a, paneId);
+	if (newA !== root.a) {
+		// Found in A subtree
+		if (newA === null) return root.b;
+		return { ...root, a: newA };
+	}
+
+	const newB = removePane(root.b, paneId);
+	if (newB !== root.b) {
+		// Found in B subtree
+		if (newB === null) return root.a;
+		return { ...root, b: newB };
+	}
+
+	// paneId not found — return tree unchanged
+	return root;
+}
+
+/**
+ * Depth-first list of all pane IDs in the tree.
+ */
+export function allPanes(root: SplitNode): string[] {
+	if (root.type === "leaf") return [root.paneId];
+	return [...allPanes(root.a), ...allPanes(root.b)];
+}
+
+/**
+ * Count the number of leaf panes in the tree.
+ */
+export function paneCount(root: SplitNode): number {
+	if (root.type === "leaf") return 1;
+	return paneCount(root.a) + paneCount(root.b);
+}
+
+/**
+ * Set the split ratio of the parent split containing `paneId`.
+ *
+ * The ratio is clamped to [0.1, 0.9]. Returns the tree unchanged if
+ * `paneId` is not found or is the root leaf (no parent split).
+ */
+export function setRatio(root: SplitNode, paneId: string, ratio: number): SplitNode {
+	const clamped = Math.max(0.1, Math.min(0.9, ratio));
+	return setRatioRec(root, paneId, clamped);
+}
+
+function setRatioRec(node: SplitNode, paneId: string, ratio: number): SplitNode {
+	if (node.type === "leaf") return node;
+
+	// Check if either immediate child is the target leaf
+	const aIsTarget = (node.a.type === "leaf" && node.a.paneId === paneId) || containsPane(node.a, paneId);
+	const bIsTarget = (node.b.type === "leaf" && node.b.paneId === paneId) || containsPane(node.b, paneId);
+
+	if (aIsTarget || bIsTarget) {
+		// If the target is a direct child, update this split's ratio
+		if (
+			(node.a.type === "leaf" && node.a.paneId === paneId) ||
+			(node.b.type === "leaf" && node.b.paneId === paneId)
+		) {
+			return { ...node, ratio };
+		}
+		// Otherwise recurse into the subtree that contains it
+		if (aIsTarget) {
+			return { ...node, a: setRatioRec(node.a, paneId, ratio) };
+		}
+		return { ...node, b: setRatioRec(node.b, paneId, ratio) };
+	}
+
+	return node;
+}
+
+/**
+ * Find the nearest pane in the given direction from `paneId`.
+ *
+ * Uses the computed layout to determine spatial adjacency. Returns `null`
+ * if there is no pane in that direction.
+ */
+export function adjacentPane(
+	root: SplitNode,
+	paneId: string,
+	direction: "up" | "down" | "left" | "right",
+): string | null {
+	// We need a layout to determine spatial adjacency. Use a generous default
+	// bounds — the actual terminal size doesn't matter for adjacency, only
+	// relative positioning does.
+	const layout = computeLayout(root, { x: 0, y: 0, width: 200, height: 60 });
+
+	const sourcePane = layout.panes.find((p) => p.paneId === paneId);
+	if (!sourcePane) return null;
+
+	const src = sourcePane.rect;
+	// Center of source pane
+	const srcCenterX = src.x + src.width / 2;
+	const srcCenterY = src.y + src.height / 2;
+
+	let bestId: string | null = null;
+	let bestDist = Infinity;
+
+	for (const candidate of layout.panes) {
+		if (candidate.paneId === paneId) continue;
+
+		const cr = candidate.rect;
+		const candCenterX = cr.x + cr.width / 2;
+		const candCenterY = cr.y + cr.height / 2;
+
+		let valid = false;
+		switch (direction) {
+			case "left":
+				// Candidate must be to the left and overlap vertically
+				valid = cr.x + cr.width <= src.x && overlapsVertically(src, cr);
+				break;
+			case "right":
+				valid = cr.x >= src.x + src.width && overlapsVertically(src, cr);
+				break;
+			case "up":
+				valid = cr.y + cr.height <= src.y && overlapsHorizontally(src, cr);
+				break;
+			case "down":
+				valid = cr.y >= src.y + src.height && overlapsHorizontally(src, cr);
+				break;
+		}
+
+		if (!valid) continue;
+
+		const dx = candCenterX - srcCenterX;
+		const dy = candCenterY - srcCenterY;
+		const dist = dx * dx + dy * dy;
+		if (dist < bestDist) {
+			bestDist = dist;
+			bestId = candidate.paneId;
+		}
+	}
+
+	return bestId;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Check if two rects overlap on the vertical axis. */
+function overlapsVertically(a: Rect, b: Rect): boolean {
+	return a.y < b.y + b.height && b.y < a.y + a.height;
+}
+
+/** Check if two rects overlap on the horizontal axis. */
+function overlapsHorizontally(a: Rect, b: Rect): boolean {
+	return a.x < b.x + b.width && b.x < a.x + a.width;
+}
+
+/** Check whether a subtree contains a pane with the given ID. */
+function containsPane(node: SplitNode, paneId: string): boolean {
+	if (node.type === "leaf") return node.paneId === paneId;
+	return containsPane(node.a, paneId) || containsPane(node.b, paneId);
+}
+
+/**
+ * Immutable map over the tree: find the leaf with `paneId` and replace it
+ * with the result of `fn`. Returns the original tree structure unchanged
+ * if `paneId` is not found.
+ */
+function mapLeaf(node: SplitNode, paneId: string, fn: (leaf: SplitNode & { type: "leaf" }) => SplitNode): SplitNode {
+	if (node.type === "leaf") {
+		return node.paneId === paneId ? fn(node) : node;
+	}
+	const newA = mapLeaf(node.a, paneId, fn);
+	const newB = mapLeaf(node.b, paneId, fn);
+	if (newA === node.a && newB === node.b) return node;
+	return { ...node, a: newA, b: newB };
+}

--- a/packages/tui/test/split-tree.test.ts
+++ b/packages/tui/test/split-tree.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import {
+	adjacentPane,
+	allPanes,
+	computeLayout,
+	newLeaf,
+	paneCount,
+	removePane,
+	setRatio,
+	splitPane,
+	type SplitNode,
+} from "../src/split-tree.js";
+
+describe("split-tree", () => {
+	describe("newLeaf", () => {
+		it("creates a leaf node", () => {
+			const leaf = newLeaf("p1");
+			assert.deepStrictEqual(leaf, { type: "leaf", paneId: "p1" });
+		});
+	});
+
+	describe("splitPane", () => {
+		it("splits a single leaf horizontally", () => {
+			const root = newLeaf("p1");
+			const result = splitPane(root, "p1", "horizontal", "p2");
+			assert.strictEqual(result.type, "split");
+			if (result.type === "split") {
+				assert.strictEqual(result.direction, "horizontal");
+				assert.strictEqual(result.ratio, 0.5);
+				assert.deepStrictEqual(result.a, { type: "leaf", paneId: "p1" });
+				assert.deepStrictEqual(result.b, { type: "leaf", paneId: "p2" });
+			}
+		});
+
+		it("splits a nested leaf", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			const result = splitPane(root, "p2", "vertical", "p3");
+			assert.strictEqual(paneCount(result), 3);
+			assert.deepStrictEqual(allPanes(result).sort(), ["p1", "p2", "p3"]);
+		});
+
+		it("returns original tree if paneId not found", () => {
+			const root = newLeaf("p1");
+			const result = splitPane(root, "nonexistent", "horizontal", "p2");
+			assert.strictEqual(result, root);
+		});
+
+		it("uses custom ratio", () => {
+			const root = newLeaf("p1");
+			const result = splitPane(root, "p1", "horizontal", "p2", 0.3);
+			if (result.type === "split") {
+				assert.strictEqual(result.ratio, 0.3);
+			}
+		});
+	});
+
+	describe("removePane", () => {
+		it("returns null when removing the only pane", () => {
+			const root = newLeaf("p1");
+			assert.strictEqual(removePane(root, "p1"), null);
+		});
+
+		it("promotes sibling when removing from a split", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			const result = removePane(root, "p1");
+			assert.deepStrictEqual(result, { type: "leaf", paneId: "p2" });
+		});
+
+		it("promotes sibling (other side)", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			const result = removePane(root, "p2");
+			assert.deepStrictEqual(result, { type: "leaf", paneId: "p1" });
+		});
+
+		it("returns original tree if paneId not found", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			const result = removePane(root, "nonexistent");
+			assert.strictEqual(result, root);
+		});
+
+		it("handles deep removal in 3-pane layout", () => {
+			let root: SplitNode = newLeaf("p1");
+			root = splitPane(root, "p1", "horizontal", "p2");
+			root = splitPane(root, "p2", "vertical", "p3");
+			// Tree: split(h, p1, split(v, p2, p3))
+			assert.strictEqual(paneCount(root), 3);
+
+			const result = removePane(root, "p3");
+			assert.ok(result);
+			assert.strictEqual(paneCount(result!), 2);
+			assert.deepStrictEqual(allPanes(result!).sort(), ["p1", "p2"]);
+		});
+	});
+
+	describe("allPanes / paneCount", () => {
+		it("single leaf", () => {
+			const root = newLeaf("p1");
+			assert.deepStrictEqual(allPanes(root), ["p1"]);
+			assert.strictEqual(paneCount(root), 1);
+		});
+
+		it("complex tree", () => {
+			let root: SplitNode = newLeaf("a");
+			root = splitPane(root, "a", "horizontal", "b");
+			root = splitPane(root, "b", "vertical", "c");
+			root = splitPane(root, "a", "vertical", "d");
+			assert.strictEqual(paneCount(root), 4);
+			assert.deepStrictEqual(allPanes(root).sort(), ["a", "b", "c", "d"]);
+		});
+	});
+
+	describe("computeLayout", () => {
+		it("single pane fills bounds", () => {
+			const root = newLeaf("p1");
+			const layout = computeLayout(root, { x: 0, y: 0, width: 80, height: 24 });
+			assert.strictEqual(layout.panes.length, 1);
+			assert.deepStrictEqual(layout.panes[0].rect, { x: 0, y: 0, width: 80, height: 24 });
+			assert.strictEqual(layout.dividers.length, 0);
+		});
+
+		it("horizontal split creates two side-by-side panes", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			const layout = computeLayout(root, { x: 0, y: 0, width: 80, height: 24 });
+			assert.strictEqual(layout.panes.length, 2);
+			assert.strictEqual(layout.dividers.length, 1);
+
+			const left = layout.panes.find((p) => p.paneId === "p1")!;
+			const right = layout.panes.find((p) => p.paneId === "p2")!;
+			assert.ok(left.rect.width > 0);
+			assert.ok(right.rect.width > 0);
+			assert.ok(left.rect.x < right.rect.x);
+			// Both should have full height
+			assert.strictEqual(left.rect.height, 24);
+			assert.strictEqual(right.rect.height, 24);
+		});
+
+		it("vertical split creates two stacked panes", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "vertical", "p2");
+			const layout = computeLayout(root, { x: 0, y: 0, width: 80, height: 24 });
+			assert.strictEqual(layout.panes.length, 2);
+
+			const top = layout.panes.find((p) => p.paneId === "p1")!;
+			const bottom = layout.panes.find((p) => p.paneId === "p2")!;
+			assert.ok(top.rect.y < bottom.rect.y);
+			// Both should have full width
+			assert.strictEqual(top.rect.width, 80);
+			assert.strictEqual(bottom.rect.width, 80);
+		});
+
+		it("respects minimum pane dimensions", () => {
+			// Try to split a very small area — should still produce valid rects
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			const layout = computeLayout(root, { x: 0, y: 0, width: 20, height: 6 });
+			for (const pane of layout.panes) {
+				assert.ok(pane.rect.width > 0, `Pane ${pane.paneId} has zero width`);
+				assert.ok(pane.rect.height > 0, `Pane ${pane.paneId} has zero height`);
+			}
+		});
+	});
+
+	describe("setRatio", () => {
+		it("updates parent split ratio for direct child", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			const result = setRatio(root, "p1", 0.3);
+			assert.strictEqual(result.type, "split");
+			if (result.type === "split") {
+				assert.strictEqual(result.ratio, 0.3);
+			}
+		});
+
+		it("updates innermost parent for nested pane", () => {
+			// Tree: split(h, A, split(v, B, C))
+			let root: SplitNode = newLeaf("a");
+			root = splitPane(root, "a", "horizontal", "bc");
+			root = splitPane(root, "bc", "vertical", "c");
+			// bc got replaced by split(v, bc, c). So the tree is:
+			// split(h, a, split(v, bc, c))
+
+			const result = setRatio(root, "bc", 0.7);
+			// The inner split (containing bc) should get ratio 0.7
+			assert.strictEqual(result.type, "split");
+			if (result.type === "split") {
+				// Outer split ratio should be unchanged
+				assert.strictEqual(result.ratio, 0.5);
+				// Inner split should have the new ratio
+				assert.strictEqual(result.b.type, "split");
+				if (result.b.type === "split") {
+					assert.strictEqual(result.b.ratio, 0.7);
+				}
+			}
+		});
+
+		it("clamps ratio to [0.1, 0.9]", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			const tooLow = setRatio(root, "p1", 0.01);
+			const tooHigh = setRatio(root, "p1", 0.99);
+			if (tooLow.type === "split") assert.strictEqual(tooLow.ratio, 0.1);
+			if (tooHigh.type === "split") assert.strictEqual(tooHigh.ratio, 0.9);
+		});
+
+		it("returns original tree if pane not found", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			const result = setRatio(root, "nonexistent", 0.7);
+			assert.strictEqual(result, root);
+		});
+	});
+
+	describe("adjacentPane", () => {
+		it("returns null for single pane", () => {
+			const root = newLeaf("p1");
+			assert.strictEqual(adjacentPane(root, "p1", "right"), null);
+			assert.strictEqual(adjacentPane(root, "p1", "left"), null);
+		});
+
+		it("finds horizontal neighbor", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			assert.strictEqual(adjacentPane(root, "p1", "right"), "p2");
+			assert.strictEqual(adjacentPane(root, "p2", "left"), "p1");
+		});
+
+		it("finds vertical neighbor", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "vertical", "p2");
+			assert.strictEqual(adjacentPane(root, "p1", "down"), "p2");
+			assert.strictEqual(adjacentPane(root, "p2", "up"), "p1");
+		});
+
+		it("returns null when no neighbor in direction", () => {
+			const root = splitPane(newLeaf("p1"), "p1", "horizontal", "p2");
+			assert.strictEqual(adjacentPane(root, "p1", "left"), null);
+			assert.strictEqual(adjacentPane(root, "p2", "right"), null);
+			assert.strictEqual(adjacentPane(root, "p1", "up"), null);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds tmux-style terminal multiplexing to Pi's interactive mode. Each split pane runs a fully independent agent session with its own header, chat history, editor, and footer.

- **Split panes** — pure functional binary split tree (`SplitNode`) with `PaneContainer` compositor, ANSI-aware line splicing, active pane highlighted with colored dividers
- **Full-instance panes** — each pane gets an independent `AgentSessionRuntime` via `runtimeFactory` getter, not a shared view
- **Tab management** — `TabManager` coordinates `Tab[]` with a split tree per tab, `TabBar` component hidden for single tab
- **PTY shell panes** — `PtyPane` wraps `node-pty` + `@xterm/headless` for terminal emulation with lazy spawn
- **Layout persistence** — debounced 2s JSON save/restore of tab and pane structure
- **12 keybindings** using `alt+letter` for legacy terminal compatibility (`alt+h/s` split, `alt+a/d/e/x` focus, `alt+t/q` tabs, `alt+n/b` tab nav, `alt+w` close)
- **Mouse click-to-focus** via SGR mouse reporting + coordinate mapping through `computeLayout`
- **`/keys` command** shows all multiplexer bindings

## Architecture

**TUI package (foundation):**
- `split-tree.ts` (382 lines) — pure functional binary tree with immutable transforms: `splitPane`, `removePane`, `setRatio`, `adjacentPane`, `computeLayout`
- `pane-container.ts` (243 lines) — composites `BoundsAwareComponent`s into a 2D grid with divider rendering

**Coding agent package (integration):**
- `tab-manager.ts` (174 lines) — tab collection with split-tree management per tab
- `interactive-pane.ts` (402 lines) — full Pi instance per pane (header, chat, editor, footer, independent session)
- `pty-pane.ts` (190 lines) — node-pty + @xterm/headless wrapper
- `layout-persistence.ts` (105 lines) — debounced save/restore
- `tab-bar.ts` (59 lines) — single-line tab strip component
- `interactive-mode.ts` (+293 lines) — multiplexer router, keybinding handlers, mouse input
- `keybindings.ts` (+59 lines) — 12 new `app.pane.*` and `app.tab.*` bindings
- `agent-session-runtime.ts` (+5 lines) — `runtimeFactory` getter for pane session creation

## Test plan

- 24 unit tests for split-tree (all tree operations, layout computation, ratio clamping, adjacency)
- 20 unit tests for TabManager (tab lifecycle, pane operations, focus navigation, edge cases)
- Manual testing: single-pane mode unchanged (no regression), multi-pane splits, tab switching, PTY shell, layout persistence across restart, mouse click-to-focus