### PR TITLE
fix(coding-agent): support bun package roots and capture

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -39,7 +39,7 @@ export function detectInstallMethod(): InstallMethod {
 	if (resolvedPath.includes("/yarn/") || resolvedPath.includes("/.yarn/") || resolvedPath.includes("\\yarn\\")) {
 		return "yarn";
 	}
-	if (isBunRuntime) {
+	if (isBunRuntime || resolvedPath.includes("/.bun/") || resolvedPath.includes("\\.bun\\")) {
 		return "bun";
 	}
 	if (resolvedPath.includes("/npm/") || resolvedPath.includes("/node_modules/") || resolvedPath.includes("\\npm\\")) {
@@ -110,7 +110,7 @@ export function getPackageDir(): string {
  */
 export function getThemesDir(): string {
 	if (isBunBinary) {
-		return join(dirname(process.execPath), "theme");
+		return join(getPackageDir(), "theme");
 	}
 	// Theme is in modes/interactive/theme/ relative to src/ or dist/
 	const packageDir = getPackageDir();
@@ -126,7 +126,7 @@ export function getThemesDir(): string {
  */
 export function getExportTemplateDir(): string {
 	if (isBunBinary) {
-		return join(dirname(process.execPath), "export-html");
+		return join(getPackageDir(), "export-html");
 	}
 	const packageDir = getPackageDir();
 	const srcOrDist = existsSync(join(packageDir, "src")) ? "src" : "dist";
@@ -166,7 +166,7 @@ export function getChangelogPath(): string {
  */
 export function getInteractiveAssetsDir(): string {
 	if (isBunBinary) {
-		return join(dirname(process.execPath), "assets");
+		return join(getPackageDir(), "assets");
 	}
 	const packageDir = getPackageDir();
 	const srcOrDist = existsSync(join(packageDir, "src")) ? "src" : "dist";

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -5,7 +5,7 @@ import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import ignore from "ignore";
 import { minimatch } from "minimatch";
-import { CONFIG_DIR_NAME } from "../config.js";
+import { CONFIG_DIR_NAME, isBunRuntime } from "../config.js";
 import { type GitSource, parseGitUrl } from "../utils/git.js";
 import { isLocalPath } from "../utils/paths.js";
 import { isStdoutTakenOver } from "./output-guard.js";
@@ -1539,6 +1539,7 @@ export class DefaultPackageManager implements PackageManager {
 	private getNpmCommand(): { command: string; args: string[] } {
 		const configuredCommand = this.settingsManager.getNpmCommand();
 		if (!configuredCommand || configuredCommand.length === 0) {
+			if (isBunRuntime) return { command: "bun", args: [] };
 			return { command: "npm", args: [] };
 		}
 		const [command, ...args] = configuredCommand;
@@ -1712,12 +1713,18 @@ export class DefaultPackageManager implements PackageManager {
 
 	private getGlobalNpmRoot(): string {
 		const npmCommand = this.getNpmCommand();
-		const commandKey = [npmCommand.command, ...npmCommand.args].join("\0");
+		const commandKey = [npmCommand.command, ...npmCommand.args].join(" ");
 		if (this.globalNpmRoot && this.globalNpmRootCommandKey === commandKey) {
 			return this.globalNpmRoot;
 		}
-		const result = this.runNpmCommandSync(["root", "-g"]);
-		this.globalNpmRoot = result.trim();
+		if (npmCommand.command === "bun") {
+			// bun does not implement "root -g"; use "bun pm bin -g" and resolve ../node_modules
+			const binDir = this.runNpmCommandSync(["pm", "bin", "-g"]);
+			this.globalNpmRoot = join(binDir.trim(), "..", "node_modules");
+		} else {
+			const result = this.runNpmCommandSync(["root", "-g"]);
+			this.globalNpmRoot = result.trim();
+		}
 		this.globalNpmRootCommandKey = commandKey;
 		return this.globalNpmRoot;
 	}
@@ -2210,7 +2217,7 @@ export class DefaultPackageManager implements PackageManager {
 				if (timeout) clearTimeout(timeout);
 				reject(error);
 			});
-			child.on("exit", (code) => {
+			child.on("close", (code) => {
 				if (timeout) clearTimeout(timeout);
 				if (timedOut) {
 					reject(new Error(`${command} ${args.join(" ")} timed out after ${options?.timeoutMs}ms`));


### PR DESCRIPTION
Fix bun compatibility in coding-agent package manager and config.

Changes:
- default to bun when running under bun runtime
- use bun pm bin -g instead of bun root -g
- respect PI_PACKAGE_DIR for bundled assets
- detect .bun install paths correctly
- resolve captured process output on close instead of exit

Addresses issues around bun compatibility and package manager behavior.