### PR TITLE
fix(ai): trim immediate orphan tool results after malformed calls

### DIFF
--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -12,9 +12,12 @@ export function transformMessages<TApi extends Api>(
 ): Message[] {
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
+	// Track assistant turns where malformed tool calls were removed.
+	// We use this to trim only the immediately following tool results.
+	const droppedMalformedToolCallsByAssistantIndex = new Set<number>();
 
 	// First pass: transform messages (thinking blocks, tool call ID normalization)
-	const transformed = messages.map((msg) => {
+	const transformed = messages.map((msg, msgIndex) => {
 		// User messages pass through unchanged
 		if (msg.role === "user") {
 			return msg;
@@ -32,6 +35,7 @@ export function transformMessages<TApi extends Api>(
 		// Assistant messages need transformation check
 		if (msg.role === "assistant") {
 			const assistantMsg = msg as AssistantMessage;
+			let droppedMalformedToolCall = false;
 			const isSameModel =
 				assistantMsg.provider === model.provider &&
 				assistantMsg.api === model.api &&
@@ -66,6 +70,11 @@ export function transformMessages<TApi extends Api>(
 
 				if (block.type === "toolCall") {
 					const toolCall = block as ToolCall;
+					if (!toolCall.name || toolCall.name.trim().length === 0) {
+						droppedMalformedToolCall = true;
+						return [];
+					}
+
 					let normalizedToolCall: ToolCall = toolCall;
 
 					if (!isSameModel && toolCall.thoughtSignature) {
@@ -87,6 +96,10 @@ export function transformMessages<TApi extends Api>(
 				return block;
 			});
 
+			if (droppedMalformedToolCall) {
+				droppedMalformedToolCallsByAssistantIndex.add(msgIndex);
+			}
+
 			return {
 				...assistantMsg,
 				content: transformedContent,
@@ -100,6 +113,7 @@ export function transformMessages<TApi extends Api>(
 	const result: Message[] = [];
 	let pendingToolCalls: ToolCall[] = [];
 	let existingToolResultIds = new Set<string>();
+	let immediateToolResultAllowlist: Set<string> | undefined;
 
 	for (let i = 0; i < transformed.length; i++) {
 		const msg = transformed[i];
@@ -130,11 +144,25 @@ export function transformMessages<TApi extends Api>(
 			// - The model should retry from the last valid state
 			const assistantMsg = msg as AssistantMessage;
 			if (assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") {
+				immediateToolResultAllowlist = undefined;
+				continue;
+			}
+
+			// If this assistant originally contained malformed tool calls, only keep
+			// immediate tool results that match surviving tool calls from this turn.
+			const toolCalls = assistantMsg.content.filter((b) => b.type === "toolCall") as ToolCall[];
+			if (droppedMalformedToolCallsByAssistantIndex.has(i)) {
+				immediateToolResultAllowlist = new Set(toolCalls.map((tc) => tc.id));
+			} else {
+				immediateToolResultAllowlist = undefined;
+			}
+
+			// Skip empty assistant messages created by sanitization (for instance, invalid tool calls removed).
+			if (assistantMsg.content.length === 0) {
 				continue;
 			}
 
 			// Track tool calls from this assistant message
-			const toolCalls = assistantMsg.content.filter((b) => b.type === "toolCall") as ToolCall[];
 			if (toolCalls.length > 0) {
 				pendingToolCalls = toolCalls;
 				existingToolResultIds = new Set();
@@ -142,9 +170,13 @@ export function transformMessages<TApi extends Api>(
 
 			result.push(msg);
 		} else if (msg.role === "toolResult") {
+			if (immediateToolResultAllowlist && !immediateToolResultAllowlist.has(msg.toolCallId)) {
+				continue;
+			}
 			existingToolResultIds.add(msg.toolCallId);
 			result.push(msg);
 		} else if (msg.role === "user") {
+			immediateToolResultAllowlist = undefined;
 			// User message interrupts tool flow - insert synthetic results for orphaned calls
 			if (pendingToolCalls.length > 0) {
 				for (const tc of pendingToolCalls) {
@@ -164,6 +196,7 @@ export function transformMessages<TApi extends Api>(
 			}
 			result.push(msg);
 		} else {
+			immediateToolResultAllowlist = undefined;
 			result.push(msg);
 		}
 	}

--- a/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
+++ b/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
@@ -112,4 +112,104 @@ describe("OpenAI to Anthropic session migration for Copilot Claude", () => {
 
 		expect(toolCall.thoughtSignature).toBeUndefined();
 	});
+
+	it("drops immediate orphan tool results for malformed calls while preserving valid and later-colliding ids", () => {
+		const model = makeCopilotClaudeModel();
+		const ts = Date.now();
+		const usage = {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		const messages: Message[] = [
+			{ role: "user", content: "run", timestamp: ts },
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Working on it" },
+					{ type: "toolCall", id: "abc_def", name: "", arguments: { "": "bad" } },
+					{ type: "toolCall", id: "good|id", name: "bash", arguments: { command: "pwd" } },
+				],
+				api: "openai-completions",
+				provider: "github-copilot",
+				model: "gpt-4o",
+				usage,
+				stopReason: "toolUse",
+				timestamp: ts,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "abc_def",
+				toolName: "",
+				content: [{ type: "text", text: "dropped malformed result" }],
+				isError: true,
+				timestamp: ts,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "good|id",
+				toolName: "bash",
+				content: [{ type: "text", text: "kept immediate valid result" }],
+				isError: false,
+				timestamp: ts,
+			},
+			{
+				role: "assistant",
+				content: [{ type: "toolCall", id: "abc|def", name: "bash", arguments: { command: "ls" } }],
+				api: "openai-completions",
+				provider: "github-copilot",
+				model: "gpt-4o",
+				usage,
+				stopReason: "toolUse",
+				timestamp: ts,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "abc|def",
+				toolName: "bash",
+				content: [{ type: "text", text: "kept later colliding result" }],
+				isError: false,
+				timestamp: ts,
+			},
+			{ role: "user", content: "continue", timestamp: ts },
+		];
+
+		const result = transformMessages(messages, model, anthropicNormalizeToolCallId);
+
+		expect(result.map((m) => m.role)).toEqual(["user", "assistant", "toolResult", "assistant", "toolResult", "user"]);
+		expect(
+			result.some(
+				(m) =>
+					m.role === "toolResult" &&
+					m.content[0]?.type === "text" &&
+					m.content[0].text === "kept immediate valid result",
+			),
+		).toBe(true);
+		expect(
+			result.some(
+				(m) =>
+					m.role === "toolResult" &&
+					m.content[0]?.type === "text" &&
+					m.content[0].text === "kept later colliding result",
+			),
+		).toBe(true);
+		expect(
+			result.some(
+				(m) =>
+					m.role === "toolResult" &&
+					m.content[0]?.type === "text" &&
+					m.content[0].text === "dropped malformed result",
+			),
+		).toBe(false);
+		expect(
+			result.some(
+				(m) =>
+					m.role === "toolResult" && m.content[0]?.type === "text" && m.content[0].text === "No result provided",
+			),
+		).toBe(false);
+	});
 });


### PR DESCRIPTION
Keep malformed tool-call recovery local to the assistant turn by filtering only the immediate contiguous toolResult block against surviving tool-call IDs.

This is a potential fix for #3108.