### PR TITLE
feat(coding-agent): support multiple --append-system-prompt flags

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for multiple `--append-system-prompt` flags, each value is appended to the system prompt separated by double newlines ([#3169](https://github.com/badlogic/pi-mono/pull/3169) by [@aliou](https://github.com/aliou))
+
 ## [0.67.1] - 2026-04-13
 
 ### Telemetry

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -15,7 +15,7 @@ export interface Args {
 	model?: string;
 	apiKey?: string;
 	systemPrompt?: string;
-	appendSystemPrompt?: string;
+	appendSystemPrompt?: string[];
 	thinking?: ThinkingLevel;
 	continue?: boolean;
 	resume?: boolean;
@@ -88,7 +88,8 @@ export function parseArgs(args: string[]): Args {
 		} else if (arg === "--system-prompt" && i + 1 < args.length) {
 			result.systemPrompt = args[++i];
 		} else if (arg === "--append-system-prompt" && i + 1 < args.length) {
-			result.appendSystemPrompt = args[++i];
+			result.appendSystemPrompt = result.appendSystemPrompt ?? [];
+			result.appendSystemPrompt.push(args[++i]);
 		} else if (arg === "--no-session") {
 			result.noSession = true;
 		} else if (arg === "--session" && i + 1 < args.length) {
@@ -216,7 +217,7 @@ ${chalk.bold("Options:")}
   --model <pattern>              Model pattern or ID (supports "provider/id" and optional ":<thinking>")
   --api-key <key>                API key (defaults to env vars)
   --system-prompt <text>         System prompt (default: coding assistant prompt)
-  --append-system-prompt <text>  Append text or file contents to the system prompt
+  --append-system-prompt <text>  Append text or file contents to the system prompt (can be used multiple times)
   --mode <mode>                  Output mode: text (default), json, or rpc
   --print, -p                    Non-interactive mode: process prompt and exit
   --continue, -c                 Continue previous session

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -127,7 +127,7 @@ export interface DefaultResourceLoaderOptions {
 	noPromptTemplates?: boolean;
 	noThemes?: boolean;
 	systemPrompt?: string;
-	appendSystemPrompt?: string;
+	appendSystemPrompt?: string[];
 	extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
 	skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
 		skills: Skill[];
@@ -164,7 +164,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private noPromptTemplates: boolean;
 	private noThemes: boolean;
 	private systemPromptSource?: string;
-	private appendSystemPromptSource?: string;
+	private appendSystemPromptSource?: string[];
 	private extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
 	private skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
 		skills: Skill[];
@@ -458,9 +458,12 @@ export class DefaultResourceLoader implements ResourceLoader {
 		);
 		this.systemPrompt = this.systemPromptOverride ? this.systemPromptOverride(baseSystemPrompt) : baseSystemPrompt;
 
-		const appendSource = this.appendSystemPromptSource ?? this.discoverAppendSystemPromptFile();
-		const resolvedAppend = resolvePromptInput(appendSource, "append system prompt");
-		const baseAppend = resolvedAppend ? [resolvedAppend] : [];
+		const appendSources =
+			this.appendSystemPromptSource ??
+			(this.discoverAppendSystemPromptFile() ? [this.discoverAppendSystemPromptFile()!] : []);
+		const baseAppend = appendSources
+			.map((s) => resolvePromptInput(s, "append system prompt"))
+			.filter((s): s is string => s !== undefined);
 		this.appendSystemPrompt = this.appendSystemPromptOverride
 			? this.appendSystemPromptOverride(baseAppend)
 			: baseAppend;

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -92,7 +92,12 @@ describe("parseArgs", () => {
 
 		test("parses --append-system-prompt", () => {
 			const result = parseArgs(["--append-system-prompt", "Additional context"]);
-			expect(result.appendSystemPrompt).toBe("Additional context");
+			expect(result.appendSystemPrompt).toEqual(["Additional context"]);
+		});
+
+		test("parses multiple --append-system-prompt flags", () => {
+			const result = parseArgs(["--append-system-prompt", "Context A", "--append-system-prompt", "Context B"]);
+			expect(result.appendSystemPrompt).toEqual(["Context A", "Context B"]);
 		});
 
 		test("parses --mode", () => {


### PR DESCRIPTION
Hello! Noticed this while testing some stuff and saw that this is an open issue too, fixes #2990


Session: https://pi.dev/session/#13982d45b5fe2f7708bc3acd88ab0c6a


------

<details><summary>Summary by glm-5.1:</summary>
<p>

## Summary

Allow `--append-system-prompt` to be specified multiple times. Each value is appended to the system prompt, separated by double newlines (`\n\n`). This follows the same pattern as `--extension`, `--skill`, `--prompt-template`, and `--theme`.

## Changes

### `packages/coding-agent/src/cli/args.ts`
- `Args.appendSystemPrompt`: `string` → `string[]`
- Parser uses push pattern (init array if needed, then push) instead of direct assignment
- Help text: added `(can be used multiple times)`

### `packages/coding-agent/src/core/resource-loader.ts`
- `DefaultResourceLoaderOptions.appendSystemPrompt`: `string` → `string[]`
- `appendSystemPromptSource` private field: `string` → `string[]`
- `resolveResources()`: iterates over array of sources, maps each through `resolvePromptInput`, filters undefineds
- No changes to `appendSystemPromptOverride` (already `string[]` → `string[]`)

### `packages/coding-agent/test/args.test.ts`
- Updated single-value test to expect `["Additional context"]`
- Added test for multiple `--append-system-prompt` flags

### `packages/coding-agent/CHANGELOG.md`
- Added entry under `[Unreleased]` → `### Added`

## What stays the same
- `system-prompt.ts` — receives the already-joined string, no change needed
- `agent-session.ts` — already joins with `.join("\n\n")`, no change needed
- `main.ts` — passes `parsed.appendSystemPrompt` which is now naturally `string[]`

## Verified
Tested with a temporary extension that dumps the system prompt to a temp file:
- Two `--append-system-prompt` flags: both values present, separated by `\n\n`
- Single flag: value present
- No flag: no stale append data

</p>
</details>