### PR TITLE
fix(compaction): align token estimation with API usage to prevent cutIndex=0

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -388,6 +388,7 @@ export function findCutPoint(
 	startIndex: number,
 	endIndex: number,
 	keepRecentTokens: number,
+	scaleFactor = 1,
 ): CutPointResult {
 	const cutPoints = findValidCutPoints(entries, startIndex, endIndex);
 
@@ -403,8 +404,8 @@ export function findCutPoint(
 		const entry = entries[i];
 		if (entry.type !== "message") continue;
 
-		// Estimate this message's size
-		const messageTokens = estimateTokens(entry.message);
+		// Estimate this message's size; scale to match API usage when provided
+		const messageTokens = Math.ceil(estimateTokens(entry.message) * scaleFactor);
 		accumulatedTokens += messageTokens;
 
 		// Check if we've exceeded the budget
@@ -635,9 +636,26 @@ export function prepareCompaction(
 	}
 	const boundaryEnd = pathEntries.length;
 
-	const tokensBefore = estimateContextTokens(buildSessionContext(pathEntries).messages).tokens;
+	const usageStart = prevCompactionIndex >= 0 ? prevCompactionIndex : 0;
+	const usageMessages: AgentMessage[] = [];
+	for (let i = usageStart; i < boundaryEnd; i++) {
+		const msg = getMessageFromEntry(pathEntries[i]);
+		if (msg) usageMessages.push(msg);
+	}
+	const { tokens: tokensBefore } = estimateContextTokens(usageMessages);
 
-	const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens);
+	// Align findCutPoint accumulation with tokensBefore (API usage) to avoid
+	// cutIndex=0 when local estimates undercount (common for CJK-heavy sessions).
+	// Scale factor converts estimate sum to usage scale.
+	let totalEstimate = 0;
+	for (let i = boundaryStart; i < boundaryEnd; i++) {
+		const entry = pathEntries[i];
+		if (entry.type === "message") {
+			totalEstimate += estimateTokens(entry.message);
+		}
+	}
+	const scaleFactor = totalEstimate > 0 && tokensBefore > 0 ? tokensBefore / totalEstimate : 1;
+	const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens, scaleFactor);
 
 	// Get UUID of first kept entry
 	const firstKeptEntry = pathEntries[cutPoint.firstKeptEntryIndex];


### PR DESCRIPTION
Aligns local token estimation with actual API usage by introducing a scale factor, preventing cutIndex=0 in CJK-heavy sessions.

Rebased onto main from the original fix in fix/compaction-scale-factor.