### PR TITLE
Hide headless sessions by default in Resume Session

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -100,6 +100,7 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.session.togglePath` | `ctrl+p` | Toggle path display |
 | `app.session.toggleSort` | `ctrl+s` | Toggle sort mode |
 | `app.session.toggleNamedFilter` | `ctrl+n` | Toggle named-only filter |
+| `app.session.toggleHidden` | `ctrl+shift+h` | Toggle hidden auto-detected sessions |
 | `app.session.rename` | `ctrl+r` | Rename session |
 | `app.session.delete` | `ctrl+d` | Delete session |
 | `app.session.deleteNoninvasive` | `ctrl+backspace` | Delete session when query is empty |

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -132,7 +132,8 @@ export class AgentSessionRuntime {
 		}
 
 		const previousSessionFile = this.session.sessionFile;
-		const sessionManager = SessionManager.open(sessionPath, undefined, cwdOverride);
+		const defaultSessionMode = this.session.sessionManager.getDefaultSessionMode();
+		const sessionManager = SessionManager.open(sessionPath, undefined, cwdOverride, defaultSessionMode);
 		assertSessionCwdExists(sessionManager, this.cwd);
 		await this.teardownCurrent();
 		this.apply(
@@ -157,7 +158,8 @@ export class AgentSessionRuntime {
 
 		const previousSessionFile = this.session.sessionFile;
 		const sessionDir = this.session.sessionManager.getSessionDir();
-		const sessionManager = SessionManager.create(this.cwd, sessionDir);
+		const defaultSessionMode = this.session.sessionManager.getDefaultSessionMode();
+		const sessionManager = SessionManager.create(this.cwd, sessionDir, defaultSessionMode);
 		if (options?.parentSession) {
 			sessionManager.newSession({ parentSession: options.parentSession });
 		}
@@ -191,6 +193,7 @@ export class AgentSessionRuntime {
 
 		const previousSessionFile = this.session.sessionFile;
 		const selectedText = extractUserMessageText(selectedEntry.message.content);
+		const defaultSessionMode = this.session.sessionManager.getDefaultSessionMode();
 		if (this.session.sessionManager.isPersisted()) {
 			const currentSessionFile = this.session.sessionFile;
 			if (!currentSessionFile) {
@@ -198,7 +201,7 @@ export class AgentSessionRuntime {
 			}
 			const sessionDir = this.session.sessionManager.getSessionDir();
 			if (!selectedEntry.parentId) {
-				const sessionManager = SessionManager.create(this.cwd, sessionDir);
+				const sessionManager = SessionManager.create(this.cwd, sessionDir, defaultSessionMode);
 				sessionManager.newSession({ parentSession: currentSessionFile });
 				await this.teardownCurrent();
 				this.apply(
@@ -212,12 +215,12 @@ export class AgentSessionRuntime {
 				return { cancelled: false, selectedText };
 			}
 
-			const sourceManager = SessionManager.open(currentSessionFile, sessionDir);
+			const sourceManager = SessionManager.open(currentSessionFile, sessionDir, undefined, defaultSessionMode);
 			const forkedSessionPath = sourceManager.createBranchedSession(selectedEntry.parentId);
 			if (!forkedSessionPath) {
 				throw new Error("Failed to create forked session");
 			}
-			const sessionManager = SessionManager.open(forkedSessionPath, sessionDir);
+			const sessionManager = SessionManager.open(forkedSessionPath, sessionDir, undefined, defaultSessionMode);
 			await this.teardownCurrent();
 			this.apply(
 				await this.createRuntime({
@@ -270,7 +273,8 @@ export class AgentSessionRuntime {
 			copyFileSync(resolvedPath, destinationPath);
 		}
 
-		const sessionManager = SessionManager.open(destinationPath, sessionDir, cwdOverride);
+		const defaultSessionMode = this.session.sessionManager.getDefaultSessionMode();
+		const sessionManager = SessionManager.open(destinationPath, sessionDir, cwdOverride, defaultSessionMode);
 		assertSessionCwdExists(sessionManager, this.cwd);
 		await this.teardownCurrent();
 		this.apply(

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -22,6 +22,7 @@ export interface AppKeybindings {
 	"app.tools.expand": true;
 	"app.thinking.toggle": true;
 	"app.session.toggleNamedFilter": true;
+	"app.session.toggleHidden": true;
 	"app.editor.external": true;
 	"app.message.followUp": true;
 	"app.message.dequeue": true;
@@ -74,6 +75,10 @@ export const KEYBINDINGS = {
 	"app.session.toggleNamedFilter": {
 		defaultKeys: "ctrl+n",
 		description: "Toggle named session filter",
+	},
+	"app.session.toggleHidden": {
+		defaultKeys: "ctrl+shift+h",
+		description: "Toggle hidden session visibility",
 	},
 	"app.editor.external": {
 		defaultKeys: "ctrl+g",
@@ -176,6 +181,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	expandTools: "app.tools.expand",
 	toggleThinking: "app.thinking.toggle",
 	toggleSessionNamedFilter: "app.session.toggleNamedFilter",
+	toggleSessionHidden: "app.session.toggleHidden",
 	externalEditor: "app.editor.external",
 	followUp: "app.message.followUp",
 	dequeue: "app.message.dequeue",

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -26,6 +26,8 @@ import {
 
 export const CURRENT_SESSION_VERSION = 3;
 
+export type SessionMode = "interactive" | "headless";
+
 export interface SessionHeader {
 	type: "session";
 	version?: number; // v1 sessions don't have this
@@ -33,6 +35,7 @@ export interface SessionHeader {
 	timestamp: string;
 	cwd: string;
 	parentSession?: string;
+	sessionMode?: SessionMode;
 }
 
 export interface NewSessionOptions {
@@ -178,6 +181,7 @@ export interface SessionInfo {
 	messageCount: number;
 	firstMessage: string;
 	allMessagesText: string;
+	isHeadless: boolean;
 }
 
 export type ReadonlySessionManager = Pick<
@@ -541,6 +545,27 @@ function getSessionModifiedDate(entries: FileEntry[], header: SessionHeader, sta
 	return !Number.isNaN(headerTime) ? new Date(headerTime) : statsMtime;
 }
 
+function inferHeadlessSession(header: SessionHeader, firstMessage: string, userMessageCount: number): boolean {
+	if (header.sessionMode === "interactive") {
+		return false;
+	}
+	if (header.sessionMode === "headless") {
+		return true;
+	}
+
+	const normalized = firstMessage.trim();
+	if (!normalized || userMessageCount !== 1) {
+		return false;
+	}
+
+	return (
+		(/^you are\b/i.test(normalized) && normalized.length > 200) ||
+		/\bOutput EXACTLY one JSON block\b/i.test(normalized) ||
+		/\bYour job is to\b/i.test(normalized) ||
+		/\bTreat these operator feedback rules as required instructions\b/i.test(normalized)
+	);
+}
+
 async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 	try {
 		const content = await readFile(filePath, "utf8");
@@ -562,6 +587,7 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 
 		const stats = await stat(filePath);
 		let messageCount = 0;
+		let userMessageCount = 0;
 		let firstMessage = "";
 		const allMessages: string[] = [];
 		let name: string | undefined;
@@ -584,8 +610,11 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 			if (!textContent) continue;
 
 			allMessages.push(textContent);
-			if (!firstMessage && message.role === "user") {
-				firstMessage = textContent;
+			if (message.role === "user") {
+				userMessageCount++;
+				if (!firstMessage) {
+					firstMessage = textContent;
+				}
 			}
 		}
 
@@ -605,6 +634,7 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 			messageCount,
 			firstMessage: firstMessage || "(no messages)",
 			allMessagesText: allMessages.join(" "),
+			isHeadless: inferHeadlessSession(header as SessionHeader, firstMessage, userMessageCount),
 		};
 	} catch {
 		return null;
@@ -673,11 +703,19 @@ export class SessionManager {
 	private labelsById: Map<string, string> = new Map();
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
+	private defaultSessionMode?: SessionMode;
 
-	private constructor(cwd: string, sessionDir: string, sessionFile: string | undefined, persist: boolean) {
+	private constructor(
+		cwd: string,
+		sessionDir: string,
+		sessionFile: string | undefined,
+		persist: boolean,
+		defaultSessionMode?: SessionMode,
+	) {
 		this.cwd = cwd;
 		this.sessionDir = sessionDir;
 		this.persist = persist;
+		this.defaultSessionMode = defaultSessionMode;
 		if (persist && sessionDir && !existsSync(sessionDir)) {
 			mkdirSync(sessionDir, { recursive: true });
 		}
@@ -732,6 +770,7 @@ export class SessionManager {
 			timestamp,
 			cwd: this.cwd,
 			parentSession: options?.parentSession,
+			sessionMode: this.defaultSessionMode,
 		};
 		this.fileEntries = [header];
 		this.byId.clear();
@@ -791,6 +830,10 @@ export class SessionManager {
 
 	getSessionFile(): string | undefined {
 		return this.sessionFile;
+	}
+
+	getDefaultSessionMode(): SessionMode | undefined {
+		return this.defaultSessionMode;
 	}
 
 	_persist(entry: SessionEntry): void {
@@ -1261,9 +1304,9 @@ export class SessionManager {
 	 * @param cwd Working directory (stored in session header)
 	 * @param sessionDir Optional session directory. If omitted, uses default (~/.pi/agent/sessions/<encoded-cwd>/).
 	 */
-	static create(cwd: string, sessionDir?: string): SessionManager {
+	static create(cwd: string, sessionDir?: string, defaultSessionMode?: SessionMode): SessionManager {
 		const dir = sessionDir ?? getDefaultSessionDir(cwd);
-		return new SessionManager(cwd, dir, undefined, true);
+		return new SessionManager(cwd, dir, undefined, true, defaultSessionMode);
 	}
 
 	/**
@@ -1272,14 +1315,19 @@ export class SessionManager {
 	 * @param sessionDir Optional session directory for /new or /branch. If omitted, derives from file's parent.
 	 * @param cwdOverride Optional cwd override instead of the session header cwd.
 	 */
-	static open(path: string, sessionDir?: string, cwdOverride?: string): SessionManager {
+	static open(
+		path: string,
+		sessionDir?: string,
+		cwdOverride?: string,
+		defaultSessionMode?: SessionMode,
+	): SessionManager {
 		// Extract cwd from session header if possible, otherwise use process.cwd()
 		const entries = loadEntriesFromFile(path);
 		const header = entries.find((e) => e.type === "session") as SessionHeader | undefined;
 		const cwd = cwdOverride ?? header?.cwd ?? process.cwd();
 		// If no sessionDir provided, derive from file's parent directory
 		const dir = sessionDir ?? resolve(path, "..");
-		return new SessionManager(cwd, dir, path, true);
+		return new SessionManager(cwd, dir, path, true, defaultSessionMode);
 	}
 
 	/**
@@ -1287,18 +1335,18 @@ export class SessionManager {
 	 * @param cwd Working directory
 	 * @param sessionDir Optional session directory. If omitted, uses default (~/.pi/agent/sessions/<encoded-cwd>/).
 	 */
-	static continueRecent(cwd: string, sessionDir?: string): SessionManager {
+	static continueRecent(cwd: string, sessionDir?: string, defaultSessionMode?: SessionMode): SessionManager {
 		const dir = sessionDir ?? getDefaultSessionDir(cwd);
 		const mostRecent = findMostRecentSession(dir);
 		if (mostRecent) {
-			return new SessionManager(cwd, dir, mostRecent, true);
+			return new SessionManager(cwd, dir, mostRecent, true, defaultSessionMode);
 		}
-		return new SessionManager(cwd, dir, undefined, true);
+		return new SessionManager(cwd, dir, undefined, true, defaultSessionMode);
 	}
 
 	/** Create an in-memory session (no file persistence) */
-	static inMemory(cwd: string = process.cwd()): SessionManager {
-		return new SessionManager(cwd, "", undefined, false);
+	static inMemory(cwd: string = process.cwd(), defaultSessionMode?: SessionMode): SessionManager {
+		return new SessionManager(cwd, "", undefined, false, defaultSessionMode);
 	}
 
 	/**
@@ -1308,7 +1356,12 @@ export class SessionManager {
 	 * @param targetCwd Target working directory (where the new session will be stored)
 	 * @param sessionDir Optional session directory. If omitted, uses default for targetCwd.
 	 */
-	static forkFrom(sourcePath: string, targetCwd: string, sessionDir?: string): SessionManager {
+	static forkFrom(
+		sourcePath: string,
+		targetCwd: string,
+		sessionDir?: string,
+		defaultSessionMode?: SessionMode,
+	): SessionManager {
 		const sourceEntries = loadEntriesFromFile(sourcePath);
 		if (sourceEntries.length === 0) {
 			throw new Error(`Cannot fork: source session file is empty or invalid: ${sourcePath}`);
@@ -1338,6 +1391,7 @@ export class SessionManager {
 			timestamp,
 			cwd: targetCwd,
 			parentSession: sourcePath,
+			sessionMode: defaultSessionMode,
 		};
 		appendFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`);
 
@@ -1348,7 +1402,7 @@ export class SessionManager {
 			}
 		}
 
-		return new SessionManager(targetCwd, dir, newSessionFile, true);
+		return new SessionManager(targetCwd, dir, newSessionFile, true, defaultSessionMode);
 	}
 
 	/**

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -200,9 +200,14 @@ function validateForkFlags(parsed: Args): void {
 	}
 }
 
-function forkSessionOrExit(sourcePath: string, cwd: string, sessionDir?: string): SessionManager {
+function forkSessionOrExit(
+	sourcePath: string,
+	cwd: string,
+	sessionDir: string | undefined,
+	defaultSessionMode: "interactive" | "headless",
+): SessionManager {
 	try {
-		return SessionManager.forkFrom(sourcePath, cwd, sessionDir);
+		return SessionManager.forkFrom(sourcePath, cwd, sessionDir, defaultSessionMode);
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);
 		console.error(chalk.red(`Error: ${message}`));
@@ -215,9 +220,10 @@ async function createSessionManager(
 	cwd: string,
 	sessionDir: string | undefined,
 	settingsManager: SettingsManager,
+	defaultSessionMode: "interactive" | "headless",
 ): Promise<SessionManager> {
 	if (parsed.noSession) {
-		return SessionManager.inMemory();
+		return SessionManager.inMemory(cwd, defaultSessionMode);
 	}
 
 	if (parsed.fork) {
@@ -227,7 +233,7 @@ async function createSessionManager(
 			case "path":
 			case "local":
 			case "global":
-				return forkSessionOrExit(resolved.path, cwd, sessionDir);
+				return forkSessionOrExit(resolved.path, cwd, sessionDir, defaultSessionMode);
 
 			case "not_found":
 				console.error(chalk.red(`No session found matching '${resolved.arg}'`));
@@ -241,7 +247,7 @@ async function createSessionManager(
 		switch (resolved.type) {
 			case "path":
 			case "local":
-				return SessionManager.open(resolved.path, sessionDir);
+				return SessionManager.open(resolved.path, sessionDir, undefined, defaultSessionMode);
 
 			case "global": {
 				console.log(chalk.yellow(`Session found in different project: ${resolved.cwd}`));
@@ -250,7 +256,7 @@ async function createSessionManager(
 					console.log(chalk.dim("Aborted."));
 					process.exit(0);
 				}
-				return forkSessionOrExit(resolved.path, cwd, sessionDir);
+				return forkSessionOrExit(resolved.path, cwd, sessionDir, defaultSessionMode);
 			}
 
 			case "not_found":
@@ -270,17 +276,17 @@ async function createSessionManager(
 				console.log(chalk.dim("No session selected"));
 				process.exit(0);
 			}
-			return SessionManager.open(selectedPath, sessionDir);
+			return SessionManager.open(selectedPath, sessionDir, undefined, defaultSessionMode);
 		} finally {
 			stopThemeWatcher();
 		}
 	}
 
 	if (parsed.continue) {
-		return SessionManager.continueRecent(cwd, sessionDir);
+		return SessionManager.continueRecent(cwd, sessionDir, defaultSessionMode);
 	}
 
-	return SessionManager.create(cwd, sessionDir);
+	return SessionManager.create(cwd, sessionDir, defaultSessionMode);
 }
 
 function buildSessionOptions(
@@ -446,6 +452,7 @@ export async function main(args: string[]) {
 	}
 	time("parseArgs");
 	let appMode = resolveAppMode(parsed, process.stdin.isTTY);
+	const defaultSessionMode = appMode === "interactive" ? "interactive" : "headless";
 	const shouldTakeOverStdout = appMode !== "interactive";
 	if (shouldTakeOverStdout) {
 		takeOverStdout();
@@ -492,7 +499,7 @@ export async function main(args: string[]) {
 	// the target session cwd is known. The startup-cwd settings manager is used only for
 	// sessionDir lookup during session selection.
 	const sessionDir = parsed.sessionDir ?? startupSettingsManager.getSessionDir();
-	let sessionManager = await createSessionManager(parsed, cwd, sessionDir, startupSettingsManager);
+	let sessionManager = await createSessionManager(parsed, cwd, sessionDir, startupSettingsManager, defaultSessionMode);
 	const missingSessionCwdIssue = getMissingSessionCwdIssue(sessionManager, cwd);
 	if (missingSessionCwdIssue) {
 		if (appMode === "interactive") {
@@ -500,7 +507,12 @@ export async function main(args: string[]) {
 			if (!selectedCwd) {
 				process.exit(0);
 			}
-			sessionManager = SessionManager.open(missingSessionCwdIssue.sessionFile!, sessionDir, selectedCwd);
+			sessionManager = SessionManager.open(
+				missingSessionCwdIssue.sessionFile!,
+				sessionDir,
+				selectedCwd,
+				defaultSessionMode,
+			);
 		} else {
 			console.error(chalk.red(new MissingSessionCwdError(missingSessionCwdIssue).message));
 			process.exit(1);

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -51,6 +51,7 @@ class SessionSelectorHeader implements Component {
 	private scope: SessionScope;
 	private sortMode: SortMode;
 	private nameFilter: NameFilter;
+	private showHidden: boolean;
 	private requestRender: () => void;
 	private loading = false;
 	private loadProgress: { loaded: number; total: number } | null = null;
@@ -60,10 +61,17 @@ class SessionSelectorHeader implements Component {
 	private statusTimeout: ReturnType<typeof setTimeout> | null = null;
 	private showRenameHint = false;
 
-	constructor(scope: SessionScope, sortMode: SortMode, nameFilter: NameFilter, requestRender: () => void) {
+	constructor(
+		scope: SessionScope,
+		sortMode: SortMode,
+		nameFilter: NameFilter,
+		showHidden: boolean,
+		requestRender: () => void,
+	) {
 		this.scope = scope;
 		this.sortMode = sortMode;
 		this.nameFilter = nameFilter;
+		this.showHidden = showHidden;
 		this.requestRender = requestRender;
 	}
 
@@ -77,6 +85,10 @@ class SessionSelectorHeader implements Component {
 
 	setNameFilter(nameFilter: NameFilter): void {
 		this.nameFilter = nameFilter;
+	}
+
+	setShowHidden(showHidden: boolean): void {
+		this.showHidden = showHidden;
 	}
 
 	setLoading(loading: boolean): void {
@@ -131,6 +143,9 @@ class SessionSelectorHeader implements Component {
 		const nameLabel = this.nameFilter === "all" ? "All" : "Named";
 		const nameText = theme.fg("muted", "Name: ") + theme.fg("accent", nameLabel);
 
+		const hiddenLabel = this.showHidden ? "Shown" : "Hidden";
+		const hiddenText = theme.fg("muted", "Auto: ") + theme.fg("accent", hiddenLabel);
+
 		let scopeText: string;
 		if (this.loading) {
 			const progressText = this.loadProgress ? `${this.loadProgress.loaded}/${this.loadProgress.total}` : "...";
@@ -141,7 +156,7 @@ class SessionSelectorHeader implements Component {
 			scopeText = `${theme.fg("muted", "○ Current Folder | ")}${theme.fg("accent", "◉ All")}`;
 		}
 
-		const rightText = truncateToWidth(`${scopeText}  ${nameText}  ${sortText}`, width, "");
+		const rightText = truncateToWidth(`${scopeText}  ${nameText}  ${hiddenText}  ${sortText}`, width, "");
 		const availableLeft = Math.max(0, width - visibleWidth(rightText) - 1);
 		const left = truncateToWidth(leftText, availableLeft, "");
 		const spacing = Math.max(0, width - visibleWidth(left) - visibleWidth(rightText));
@@ -165,6 +180,7 @@ class SessionSelectorHeader implements Component {
 			const hint2Parts = [
 				keyHint("app.session.toggleSort", "sort"),
 				keyHint("app.session.toggleNamedFilter", "named"),
+				keyHint("app.session.toggleHidden", `auto ${this.showHidden ? "shown" : "hidden"}`),
 				keyHint("app.session.delete", "delete"),
 				keyHint("app.session.togglePath", `path ${pathState}`),
 			];
@@ -270,6 +286,7 @@ class SessionList implements Component, Focusable {
 	private showCwd = false;
 	private sortMode: SortMode = "threaded";
 	private nameFilter: NameFilter = "all";
+	private showHidden = false;
 	private keybindings: KeybindingsManager;
 	private showPath = false;
 	private confirmingDeletePath: string | null = null;
@@ -280,6 +297,7 @@ class SessionList implements Component, Focusable {
 	public onToggleScope?: () => void;
 	public onToggleSort?: () => void;
 	public onToggleNameFilter?: () => void;
+	public onToggleHidden?: () => void;
 	public onTogglePath?: (showPath: boolean) => void;
 	public onDeleteConfirmationChange?: (path: string | null) => void;
 	public onDeleteSession?: (sessionPath: string) => Promise<void>;
@@ -342,10 +360,20 @@ class SessionList implements Component, Focusable {
 		this.filterSessions(this.searchInput.getValue());
 	}
 
+	setShowHidden(showHidden: boolean): void {
+		this.showHidden = showHidden;
+		this.filterSessions(this.searchInput.getValue());
+	}
+
 	private filterSessions(query: string): void {
 		const trimmed = query.trim();
+		const visibilityFiltered = this.showHidden
+			? this.allSessions
+			: this.allSessions.filter((session) => !session.isHeadless);
 		const nameFiltered =
-			this.nameFilter === "all" ? this.allSessions : this.allSessions.filter((session) => hasSessionName(session));
+			this.nameFilter === "all"
+				? visibilityFiltered
+				: visibilityFiltered.filter((session) => hasSessionName(session));
 
 		if (this.sortMode === "threaded" && !trimmed) {
 			// Threaded mode without search: show tree structure
@@ -538,6 +566,11 @@ class SessionList implements Component, Focusable {
 			return;
 		}
 
+		if (this.keybindings.matches(keyData, "app.session.toggleHidden")) {
+			this.onToggleHidden?.();
+			return;
+		}
+
 		// Ctrl+P: toggle path display
 		if (kb.matches(keyData, "app.session.togglePath")) {
 			this.showPath = !this.showPath;
@@ -677,6 +710,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 	private scope: SessionScope = "current";
 	private sortMode: SortMode = "threaded";
 	private nameFilter: NameFilter = "all";
+	private showHidden = false;
 	private currentSessions: SessionInfo[] | null = null;
 	private allSessions: SessionInfo[] | null = null;
 	private currentSessionsLoader: SessionsLoader;
@@ -740,7 +774,13 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		this.allSessionsLoader = allSessionsLoader;
 		this.onCancel = onCancel;
 		this.requestRender = requestRender;
-		this.header = new SessionSelectorHeader(this.scope, this.sortMode, this.nameFilter, this.requestRender);
+		this.header = new SessionSelectorHeader(
+			this.scope,
+			this.sortMode,
+			this.nameFilter,
+			this.showHidden,
+			this.requestRender,
+		);
 		const renameSession = options?.renameSession;
 		this.renameSession = renameSession;
 		this.canRename = !!renameSession;
@@ -755,6 +795,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 			this.keybindings,
 			currentSessionFilePath,
 		);
+		this.sessionList.setShowHidden(this.showHidden);
 
 		this.buildBaseLayout(this.sessionList);
 
@@ -779,6 +820,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		this.sessionList.onToggleScope = () => this.toggleScope();
 		this.sessionList.onToggleSort = () => this.toggleSortMode();
 		this.sessionList.onToggleNameFilter = () => this.toggleNameFilter();
+		this.sessionList.onToggleHidden = () => this.toggleHidden();
 		this.sessionList.onRenameSession = (sessionPath) => {
 			if (!renameSession) return;
 			if (this.scope === "current" && this.currentLoading) return;
@@ -972,6 +1014,13 @@ export class SessionSelectorComponent extends Container implements Focusable {
 		this.nameFilter = this.nameFilter === "all" ? "named" : "all";
 		this.header.setNameFilter(this.nameFilter);
 		this.sessionList.setNameFilter(this.nameFilter);
+		this.requestRender();
+	}
+
+	private toggleHidden(): void {
+		this.showHidden = !this.showHidden;
+		this.header.setShowHidden(this.showHidden);
+		this.sessionList.setShowHidden(this.showHidden);
 		this.requestRender();
 	}
 

--- a/packages/coding-agent/test/session-info-headless-detection.test.ts
+++ b/packages/coding-agent/test/session-info-headless-detection.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { SessionHeader } from "../src/core/session-manager.js";
+import { SessionManager } from "../src/core/session-manager.js";
+
+function writeSessionFile(dir: string, name: string, header: SessionHeader, messages: unknown[]): string {
+	const path = join(dir, name);
+	const lines = `${[JSON.stringify(header), ...messages.map((message) => JSON.stringify(message))].join("\n")}\n`;
+	writeFileSync(path, lines, "utf8");
+	return path;
+}
+
+function createHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
+	return {
+		type: "session",
+		version: 3,
+		id: overrides.id ?? "test-session",
+		timestamp: overrides.timestamp ?? new Date("2026-04-08T00:00:00.000Z").toISOString(),
+		cwd: overrides.cwd ?? "/tmp/project",
+		parentSession: overrides.parentSession,
+		sessionMode: overrides.sessionMode,
+	};
+}
+
+describe("SessionInfo.isHeadless", () => {
+	it("hides explicit headless sessions and keeps explicit interactive ones visible", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-headless-session-mode-"));
+
+		writeSessionFile(dir, "headless.jsonl", createHeader({ id: "headless", sessionMode: "headless" }), [
+			{
+				type: "message",
+				message: { role: "user", content: "You are investigating a triage ticket. Output EXACTLY one JSON block." },
+			},
+		]);
+
+		writeSessionFile(dir, "interactive.jsonl", createHeader({ id: "interactive", sessionMode: "interactive" }), [
+			{
+				type: "message",
+				message: { role: "user", content: "You are investigating a triage ticket. Output EXACTLY one JSON block." },
+			},
+		]);
+
+		const sessions = await SessionManager.list("/tmp/project", dir);
+		expect(sessions.find((session) => session.id === "headless")?.isHeadless).toBe(true);
+		expect(sessions.find((session) => session.id === "interactive")?.isHeadless).toBe(false);
+	});
+
+	it("falls back to generic automation prompt detection for legacy sessions", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-headless-legacy-"));
+		writeSessionFile(dir, "legacy.jsonl", createHeader({ id: "legacy" }), [
+			{
+				type: "message",
+				message: {
+					role: "user",
+					content:
+						"You are investigating a support incident. Your job is to gather evidence, not speculate. Output EXACTLY one JSON block with your findings.",
+				},
+			},
+		]);
+
+		const sessions = await SessionManager.list("/tmp/project", dir);
+		expect(sessions.find((session) => session.id === "legacy")?.isHeadless).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -38,6 +38,7 @@ function makeSession(overrides: Partial<SessionInfo> & { id: string }): SessionI
 		messageCount: overrides.messageCount ?? 1,
 		firstMessage: overrides.firstMessage ?? "hello",
 		allMessagesText: overrides.allMessagesText ?? "hello",
+		isHeadless: overrides.isHeadless ?? false,
 	};
 }
 

--- a/packages/coding-agent/test/session-selector-rename.test.ts
+++ b/packages/coding-agent/test/session-selector-rename.test.ts
@@ -22,6 +22,7 @@ function makeSession(overrides: Partial<SessionInfo> & { id: string }): SessionI
 		messageCount: overrides.messageCount ?? 1,
 		firstMessage: overrides.firstMessage ?? "hello",
 		allMessagesText: overrides.allMessagesText ?? "hello",
+		isHeadless: overrides.isHeadless ?? false,
 	};
 }
 

--- a/packages/coding-agent/test/session-selector-search.test.ts
+++ b/packages/coding-agent/test/session-selector-search.test.ts
@@ -15,6 +15,7 @@ function makeSession(
 		messageCount: overrides.messageCount ?? 1,
 		firstMessage: overrides.firstMessage ?? "(no messages)",
 		allMessagesText: overrides.allMessagesText,
+		isHeadless: overrides.isHeadless ?? false,
 	};
 }
 


### PR DESCRIPTION
## Summary
- hide headless sessions from the default Resume Session picker
- add a toggle to reveal hidden sessions on demand
- persist `sessionMode` metadata and infer legacy headless sessions conservatively

## Changes
- add `sessionMode` plumbing to session creation/open/fork flows
- mark `SessionInfo` with `isHeadless`
- hide headless sessions by default in the session selector and surface a toggle (`ctrl+shift+h`)
- add a headless detection test and update selector test fixtures for the new `SessionInfo` shape

## Validation
- `npm run test -w @mariozechner/pi-coding-agent -- test/session-info-headless-detection.test.ts` ✅
- `npm run test -w @mariozechner/pi-coding-agent -- test/session-info-headless-detection.test.ts test/session-selector-path-delete.test.ts test/session-selector-rename.test.ts test/session-selector-search.test.ts` ⚠️ blocked by existing workspace resolution failure for `@mariozechner/pi-tui`
- repo pre-commit `npm run check` ⚠️ blocked by existing monorepo type-resolution failures in `packages/web-ui`

Refs #3173
