### PR TITLE
test(tui): isolate raw 0x08 Windows Terminal env coverage

### DIFF
--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -18,6 +18,19 @@ function withEnv(name: string, value: string | undefined, fn: () => void): void 
 	}
 }
 
+function withEnvVars(vars: Record<string, string | undefined>, fn: () => void): void {
+	const entries = Object.entries(vars);
+	const run = (index: number): void => {
+		if (index >= entries.length) {
+			fn();
+			return;
+		}
+		const [name, value] = entries[index]!;
+		withEnv(name, value, () => run(index + 1));
+	};
+	run(0);
+}
+
 describe("matchesKey", () => {
 	describe("Kitty protocol with alternate keys (non-Latin layouts)", () => {
 		// Kitty protocol flag 4 (Report alternate keys) sends:
@@ -351,14 +364,40 @@ describe("matchesKey", () => {
 			});
 		});
 
-		it("should treat raw 0x08 as ctrl+backspace in Windows Terminal", () => {
+		it("should treat raw 0x08 as ctrl+backspace in local Windows Terminal", () => {
 			setKittyProtocolActive(false);
-			withEnv("WT_SESSION", "test-session", () => {
-				assert.strictEqual(matchesKey("\x08", "ctrl+backspace"), true);
-				assert.strictEqual(matchesKey("\x08", "backspace"), false);
-				assert.strictEqual(parseKey("\x08"), "ctrl+backspace");
-				assert.strictEqual(matchesKey("\x08", "ctrl+h"), true);
-			});
+			withEnvVars(
+				{
+					WT_SESSION: "test-session",
+					SSH_CONNECTION: undefined,
+					SSH_CLIENT: undefined,
+					SSH_TTY: undefined,
+				},
+				() => {
+					assert.strictEqual(matchesKey("\x08", "ctrl+backspace"), true);
+					assert.strictEqual(matchesKey("\x08", "backspace"), false);
+					assert.strictEqual(parseKey("\x08"), "ctrl+backspace");
+					assert.strictEqual(matchesKey("\x08", "ctrl+h"), true);
+				},
+			);
+		});
+
+		it("should treat raw 0x08 as plain backspace in Windows Terminal over SSH", () => {
+			setKittyProtocolActive(false);
+			withEnvVars(
+				{
+					WT_SESSION: "test-session",
+					SSH_CONNECTION: "1 2 3 4",
+					SSH_CLIENT: "1 2 3",
+					SSH_TTY: "/dev/pts/1",
+				},
+				() => {
+					assert.strictEqual(matchesKey("\x08", "ctrl+backspace"), false);
+					assert.strictEqual(matchesKey("\x08", "backspace"), true);
+					assert.strictEqual(parseKey("\x08"), "backspace");
+					assert.strictEqual(matchesKey("\x08", "ctrl+h"), true);
+				},
+			);
 		});
 
 		it("should parse legacy alt-prefixed sequences when kitty inactive", () => {


### PR DESCRIPTION
   ## Summary

   Fix `packages/tui/test/keys.test.ts` so raw `0x08` Windows Terminal coverage is isolated from inherited runner environment variables.

   ## Background

   Commit `fa877de1fb85a854edeb06630411cd2eeec8cb2e` (`fix(tui): resolve raw backspace ambiguity closes #2293`) changed the implementation to treat raw `0x08` as `ctrl+backspace` only for a local Windows
 Terminal heuristic:

   - `WT_SESSION` set
   - `SSH_CONNECTION`, `SSH_CLIENT`, and `SSH_TTY` unset

   The existing test only set `WT_SESSION`, so it did not fully simulate that heuristic. As a result, it could fail when run in a Linux shell reached over SSH from Windows Terminal, because the test
 process would still inherit `SSH_*` variables.

   ## Changes

   - add a helper to set/clear multiple env vars deterministically
   - update the local Windows Terminal test to clear `SSH_*`
   - add coverage for Windows Terminal over SSH, where raw `0x08` remains plain `backspace`

   ## Validation

   - `cd packages/tui && node --test --import tsx test/keys.test.ts`
   - `npm run check`
