### PR TITLE
fix(ai): omit reasoning none for gpt-5 family closes #3060

### DIFF
--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -232,7 +232,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 				summary: options?.reasoningSummary || "auto",
 			};
 			params.include = ["reasoning.encrypted_content"];
-		} else if (model.provider !== "github-copilot") {
+		} else if (!model.id.startsWith("gpt-5-") && model.id !== "gpt-5") {
 			params.reasoning = { effort: "none" };
 		}
 	}


### PR DESCRIPTION
Hi! First PR here:
This fixes #3060 
Compaction via `generateTurnPrefixSummary()` was failing due to the reasoning value not being permitted in gpt-5 family models.
I think the  original problem wasn't the model provider (github-copilot) but the model itself (in this case, all gpt-5 models).

Tests and build passed ok. Tested it locally with all gpt-5 models and it's working fine.
Of course, open for suggestions if you think there's a better way to solve it.