### PR TITLE
fix(coding-agent): prevent race condition in auto-compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1820,6 +1820,12 @@ export class AgentSession {
 	 * Internal: Run auto-compaction with events.
 	 */
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<void> {
+		// Guard against concurrent executions that could corrupt shared abort controller state
+		if (this.isCompacting) {
+			this._emit({ type: "compaction_end", reason, result: undefined, aborted: true, willRetry: false });
+			return;
+		}
+
 		const settings = this.settingsManager.getCompactionSettings();
 
 		this._emit({ type: "compaction_start", reason });


### PR DESCRIPTION
Add guard at start of _runAutoCompaction to prevent concurrent executions that corrupt shared _autoCompactionAbortController state.

Race condition scenario:

- Call A starts, sets _autoCompactionAbortController
- Call A awaits getApiKeyAndHeaders(), yields control
- Call B starts concurrently, overwrites _autoCompactionAbortController
- Call B completes, finally block sets _autoCompactionAbortController = undefined
- Call A resumes, accesses this._autoCompactionAbortController.signal
- ERROR: undefined is not an object

The guard checks isCompacting before proceeding and emits compaction_end with aborted: true to maintain expected event flow.

Fixes: #3189