### PR TITLE
fix(anthropic): harden tool-call streaming and recovery

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -476,6 +476,16 @@ async function prepareToolCall(
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 ): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
+	if (toolCall.argumentsParseError) {
+		return {
+			kind: "immediate",
+			result: createErrorToolResult(
+				`Invalid tool arguments JSON for "${toolCall.name}": ${toolCall.argumentsParseError}`,
+			),
+			isError: true,
+		};
+	}
+
 	const tool = currentContext.tools?.find((t) => t.name === toolCall.name);
 	if (!tool) {
 		return {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -307,6 +307,94 @@ describe("agentLoop with AgentMessage", () => {
 		}
 	});
 
+	it("should skip tool execution when tool arguments JSON is invalid", async () => {
+		const toolSchema = Type.Object({});
+		let executed = false;
+		const tool: AgentTool<typeof toolSchema, { ok: true }> = {
+			name: "noop",
+			label: "Noop",
+			description: "No-op tool",
+			parameters: toolSchema,
+			async execute() {
+				executed = true;
+				return {
+					content: [{ type: "text", text: "executed" }],
+					details: { ok: true },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const userPrompt: AgentMessage = createUserMessage("run noop");
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let callIndex = 0;
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([userPrompt], context, config, undefined, () => {
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					const message = createAssistantMessage(
+						[
+							{
+								type: "toolCall",
+								id: "tool-1",
+								name: "noop",
+								arguments: {},
+								argumentsParseError: "parse error",
+							},
+						],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					const message = createAssistantMessage([{ type: "text", text: "done" }]);
+					mockStream.push({ type: "done", reason: "stop", message });
+				}
+				callIndex++;
+			});
+			return mockStream;
+		});
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		expect(executed).toBe(false);
+
+		const toolExecutionEnd = events.find(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				event.type === "tool_execution_end" && event.toolCallId === "tool-1",
+		);
+		expect(toolExecutionEnd).toBeDefined();
+		expect(toolExecutionEnd?.isError).toBe(true);
+
+		const toolResultMessage = events.find(
+			(event): event is Extract<AgentEvent, { type: "message_end" }> =>
+				event.type === "message_end" &&
+				event.message.role === "toolResult" &&
+				event.message.toolCallId === "tool-1",
+		);
+		expect(toolResultMessage).toBeDefined();
+		if (toolResultMessage && toolResultMessage.message.role === "toolResult") {
+			expect(toolResultMessage.message.isError).toBe(true);
+			expect(toolResultMessage.message.content).toEqual([
+				{
+					type: "text",
+					text: 'Invalid tool arguments JSON for "noop": parse error',
+				},
+			]);
+		}
+	});
+
 	it("should execute mutated beforeToolCall args without revalidation", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		const executed: Array<string | number> = [];

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1,6 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type {
+	Message as AnthropicMessage,
 	ContentBlockParam,
+	MessageCreateParamsNonStreaming,
 	MessageCreateParamsStreaming,
 	MessageParam,
 } from "@anthropic-ai/sdk/resources/messages.js";
@@ -25,7 +27,6 @@ import type {
 	ToolResultMessage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
-import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
@@ -196,6 +197,124 @@ function mergeHeaders(...headerSources: (Record<string, string> | undefined)[]):
 	return merged;
 }
 
+function logMalformedToolInputJson(reason: string): void {
+	console.warn(`[anthropic] malformed tool input JSON (${reason}); falling back to {}`);
+}
+
+type ParsedToolInput = {
+	arguments: Record<string, unknown>;
+	argumentsParseError?: string;
+};
+
+function parseToolInputJson(rawJson: string): ParsedToolInput {
+	if (rawJson.trim().length === 0) {
+		return { arguments: {} };
+	}
+
+	try {
+		const parsed = JSON.parse(rawJson) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return {
+				arguments: parsed as Record<string, unknown>,
+			};
+		}
+		logMalformedToolInputJson("top-level value is not an object");
+		return {
+			arguments: {},
+			argumentsParseError: "top-level value is not an object",
+		};
+	} catch {
+		logMalformedToolInputJson("parse error");
+		return {
+			arguments: {},
+			argumentsParseError: "parse error",
+		};
+	}
+}
+
+function normalizeToolInput(input: unknown): ParsedToolInput {
+	if (!input) {
+		return { arguments: {} };
+	}
+
+	if (typeof input === "string") {
+		return parseToolInputJson(input);
+	}
+
+	if (typeof input === "object" && !Array.isArray(input)) {
+		return {
+			arguments: input as Record<string, unknown>,
+		};
+	}
+
+	logMalformedToolInputJson(`unexpected input type: ${typeof input}`);
+	return {
+		arguments: {},
+		argumentsParseError: `unexpected input type: ${typeof input}`,
+	};
+}
+
+function toNonStreamingParams(params: MessageCreateParamsStreaming): MessageCreateParamsNonStreaming {
+	const { stream: _stream, ...rest } = params;
+	return {
+		...rest,
+		stream: false,
+	};
+}
+
+function applyNonStreamingMessage(
+	model: Model<"anthropic-messages">,
+	output: AssistantMessage,
+	message: AnthropicMessage,
+	isOAuth: boolean,
+	tools: Tool[] | undefined,
+): void {
+	output.responseId = message.id;
+	output.content = [];
+
+	for (const block of message.content) {
+		if (block.type === "text") {
+			output.content.push({
+				type: "text",
+				text: block.text,
+			});
+		} else if (block.type === "thinking") {
+			output.content.push({
+				type: "thinking",
+				thinking: block.thinking,
+				thinkingSignature: block.signature,
+			});
+		} else if (block.type === "redacted_thinking") {
+			output.content.push({
+				type: "thinking",
+				thinking: "[Reasoning redacted]",
+				thinkingSignature: block.data,
+				redacted: true,
+			});
+		} else if (block.type === "tool_use") {
+			const normalizedInput = normalizeToolInput(block.input);
+			output.content.push({
+				type: "toolCall",
+				id: block.id,
+				name: isOAuth ? fromClaudeCodeName(block.name, tools) : block.name,
+				arguments: normalizedInput.arguments,
+				...(normalizedInput.argumentsParseError
+					? { argumentsParseError: normalizedInput.argumentsParseError }
+					: {}),
+			});
+		}
+	}
+
+	output.stopReason = message.stop_reason ? mapStopReason(message.stop_reason) : "stop";
+	output.usage.input = message.usage.input_tokens ?? 0;
+	output.usage.output = message.usage.output_tokens ?? 0;
+	output.usage.cacheRead = message.usage.cache_read_input_tokens ?? 0;
+	output.usage.cacheWrite = message.usage.cache_creation_input_tokens ?? 0;
+	output.usage.totalTokens =
+		output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
+	calculateCost(model, output.usage);
+}
+
 export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 	model: Model<"anthropic-messages">,
 	context: Context,
@@ -256,167 +375,195 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			if (nextParams !== undefined) {
 				params = nextParams as MessageCreateParamsStreaming;
 			}
-			const anthropicStream = client.messages.stream({ ...params, stream: true }, { signal: options?.signal });
-			stream.push({ type: "start", partial: output });
+			let streamCompleted = false;
 
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
 			const blocks = output.content as Block[];
+			try {
+				const anthropicStream = await client.messages.create(
+					{ ...params, stream: true },
+					{ signal: options?.signal },
+				);
+				stream.push({ type: "start", partial: output });
 
-			for await (const event of anthropicStream) {
-				if (event.type === "message_start") {
-					output.responseId = event.message.id;
-					// Capture initial token usage from message_start event
-					// This ensures we have input token counts even if the stream is aborted early
-					output.usage.input = event.message.usage.input_tokens || 0;
-					output.usage.output = event.message.usage.output_tokens || 0;
-					output.usage.cacheRead = event.message.usage.cache_read_input_tokens || 0;
-					output.usage.cacheWrite = event.message.usage.cache_creation_input_tokens || 0;
-					// Anthropic doesn't provide total_tokens, compute from components
-					output.usage.totalTokens =
-						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
-					calculateCost(model, output.usage);
-				} else if (event.type === "content_block_start") {
-					if (event.content_block.type === "text") {
-						const block: Block = {
-							type: "text",
-							text: "",
-							index: event.index,
-						};
-						output.content.push(block);
-						stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
-					} else if (event.content_block.type === "thinking") {
-						const block: Block = {
-							type: "thinking",
-							thinking: "",
-							thinkingSignature: "",
-							index: event.index,
-						};
-						output.content.push(block);
-						stream.push({ type: "thinking_start", contentIndex: output.content.length - 1, partial: output });
-					} else if (event.content_block.type === "redacted_thinking") {
-						const block: Block = {
-							type: "thinking",
-							thinking: "[Reasoning redacted]",
-							thinkingSignature: event.content_block.data,
-							redacted: true,
-							index: event.index,
-						};
-						output.content.push(block);
-						stream.push({ type: "thinking_start", contentIndex: output.content.length - 1, partial: output });
-					} else if (event.content_block.type === "tool_use") {
-						const block: Block = {
-							type: "toolCall",
-							id: event.content_block.id,
-							name: isOAuth
-								? fromClaudeCodeName(event.content_block.name, context.tools)
-								: event.content_block.name,
-							arguments: (event.content_block.input as Record<string, any>) ?? {},
-							partialJson: "",
-							index: event.index,
-						};
-						output.content.push(block);
-						stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
-					}
-				} else if (event.type === "content_block_delta") {
-					if (event.delta.type === "text_delta") {
+				for await (const event of anthropicStream) {
+					if (event.type === "message_start") {
+						output.responseId = event.message.id;
+						// Capture initial token usage from message_start event
+						// This ensures we have input token counts even if the stream is aborted early
+						output.usage.input = event.message.usage.input_tokens || 0;
+						output.usage.output = event.message.usage.output_tokens || 0;
+						output.usage.cacheRead = event.message.usage.cache_read_input_tokens || 0;
+						output.usage.cacheWrite = event.message.usage.cache_creation_input_tokens || 0;
+						// Anthropic doesn't provide total_tokens, compute from components
+						output.usage.totalTokens =
+							output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
+						calculateCost(model, output.usage);
+					} else if (event.type === "content_block_start") {
+						if (event.content_block.type === "text") {
+							const block: Block = {
+								type: "text",
+								text: "",
+								index: event.index,
+							};
+							output.content.push(block);
+							stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
+						} else if (event.content_block.type === "thinking") {
+							const block: Block = {
+								type: "thinking",
+								thinking: "",
+								thinkingSignature: "",
+								index: event.index,
+							};
+							output.content.push(block);
+							stream.push({ type: "thinking_start", contentIndex: output.content.length - 1, partial: output });
+						} else if (event.content_block.type === "redacted_thinking") {
+							const block: Block = {
+								type: "thinking",
+								thinking: "[Reasoning redacted]",
+								thinkingSignature: event.content_block.data,
+								redacted: true,
+								index: event.index,
+							};
+							output.content.push(block);
+							stream.push({ type: "thinking_start", contentIndex: output.content.length - 1, partial: output });
+						} else if (event.content_block.type === "tool_use") {
+							const normalizedInput = normalizeToolInput(event.content_block.input);
+							const block: Block = {
+								type: "toolCall",
+								id: event.content_block.id,
+								name: isOAuth
+									? fromClaudeCodeName(event.content_block.name, context.tools)
+									: event.content_block.name,
+								arguments: normalizedInput.arguments,
+								...(normalizedInput.argumentsParseError
+									? { argumentsParseError: normalizedInput.argumentsParseError }
+									: {}),
+								partialJson: "",
+								index: event.index,
+							};
+							output.content.push(block);
+							stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+						}
+					} else if (event.type === "content_block_delta") {
+						if (event.delta.type === "text_delta") {
+							const index = blocks.findIndex((b) => b.index === event.index);
+							const block = blocks[index];
+							if (block && block.type === "text") {
+								block.text += event.delta.text;
+								stream.push({
+									type: "text_delta",
+									contentIndex: index,
+									delta: event.delta.text,
+									partial: output,
+								});
+							}
+						} else if (event.delta.type === "thinking_delta") {
+							const index = blocks.findIndex((b) => b.index === event.index);
+							const block = blocks[index];
+							if (block && block.type === "thinking") {
+								block.thinking += event.delta.thinking;
+								stream.push({
+									type: "thinking_delta",
+									contentIndex: index,
+									delta: event.delta.thinking,
+									partial: output,
+								});
+							}
+						} else if (event.delta.type === "input_json_delta") {
+							const index = blocks.findIndex((b) => b.index === event.index);
+							const block = blocks[index];
+							if (block && block.type === "toolCall") {
+								block.partialJson += event.delta.partial_json;
+								stream.push({
+									type: "toolcall_delta",
+									contentIndex: index,
+									delta: event.delta.partial_json,
+									partial: output,
+								});
+							}
+						} else if (event.delta.type === "signature_delta") {
+							const index = blocks.findIndex((b) => b.index === event.index);
+							const block = blocks[index];
+							if (block && block.type === "thinking") {
+								block.thinkingSignature = block.thinkingSignature || "";
+								block.thinkingSignature += event.delta.signature;
+							}
+						}
+					} else if (event.type === "content_block_stop") {
 						const index = blocks.findIndex((b) => b.index === event.index);
 						const block = blocks[index];
-						if (block && block.type === "text") {
-							block.text += event.delta.text;
-							stream.push({
-								type: "text_delta",
-								contentIndex: index,
-								delta: event.delta.text,
-								partial: output,
-							});
+						if (block) {
+							delete (block as any).index;
+							if (block.type === "text") {
+								stream.push({
+									type: "text_end",
+									contentIndex: index,
+									content: block.text,
+									partial: output,
+								});
+							} else if (block.type === "thinking") {
+								stream.push({
+									type: "thinking_end",
+									contentIndex: index,
+									content: block.thinking,
+									partial: output,
+								});
+							} else if (block.type === "toolCall") {
+								if (block.partialJson.trim().length > 0) {
+									const parsedInput = parseToolInputJson(block.partialJson);
+									block.arguments = parsedInput.arguments;
+									if (parsedInput.argumentsParseError) {
+										block.argumentsParseError = parsedInput.argumentsParseError;
+									} else {
+										delete block.argumentsParseError;
+									}
+								}
+								// Finalize in-place and strip the scratch buffer so replay only
+								// carries parsed arguments.
+								delete (block as { partialJson?: string }).partialJson;
+								stream.push({
+									type: "toolcall_end",
+									contentIndex: index,
+									toolCall: block,
+									partial: output,
+								});
+							}
 						}
-					} else if (event.delta.type === "thinking_delta") {
-						const index = blocks.findIndex((b) => b.index === event.index);
-						const block = blocks[index];
-						if (block && block.type === "thinking") {
-							block.thinking += event.delta.thinking;
-							stream.push({
-								type: "thinking_delta",
-								contentIndex: index,
-								delta: event.delta.thinking,
-								partial: output,
-							});
+					} else if (event.type === "message_delta") {
+						if (event.delta.stop_reason) {
+							output.stopReason = mapStopReason(event.delta.stop_reason);
 						}
-					} else if (event.delta.type === "input_json_delta") {
-						const index = blocks.findIndex((b) => b.index === event.index);
-						const block = blocks[index];
-						if (block && block.type === "toolCall") {
-							block.partialJson += event.delta.partial_json;
-							block.arguments = parseStreamingJson(block.partialJson);
-							stream.push({
-								type: "toolcall_delta",
-								contentIndex: index,
-								delta: event.delta.partial_json,
-								partial: output,
-							});
+						// Only update usage fields if present (not null).
+						// Preserves input_tokens from message_start when proxies omit it in message_delta.
+						if (event.usage.input_tokens != null) {
+							output.usage.input = event.usage.input_tokens;
 						}
-					} else if (event.delta.type === "signature_delta") {
-						const index = blocks.findIndex((b) => b.index === event.index);
-						const block = blocks[index];
-						if (block && block.type === "thinking") {
-							block.thinkingSignature = block.thinkingSignature || "";
-							block.thinkingSignature += event.delta.signature;
+						if (event.usage.output_tokens != null) {
+							output.usage.output = event.usage.output_tokens;
 						}
-					}
-				} else if (event.type === "content_block_stop") {
-					const index = blocks.findIndex((b) => b.index === event.index);
-					const block = blocks[index];
-					if (block) {
-						delete (block as any).index;
-						if (block.type === "text") {
-							stream.push({
-								type: "text_end",
-								contentIndex: index,
-								content: block.text,
-								partial: output,
-							});
-						} else if (block.type === "thinking") {
-							stream.push({
-								type: "thinking_end",
-								contentIndex: index,
-								content: block.thinking,
-								partial: output,
-							});
-						} else if (block.type === "toolCall") {
-							block.arguments = parseStreamingJson(block.partialJson);
-							// Finalize in-place and strip the scratch buffer so replay only
-							// carries parsed arguments.
-							delete (block as { partialJson?: string }).partialJson;
-							stream.push({
-								type: "toolcall_end",
-								contentIndex: index,
-								toolCall: block,
-								partial: output,
-							});
+						if (event.usage.cache_read_input_tokens != null) {
+							output.usage.cacheRead = event.usage.cache_read_input_tokens;
 						}
+						if (event.usage.cache_creation_input_tokens != null) {
+							output.usage.cacheWrite = event.usage.cache_creation_input_tokens;
+						}
+						// Anthropic doesn't provide total_tokens, compute from components
+						output.usage.totalTokens =
+							output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
+						calculateCost(model, output.usage);
 					}
-				} else if (event.type === "message_delta") {
-					if (event.delta.stop_reason) {
-						output.stopReason = mapStopReason(event.delta.stop_reason);
-					}
-					// Only update usage fields if present (not null).
-					// Preserves input_tokens from message_start when proxies omit it in message_delta.
-					if (event.usage.input_tokens != null) {
-						output.usage.input = event.usage.input_tokens;
-					}
-					if (event.usage.output_tokens != null) {
-						output.usage.output = event.usage.output_tokens;
-					}
-					if (event.usage.cache_read_input_tokens != null) {
-						output.usage.cacheRead = event.usage.cache_read_input_tokens;
-					}
-					if (event.usage.cache_creation_input_tokens != null) {
-						output.usage.cacheWrite = event.usage.cache_creation_input_tokens;
-					}
-					// Anthropic doesn't provide total_tokens, compute from components
-					output.usage.totalTokens =
-						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
-					calculateCost(model, output.usage);
+				}
+
+				streamCompleted = true;
+			} catch (streamError) {
+				if (!options?.signal?.aborted && !streamCompleted) {
+					const fallbackResponse = await client.messages.create(toNonStreamingParams(params), {
+						signal: options?.signal,
+					});
+					applyNonStreamingMessage(model, output, fallbackResponse, isOAuth, context.tools);
+				} else {
+					throw streamError;
 				}
 			}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -161,6 +161,12 @@ export interface ToolCall {
 	id: string;
 	name: string;
 	arguments: Record<string, any>;
+	/**
+	 * Provider-reported parse/normalization error for tool-call arguments.
+	 * When present, runtimes should treat this tool call as invalid input and
+	 * skip execution, returning an error tool result instead.
+	 */
+	argumentsParseError?: string;
 	thoughtSignature?: string; // Google-specific: opaque signature for reusing thought context
 }
 

--- a/packages/ai/test/anthropic-fine-grained-tool-streaming.test.ts
+++ b/packages/ai/test/anthropic-fine-grained-tool-streaming.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.js";
+import type { Context } from "../src/types.js";
+
+const mockState = vi.hoisted(() => ({
+	createCalled: false,
+	streamCalled: false,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	const fakeStream = {
+		async *[Symbol.asyncIterator]() {
+			yield {
+				type: "message_start",
+				message: {
+					id: "msg_test",
+					usage: {
+						input_tokens: 12,
+						output_tokens: 0,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				},
+			};
+			yield {
+				type: "content_block_start",
+				index: 0,
+				content_block: {
+					type: "tool_use",
+					id: "toolu_test",
+					name: "edit",
+					input: {},
+				},
+			};
+			yield {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: '{"project_id": 3' },
+			};
+			yield {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: ', "ref": "HEAD"' },
+			};
+			yield {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: ', "path": ' },
+			};
+			yield {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: "}" },
+			};
+			yield {
+				type: "content_block_stop",
+				index: 0,
+			};
+			yield {
+				type: "message_delta",
+				delta: { stop_reason: "tool_use" },
+				usage: {
+					input_tokens: 12,
+					output_tokens: 4,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+			};
+		},
+	};
+
+	class FakeAnthropic {
+		messages = {
+			create: async (_params: Record<string, unknown>) => {
+				mockState.createCalled = true;
+				return fakeStream;
+			},
+			stream: (_params: Record<string, unknown>) => {
+				mockState.streamCalled = true;
+				throw new Error("messages.stream should not be called");
+			},
+		};
+	}
+
+	return { default: FakeAnthropic };
+});
+
+describe("anthropic fine-grained tool streaming", () => {
+	it("falls back to empty arguments when streamed tool-input JSON is malformed", async () => {
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+		const context: Context = {
+			messages: [{ role: "user", content: "run edit", timestamp: Date.now() }],
+		};
+
+		const { streamAnthropic } = await import("../src/providers/anthropic.js");
+		const result = await streamAnthropic(model, context, { apiKey: "sk-ant-api03-test" }).result();
+
+		expect(mockState.createCalled).toBe(true);
+		expect(mockState.streamCalled).toBe(false);
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.content).toHaveLength(1);
+
+		const toolCall = result.content[0];
+		expect(toolCall?.type).toBe("toolCall");
+		if (!toolCall || toolCall.type !== "toolCall") {
+			throw new Error("Expected toolCall block");
+		}
+
+		expect(toolCall.arguments).toEqual({});
+		expect(toolCall.argumentsParseError).toBe("parse error");
+		expect("partialJson" in toolCall).toBe(false);
+	});
+});

--- a/packages/ai/test/anthropic-stream-fallback.test.ts
+++ b/packages/ai/test/anthropic-stream-fallback.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.js";
+import type { Context } from "../src/types.js";
+
+const state = vi.hoisted(() => ({
+	createCalls: [] as Array<Record<string, unknown>>,
+	streamCalled: false,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	const failingStream = {
+		async *[Symbol.asyncIterator]() {
+			yield {
+				type: "message_start",
+				message: {
+					id: "msg_stream",
+					usage: {
+						input_tokens: 8,
+						output_tokens: 0,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				},
+			};
+			yield {
+				type: "content_block_start",
+				index: 0,
+				content_block: {
+					type: "text",
+					text: "",
+				},
+			};
+			yield {
+				type: "content_block_delta",
+				index: 0,
+				delta: {
+					type: "text_delta",
+					text: "partial",
+				},
+			};
+			throw new Error("stream dropped");
+		},
+	};
+
+	const nonStreamingResponse = {
+		id: "msg_fallback",
+		content: [
+			{
+				type: "text",
+				text: "Recovered in non-streaming mode",
+			},
+		],
+		stop_reason: "end_turn",
+		usage: {
+			input_tokens: 8,
+			output_tokens: 6,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+		},
+	};
+
+	class FakeAnthropic {
+		messages = {
+			create: async (params: Record<string, unknown>) => {
+				state.createCalls.push(params);
+				if (params.stream === true) {
+					return failingStream;
+				}
+				return nonStreamingResponse;
+			},
+			stream: (_params: Record<string, unknown>) => {
+				state.streamCalled = true;
+				throw new Error("messages.stream should not be called");
+			},
+		};
+	}
+
+	return { default: FakeAnthropic };
+});
+
+describe("anthropic streaming fallback", () => {
+	it("retries in non-streaming mode when raw streaming fails mid-turn", async () => {
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+		const context: Context = {
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+		};
+
+		const { streamAnthropic } = await import("../src/providers/anthropic.js");
+		const s = streamAnthropic(model, context, { apiKey: "sk-ant-api03-test" });
+
+		const eventTypes: string[] = [];
+		for await (const event of s) {
+			eventTypes.push(event.type);
+		}
+
+		const result = await s.result();
+
+		expect(state.streamCalled).toBe(false);
+		expect(state.createCalls).toHaveLength(2);
+		expect(state.createCalls[0]?.stream).toBe(true);
+		expect(state.createCalls[1]?.stream).toBe(false);
+
+		expect(eventTypes).toContain("start");
+		expect(eventTypes).toContain("done");
+		expect(eventTypes).not.toContain("error");
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([
+			{
+				type: "text",
+				text: "Recovered in non-streaming mode",
+			},
+		]);
+	});
+});

--- a/packages/ai/test/github-copilot-anthropic.test.ts
+++ b/packages/ai/test/github-copilot-anthropic.test.ts
@@ -4,7 +4,8 @@ import type { Context } from "../src/types.js";
 
 const mockState = vi.hoisted(() => ({
 	constructorOpts: undefined as Record<string, unknown> | undefined,
-	streamParams: undefined as Record<string, unknown> | undefined,
+	createParams: undefined as Record<string, unknown> | undefined,
+	streamCalled: false,
 }));
 
 vi.mock("@anthropic-ai/sdk", () => {
@@ -32,9 +33,13 @@ vi.mock("@anthropic-ai/sdk", () => {
 			mockState.constructorOpts = opts;
 		}
 		messages = {
-			stream: (params: Record<string, unknown>) => {
-				mockState.streamParams = params;
+			create: async (params: Record<string, unknown>) => {
+				mockState.createParams = params;
 				return fakeStream;
+			},
+			stream: (_params: Record<string, unknown>) => {
+				mockState.streamCalled = true;
+				throw new Error("messages.stream should not be called");
 			},
 		};
 	}
@@ -79,7 +84,8 @@ describe("Copilot Claude via Anthropic Messages", () => {
 		expect(beta).not.toContain("fine-grained-tool-streaming");
 
 		// Payload is valid Anthropic Messages format
-		const params = mockState.streamParams!;
+		expect(mockState.streamCalled).toBe(false);
+		const params = mockState.createParams!;
 		expect(params.model).toBe("claude-sonnet-4");
 		expect(params.stream).toBe(true);
 		expect(params.max_tokens).toBeGreaterThan(0);


### PR DESCRIPTION
This switches from `messages.stream()` to raw `messages.create(..., stream: true)` event iteration and adds a non-stream fallback when streaming fails mid-turn (`stream: false` retry).

This is closer in behavior to what Claude Code does.

Fixes #3175