### PR TITLE
fix(tui): skip Kitty keyboard protocol in multiplexer environments

### DIFF
--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -184,6 +184,21 @@ export class ProcessTerminal implements Terminal {
 	private queryAndEnableKittyProtocol(): void {
 		this.setupStdinBuffer();
 		process.stdin.on("data", this.stdinDataHandler!);
+
+		// Skip Kitty protocol query inside terminal multiplexers that
+		// advertise partial support.  Zellij responds to CSI ? u (via the
+		// outer emulator) but only implements progressive enhancement
+		// level 1, so Pi's parser activates with flags 1+2+4 and then
+		// silently rejects ESC-prefix Alt sequences.  The Kitty spec has
+		// no capability negotiation — a response implies full support.
+		// Fall back to modifyOtherKeys mode 2 directly instead.
+		// Ref: https://github.com/zellij-org/zellij/issues/3789
+		if (process.env.ZELLIJ || process.env.PI_FORCE_LEGACY_KEYS) {
+			process.stdout.write("\x1b[>4;2m");
+			this._modifyOtherKeysActive = true;
+			return;
+		}
+
 		process.stdout.write("\x1b[?u");
 		setTimeout(() => {
 			if (!this._kittyProtocolActive && !this._modifyOtherKeysActive) {


### PR DESCRIPTION
Terminal multiplexers like Zellij only implement Kitty progressive enhancement
level 1, but the `CSI ? u` query travels through to the outer terminal emulator
(which may have full Kitty support) and comes back as a valid response. Pi then
activates its Kitty parser with flags `1+2+4`, but Alt sequences still arrive as
ESC-prefix encoding through the multiplexer — and get silently dropped.

The Kitty keyboard protocol spec has no capability negotiation mechanism. A
response to `CSI ? u` implies full support; there's no way to distinguish
partial from complete implementations.

### Fix

When `$ZELLIJ` is set (Zellij injects this automatically) or `$PI_FORCE_LEGACY_KEYS`
is set (generic escape hatch for any broken multiplexer), skip the Kitty query and
immediately activate `modifyOtherKeys` mode 2. This is the same fallback that the
existing 150ms timeout triggers — just without the delay.

`$PI_FORCE_LEGACY_KEYS` is intentionally generic so users in other multiplexers
with similar issues (screen, dvtm, etc.) can use it too.

### Testing

Tested in Zellij 0.44.1 inside Tabby (full Kitty support). Before: Alt+G, Alt+E,
Alt+N etc. not recognized. After: all Alt keybindings work correctly.

Ref: https://github.com/zellij-org/zellij/issues/3789