### PR TITLE
fix(ai): coerce stringified JSON arrays/objects in tool call arguments

### DIFF
--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -73,6 +73,8 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): any {
 	// Clone arguments so AJV can safely mutate for type coercion
 	const args = structuredClone(toolCall.arguments);
 
+	coerceStringifiedJsonFields(args, tool.parameters);
+
 	// Validate the arguments (AJV mutates args in-place for type coercion)
 	if (validate(args)) {
 		return args;
@@ -90,4 +92,35 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): any {
 	const errorMessage = `Validation failed for tool "${toolCall.name}":\n${errors}\n\nReceived arguments:\n${JSON.stringify(toolCall.arguments, null, 2)}`;
 
 	throw new Error(errorMessage);
+}
+
+/**
+ * Some models (Opus 4.6, GLM-5.1) send array/object parameters as JSON strings.
+ * Parse them back into real values before AJV validation.
+ */
+function coerceStringifiedJsonFields(args: Record<string, any>, schema: any): void {
+	const properties = schema?.properties;
+	if (!properties || typeof args !== "object" || args === null) return;
+
+	for (const [key, propSchema] of Object.entries<any>(properties)) {
+		const value = args[key];
+		if (typeof value !== "string") continue;
+
+		const expectedType = propSchema?.type;
+		if (expectedType !== "array" && expectedType !== "object") continue;
+
+		try {
+			const parsed = JSON.parse(value);
+			if (expectedType === "array" && Array.isArray(parsed)) {
+				args[key] = parsed;
+			} else if (
+				expectedType === "object" &&
+				typeof parsed === "object" &&
+				parsed !== null &&
+				!Array.isArray(parsed)
+			) {
+				args[key] = parsed;
+			}
+		} catch {}
+	}
 }

--- a/packages/ai/test/validation.test.ts
+++ b/packages/ai/test/validation.test.ts
@@ -8,6 +8,79 @@ afterEach(() => {
 });
 
 describe("validateToolArguments", () => {
+	it("coerces stringified JSON arrays into real arrays before validation", () => {
+		const tool = {
+			name: "edit",
+			description: "Edit tool",
+			parameters: Type.Object({
+				path: Type.String(),
+				edits: Type.Array(
+					Type.Object({
+						oldText: Type.String(),
+						newText: Type.String(),
+					}),
+				),
+			}),
+		};
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "tool-1",
+			name: "edit",
+			arguments: {
+				path: "/tmp/test.ts",
+				edits: JSON.stringify([{ oldText: "foo", newText: "bar" }]),
+			},
+		};
+
+		const result = validateToolArguments(tool, toolCall);
+		expect(result.edits).toEqual([{ oldText: "foo", newText: "bar" }]);
+	});
+
+	it("coerces stringified JSON objects into real objects before validation", () => {
+		const tool = {
+			name: "config",
+			description: "Config tool",
+			parameters: Type.Object({
+				settings: Type.Object({
+					verbose: Type.Boolean(),
+				}),
+			}),
+		};
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "tool-1",
+			name: "config",
+			arguments: {
+				settings: JSON.stringify({ verbose: true }),
+			},
+		};
+
+		const result = validateToolArguments(tool, toolCall);
+		expect(result.settings).toEqual({ verbose: true });
+	});
+
+	it("does not coerce strings that are not valid JSON", () => {
+		const tool = {
+			name: "edit",
+			description: "Edit tool",
+			parameters: Type.Object({
+				path: Type.String(),
+				edits: Type.Array(Type.String()),
+			}),
+		};
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "tool-1",
+			name: "edit",
+			arguments: {
+				path: "/tmp/test.ts",
+				edits: "not json at all",
+			},
+		};
+
+		expect(() => validateToolArguments(tool, toolCall)).toThrow("Validation failed");
+	});
+
 	it("falls back to raw arguments without writing to stderr when runtime code generation is blocked", () => {
 		const originalFunction = globalThis.Function;
 		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
I tried to live with the new edit tool validation, but I can't take it anymore. Models like Opus 4.6 and GLM-5.1 love to send `edits` as a JSON string instead of a parsed array. Validation rejects it, the model panics, falls back to `sed` and Python, and everything turns into chaos.

<img width="874" height="866" alt="pi-edit-bug" src="https://github.com/user-attachments/assets/49741f2b-310f-48a4-bade-476f79247097" />

AJV's `coerceTypes` handles scalar coercions (string `"42"` to number `42`) but can't parse a JSON string into an array. Added a pre-validation step that detects string values where the schema expects `array` or `object`, and `JSON.parse`s them back into real values.

Considered using an AJV custom keyword (`addKeyword` with `modifying: true`) but it requires opt-in annotation on every schema property, doesn't play well with TypeBox, and has keyword ordering issues with `type` validation. The pre-processing approach handles all tools automatically.
