### PR TITLE
fix(ai,coding-agent): replace deprecated k2p5 with kimi-for-coding

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -609,6 +609,8 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 			for (const [modelId, model] of Object.entries(data["kimi-for-coding"].models)) {
 				const m = model as ModelsDevModel;
 				if (m.tool_call !== true) continue;
+				// Skip deprecated model slug
+				if (modelId === "k2p5") continue;
 
 				models.push({
 					id: modelId,
@@ -1475,13 +1477,13 @@ async function generateModels() {
 			maxTokens: 32768,
 		},
 		{
-			id: "k2p5",
-			name: "Kimi K2.5",
+			id: "kimi-for-coding",
+			name: "Kimi For Coding",
 			api: "anthropic-messages",
 			provider: "kimi-coding",
 			baseUrl: KIMI_CODING_BASE_URL,
 			reasoning: true,
-			input: ["text"],
+			input: ["text", "image"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 262144,
 			maxTokens: 32768,

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -4685,9 +4685,9 @@ export const MODELS = {
 		} satisfies Model<"openai-completions">,
 	},
 	"kimi-coding": {
-		"k2p5": {
-			id: "k2p5",
-			name: "Kimi K2.5",
+		"kimi-for-coding": {
+			id: "kimi-for-coding",
+			name: "Kimi For Coding",
 			api: "anthropic-messages",
 			provider: "kimi-coding",
 			baseUrl: "https://api.kimi.com/coding",
@@ -7744,23 +7744,6 @@ export const MODELS = {
 			contextWindow: 262144,
 			maxTokens: 32768,
 		} satisfies Model<"openai-completions">,
-		"inception/mercury": {
-			id: "inception/mercury",
-			name: "Inception: Mercury",
-			api: "openai-completions",
-			provider: "openrouter",
-			baseUrl: "https://openrouter.ai/api/v1",
-			reasoning: false,
-			input: ["text"],
-			cost: {
-				input: 0.25,
-				output: 0.75,
-				cacheRead: 0.024999999999999998,
-				cacheWrite: 0,
-			},
-			contextWindow: 128000,
-			maxTokens: 32000,
-		} satisfies Model<"openai-completions">,
 		"inception/mercury-2": {
 			id: "inception/mercury-2",
 			name: "Inception: Mercury 2",
@@ -7777,23 +7760,6 @@ export const MODELS = {
 			},
 			contextWindow: 128000,
 			maxTokens: 50000,
-		} satisfies Model<"openai-completions">,
-		"inception/mercury-coder": {
-			id: "inception/mercury-coder",
-			name: "Inception: Mercury Coder",
-			api: "openai-completions",
-			provider: "openrouter",
-			baseUrl: "https://openrouter.ai/api/v1",
-			reasoning: false,
-			input: ["text"],
-			cost: {
-				input: 0.25,
-				output: 0.75,
-				cacheRead: 0.024999999999999998,
-				cacheWrite: 0,
-			},
-			contextWindow: 128000,
-			maxTokens: 32000,
 		} satisfies Model<"openai-completions">,
 		"kwaipilot/kat-coder-pro-v2": {
 			id: "kwaipilot/kat-coder-pro-v2",

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -300,8 +300,8 @@ describe("Tool Results with Images", () => {
 		});
 	});
 
-	describe.skipIf(!process.env.KIMI_API_KEY)("Kimi For Coding Provider (k2p5)", () => {
-		const llm = getModel("kimi-coding", "k2p5");
+	describe.skipIf(!process.env.KIMI_API_KEY)("Kimi For Coding Provider (kimi-for-coding)", () => {
+		const llm = getModel("kimi-coding", "kimi-for-coding");
 
 		it("should handle tool result with only image", { retry: 3, timeout: 30000 }, async () => {
 			await handleToolWithImageResult(llm);

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -192,7 +192,7 @@ describe("Token Statistics on Abort", () => {
 	});
 
 	describe.skipIf(!process.env.KIMI_API_KEY)("Kimi For Coding Provider", () => {
-		const llm = getModel("kimi-coding", "k2p5");
+		const llm = getModel("kimi-coding", "kimi-for-coding");
 
 		it("should include token stats when aborted mid-stream", { retry: 3, timeout: 30000 }, async () => {
 			await testTokensOnAbort(llm);

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -34,7 +34,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	huggingface: "moonshotai/Kimi-K2.5",
 	opencode: "claude-opus-4-6",
 	"opencode-go": "kimi-k2.5",
-	"kimi-coding": "kimi-k2-thinking",
+	"kimi-coding": "kimi-for-coding",
 };
 
 export interface ScopedModel {


### PR DESCRIPTION
Sorry in advance if i'm not supposed to open a PR unless I received a lgtm or lgtmi

### Summary
Replaces the deprecated k2p5 model slug with kimi-for-coding in the kimi-coding provider, matching the current Kimi CLI API.

Closes [#3242](https://github.com/badlogic/pi-mono/issues/3242)

### Changes
- Replace k2p5 static fallback entry in generate-models.ts with kimi-for-coding (id: kimi-for-coding, name: Kimi For Coding, input: ["text", "image"])
- Add filter to skip deprecated k2p5 slug from models.dev data
- Regenerate models.generated.ts
- Update default model for kimi-coding provider from kimi-k2-thinking to kimi-for-coding
- Update test references in image-tool-result.test.ts and tokens.test.ts