### PR TITLE
chore(coding-agent): replace exa with eza in plan-mode extension

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed the `plan-mode` example extension to allow `eza` in the read-only bash allowlist instead of the deprecated `exa` command ([#3160](https://github.com/badlogic/pi-mono/issues/3160))
 - Fixed Alt keybindings inside Zellij by skipping the Kitty keyboard protocol query there and enabling xterm `modifyOtherKeys` mode 2 directly ([#3163](https://github.com/badlogic/pi-mono/issues/3163))
 - Fixed `/scoped-models` reordering to propagate into the `/model` scoped tab, preserving the user-defined scoped model order instead of re-sorting it ([#3217](https://github.com/badlogic/pi-mono/issues/3217))
 - Fixed `session_shutdown` to fire on `SIGHUP` and `SIGTERM` in interactive, print, and RPC modes so extensions can run shutdown cleanup on those signal-driven exits ([#3212](https://github.com/badlogic/pi-mono/issues/3212))

--- a/packages/coding-agent/examples/extensions/plan-mode/utils.ts
+++ b/packages/coding-agent/examples/extensions/plan-mode/utils.ts
@@ -91,7 +91,7 @@ const SAFE_PATTERNS = [
 	/^\s*rg\b/,
 	/^\s*fd\b/,
 	/^\s*bat\b/,
-	/^\s*exa\b/,
+	/^\s*eza\b/,
 ];
 
 export function isSafeCommand(command: string): boolean {


### PR DESCRIPTION
**Description**

- replace the `plan-mode` safe-command allowlist entry from `exa` to `eza`
  - checked the [exa repo](https://github.com/ogham/exa) - which states that it's unmaintained and points to [eza](https://github.com/eza-community/eza) 
  - maintainers socials / website and also the [Brew page](https://formulae.brew.sh/formula/exa) and [Macports](https://ports.macports.org/port/exa/details/) of `exa` are dead
- fixes #3160 

**Local tests**

| Case | Result |
| ------------- | ------------- |
| Instructed LLM to test via `tmux` - `eza` - **allowed** | <img width="800" height="auto" alt="CleanShot 2026-04-15 at 19 53 33@2x" src="https://github.com/user-attachments/assets/7f64691e-3a49-48cf-a4b2-182a69f24e2f" /> |
| Instructed LLM to test via `tmux` - `exa` - **blocked** | <img width="800" height="auto" alt="CleanShot 2026-04-15 at 19 54 00@2x" src="https://github.com/user-attachments/assets/fe972b89-713d-43a8-8c96-5a385a3fdf68" /> |
| Manual verification (video) | <video src="https://github.com/user-attachments/assets/7e497a06-5e7b-4c18-93a0-a1fab50501d1" /> |