### PR TITLE
fix(ai): support adaptive thinking for Claude Opus 4.7+ and Sonnet 4.7+

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -448,21 +448,24 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 };
 
 /**
- * Check if a model supports adaptive thinking (Opus 4.6 and Sonnet 4.6)
+ * Check if a model supports adaptive thinking (Opus 4.6+, Sonnet 4.6+)
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
-	// Opus 4.6 and Sonnet 4.6 model IDs (with or without date suffix)
-	return (
-		modelId.includes("opus-4-6") ||
-		modelId.includes("opus-4.6") ||
-		modelId.includes("sonnet-4-6") ||
-		modelId.includes("sonnet-4.6")
-	);
+	const adaptivePattern = /(?:opus|sonnet)-4[-.](\d+)/;
+	const match = modelId.match(adaptivePattern);
+	return match !== null && parseInt(match[1], 10) >= 6;
+}
+
+/**
+ * Check if a model is an Opus variant (supports effort "max").
+ */
+function isOpusModel(modelId: string): boolean {
+	return modelId.includes("opus");
 }
 
 /**
  * Map ThinkingLevel to Anthropic effort levels for adaptive thinking.
- * Note: effort "max" is only valid on Opus 4.6.
+ * Note: effort "max" is only valid on Opus models.
  */
 function mapThinkingLevelToEffort(level: SimpleStreamOptions["reasoning"], modelId: string): AnthropicEffort {
 	switch (level) {
@@ -475,7 +478,7 @@ function mapThinkingLevelToEffort(level: SimpleStreamOptions["reasoning"], model
 		case "high":
 			return "high";
 		case "xhigh":
-			return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
+			return isOpusModel(modelId) ? "max" : "high";
 		default:
 			return "high";
 	}


### PR DESCRIPTION
## Problem

`supportsAdaptiveThinking()` in `packages/ai/src/providers/anthropic.ts` only matches `opus-4-6`/`opus-4.6` and `sonnet-4-6`/`sonnet-4.6` model IDs.

When using `claude-opus-4-7`, the function returns `false`, so the code falls through to the budget-based thinking path and sends:

```json
{ "thinking": { "type": "enabled", "budget_tokens": 1024 } }
```

The API rejects this with:

```
"thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

## Fix

Replace hardcoded version string checks with a regex `/(?:opus|sonnet)-4[-.](\d+)/` that matches any Opus/Sonnet 4.x where x >= 6. Future model versions (4.8, 4.9, etc.) will work automatically.

Also extract `isOpusModel()` helper for the effort `"max"` gate in `mapThinkingLevelToEffort`, replacing the duplicated `opus-4-6`/`opus-4.6` check.

## Testing

- `npm run check` passes (biome + tsgo). The web-ui tsc errors are pre-existing on main.
- Verified regex matches: `opus-4-6`, `opus-4.6`, `opus-4-7`, `sonnet-4-6`, `sonnet-4.7`, `sonnet-4-10`
- Verified regex rejects: `opus-4-5`, `sonnet-4-3`, `haiku-4-6`
