### PR TITLE
feat(coding-agent,tui): add interactive extension widgets

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -2002,6 +2002,22 @@ ctx.ui.setWidget("my-widget", ["Line 1", "Line 2"]);
 // Widget below editor
 ctx.ui.setWidget("my-widget", ["Line 1", "Line 2"], { placement: "belowEditor" });
 ctx.ui.setWidget("my-widget", (tui, theme) => new Text(theme.fg("accent", "Custom"), 0, 0));
+
+// Interactive widget: click to focus, optional widget-local mouse events
+ctx.ui.setWidget("widget-mouse", (_tui, theme) => ({
+  focused: false,
+  render(width) {
+    return [this.focused ? theme.fg("accent", "Focused widget") : "Widget"];
+  },
+  handleMouse(event) {
+    // event.row / event.col are zero-based within this widget
+  },
+  handleInput(data) {
+    // receives keyboard input after the widget is focused
+  },
+  invalidate() {},
+}));
+
 ctx.ui.setWidget("my-widget", undefined);  // Clear
 
 // Custom footer (replaces built-in footer entirely)
@@ -2040,6 +2056,11 @@ if (!result.success) {
 ctx.ui.setTheme(lightTheme!);  // Or switch by Theme object
 ctx.ui.theme.fg("accent", "styled text");  // Access current theme
 ```
+
+Interactive widgets are an extension-widget-only capability:
+- `focused?: boolean` is toggled by the coding agent when widget focus changes
+- `handleMouse?(event)` receives left-click events with widget-local zero-based `row` / `col`
+- widgets without `focused` / `handleMouse` continue to work unchanged
 
 ### Custom Components
 
@@ -2266,6 +2287,7 @@ All examples in [examples/extensions/](../examples/extensions/).
 | `modal-editor.ts` | Vim-style modal editor | `setEditorComponent`, `CustomEditor` |
 | `rainbow-editor.ts` | Custom editor styling | `setEditorComponent` |
 | `widget-placement.ts` | Widget above/below editor | `setWidget` |
+| `widget-mouse.ts` | Clickable/focusable widget with widget-local mouse events | `setWidget`, `handleMouse`, `focused` |
 | `overlay-test.ts` | Overlay components | `ui.custom` with overlay options |
 | `overlay-qa-tests.ts` | Comprehensive overlay tests | `ui.custom`, all overlay options |
 | `notify.ts` | Simple notifications | `ui.notify` |

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -739,6 +739,13 @@ ctx.ui.setStatus("my-ext", undefined);
 
 Show persistent content above or below the input editor. Good for todo lists, progress.
 
+When a widget is returned from `ctx.ui.setWidget(...)`, it can also be interactive:
+- `focused?: boolean` — toggled when the widget gains or loses focus
+- `handleMouse?(event)` — receives left-click events with widget-local zero-based `row` / `col`
+- `handleInput?(data)` — receives keyboard input once the widget is focused
+
+This is an extension-widget feature provided by the coding agent. It does **not** add `handleMouse` to the generic `@mariozechner/pi-tui` `Component` interface.
+
 ```typescript
 // Simple string array (above editor by default)
 ctx.ui.setWidget("my-widget", ["Line 1", "Line 2"]);
@@ -759,11 +766,26 @@ ctx.ui.setWidget("my-widget", (_tui, theme) => {
   };
 });
 
+// Interactive widget
+ctx.ui.setWidget("my-widget", (_tui, theme) => ({
+  focused: false,
+  render(width: number) {
+    return [this.focused ? theme.fg("accent", "Focused") : "Widget"];
+  },
+  handleMouse(event) {
+    // event.row / event.col are local to this widget
+  },
+  handleInput(data: string) {
+    // keyboard input after click-to-focus
+  },
+  invalidate() {},
+}));
+
 // Clear
 ctx.ui.setWidget("my-widget", undefined);
 ```
 
-**Examples:** [plan-mode.ts](../examples/extensions/plan-mode.ts)
+**Examples:** [plan-mode.ts](../examples/extensions/plan-mode.ts), [widget-mouse.ts](../examples/extensions/widget-mouse.ts)
 
 ### Pattern 6: Custom Footer
 

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -52,6 +52,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `qna.ts` | Extracts questions from last response into editor via `ctx.ui.setEditorText()` |
 | `status-line.ts` | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors |
 | `widget-placement.ts` | Shows widgets above and below the editor via `ctx.ui.setWidget()` placement |
+| `widget-mouse.ts` | Demonstrates clickable/focusable widgets with widget-local mouse events |
 | `hidden-thinking-label.ts` | Customizes the collapsed thinking label via `ctx.ui.setHiddenThinkingLabel()` |
 | `model-status.ts` | Shows model changes in status bar via `model_select` hook |
 | `snake.ts` | Snake game with custom UI, keyboard handling, and session persistence |

--- a/packages/coding-agent/examples/extensions/widget-mouse.ts
+++ b/packages/coding-agent/examples/extensions/widget-mouse.ts
@@ -1,0 +1,27 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+
+export default function (pi: ExtensionAPI) {
+	pi.on("session_start", (_event, ctx) => {
+		let last = "No click yet";
+
+		ctx.ui.setWidget("widget-mouse-demo", (_tui, theme) => ({
+			focused: false,
+			render(width: number) {
+				const title = this.focused
+					? theme.fg("accent", "Widget mouse demo [focused]")
+					: theme.fg("text", "Widget mouse demo");
+				return [title, `Last: ${last}`, theme.fg("dim", "Click here or type while focused")].map((line) =>
+					truncateToWidth(line, width),
+				);
+			},
+			handleMouse(event) {
+				last = `click row=${event.row} col=${event.col}`;
+			},
+			handleInput(data: string) {
+				last = `key ${JSON.stringify(data)}`;
+			},
+			invalidate() {},
+		}));
+	});
+}

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -81,6 +81,7 @@ export type {
 	InputEvent,
 	InputEventResult,
 	InputSource,
+	InteractiveWidgetComponent,
 	KeybindingsManager,
 	LoadExtensionsResult,
 	LsToolCallEvent,

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -35,6 +35,7 @@ import type {
 	KeyId,
 	OverlayHandle,
 	OverlayOptions,
+	ParsedMouseEvent,
 	TUI,
 } from "@mariozechner/pi-tui";
 import type { Static, TSchema } from "@sinclair/typebox";
@@ -101,6 +102,13 @@ export interface ExtensionWidgetOptions {
 /** Raw terminal input listener for extensions. */
 export type TerminalInputHandler = (data: string) => { consume?: boolean; data?: string } | undefined;
 
+/** Optional interactive widget surface for extension widgets. */
+export type InteractiveWidgetComponent = Component & {
+	dispose?(): void;
+	focused?: boolean;
+	handleMouse?(event: ParsedMouseEvent): void;
+};
+
 /**
  * UI context for extensions to request interactive UI.
  * Each mode (interactive, RPC, print) provides its own implementation.
@@ -134,7 +142,7 @@ export interface ExtensionUIContext {
 	setWidget(key: string, content: string[] | undefined, options?: ExtensionWidgetOptions): void;
 	setWidget(
 		key: string,
-		content: ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined,
+		content: ((tui: TUI, theme: Theme) => InteractiveWidgetComponent) | undefined,
 		options?: ExtensionWidgetOptions,
 	): void;
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -87,6 +87,7 @@ export type {
 	InputEvent,
 	InputEventResult,
 	InputSource,
+	InteractiveWidgetComponent,
 	KeybindingsManager,
 	LoadExtensionsResult,
 	LsToolCallEvent,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -29,6 +29,7 @@ import {
 	Markdown,
 	matchesKey,
 	ProcessTerminal,
+	parseSgrMouseEvent,
 	Spacer,
 	setKeybindings,
 	Text,
@@ -54,6 +55,7 @@ import type {
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
 	ExtensionWidgetOptions,
+	InteractiveWidgetComponent,
 } from "../../core/extensions/index.js";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.js";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.js";
@@ -146,6 +148,22 @@ type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
 };
+
+type WidgetRegion = {
+	component: InteractiveWidgetComponent;
+	placement: "aboveEditor" | "belowEditor";
+	startRow: number;
+	height: number;
+	width: number;
+};
+
+function isInteractiveWidgetComponent(component: InteractiveWidgetComponent): boolean {
+	return (
+		typeof component.handleMouse === "function" ||
+		typeof component.handleInput === "function" ||
+		"focused" in component
+	);
+}
 
 const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
 	"Anthropic subscription auth is active. Third-party usage now draws from extra usage and is billed per token, not your Claude plan limits. Manage extra usage at https://claude.ai/settings/usage.";
@@ -273,8 +291,8 @@ export class InteractiveMode {
 	private extensionTerminalInputUnsubscribers = new Set<() => void>();
 
 	// Extension widgets (components rendered above/below the editor)
-	private extensionWidgetsAbove = new Map<string, Component & { dispose?(): void }>();
-	private extensionWidgetsBelow = new Map<string, Component & { dispose?(): void }>();
+	private extensionWidgetsAbove = new Map<string, InteractiveWidgetComponent>();
+	private extensionWidgetsBelow = new Map<string, InteractiveWidgetComponent>();
 	private widgetContainerAbove!: Container;
 	private widgetContainerBelow!: Container;
 
@@ -332,6 +350,12 @@ export class InteractiveMode {
 		this.footerDataProvider = new FooterDataProvider(this.sessionManager.getCwd());
 		this.footer = new FooterComponent(this.session, this.footerDataProvider);
 		this.footer.setAutoCompactEnabled(this.session.autoCompactionEnabled);
+		this.ui.addInputListener((data) => {
+			if (this.handleInteractiveWidgetEscape(data)) {
+				return { consume: true };
+			}
+			return this.routeWidgetMouseInput(data) ? { consume: true } : undefined;
+		});
 
 		// Load hide thinking block setting
 		this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
@@ -1546,11 +1570,11 @@ export class InteractiveMode {
 	 */
 	private setExtensionWidget(
 		key: string,
-		content: string[] | ((tui: TUI, thm: Theme) => Component & { dispose?(): void }) | undefined,
+		content: string[] | ((tui: TUI, thm: Theme) => InteractiveWidgetComponent) | undefined,
 		options?: ExtensionWidgetOptions,
 	): void {
 		const placement = options?.placement ?? "aboveEditor";
-		const removeExisting = (map: Map<string, Component & { dispose?(): void }>) => {
+		const removeExisting = (map: Map<string, InteractiveWidgetComponent>) => {
 			const existing = map.get(key);
 			if (existing?.dispose) existing.dispose();
 			map.delete(key);
@@ -1564,7 +1588,7 @@ export class InteractiveMode {
 			return;
 		}
 
-		let component: Component & { dispose?(): void };
+		let component: InteractiveWidgetComponent;
 
 		if (Array.isArray(content)) {
 			// Wrap string array in a Container with Text components
@@ -1639,7 +1663,7 @@ export class InteractiveMode {
 
 	private renderWidgetContainer(
 		container: Container,
-		widgets: Map<string, Component & { dispose?(): void }>,
+		widgets: Map<string, InteractiveWidgetComponent>,
 		spacerWhenEmpty: boolean,
 		leadingSpacer: boolean,
 	): void {
@@ -1658,6 +1682,104 @@ export class InteractiveMode {
 		for (const component of widgets.values()) {
 			container.addChild(component);
 		}
+	}
+
+	private getComponentHeight(component: Component, width: number): number {
+		return component.render(width).length;
+	}
+
+	private appendWidgetRegions(
+		regions: WidgetRegion[],
+		widgets: Map<string, InteractiveWidgetComponent>,
+		startRow: number,
+		width: number,
+		placement: "aboveEditor" | "belowEditor",
+		spacerWhenEmpty: boolean,
+		leadingSpacer: boolean,
+	): number {
+		let row = startRow;
+		if (widgets.size === 0) {
+			return row + (spacerWhenEmpty ? 1 : 0);
+		}
+
+		if (leadingSpacer) {
+			row += 1;
+		}
+
+		for (const component of widgets.values()) {
+			const height = this.getComponentHeight(component, width);
+			regions.push({ component, placement, startRow: row, height, width });
+			row += height;
+		}
+
+		return row;
+	}
+
+	private buildWidgetRegions(): WidgetRegion[] {
+		const width = Math.max(1, this.ui.terminal.columns || 1);
+		let row = 0;
+		const regions: WidgetRegion[] = [];
+
+		row += this.getComponentHeight(this.headerContainer, width);
+		row += this.getComponentHeight(this.chatContainer, width);
+		row += this.getComponentHeight(this.pendingMessagesContainer, width);
+		row += this.getComponentHeight(this.statusContainer, width);
+		row = this.appendWidgetRegions(regions, this.extensionWidgetsAbove, row, width, "aboveEditor", true, true);
+		row += this.getComponentHeight(this.editorContainer, width);
+		this.appendWidgetRegions(regions, this.extensionWidgetsBelow, row, width, "belowEditor", false, false);
+
+		return regions;
+	}
+
+	private handleInteractiveWidgetEscape(data: string): boolean {
+		if (!matchesKey(data, "escape")) {
+			return false;
+		}
+		const focusedComponent = this.ui.getFocusedComponent();
+		if (!focusedComponent || focusedComponent === this.editor) {
+			return false;
+		}
+		if (!isInteractiveWidgetComponent(focusedComponent as InteractiveWidgetComponent)) {
+			return false;
+		}
+		this.ui.setFocus(this.editor);
+		this.ui.requestRender();
+		return true;
+	}
+
+	private routeWidgetMouseInput(data: string): boolean {
+		const event = parseSgrMouseEvent(data);
+		if (!event) {
+			return false;
+		}
+
+		const contentRow = this.ui.screenRowToContentRow(event.row);
+		const region = this.buildWidgetRegions().find(
+			(candidate) =>
+				contentRow >= candidate.startRow &&
+				contentRow < candidate.startRow + candidate.height &&
+				event.col >= 0 &&
+				event.col < candidate.width,
+		);
+		if (!region) {
+			this.ui.setFocus(this.editor);
+			this.ui.requestRender();
+			return true;
+		}
+		if (!isInteractiveWidgetComponent(region.component)) {
+			this.ui.setFocus(this.editor);
+			this.ui.requestRender();
+			return true;
+		}
+
+		this.ui.setFocus(region.component);
+		region.component.handleMouse?.({
+			...event,
+			row: contentRow - region.startRow,
+			col: event.col,
+		});
+		this.ui.requestRender();
+		return true;
 	}
 
 	/**

--- a/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
+++ b/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
@@ -12,6 +12,7 @@ class FakeTerminal implements Terminal {
 	columns = 80;
 	rows = 24;
 	kittyProtocolActive = true;
+	contentOriginRow = 0;
 	writes: string[] = [];
 
 	start(): void {}

--- a/packages/coding-agent/test/interactive-mode-widget-mouse.test.ts
+++ b/packages/coding-agent/test/interactive-mode-widget-mouse.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+
+function createComponent(lines: string[]) {
+	return {
+		render: () => lines,
+		invalidate: () => {},
+	};
+}
+
+function createModeStub(options?: {
+	above?: Map<string, any>;
+	below?: Map<string, any>;
+	headerLines?: string[];
+	chatLines?: string[];
+	pendingLines?: string[];
+	statusLines?: string[];
+	editorLines?: string[];
+	width?: number;
+	screenRowToContentRow?: (row: number) => number;
+	focusedComponent?: any;
+}) {
+	const mode = Object.create(InteractiveMode.prototype) as any;
+	const setFocus = vi.fn();
+	const requestRender = vi.fn();
+	const focusedComponent = options?.focusedComponent ?? null;
+
+	mode.ui = {
+		terminal: { columns: options?.width ?? 80 },
+		setFocus,
+		requestRender,
+		getFocusedComponent: () => focusedComponent,
+		screenRowToContentRow: options?.screenRowToContentRow ?? ((row: number) => row),
+	};
+	mode.headerContainer = createComponent(options?.headerLines ?? []);
+	mode.chatContainer = createComponent(options?.chatLines ?? []);
+	mode.pendingMessagesContainer = createComponent(options?.pendingLines ?? []);
+	mode.statusContainer = createComponent(options?.statusLines ?? []);
+	mode.editorContainer = createComponent(options?.editorLines ?? ["editor"]);
+	mode.extensionWidgetsAbove = options?.above ?? new Map();
+	mode.extensionWidgetsBelow = options?.below ?? new Map();
+
+	return { mode, setFocus, requestRender };
+}
+
+describe("InteractiveMode widget mouse routing", () => {
+	it("focuses and dispatches clicks to above-editor widgets with local coordinates", () => {
+		const calls: Array<{ row: number; col: number }> = [];
+		const widget = {
+			focused: false,
+			render: () => ["row 0", "row 1"],
+			handleMouse: (event: { row: number; col: number }) => calls.push({ row: event.row, col: event.col }),
+			invalidate: () => {},
+		};
+		const { mode, setFocus, requestRender } = createModeStub({
+			above: new Map([["demo", widget]]),
+			editorLines: ["editor"],
+			screenRowToContentRow: (row: number) => row + 2,
+		});
+
+		const consumed = mode.routeWidgetMouseInput("\x1b[<0;3;1M");
+
+		expect(consumed).toBe(true);
+		expect(calls).toEqual([{ row: 1, col: 2 }]);
+		expect(setFocus).toHaveBeenCalledWith(widget);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores editor focus when clicking outside widget regions", () => {
+		const widget = {
+			render: () => ["row 0", "row 1"],
+			handleMouse: vi.fn(),
+			invalidate: () => {},
+		};
+		const { mode, setFocus, requestRender } = createModeStub({
+			above: new Map([["demo", widget]]),
+		});
+
+		mode.editor = { render: () => ["editor"], invalidate: () => {} };
+		const consumed = mode.routeWidgetMouseInput("\x1b[<0;1;1M");
+
+		expect(consumed).toBe(true);
+		expect(widget.handleMouse).not.toHaveBeenCalled();
+		expect(setFocus).toHaveBeenCalledWith(mode.editor);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("accounts for editor height when routing clicks to below-editor widgets", () => {
+		const calls: Array<{ row: number; col: number }> = [];
+		const widget = {
+			focused: false,
+			render: () => ["below 0", "below 1"],
+			handleMouse: (event: { row: number; col: number }) => calls.push({ row: event.row, col: event.col }),
+			invalidate: () => {},
+		};
+		const { mode, setFocus, requestRender } = createModeStub({
+			below: new Map([["demo", widget]]),
+			editorLines: ["editor 0", "editor 1"],
+			screenRowToContentRow: (row: number) => row + 1,
+		});
+
+		const consumed = mode.routeWidgetMouseInput("\x1b[<0;2;4M");
+
+		expect(consumed).toBe(true);
+		expect(calls).toEqual([{ row: 1, col: 1 }]);
+		expect(setFocus).toHaveBeenCalledWith(widget);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("focuses legacy interactive widgets that handle keyboard input but not mouse", () => {
+		const widget = {
+			focused: false,
+			render: () => ["legacy"],
+			handleInput: vi.fn(),
+			invalidate: () => {},
+		};
+		const { mode, setFocus, requestRender } = createModeStub({
+			above: new Map([["legacy", widget]]),
+		});
+
+		const consumed = mode.routeWidgetMouseInput("\x1b[<0;1;2M");
+
+		expect(consumed).toBe(true);
+		expect(setFocus).toHaveBeenCalledWith(widget);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("escape restores editor focus when a widget is focused", () => {
+		const widget = {
+			focused: true,
+			render: () => ["legacy"],
+			handleInput: vi.fn(),
+			invalidate: () => {},
+		};
+		const { mode, setFocus, requestRender } = createModeStub({
+			focusedComponent: widget,
+		});
+		mode.editor = { render: () => ["editor"], invalidate: () => {} };
+
+		const consumed = mode.handleInteractiveWidgetEscape("\x1b");
+
+		expect(consumed).toBe(true);
+		expect(setFocus).toHaveBeenCalledWith(mode.editor);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -57,6 +57,8 @@ export {
 	parseKey,
 	setKittyProtocolActive,
 } from "./keys.js";
+// Mouse input helpers
+export { type MouseButton, type ParsedMouseEvent, parseSgrMouseEvent } from "./mouse.js";
 // Input buffering for batch splitting
 export { StdinBuffer, type StdinBufferEventMap, type StdinBufferOptions } from "./stdin-buffer.js";
 // Terminal interface and implementations

--- a/packages/tui/src/mouse.ts
+++ b/packages/tui/src/mouse.ts
@@ -1,0 +1,42 @@
+export type MouseButton = "left";
+
+export type ParsedMouseEvent = {
+	kind: "press";
+	button: MouseButton;
+	row: number;
+	col: number;
+	shift: boolean;
+	alt: boolean;
+	ctrl: boolean;
+	raw: string;
+};
+
+export function parseSgrMouseEvent(data: string): ParsedMouseEvent | undefined {
+	const match = data.match(/^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/);
+	if (!match) return undefined;
+
+	const [, rawCode, rawCol, rawRow, suffix] = match;
+	if (suffix !== "M") return undefined;
+
+	const code = Number.parseInt(rawCode, 10);
+	const col = Number.parseInt(rawCol, 10);
+	const row = Number.parseInt(rawRow, 10);
+	if (!Number.isFinite(code) || !Number.isFinite(col) || !Number.isFinite(row)) return undefined;
+
+	const buttonBits = code & 0b11;
+	const motionBit = code & 0b100000;
+	const wheelBit = code & 0b1000000;
+	if (motionBit !== 0 || wheelBit !== 0) return undefined;
+	if (buttonBits !== 0) return undefined;
+
+	return {
+		kind: "press",
+		button: "left",
+		row: Math.max(0, row - 1),
+		col: Math.max(0, col - 1),
+		shift: (code & 0b100) !== 0,
+		alt: (code & 0b1000) !== 0,
+		ctrl: (code & 0b10000) !== 0,
+		raw: data,
+	};
+}

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -34,6 +34,9 @@ export interface Terminal {
 	// Whether Kitty keyboard protocol is active
 	get kittyProtocolActive(): boolean;
 
+	// Screen row where TUI content started rendering (0-based, best-effort)
+	get contentOriginRow(): number;
+
 	// Cursor positioning (relative to current position)
 	moveBy(lines: number): void; // Move cursor up (negative) or down (positive) by N lines
 
@@ -59,6 +62,8 @@ export class ProcessTerminal implements Terminal {
 	private resizeHandler?: () => void;
 	private _kittyProtocolActive = false;
 	private _modifyOtherKeysActive = false;
+	private _mouseReportingActive = false;
+	private _contentOriginRow = 0;
 	private stdinBuffer?: StdinBuffer;
 	private stdinDataHandler?: (data: string) => void;
 	private writeLogPath = (() => {
@@ -80,6 +85,10 @@ export class ProcessTerminal implements Terminal {
 		return this._kittyProtocolActive;
 	}
 
+	get contentOriginRow(): number {
+		return this._contentOriginRow;
+	}
+
 	start(onInput: (data: string) => void, onResize: () => void): void {
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
@@ -94,6 +103,7 @@ export class ProcessTerminal implements Terminal {
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		process.stdout.write("\x1b[?2004h");
+		this.enableMouseReporting();
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.resizeHandler);
@@ -129,6 +139,7 @@ export class ProcessTerminal implements Terminal {
 
 		// Kitty protocol response pattern: \x1b[?<flags>u
 		const kittyResponsePattern = /^\x1b\[\?(\d+)u$/;
+		const cursorPositionPattern = /^\x1b\[(\d+);(\d+)R$/;
 
 		// Forward individual sequences to the input handler
 		this.stdinBuffer.on("data", (sequence) => {
@@ -147,6 +158,15 @@ export class ProcessTerminal implements Terminal {
 					process.stdout.write("\x1b[>7u");
 					return; // Don't forward protocol response to TUI
 				}
+			}
+
+			const cursorMatch = sequence.match(cursorPositionPattern);
+			if (cursorMatch) {
+				const row = Number.parseInt(cursorMatch[1]!, 10);
+				if (Number.isFinite(row)) {
+					this._contentOriginRow = Math.max(0, row - 1);
+				}
+				return;
 			}
 
 			if (this.inputHandler) {
@@ -184,6 +204,7 @@ export class ProcessTerminal implements Terminal {
 	private queryAndEnableKittyProtocol(): void {
 		this.setupStdinBuffer();
 		process.stdin.on("data", this.stdinDataHandler!);
+		process.stdout.write("\x1b[6n");
 		process.stdout.write("\x1b[?u");
 		setTimeout(() => {
 			if (!this._kittyProtocolActive && !this._modifyOtherKeysActive) {
@@ -222,7 +243,20 @@ export class ProcessTerminal implements Terminal {
 		}
 	}
 
+	private enableMouseReporting(): void {
+		if (this._mouseReportingActive) return;
+		process.stdout.write("\x1b[?1000h\x1b[?1006h");
+		this._mouseReportingActive = true;
+	}
+
+	private disableMouseReporting(): void {
+		if (!this._mouseReportingActive) return;
+		process.stdout.write("\x1b[?1000l\x1b[?1006l");
+		this._mouseReportingActive = false;
+	}
+
 	async drainInput(maxMs = 1000, idleMs = 50): Promise<void> {
+		this.disableMouseReporting();
 		if (this._kittyProtocolActive) {
 			// Disable Kitty keyboard protocol first so any late key releases
 			// do not generate new Kitty escape sequences.
@@ -261,8 +295,9 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	stop(): void {
-		// Disable bracketed paste mode
+		// Disable bracketed paste mode and mouse reporting
 		process.stdout.write("\x1b[?2004l");
+		this.disableMouseReporting();
 
 		// Disable Kitty keyboard protocol if not already done by drainInput()
 		if (this._kittyProtocolActive) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -299,6 +299,18 @@ export class TUI extends Container {
 		}
 	}
 
+	getFocusedComponent(): Component | null {
+		return this.focusedComponent;
+	}
+
+	getViewportTop(): number {
+		return this.previousViewportTop;
+	}
+
+	screenRowToContentRow(screenRow: number): number {
+		return this.previousViewportTop + (screenRow - this.terminal.contentOriginRow);
+	}
+
 	/**
 	 * Show an overlay component with configurable positioning and sizing.
 	 * Returns a handle to control the overlay's visibility.

--- a/packages/tui/test/mouse.test.ts
+++ b/packages/tui/test/mouse.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { parseSgrMouseEvent } from "../src/mouse.js";
+
+describe("parseSgrMouseEvent", () => {
+	it("parses left-button press sequences", () => {
+		assert.deepStrictEqual(parseSgrMouseEvent("\x1b[<0;12;7M"), {
+			kind: "press",
+			button: "left",
+			row: 6,
+			col: 11,
+			shift: false,
+			alt: false,
+			ctrl: false,
+			raw: "\x1b[<0;12;7M",
+		});
+	});
+
+	it("returns undefined for release sequences in v1", () => {
+		assert.strictEqual(parseSgrMouseEvent("\x1b[<0;12;7m"), undefined);
+	});
+
+	it("returns undefined for unsupported buttons", () => {
+		assert.strictEqual(parseSgrMouseEvent("\x1b[<64;12;7M"), undefined);
+	});
+
+	it("returns undefined for non-mouse input", () => {
+		assert.strictEqual(parseSgrMouseEvent("j"), undefined);
+	});
+});

--- a/packages/tui/test/terminal-mouse-reporting.test.ts
+++ b/packages/tui/test/terminal-mouse-reporting.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert";
+import { afterEach, describe, it } from "node:test";
+import { ProcessTerminal } from "../src/terminal.js";
+
+type RestoreFn = () => void;
+const restores: RestoreFn[] = [];
+
+afterEach(() => {
+	while (restores.length > 0) {
+		restores.pop()?.();
+	}
+});
+
+function stubMethod<T extends object, K extends keyof T>(obj: T, key: K, value: T[K]): void {
+	const original = obj[key];
+	obj[key] = value;
+	restores.push(() => {
+		obj[key] = original;
+	});
+}
+
+function stubSetTimeout(): void {
+	const original = globalThis.setTimeout;
+	(globalThis as typeof globalThis & { setTimeout: typeof setTimeout }).setTimeout = ((
+		_callback: (...args: any[]) => void,
+		_delay?: number,
+	) => ({}) as ReturnType<typeof setTimeout>) as typeof setTimeout;
+	restores.push(() => {
+		(globalThis as typeof globalThis & { setTimeout: typeof setTimeout }).setTimeout = original;
+	});
+}
+
+describe("ProcessTerminal mouse reporting", () => {
+	it("enables mouse reporting on start and disables it on stop", () => {
+		const writes: string[] = [];
+		const terminal = new ProcessTerminal();
+
+		stubMethod(process.stdout, "write", ((data: string | Uint8Array) => {
+			writes.push(String(data));
+			return true;
+		}) as typeof process.stdout.write);
+		stubMethod(
+			process.stdout,
+			"on",
+			((_event: string, _listener: (...args: any[]) => void) => process.stdout) as typeof process.stdout.on,
+		);
+		stubMethod(
+			process.stdout,
+			"removeListener",
+			((_event: string, _listener: (...args: any[]) => void) =>
+				process.stdout) as typeof process.stdout.removeListener,
+		);
+		stubMethod(process.stdin, "setRawMode", ((_raw: boolean) => {}) as typeof process.stdin.setRawMode);
+		stubMethod(
+			process.stdin,
+			"setEncoding",
+			((_encoding: BufferEncoding) => process.stdin) as typeof process.stdin.setEncoding,
+		);
+		stubMethod(process.stdin, "resume", (() => process.stdin) as typeof process.stdin.resume);
+		stubMethod(process.stdin, "pause", (() => process.stdin) as typeof process.stdin.pause);
+		stubMethod(
+			process.stdin,
+			"on",
+			((_event: string, _listener: (...args: any[]) => void) => process.stdin) as typeof process.stdin.on,
+		);
+		stubMethod(
+			process.stdin,
+			"removeListener",
+			((_event: string, _listener: (...args: any[]) => void) =>
+				process.stdin) as typeof process.stdin.removeListener,
+		);
+		stubMethod(process, "kill", ((_pid: number, _signal?: NodeJS.Signals | number) => true) as typeof process.kill);
+		stubSetTimeout();
+
+		terminal.start(
+			() => {},
+			() => {},
+		);
+		terminal.stop();
+
+		const output = writes.join("");
+		assert.match(output, /\x1b\[\?2004h/);
+		assert.match(output, /\x1b\[\?1000h\x1b\[\?1006h/);
+		assert.match(output, /\x1b\[\?u/);
+		assert.match(output, /\x1b\[\?2004l/);
+		assert.match(output, /\x1b\[\?1000l\x1b\[\?1006l/);
+	});
+});

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -14,6 +14,8 @@ export class VirtualTerminal implements Terminal {
 	private resizeHandler?: () => void;
 	private _columns: number;
 	private _rows: number;
+	private _mouseReportingActive = false;
+	private _contentOriginRow = 0;
 
 	constructor(columns = 80, rows = 24) {
 		this._columns = columns;
@@ -32,8 +34,10 @@ export class VirtualTerminal implements Terminal {
 	start(onInput: (data: string) => void, onResize: () => void): void {
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
-		// Enable bracketed paste mode for consistency with ProcessTerminal
+		// Enable bracketed paste mode and mouse reporting for consistency with ProcessTerminal
 		this.xterm.write("\x1b[?2004h");
+		this.xterm.write("\x1b[?1000h\x1b[?1006h");
+		this._mouseReportingActive = true;
 	}
 
 	async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {
@@ -41,8 +45,12 @@ export class VirtualTerminal implements Terminal {
 	}
 
 	stop(): void {
-		// Disable bracketed paste mode
+		// Disable bracketed paste mode and mouse reporting
 		this.xterm.write("\x1b[?2004l");
+		if (this._mouseReportingActive) {
+			this.xterm.write("\x1b[?1000l\x1b[?1006l");
+			this._mouseReportingActive = false;
+		}
 		this.inputHandler = undefined;
 		this.resizeHandler = undefined;
 	}
@@ -62,6 +70,10 @@ export class VirtualTerminal implements Terminal {
 	get kittyProtocolActive(): boolean {
 		// Virtual terminal always reports Kitty protocol as active for testing
 		return true;
+	}
+
+	get contentOriginRow(): number {
+		return this._contentOriginRow;
 	}
 
 	moveBy(lines: number): void {

--- a/packages/web-ui/example/src/vite-env.d.ts
+++ b/packages/web-ui/example/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/web-ui/example/tsconfig.json
+++ b/packages/web-ui/example/tsconfig.json
@@ -6,10 +6,10 @@
 		"moduleResolution": "bundler",
 		"paths": {
 			"*": ["./*"],
-			"@mariozechner/pi-agent-core": ["../../agent/dist/index.d.ts"],
-			"@mariozechner/pi-ai": ["../../ai/dist/index.d.ts"],
-			"@mariozechner/pi-tui": ["../../tui/dist/index.d.ts"],
-			"@mariozechner/pi-web-ui": ["../dist/index.d.ts"]
+			"@mariozechner/pi-agent-core": ["../../agent/src/index.ts"],
+			"@mariozechner/pi-ai": ["../../ai/src/index.ts"],
+			"@mariozechner/pi-tui": ["../../tui/src/index.ts"],
+			"@mariozechner/pi-web-ui": ["../src/index.ts"]
 		},
 		"strict": true,
 		"skipLibCheck": true,
@@ -19,5 +19,5 @@
 		"useDefineForClassFields": false
 	},
 	"include": ["src/**/*"],
-	"exclude": ["../src"]
+	"exclude": ["../dist"]
 }


### PR DESCRIPTION
## Summary

This PR adds a minimal, generic interaction API for **extension widgets** in interactive mode.

Extensions can now render widgets that:
- receive widget-local mouse events
- know whether they are focused
- participate in focus routing with the editor

This was validated with a purpose-built example extension and focused tests.

A small follow-up fix is also included for `packages/web-ui/example` so the monorepo root `npm run check` passes reliably.

## What’s included

### Interactive extension widgets
- add SGR mouse event parsing in `packages/tui`
- enable/disable terminal mouse reporting
- add screen-row to content-row translation for correct hit-testing
- extend extension widget support with:
  - `handleMouse?(event)`
  - `focused?: boolean`
- dispatch mouse events to widgets in interactive mode
- focus widgets on click
- restore editor focus on outside click
- restore editor focus on `Escape` when a widget is focused

### Validation/example
- add `packages/coding-agent/examples/extensions/widget-mouse.ts`
- add focused tests for:
  - mouse parsing
  - terminal mouse reporting
  - interactive widget mouse handling
- update extension and TUI docs

### Follow-up check fix
- fix `packages/web-ui/example` TypeScript resolution to use workspace sources instead of fragile `dist/*.d.ts` paths
- add `packages/web-ui/example/src/vite-env.d.ts`
- unblocks root `npm run check`

## Why

Before this PR, extension widgets could render above the editor but had no clean core-supported way to:
- receive mouse input
- become focused
- return focus to the editor

This PR adds a small reusable primitive for extension authors without introducing a widget-specific hack or broad mouse support for all TUI components.

## Scope

Included in v1:
- widget-local mouse events
- widget focus participation
- component-level `focused` state

Not included:
- no `setWidget(...)` focus flag
- no focus/blur lifecycle callbacks
- no broader mouse support across all TUI components

## Related prior work / context

This PR was informed by earlier mouse/focus and widget-surface work in the repo:

- `#1213` — `feat(tui): add mouse click support for cursor positioning`
- `#1916` — `feat(tui): add non-capturing overlays with focus control`
- `#850` — `feat(coding-agent): Add widget placement option`
- `#2074` — `fix(tui): handle OSC 133 click events in editor`

This PR builds on those ideas by adding a generic interaction layer specifically for **extension widgets**.

## Verification

Passed:
- focused `packages/tui` tests
- focused `packages/coding-agent` tests
- manual validation with:
  - `./pi-test.sh -e ./packages/coding-agent/examples/extensions/widget-mouse.ts`
- `./test.sh`
- root `npm run check`

## Manual validation notes

Confirmed manually:
- click alignment is correct
- widget focus works
- outside click returns focus to editor
- `Escape` returns focus to editor

## Commits

- `f5050e22` — `feat(coding-agent,tui): add interactive extension widgets`
- `6c808ac1` — `fix(web-ui): typecheck example against workspace sources`
