### PR TITLE
Restore full state when cycling through presets for none preset

### DIFF
--- a/packages/coding-agent/examples/extensions/preset.ts
+++ b/packages/coding-agent/examples/extensions/preset.ts
@@ -97,10 +97,17 @@ function loadPresets(cwd: string): PresetsConfig {
 	return { ...globalPresets, ...projectPresets };
 }
 
+interface OriginalState {
+	model: import("@mariozechner/pi-coding-agent").Model<any> | undefined;
+	thinkingLevel: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	tools: string[];
+}
+
 export default function presetExtension(pi: ExtensionAPI) {
 	let presets: PresetsConfig = {};
 	let activePresetName: string | undefined;
 	let activePreset: Preset | undefined;
+	let originalState: OriginalState | undefined;
 
 	// Register --preset CLI flag
 	pi.registerFlag("preset", {
@@ -112,6 +119,15 @@ export default function presetExtension(pi: ExtensionAPI) {
 	 * Apply a preset configuration.
 	 */
 	async function applyPreset(name: string, preset: Preset, ctx: ExtensionContext): Promise<boolean> {
+		// Snapshot state before the first preset is applied (i.e. only when transitioning from no-preset)
+		if (activePresetName === undefined) {
+			originalState = {
+				model: ctx.model,
+				thinkingLevel: pi.getThinkingLevel(),
+				tools: pi.getActiveTools(),
+			};
+		}
+
 		// Apply model if specified
 		if (preset.provider && preset.model) {
 			const model = ctx.modelRegistry.find(preset.provider, preset.model);
@@ -248,10 +264,18 @@ export default function presetExtension(pi: ExtensionAPI) {
 		if (!result) return;
 
 		if (result === "(none)") {
-			// Clear preset and restore defaults
+			// Clear preset and restore original state
 			activePresetName = undefined;
 			activePreset = undefined;
-			pi.setActiveTools(["read", "bash", "edit", "write"]);
+			if (originalState) {
+				if (originalState.model) {
+					await pi.setModel(originalState.model);
+				}
+				pi.setThinkingLevel(originalState.thinkingLevel);
+				pi.setActiveTools(originalState.tools);
+			} else {
+				pi.setActiveTools(["read", "bash", "edit", "write"]);
+			}
 			ctx.ui.notify("Preset cleared, defaults restored", "info");
 			updateStatus(ctx);
 			return;
@@ -296,7 +320,15 @@ export default function presetExtension(pi: ExtensionAPI) {
 		if (nextName === "(none)") {
 			activePresetName = undefined;
 			activePreset = undefined;
-			pi.setActiveTools(["read", "bash", "edit", "write"]);
+			if (originalState) {
+				if (originalState.model) {
+					await pi.setModel(originalState.model);
+				}
+				pi.setThinkingLevel(originalState.thinkingLevel);
+				pi.setActiveTools(originalState.tools);
+			} else {
+				pi.setActiveTools(["read", "bash", "edit", "write"]);
+			}
 			ctx.ui.notify("Preset cleared, defaults restored", "info");
 			updateStatus(ctx);
 			return;


### PR DESCRIPTION
Added OriginalState interface to manage preset state and updated preset clearing logic to restore original state.