### PR TITLE
fix(ai): round-trip Gemini 3 thought_signature through OpenAI-compat tool calls

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -244,6 +244,16 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 							if (currentBlock.type === "toolCall") {
 								if (toolCall.id) currentBlock.id = toolCall.id;
 								if (toolCall.function?.name) currentBlock.name = toolCall.function.name;
+								// Gemini's OpenAI-compatibility endpoint emits its opaque thought
+								// signature on each tool_call as
+								// tool_calls[].extra_content.google.thought_signature. The signature
+								// must be echoed back on the next request or Gemini 3 rejects the
+								// turn with "Function call is missing a thought_signature…".
+								const geminiSig = (toolCall as { extra_content?: { google?: { thought_signature?: unknown } } })
+									.extra_content?.google?.thought_signature;
+								if (typeof geminiSig === "string" && geminiSig.length > 0) {
+									currentBlock.thoughtSignature = geminiSig;
+								}
 								let delta = "";
 								if (toolCall.function?.arguments) {
 									delta = toolCall.function.arguments;
@@ -611,14 +621,46 @@ export function convertMessages(
 
 			const toolCalls = msg.content.filter((b) => b.type === "toolCall") as ToolCall[];
 			if (toolCalls.length > 0) {
-				assistantMsg.tool_calls = toolCalls.map((tc) => ({
-					id: tc.id,
-					type: "function" as const,
-					function: {
-						name: tc.name,
-						arguments: JSON.stringify(tc.arguments),
-					},
-				}));
+				assistantMsg.tool_calls = toolCalls.map((tc) => {
+					const out: {
+						id: string;
+						type: "function";
+						function: { name: string; arguments: string };
+						extra_content?: { google: { thought_signature: string } };
+					} = {
+						id: tc.id,
+						type: "function" as const,
+						function: {
+							name: tc.name,
+							arguments: JSON.stringify(tc.arguments),
+						},
+					};
+					// If the captured signature is a bare Gemini thought_signature (not the
+					// JSON-wrapped OpenAI reasoning.encrypted detail), round-trip it via
+					// extra_content.google.thought_signature so Gemini 3 accepts the next turn.
+					const sig = tc.thoughtSignature;
+					if (typeof sig === "string" && sig.length > 0) {
+						let looksLikeReasoningDetail = false;
+						if (sig[0] === "{" || sig[0] === "[") {
+							try {
+								const parsed = JSON.parse(sig);
+								if (
+									parsed &&
+									typeof parsed === "object" &&
+									(parsed as { type?: unknown }).type === "reasoning.encrypted"
+								) {
+									looksLikeReasoningDetail = true;
+								}
+							} catch {
+								// not JSON — treat as bare signature
+							}
+						}
+						if (!looksLikeReasoningDetail) {
+							out.extra_content = { google: { thought_signature: sig } };
+						}
+					}
+					return out;
+				});
 				const reasoningDetails = toolCalls
 					.filter((tc) => tc.thoughtSignature)
 					.map((tc) => {

--- a/packages/ai/test/openai-completions-gemini3-thought-signature.test.ts
+++ b/packages/ai/test/openai-completions-gemini3-thought-signature.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.js";
+import { convertMessages } from "../src/providers/openai-completions.js";
+import type { AssistantMessage, Context, Model, OpenAICompletionsCompat, Usage } from "../src/types.js";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const compat: Required<OpenAICompletionsCompat> = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	reasoningEffortMap: {},
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	zaiToolStream: false,
+	supportsStrictMode: true,
+};
+
+function buildModel(): Model<"openai-completions"> {
+	const baseModel = getModel("openai", "gpt-4o-mini");
+	return {
+		...baseModel,
+		id: "gemini-3-pro-preview",
+		provider: "google",
+		api: "openai-completions",
+		baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+	};
+}
+
+function buildAssistantToolCall(thoughtSignature: string | undefined, now: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{
+				type: "toolCall",
+				id: "call_1",
+				name: "set_store",
+				arguments: { name: "nutty brown" },
+				...(thoughtSignature !== undefined ? { thoughtSignature } : {}),
+			},
+		],
+		api: "openai-completions",
+		provider: "google",
+		model: "gemini-3-pro-preview",
+		usage: emptyUsage,
+		stopReason: "toolUse",
+		timestamp: now,
+	};
+}
+
+type AssistantWire = {
+	role: string;
+	tool_calls?: Array<{
+		id: string;
+		type: "function";
+		function: { name: string; arguments: string };
+		extra_content?: { google?: { thought_signature?: string } };
+	}>;
+	reasoning_details?: unknown;
+};
+
+describe("openai-completions convertMessages — Gemini 3 thought_signature round-trip", () => {
+	it("attaches extra_content.google.thought_signature for bare base64 signatures", () => {
+		const model = buildModel();
+		const now = Date.now();
+		const sig = "Ci4BV0gGcmFnbWVudCBzaWduYXR1cmU=";
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "set nutty brown as our store", timestamp: now - 1 },
+				buildAssistantToolCall(sig, now),
+			],
+		};
+
+		const messages = convertMessages(model, context, compat) as AssistantWire[];
+		const assistant = messages.find((m) => m.role === "assistant");
+		expect(assistant).toBeTruthy();
+		const tc = assistant?.tool_calls?.[0];
+		expect(tc?.id).toBe("call_1");
+		expect(tc?.extra_content?.google?.thought_signature).toBe(sig);
+		// Bare signature must not be forwarded as a reasoning_details entry —
+		// Gemini rejects that shape.
+		expect(assistant?.reasoning_details).toBeUndefined();
+	});
+
+	it("omits extra_content when the stored signature is a JSON-wrapped reasoning.encrypted detail", () => {
+		const model = buildModel();
+		const now = Date.now();
+		const encryptedDetail = JSON.stringify({
+			type: "reasoning.encrypted",
+			data: "enc-blob",
+			format: "openai-responses-v1",
+		});
+		const context: Context = {
+			messages: [{ role: "user", content: "hi", timestamp: now - 1 }, buildAssistantToolCall(encryptedDetail, now)],
+		};
+
+		const messages = convertMessages(model, context, compat) as AssistantWire[];
+		const assistant = messages.find((m) => m.role === "assistant");
+		const tc = assistant?.tool_calls?.[0];
+		expect(tc).toBeTruthy();
+		expect(tc?.extra_content).toBeUndefined();
+		expect(Array.isArray(assistant?.reasoning_details)).toBe(true);
+		expect((assistant?.reasoning_details as unknown[]).length).toBe(1);
+	});
+
+	it("omits extra_content when no signature was captured", () => {
+		const model = buildModel();
+		const now = Date.now();
+		const context: Context = {
+			messages: [{ role: "user", content: "hi", timestamp: now - 1 }, buildAssistantToolCall(undefined, now)],
+		};
+
+		const messages = convertMessages(model, context, compat) as AssistantWire[];
+		const assistant = messages.find((m) => m.role === "assistant");
+		const tc = assistant?.tool_calls?.[0];
+		expect(tc).toBeTruthy();
+		expect(tc?.extra_content).toBeUndefined();
+		expect(assistant?.reasoning_details).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Gemini 3's OpenAI-compatibility endpoint surfaces its opaque thought signature on each streamed tool_call as `tool_calls[].extra_content.google.thought_signature`. That value must be echoed back on the next turn or Gemini 3 rejects the request with:

> Function call is missing a thought_signature in functionCall parts. ... position 44

Before this change, pi-ai dropped the signature on the floor, so every follow-up tool-calling turn against Gemini 3 over the OpenAI-compat endpoint (e.g. \`https://generativelanguage.googleapis.com/v1beta/openai\`) failed with a 400.

This patch:

1. **Streaming capture** — in \`streamOpenAICompletions\`, when a \`toolCall\` block is created, also read \`toolCall.extra_content.google.thought_signature\` and store it on the block's \`thoughtSignature\`.
2. **Outgoing inject** — in \`convertMessages\`, when emitting \`tool_calls[]\` for an assistant message, attach \`extra_content: { google: { thought_signature: sig } }\` whenever the stored signature is a bare (non-JSON) string. The existing OpenAI \`reasoning.encrypted\` \`reasoning_details\` path is preserved — we only add \`extra_content\` when \`JSON.parse(sig)\` is not a \`reasoning.encrypted\` detail.

## Test plan

- [x] Added \`packages/ai/test/openai-completions-gemini3-thought-signature.test.ts\` covering:
  - bare base64 signature round-trips via \`extra_content.google.thought_signature\` and does not populate \`reasoning_details\`
  - JSON-wrapped \`reasoning.encrypted\` detail still populates \`reasoning_details\` and does **not** emit \`extra_content\`
  - missing signature produces neither \`extra_content\` nor \`reasoning_details\`
- [x] Manually verified against Gemini 3 via bruiser / HEB MCP tool-calling — the failing "set nutty brown as our store" path now succeeds end to end instead of 400ing on the second turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)