### PR TITLE
fix(ai): preserve cache_write_tokens in openai responses

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -768,6 +768,7 @@ function parseChunkUsage(
 		cacheRead: cacheReadTokens,
 		cacheWrite: cacheWriteTokens,
 		totalTokens: input + outputTokens + cacheReadTokens + cacheWriteTokens,
+		// Initialize as zeros, but we populate this through calculateCost() below
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 	calculateCost(model, usage);

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -279,6 +279,45 @@ export function convertResponsesTools(tools: Tool[], options?: ConvertResponsesT
 // Stream processing
 // =============================================================================
 
+function parseUsage<TApi extends Api>(
+	rawUsage: {
+		input_tokens?: number;
+		input_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
+		output_tokens?: number;
+		output_tokens_details: { reasoning_tokens: number };
+	},
+	model: Model<TApi>,
+): AssistantMessage["usage"] {
+	const inputTokens = rawUsage.input_tokens || 0;
+	const reportedCachedTokens = rawUsage.input_tokens_details?.cached_tokens || 0;
+	const cacheWriteTokens = rawUsage.input_tokens_details?.cache_write_tokens || 0;
+	const reasoningTokens = rawUsage.output_tokens_details?.reasoning_tokens || 0;
+
+	// Normalize to pi-ai semantics:
+	// - cacheRead: hits from cache created by previous requests only
+	// - cacheWrite: tokens written to cache in this request
+	// Some OpenAI-compatible providers (observed on OpenRouter) report cached_tokens
+	// as (previous hits + current writes). In that case, remove cacheWrite from cacheRead.
+	const cacheReadTokens =
+		cacheWriteTokens > 0 ? Math.max(0, reportedCachedTokens - cacheWriteTokens) : reportedCachedTokens;
+
+	const input = Math.max(0, inputTokens - cacheReadTokens - cacheWriteTokens);
+	// Compute totalTokens ourselves since we add reasoning_tokens to output
+	// and some providers (e.g., Groq) don't include them in total_tokens
+	const outputTokens = (rawUsage.output_tokens || 0) + reasoningTokens;
+	const usage: AssistantMessage["usage"] = {
+		input,
+		output: outputTokens,
+		cacheRead: cacheReadTokens,
+		cacheWrite: cacheWriteTokens,
+		totalTokens: input + outputTokens + cacheReadTokens + cacheWriteTokens,
+		// Initialize as zeros, but we populate this through calculateCost() below
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	calculateCost(model, usage);
+	return usage;
+}
+
 export async function processResponsesStream<TApi extends Api>(
 	openaiStream: AsyncIterable<ResponseStreamEvent>,
 	output: AssistantMessage,
@@ -474,22 +513,12 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.completed") {
 			const response = event.response;
-			if (response?.id) {
+			if (response.id) {
 				output.responseId = response.id;
 			}
-			if (response?.usage) {
-				const cachedTokens = response.usage.input_tokens_details?.cached_tokens || 0;
-				output.usage = {
-					// OpenAI includes cached tokens in input_tokens, so subtract to get non-cached input
-					input: (response.usage.input_tokens || 0) - cachedTokens,
-					output: response.usage.output_tokens || 0,
-					cacheRead: cachedTokens,
-					cacheWrite: 0,
-					totalTokens: response.usage.total_tokens || 0,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-				};
+			if (response.usage) {
+				output.usage = parseUsage(response.usage, model);
 			}
-			calculateCost(model, output.usage);
 			if (options?.applyServiceTierPricing) {
 				const serviceTier = response?.service_tier ?? options.serviceTier;
 				options.applyServiceTierPricing(output.usage, serviceTier);

--- a/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
+++ b/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
@@ -59,6 +59,25 @@ async function* createFunctionCallEvents(argumentsJson: string): AsyncIterable<R
 	} as ResponseStreamEvent;
 }
 
+async function* createUsageEvents(): AsyncIterable<ResponseStreamEvent> {
+	yield {
+		type: "response.completed",
+		response: {
+			status: "completed",
+			usage: {
+				input_tokens: 100,
+				output_tokens: 20,
+				total_tokens: 120,
+				input_tokens_details: {
+					cached_tokens: 70,
+					cache_write_tokens: 30,
+				},
+				output_tokens_details: { reasoning_tokens: 0 },
+			},
+		},
+	} as unknown as ResponseStreamEvent;
+}
+
 describe("openai responses partialJson cleanup", () => {
 	it("removes partialJson from persisted tool-call blocks at output_item.done", async () => {
 		const model: Model<"openai-responses"> = {
@@ -97,5 +116,30 @@ describe("openai responses partialJson cleanup", () => {
 		}
 		expect(toolCallEnd.toolCall).toBe(persistedToolCall);
 		expect("partialJson" in toolCallEnd.toolCall).toBe(false);
+	});
+
+	it("parses cache_write_tokens from response usage", async () => {
+		const model: Model<"openai-responses"> = {
+			id: "gpt-5-mini",
+			name: "GPT-5 Mini",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+
+		await processResponsesStream(createUsageEvents(), output, stream, model);
+
+		expect(output.usage.input).toBe(30);
+		expect(output.usage.output).toBe(20);
+		expect(output.usage.cacheRead).toBe(40);
+		expect(output.usage.cacheWrite).toBe(30);
+		expect(output.usage.totalTokens).toBe(120);
 	});
 });


### PR DESCRIPTION
OpenAI compatible responses from the Responses API may include `input_tokens_details. cache_write_tokens`, but we are currently not trying to read that field at all. This PR mimics what was done for `openai-completions.ts` in 6044cab.

Fixes #3161, and partially solves #3196.