### PR TITLE
refactor(coding-agent): decouple RPC mode from stdio via RpcTransport

### DIFF
--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -294,9 +294,11 @@ export {
 export { type MainOptions, main } from "./main.js";
 // Run modes for programmatic SDK usage
 export {
+	createStdioTransport,
 	InteractiveMode,
 	type InteractiveModeOptions,
 	type PrintModeOptions,
+	type RpcModeOptions,
 	runPrintMode,
 	runRpcMode,
 } from "./modes/index.js";

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -5,5 +5,6 @@
 export { InteractiveMode, type InteractiveModeOptions } from "./interactive/interactive-mode.js";
 export { type PrintModeOptions, runPrintMode } from "./print-mode.js";
 export { type ModelInfo, RpcClient, type RpcClientOptions, type RpcEventListener } from "./rpc/rpc-client.js";
-export { runRpcMode } from "./rpc/rpc-mode.js";
-export type { RpcCommand, RpcResponse, RpcSessionState } from "./rpc/rpc-types.js";
+export { type RpcModeOptions, runRpcMode } from "./rpc/rpc-mode.js";
+export { createStdioTransport } from "./rpc/rpc-transport.js";
+export type { RpcCommand, RpcResponse, RpcSessionState, RpcTransport } from "./rpc/rpc-types.js";

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -18,10 +18,9 @@ import type {
 	ExtensionUIDialogOptions,
 	ExtensionWidgetOptions,
 } from "../../core/extensions/index.js";
-import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
 import { killTrackedDetachedChildren } from "../../utils/shell.js";
 import { type Theme, theme } from "../interactive/theme/theme.js";
-import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
+import { createStdioTransport } from "./rpc-transport.js";
 import type {
 	RpcCommand,
 	RpcExtensionUIRequest,
@@ -29,6 +28,7 @@ import type {
 	RpcResponse,
 	RpcSessionState,
 	RpcSlashCommand,
+	RpcTransport,
 } from "./rpc-types.js";
 
 // Re-export types for consumers
@@ -38,19 +38,29 @@ export type {
 	RpcExtensionUIResponse,
 	RpcResponse,
 	RpcSessionState,
+	RpcTransport,
 } from "./rpc-types.js";
+
+export interface RpcModeOptions {
+	/** Custom transport for the RPC protocol. Defaults to stdio. */
+	transport?: RpcTransport;
+}
 
 /**
  * Run in RPC mode.
- * Listens for JSON commands on stdin, outputs events and responses on stdout.
+ *
+ * By default, listens for JSON commands on stdin and outputs events/responses
+ * on stdout. Pass a custom {@link RpcTransport} via options to use a different
+ * channel (e.g. WebSocket).
  */
-export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<never> {
-	takeOverStdout();
+export async function runRpcMode(runtimeHost: AgentSessionRuntime, options: RpcModeOptions = {}): Promise<never> {
+	const t = options.transport ?? createStdioTransport();
+	t.setup?.();
 	let session = runtimeHost.session;
 	let unsubscribe: (() => void) | undefined;
 
 	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
-		writeRawStdout(serializeJsonLine(obj));
+		t.write(obj);
 	};
 
 	const success = <T extends RpcCommand["type"]>(
@@ -655,7 +665,7 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		unsubscribe?.();
 		await runtimeHost.dispose();
 		detachInput();
-		process.stdin.pause();
+		t.close();
 		process.exit(exitCode);
 	}
 
@@ -664,28 +674,14 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		await shutdown();
 	}
 
-	const handleInputLine = async (line: string) => {
-		let parsed: unknown;
-		try {
-			parsed = JSON.parse(line);
-		} catch (parseError: unknown) {
-			output(
-				error(
-					undefined,
-					"parse",
-					`Failed to parse command: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-				),
-			);
+	const handleMessage = async (parsed: unknown) => {
+		if (typeof parsed !== "object" || parsed === null) {
+			output(error(undefined, "parse", "Invalid message: expected a JSON object"));
 			return;
 		}
 
 		// Handle extension UI responses
-		if (
-			typeof parsed === "object" &&
-			parsed !== null &&
-			"type" in parsed &&
-			parsed.type === "extension_ui_response"
-		) {
+		if ("type" in parsed && parsed.type === "extension_ui_response") {
 			const response = parsed as RpcExtensionUIResponse;
 			const pending = pendingExtensionRequests.get(response.id);
 			if (pending) {
@@ -713,18 +709,16 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		}
 	};
 
-	const onInputEnd = () => {
-		void shutdown();
-	};
-	process.stdin.on("end", onInputEnd);
-
 	detachInput = (() => {
-		const detachJsonl = attachJsonlLineReader(process.stdin, (line) => {
-			void handleInputLine(line);
+		const detachEnd = t.onEnd(() => {
+			void shutdown();
+		});
+		const detachMessage = t.onMessage((message) => {
+			void handleMessage(message);
 		});
 		return () => {
-			detachJsonl();
-			process.stdin.off("end", onInputEnd);
+			detachMessage();
+			detachEnd();
 		};
 	})();
 

--- a/packages/coding-agent/src/modes/rpc/rpc-transport.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-transport.ts
@@ -1,0 +1,62 @@
+import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
+import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
+import type { RpcTransport } from "./rpc-types.js";
+
+/**
+ * Create the default stdio-based RPC transport.
+ *
+ * - Reads JSONL from `process.stdin`, parses each line, and delivers parsed objects
+ * - Serializes outgoing messages as JSONL and writes to `process.stdout` (via the raw write bypass)
+ * - `setup()` calls `takeOverStdout()` so stray `console.log` writes
+ *   are redirected to stderr and don't corrupt the protocol channel.
+ */
+export function createStdioTransport(): RpcTransport {
+	let detachLine: (() => void) | undefined;
+	let endHandler: (() => void) | undefined;
+
+	return {
+		setup() {
+			takeOverStdout();
+		},
+
+		write(message: object) {
+			writeRawStdout(serializeJsonLine(message));
+		},
+
+		onMessage(callback: (message: unknown) => void): () => void {
+			detachLine = attachJsonlLineReader(process.stdin, (line) => {
+				try {
+					callback(JSON.parse(line));
+				} catch (e: unknown) {
+					this.write({
+						type: "response",
+						command: "parse",
+						success: false,
+						error: `Failed to parse command: ${e instanceof Error ? e.message : String(e)}`,
+					});
+				}
+			});
+			return detachLine;
+		},
+
+		onEnd(callback: () => void): () => void {
+			endHandler = callback;
+			process.stdin.on("end", endHandler);
+			return () => {
+				if (endHandler) {
+					process.stdin.off("end", endHandler);
+					endHandler = undefined;
+				}
+			};
+		},
+
+		close() {
+			detachLine?.();
+			if (endHandler) {
+				process.stdin.off("end", endHandler);
+				endHandler = undefined;
+			}
+			process.stdin.pause();
+		},
+	};
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -6,6 +6,38 @@
  */
 
 import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
+
+// ============================================================================
+// RPC Transport
+// ============================================================================
+
+/**
+ * RpcTransport defines the I/O channel interface for the RPC protocol.
+ *
+ * Operates at the message level: each call to {@link write} sends one complete
+ * message, and each invocation of the {@link onMessage} callback delivers one
+ * complete message. Serialization format (JSONL, framed binary, etc.) is an
+ * implementation detail of the transport.
+ *
+ * The default implementation uses stdio with JSONL framing. Custom
+ * implementations can use WebSocket or other transports.
+ */
+export interface RpcTransport {
+	/** Send a single message to the remote end. */
+	write(message: object): void;
+	/** Register a callback for incoming messages. Returns a detach function. */
+	onMessage(callback: (message: unknown) => void): () => void;
+	/** Register a callback for when the transport is closed by the remote end. Returns a detach function. */
+	onEnd(callback: () => void): () => void;
+	/**
+	 * Called once before the transport is used.
+	 * Stdio uses this to take over stdout so stray writes don't corrupt the channel.
+	 */
+	setup?(): void;
+	/** Called during shutdown to release transport resources. */
+	close(): void;
+}
+
 import type { ImageContent, Model } from "@mariozechner/pi-ai";
 import type { SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";


### PR DESCRIPTION
The RPC mode is currently hard-wired to stdio, which prevents the same JSON protocol from running over WebSockets, TCP sockets, or in-memory channels.

This PR introduces an `RpcTransport` interface that separates message-level I/O from the RPC logic. `runRpcMode()` now accepts an optional `RpcModeOptions` with a custom `transport`; if omitted, it defaults to `createStdioTransport()`, which encapsulates the existing stdin/JSONL behavior. 

Considering that @badlogic is working on the server mode, I am uncertain if this PR is worth merging into `pi-mono`. Happy to adjust or just close if it's redundant.