### PR TITLE
handle lower case am/pm in macos screenshot names

### DIFF
--- a/packages/coding-agent/src/core/tools/path-utils.ts
+++ b/packages/coding-agent/src/core/tools/path-utils.ts
@@ -9,7 +9,7 @@ function normalizeUnicodeSpaces(str: string): string {
 }
 
 function tryMacOSScreenshotPath(filePath: string): string {
-	return filePath.replace(/ (AM|PM)\./g, `${NARROW_NO_BREAK_SPACE}$1.`);
+	return filePath.replace(/ (AM|PM)\./gi, `${NARROW_NO_BREAK_SPACE}$1.`);
 }
 
 function tryNFDVariant(filePath: string): string {

--- a/packages/coding-agent/test/path-utils.test.ts
+++ b/packages/coding-agent/test/path-utils.test.ts
@@ -143,5 +143,20 @@ describe("path-utils", () => {
 			// This works because tryMacOSScreenshotPath() handles this case
 			expect(result).toBe(join(tempDir, macosName));
 		});
+
+		it("should handle macOS screenshot lowercase am/pm variant (en_AU locale)", () => {
+			// Some locales like en_AU use lowercase am/pm in screenshot names
+			const macosName = "Screenshot 2024-01-01 at 10.00.00\u202Fam.png"; // U+202F + lowercase
+			const userName = "Screenshot 2024-01-01 at 10.00.00 am.png"; // regular space + lowercase
+
+			// Create file with macOS-style name
+			writeFileSync(join(tempDir, macosName), "content");
+
+			// User provides regular space path
+			const result = resolveReadPath(userName, tempDir);
+
+			// This works because tryMacOSScreenshotPath() uses case-insensitive matching
+			expect(result).toBe(join(tempDir, macosName));
+		});
 	});
 });


### PR DESCRIPTION
resolves https://github.com/badlogic/pi-mono/issues/3135 (pi cannot read macOS screenshots in en_AU)