### PR TITLE
fix(coding-agent): make rpc prompt emit a single authoritative response

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -190,6 +190,8 @@ export interface ModelCycleResult {
 	isScoped: boolean;
 }
 
+type PreparedPromptResult = { kind: "handled" } | { kind: "queued" } | { kind: "run"; messages: AgentMessage[] };
+
 /** Session statistics for /session command */
 export interface SessionStats {
 	sessionFile: string | undefined;
@@ -927,6 +929,40 @@ export class AgentSession {
 	 * @throws Error if no model selected or no API key available (when not streaming)
 	 */
 	async prompt(text: string, options?: PromptOptions): Promise<void> {
+		const prepared = await this._preparePrompt(text, options);
+		if (prepared.kind !== "run") {
+			return;
+		}
+
+		await this.agent.prompt(prepared.messages);
+		await this.waitForRetry();
+	}
+
+	/**
+	 * Start a prompt after preflight succeeds, but do not wait for the full run to finish.
+	 * RPC mode uses this so the command gets exactly one authoritative response.
+	 */
+	async startPrompt(text: string, options?: PromptOptions): Promise<void> {
+		const prepared = await this._preparePrompt(text, options);
+		if (prepared.kind !== "run") {
+			return;
+		}
+
+		let startError: unknown;
+		void this.agent.prompt(prepared.messages).catch((error) => {
+			// Only use this catch to surface immediate acceptance failures. After acceptance,
+			// run failures are reported through normal session events/messages.
+			startError = error;
+		});
+		// Give immediate rejections one microtask turn to surface so callers can treat them as
+		// acceptance failures instead of success-followed-by-error.
+		await Promise.resolve();
+		if (startError) {
+			throw startError;
+		}
+	}
+
+	private async _preparePrompt(text: string, options?: PromptOptions): Promise<PreparedPromptResult> {
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 
 		// Handle extension commands first (execute immediately, even during streaming)
@@ -934,8 +970,7 @@ export class AgentSession {
 		if (expandPromptTemplates && text.startsWith("/")) {
 			const handled = await this._tryExecuteExtensionCommand(text);
 			if (handled) {
-				// Extension command executed, no prompt to send
-				return;
+				return { kind: "handled" };
 			}
 		}
 
@@ -949,7 +984,7 @@ export class AgentSession {
 				options?.source ?? "interactive",
 			);
 			if (inputResult.action === "handled") {
-				return;
+				return { kind: "handled" };
 			}
 			if (inputResult.action === "transform") {
 				currentText = inputResult.text;
@@ -976,7 +1011,7 @@ export class AgentSession {
 			} else {
 				await this._queueSteer(expandedText, currentImages);
 			}
-			return;
+			return { kind: "queued" };
 		}
 
 		// Flush any pending bash messages before the new prompt
@@ -1061,8 +1096,7 @@ export class AgentSession {
 			}
 		}
 
-		await this.agent.prompt(messages);
-		await this.waitForRetry();
+		return { kind: "run", messages };
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -348,16 +348,13 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 			// =================================================================
 
 			case "prompt": {
-				// Don't await - events will stream
-				// Extension commands are executed immediately, file prompt templates are expanded
-				// If streaming and streamingBehavior specified, queues via steer/followUp
-				session
-					.prompt(command.message, {
-						images: command.images,
-						streamingBehavior: command.streamingBehavior,
-						source: "rpc",
-					})
-					.catch((e) => output(error(id, "prompt", e.message)));
+				// Await prompt preflight so this request gets exactly one authoritative response.
+				// Events still stream asynchronously after the prompt has started or been queued.
+				await session.startPrompt(command.message, {
+					images: command.images,
+					streamingBehavior: command.streamingBehavior,
+					source: "rpc",
+				});
 				return success(id, "prompt");
 			}
 

--- a/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.resetModules();
+});
+
+function parseOutputLines(outputLines: string[]): any[] {
+	return outputLines
+		.flatMap((line) => line.split("\n"))
+		.filter((line) => line.trim().length > 0)
+		.map((line) => JSON.parse(line));
+}
+
+async function startRpcModeWithSession(sessionOverrides: Record<string, unknown> = {}) {
+	const outputLines: string[] = [];
+	let lineHandler: ((line: string) => void) | undefined;
+
+	vi.doMock("../src/core/output-guard.js", () => ({
+		takeOverStdout: vi.fn(),
+		writeRawStdout: (line: string) => outputLines.push(line),
+	}));
+	vi.doMock("../src/modes/interactive/theme/theme.js", () => ({ theme: {} }));
+	vi.doMock("../src/modes/rpc/jsonl.js", () => ({
+		attachJsonlLineReader: vi.fn((_stream: NodeJS.ReadableStream, onLine: (line: string) => void) => {
+			lineHandler = onLine;
+			return () => {};
+		}),
+		serializeJsonLine: (value: unknown) => `${JSON.stringify(value)}\n`,
+	}));
+
+	const { runRpcMode } = await import("../src/modes/rpc/rpc-mode.js");
+	const runtimeHost = {
+		session: {
+			agent: { waitForIdle: vi.fn().mockResolvedValue(undefined) },
+			bindExtensions: vi.fn().mockResolvedValue(undefined),
+			subscribe: vi.fn(() => () => {}),
+			startPrompt: vi.fn().mockResolvedValue(undefined),
+			...sessionOverrides,
+		},
+		newSession: vi.fn(),
+		switchSession: vi.fn(),
+		fork: vi.fn(),
+		dispose: vi.fn().mockResolvedValue(undefined),
+	};
+
+	void runRpcMode(runtimeHost as any);
+	await vi.waitFor(() => expect(lineHandler).toBeDefined());
+
+	return { lineHandler: lineHandler!, outputLines, runtimeHost };
+}
+
+describe("RPC prompt response semantics", () => {
+	it("emits one failure response when prompt preflight rejects", async () => {
+		const promptError = new Error("No API key found for anthropic.");
+		const { lineHandler, outputLines } = await startRpcModeWithSession({
+			startPrompt: vi.fn().mockRejectedValue(promptError),
+		});
+
+		lineHandler(JSON.stringify({ id: "b1", type: "prompt", message: "Hello" }));
+
+		await vi.waitFor(() => {
+			const responses = parseOutputLines(outputLines).filter(
+				(record) => record?.id === "b1" && record?.type === "response" && record?.command === "prompt",
+			);
+
+			expect(responses).toHaveLength(1);
+			expect(responses[0]).toMatchObject({
+				id: "b1",
+				type: "response",
+				command: "prompt",
+				success: false,
+				error: "No API key found for anthropic.",
+			});
+		});
+	});
+
+	it("emits one success response when prompt preflight succeeds", async () => {
+		const { lineHandler, outputLines, runtimeHost } = await startRpcModeWithSession();
+
+		lineHandler(JSON.stringify({ id: "b2", type: "prompt", message: "Hello" }));
+
+		await vi.waitFor(() => {
+			const responses = parseOutputLines(outputLines).filter(
+				(record) => record?.id === "b2" && record?.type === "response" && record?.command === "prompt",
+			);
+
+			expect(responses).toHaveLength(1);
+			expect(responses[0]).toMatchObject({
+				id: "b2",
+				type: "response",
+				command: "prompt",
+				success: true,
+			});
+		});
+
+		expect(runtimeHost.session.startPrompt).toHaveBeenCalledWith("Hello", {
+			images: undefined,
+			streamingBehavior: undefined,
+			source: "rpc",
+		});
+	});
+
+	it("emits one success response when prompt is queued during streaming", async () => {
+		const { lineHandler, outputLines, runtimeHost } = await startRpcModeWithSession();
+
+		lineHandler(
+			JSON.stringify({
+				id: "b3",
+				type: "prompt",
+				message: "Queue this",
+				streamingBehavior: "followUp",
+			}),
+		);
+
+		await vi.waitFor(() => {
+			const responses = parseOutputLines(outputLines).filter(
+				(record) => record?.id === "b3" && record?.type === "response" && record?.command === "prompt",
+			);
+
+			expect(responses).toHaveLength(1);
+			expect(responses[0]).toMatchObject({
+				id: "b3",
+				type: "response",
+				command: "prompt",
+				success: true,
+			});
+		});
+
+		expect(runtimeHost.session.startPrompt).toHaveBeenCalledWith("Queue this", {
+			images: undefined,
+			streamingBehavior: "followUp",
+			source: "rpc",
+		});
+	});
+});


### PR DESCRIPTION
   Fixes #3049.

   In RPC mode, `prompt` could emit conflicting `response` objects for the same request id when prompt preflight failed.

   This change makes the RPC response authoritative:

   - `success: true` means the prompt was accepted / started / queued
   - `success: false` means the prompt was rejected before acceptance
   - failures after acceptance continue to surface through the normal event/message stream, not as a second `response`

   Implementation:
   - factor prompt preflight out from full prompt completion in `AgentSession`
   - make RPC `prompt` wait for preflight/acceptance before returning its single response

   Tests:
   - preflight failure -> exactly one failure response
   - preflight success -> exactly one success response
   - queued/streaming path -> exactly one success response
