### PR TITLE
fix: skip empty user messages and handle empty toolResult content

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -542,9 +542,11 @@ export function convertMessages(
 
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
+				const sanitized = sanitizeSurrogates(msg.content);
+				if (!sanitized || sanitized.trim().length === 0) continue;
 				params.push({
 					role: "user",
-					content: sanitizeSurrogates(msg.content),
+					content: sanitized,
 				});
 			} else {
 				const content: ChatCompletionContentPart[] = msg.content.map((item): ChatCompletionContentPart => {
@@ -664,12 +666,13 @@ export function convertMessages(
 					.join("\n");
 				const hasImages = toolMsg.content.some((c) => c.type === "image");
 
-				// Always send tool result with text (or placeholder if only images)
+				// Always send tool result with text (or placeholder if only images / no content)
 				const hasText = textResult.length > 0;
+				const toolResultContent = hasText ? textResult : hasImages ? "(see attached image)" : "(no output)";
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {
 					role: "tool",
-					content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
+					content: sanitizeSurrogates(toolResultContent),
 					tool_call_id: toolMsg.toolCallId,
 				};
 				if (compat.requiresToolResultName && toolMsg.toolName) {


### PR DESCRIPTION
## Problem

Strict-format LLM providers (e.g. **GLM-5/ZAI**, **MiniMax**) reject API requests where any message has an empty `content` string. This causes `400` errors like:
- GLM-5: `未正常接收到prompt参数`
- MiniMax: `chat content is empty (2013)`

This was observed consistently when tools return empty/error output and the resulting `toolResult` or follow-up `user` message ends up with `content: ""`.

## Root Cause

In `openai-completions.ts` → `convertMessages()`:

1. **User messages (string branch)**: No guard against empty/whitespace-only strings. `sanitizeSurrogates("")` returns `""`, which gets pushed directly into `params`.

2. **toolResult messages**: When tool output has neither text nor image content, the code was sending `content: ""` (the fallback was only for the image-only case).

## Fix

1. Skip user string messages where sanitized content is empty/whitespace.
2. For `toolResult` with no text and no images, use `"(no output)"` placeholder instead of empty string.

## Related

- Observed in production with GLM-5 via ZAI proxy after multiple consecutive tool calls where some return empty output
- Similar to MiniMax `chat content is empty` reports