### PR TITLE
fix(coding-agent) Fix gemma4 ollama no thinking

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -429,9 +429,13 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 		} else {
 			openRouterParams.reasoning = { effort: "none" };
 		}
-	} else if (options?.reasoningEffort && model.reasoning && compat.supportsReasoningEffort) {
+	} else if (model.reasoning && compat.supportsReasoningEffort) {
 		// OpenAI-style reasoning_effort
-		(params as any).reasoning_effort = mapReasoningEffort(options.reasoningEffort, compat.reasoningEffortMap);
+		if (options?.reasoningEffort) {
+			(params as any).reasoning_effort = mapReasoningEffort(options.reasoningEffort, compat.reasoningEffortMap);
+		} else if (compat.reasoningEffortWhenDisabled) {
+			(params as any).reasoning_effort = compat.reasoningEffortWhenDisabled;
+		}
 	}
 
 	// OpenRouter provider routing preferences
@@ -842,6 +846,14 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		supportsDeveloperRole: !isNonStandard,
 		supportsReasoningEffort: !isGrok && !isZai,
 		reasoningEffortMap,
+		reasoningEffortWhenDisabled:
+			(provider === "ollama" ||
+				baseUrl.includes("11434") ||
+				baseUrl.includes("/v1") ||
+				baseUrl.includes("ollama")) &&
+			/gemma-?4/i.test(model.id)
+				? "none"
+				: "",
 		supportsUsageInStreaming: true,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: false,
@@ -872,6 +884,7 @@ function getCompat(model: Model<"openai-completions">): Required<OpenAICompletio
 		supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
 		supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
 		reasoningEffortMap: model.compat.reasoningEffortMap ?? detected.reasoningEffortMap,
+		reasoningEffortWhenDisabled: model.compat.reasoningEffortWhenDisabled ?? detected.reasoningEffortWhenDisabled,
 		supportsUsageInStreaming: model.compat.supportsUsageInStreaming ?? detected.supportsUsageInStreaming,
 		maxTokensField: model.compat.maxTokensField ?? detected.maxTokensField,
 		requiresToolResultName: model.compat.requiresToolResultName ?? detected.requiresToolResultName,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -261,6 +261,8 @@ export interface OpenAICompletionsCompat {
 	supportsReasoningEffort?: boolean;
 	/** Optional mapping from pi-ai reasoning levels to provider/model-specific `reasoning_effort` values. */
 	reasoningEffortMap?: Partial<Record<ThinkingLevel, string>>;
+	/** Optional `reasoning_effort` value to send when no reasoning effort is explicitly requested. */
+	reasoningEffortWhenDisabled?: string;
 	/** Whether the provider supports `stream_options: { include_usage: true }` for token usage in streaming responses. Default: true. */
 	supportsUsageInStreaming?: boolean;
 	/** Which field to use for max tokens. Default: auto-detected from URL. */

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -200,6 +200,46 @@ describe("openai-completions tool_choice", () => {
 		expect(params.reasoning_effort).toBe("medium");
 	});
 
+	it("sends reasoning_effort=none for ollama gemma4 when reasoning is off", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = {
+			...baseModel,
+			api: "openai-completions",
+			provider: "ollama",
+			baseUrl: "http://localhost:11434/v1",
+			id: "gemma-4-27b-it",
+			reasoning: true,
+			compat: {
+				supportsReasoningEffort: true,
+				thinkingFormat: "openai",
+				reasoningEffortWhenDisabled: "none",
+			},
+		} as const;
+		let payload: unknown;
+
+		await streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Hi",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? mockState.lastParams) as { reasoning_effort?: string };
+		expect(params.reasoning_effort).toBe("none");
+	});
+
 	it("enables tool_stream for supported z.ai models with tools", async () => {
 		const model = getModel("zai", "glm-5")!;
 		const tools: Tool[] = [

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -24,6 +24,7 @@ const compat: Required<OpenAICompletionsCompat> = {
 	supportsDeveloperRole: true,
 	supportsReasoningEffort: true,
 	reasoningEffortMap: {},
+	reasoningEffortWhenDisabled: "",
 	supportsUsageInStreaming: true,
 	maxTokensField: "max_completion_tokens",
 	requiresToolResultName: false,


### PR DESCRIPTION
Gemma4 through the ollama api needs "reasoning_effort": "none". Currently thinking off is still minimal. 