### PR TITLE
fix(ai): treat gcp vertex marker as ADC auth

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -45,6 +45,7 @@ export interface GoogleVertexOptions extends StreamOptions {
 }
 
 const API_VERSION = "v1";
+const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
 
 const THINKING_LEVEL_MAP: Record<GoogleThinkingLevel, ThinkingLevel> = {
 	THINKING_LEVEL_UNSPECIFIED: ThinkingLevel.THINKING_LEVEL_UNSPECIFIED,
@@ -370,7 +371,7 @@ function createClientWithApiKey(
 
 function resolveApiKey(options?: GoogleVertexOptions): string | undefined {
 	const apiKey = options?.apiKey?.trim() || process.env.GOOGLE_CLOUD_API_KEY?.trim();
-	if (!apiKey || isPlaceholderApiKey(apiKey)) {
+	if (!apiKey || apiKey === GCP_VERTEX_CREDENTIALS_MARKER || isPlaceholderApiKey(apiKey)) {
 		return undefined;
 	}
 	return apiKey;

--- a/packages/ai/test/google-vertex-api-key-resolution.test.ts
+++ b/packages/ai/test/google-vertex-api-key-resolution.test.ts
@@ -86,6 +86,25 @@ describe("google-vertex api key resolution", () => {
 		expect(googleGenAiMock.constructorCalls[0]).not.toHaveProperty("apiKey");
 	});
 
+	it("falls back to ADC when options.apiKey is the gcp-vertex-credentials marker", async () => {
+		const stream = streamGoogleVertex(model, context, {
+			apiKey: "gcp-vertex-credentials",
+			project: "test-project",
+			location: "us-central1",
+		});
+
+		await stream.result();
+
+		expect(googleGenAiMock.constructorCalls).toHaveLength(1);
+		expect(googleGenAiMock.constructorCalls[0]).toMatchObject({
+			vertexai: true,
+			project: "test-project",
+			location: "us-central1",
+			apiVersion: "v1",
+		});
+		expect(googleGenAiMock.constructorCalls[0]).not.toHaveProperty("apiKey");
+	});
+
 	it("falls back to ADC when GOOGLE_CLOUD_API_KEY is a placeholder marker", async () => {
 		process.env.GOOGLE_CLOUD_API_KEY = "<authenticated>";
 


### PR DESCRIPTION
## Summary
- treat `gcp-vertex-credentials` as an ADC marker for `google-vertex` instead of a literal Vertex API key
- keep the existing real API key path unchanged
- add a regression test for the marker-based auth flow

## Problem
Some downstream integrations pass `gcp-vertex-credentials` as a sentinel value to indicate that Vertex auth should come from ADC. Today `resolveApiKey()` treats any non-empty string as a real API key, so `@google/genai` is initialized in API-key mode and Vertex rejects the request with a 401 (`API keys are not supported by this API`).

## Fix
When the provider receives `gcp-vertex-credentials`, it now falls back to the existing ADC path instead of the API key path.

## Test
- `npm run test --workspace packages/ai -- test/google-vertex-api-key-resolution.test.ts`