### PR TITLE
fix: filter empty user messages and add placeholder for empty tool results

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -542,9 +542,12 @@ export function convertMessages(
 
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
+				const sanitized = sanitizeSurrogates(msg.content);
+				if (!sanitized || sanitized.trim().length === 0)
+					continue;
 				params.push({
 					role: "user",
-					content: sanitizeSurrogates(msg.content),
+					content: sanitized,
 				});
 			} else {
 				const content: ChatCompletionContentPart[] = msg.content.map((item): ChatCompletionContentPart => {
@@ -669,7 +672,7 @@ export function convertMessages(
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {
 					role: "tool",
-					content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
+					content: sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : "(no output)"),
 					tool_call_id: toolMsg.toolCallId,
 				};
 				if (compat.requiresToolResultName && toolMsg.toolName) {


### PR DESCRIPTION
## Problem

Some LLM providers reject messages with empty string content, returning HTTP 400 errors:

- **GLM-5** (via Z.ai): `400 未正常接收到prompt参数 (code 1213)`
- **MiniMax**: `400 chat content is empty (code 2013)`

In `convertMessages()`, user messages with `content: ""` are pushed to params without validation. This happens after tool errors when the session assembler creates a synthetic empty user message.

Tool results with no text/images used misleading placeholder `(see attached image)`.

Related: openclaw/openclaw#63667

## Changes

**`packages/ai/src/providers/openai-completions.ts`:**

1. **User messages**: Skip when sanitized content is empty/whitespace-only
2. **Tool results**: Use `"(no output)"` when no text AND no images

## Impact

- Zero risk for GPT/Claude/Gemini
- Fixes 400 errors for strict providers (GLM-5, MiniMax, etc.)

## Tested

- curl-verified GLM-5 returns 400 with empty content, 200 after fix
- Running in production on 2 servers with GLM-5 as primary model