### PR TITLE
fix(coding-agent): clarify login link hint

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -86,7 +86,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		this.contentContainer.addChild(new Spacer(1));
 		this.contentContainer.addChild(new Text(theme.fg("accent", url), 1, 0));
 
-		const clickHint = process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open";
+		const clickHint = process.platform === "darwin" ? "Cmd+click here to open" : "Ctrl+click here to open";
 		const hyperlink = `\x1b]8;;${url}\x07${clickHint}\x1b]8;;\x07`;
 		this.contentContainer.addChild(new Text(theme.fg("dim", hyperlink), 1, 0));
 


### PR DESCRIPTION
Not all terminals will indicate that the `Ctrl+click to open` is itself clickable, and then it seems like the link displayed right above is what this message refers to. I know because I got confused like that myself.

<img width="1003" height="686" alt="image" src="https://github.com/user-attachments/assets/fb114009-17f2-4583-9be1-f327d921cecc" />

And then the link above is garbled due to layout formatting, so fixing it manually is a rather frustrating experience.

Notably e.g. in WezTerm it does not seem possible to configure always-on decoration for clickable links. The link will be underlined _on hover only_. The code rendering it is supposed to "decorate" it if desired, which is also maybe something you should consider.

But adding `here` word seems like a simple way to avoid confusion.