### PR TITLE
fix: show meaningful names for extensions in startup listing

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1128,7 +1128,24 @@ export class InteractiveMode {
 			const normalizedPath = shortPath.replace(/\\/g, "/");
 			const segments = normalizedPath.split("/").filter((segment) => segment.length > 0 && segment !== "~");
 			if (segments.length > 0) {
-				return segments[segments.length - 1]!;
+				let name = segments[segments.length - 1]!;
+				// For index.ts/index.js, use a meaningful parent directory or package name
+				if (/^index\.[tj]sx?$/.test(name)) {
+					const genericDirs = new Set(["dist", "src", "lib", "build", "out"]);
+					let parentIdx = segments.length - 2;
+					while (parentIdx >= 0 && genericDirs.has(segments[parentIdx]!)) {
+						parentIdx--;
+					}
+					if (parentIdx >= 0) {
+						name = segments[parentIdx]!;
+					} else {
+						const npmMatch = resourcePath.match(/node_modules\/(@?[^/]+(?:\/[^/]+)?)/);
+						if (npmMatch) {
+							name = npmMatch[1]!;
+						}
+					}
+				}
+				return name.replace(/\.[tj]sx?$/, "");
 			}
 			return shortPath;
 		};

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -247,8 +247,43 @@ describe("InteractiveMode.showLoadedResources", () => {
 
 		const output = renderAll(fakeThis.chatContainer);
 		expect(output).toContain("[Extensions]");
-		expect(output).toContain("answer.ts, btw.ts");
-		expect(output).not.toContain("extensions/answer.ts");
+		expect(output).toContain("answer, btw");
+		expect(output).not.toContain("extensions/answer");
+	});
+
+	test("uses parent directory name for index.ts extensions", () => {
+		const fakeThis = createShowLoadedResourcesThis({
+			quietStartup: false,
+			extensions: [
+				{ path: "/tmp/extensions/my-plugin/index.ts" },
+				{ path: "/tmp/extensions/standalone.ts" },
+			],
+		});
+
+		(InteractiveMode as any).prototype.showLoadedResources.call(fakeThis, {
+			force: false,
+		});
+
+		const output = renderAll(fakeThis.chatContainer);
+		expect(output).toContain("my-plugin");
+		expect(output).toContain("standalone");
+		expect(output).not.toContain("index");
+	});
+
+	test("skips generic parent dirs like dist for index.js extensions", () => {
+		const fakeThis = createShowLoadedResourcesThis({
+			quietStartup: false,
+			extensions: [{ path: "/tmp/extensions/cool-ext/dist/index.js" }],
+		});
+
+		(InteractiveMode as any).prototype.showLoadedResources.call(fakeThis, {
+			force: false,
+		});
+
+		const output = renderAll(fakeThis.chatContainer);
+		expect(output).toContain("cool-ext");
+		expect(output).not.toContain("dist");
+		expect(output).not.toContain("index");
 	});
 
 	test("shows context paths relative to cwd while preserving full external paths", () => {


### PR DESCRIPTION
## Problem

Extensions using `index.ts`/`index.js` (common for subdirectory and npm package extensions) all display as `index.ts` in the compact startup listing, making it impossible to tell them apart:

```
[Extensions]
  dangerous-commands.ts, index.ts, index.ts, index.ts, index.ts, index.ts, index.ts, jhlabs-image-gen.ts, resize-tool-images.ts
```

## Fix

Improved `compactPath()` in `interactive-mode.ts`:

- **index.ts/index.js files**: use the parent directory name instead of the meaningless filename
- **Generic parent dirs** (dist, src, lib, build, out): walk up to find a meaningful name
- **npm packages** where the short path resolves to just `index.ts`: extract the package name from the full path
- **Strip file extensions** (.ts, .js) from all display names for cleaner output

### After

```
[Extensions]
  @0xkobold/pi-ollama, claude-compat, dangerous-commands, jhlabs-image-gen, pi-markdown-preview, pi-mcp-adapter, pi-web-access, resize-tool-images, subagent
```

## Tests

- Updated existing test to match new extension-less display format
- Added test for index.ts → parent directory name resolution
- Added test for skipping generic dirs (dist/src/lib) in the parent chain