### PR TITLE
feat(ai): support video and audio mimeTypes in prompt content (closes #3200)

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -528,18 +528,32 @@ export function convertMessages(
 							type: "text",
 							text: sanitizeSurrogates(item.text),
 						} satisfies ChatCompletionContentPartText;
-					} else {
-						return {
-							type: "image_url",
-							image_url: {
-								url: `data:${item.mimeType};base64,${item.data}`,
-							},
-						} satisfies ChatCompletionContentPartImage;
 					}
+					const dataUrl = `data:${item.mimeType};base64,${item.data}`;
+					// video_url and audio_url are non-standard OpenAI extensions supported by
+					// vLLM, Ollama, and other OpenAI-compatible servers hosting multimodal
+					// models (Gemma 3/4, Qwen2.5-Omni). The SDK forwards unknown part types
+					// unchanged, so passing `as any` is safe and intentional.
+					if (item.mimeType.startsWith("video/")) {
+						return { type: "video_url", video_url: { url: dataUrl } } as any;
+					}
+					if (item.mimeType.startsWith("audio/")) {
+						return { type: "audio_url", audio_url: { url: dataUrl } } as any;
+					}
+					return {
+						type: "image_url",
+						image_url: {
+							url: dataUrl,
+						},
+					} satisfies ChatCompletionContentPartImage;
 				});
-				const filteredContent = !model.input.includes("image")
-					? content.filter((c) => c.type !== "image_url")
-					: content;
+				const filteredContent = content.filter((c) => {
+					if (c.type === "text") return true;
+					if (c.type === "image_url") return model.input.includes("image");
+					if ((c as any).type === "video_url") return model.input.includes("video");
+					if ((c as any).type === "audio_url") return model.input.includes("audio");
+					return true;
+				});
 				if (filteredContent.length === 0) continue;
 				params.push({
 					role: "user",

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -136,15 +136,29 @@ export function convertResponsesMessages<TApi extends Api>(
 							text: sanitizeSurrogates(item.text),
 						} satisfies ResponseInputText;
 					}
+					const dataUrl = `data:${item.mimeType};base64,${item.data}`;
+					// Non-standard content parts for multimodal models served via OpenAI-
+					// compatible gateways (vLLM, Ollama) — the Responses API forwards
+					// unknown part types unchanged.
+					if (item.mimeType.startsWith("video/")) {
+						return { type: "input_video", video_url: dataUrl } as any;
+					}
+					if (item.mimeType.startsWith("audio/")) {
+						return { type: "input_audio", audio_url: dataUrl } as any;
+					}
 					return {
 						type: "input_image",
 						detail: "auto",
-						image_url: `data:${item.mimeType};base64,${item.data}`,
+						image_url: dataUrl,
 					} satisfies ResponseInputImage;
 				});
-				const filteredContent = !model.input.includes("image")
-					? content.filter((c) => c.type !== "input_image")
-					: content;
+				const filteredContent = content.filter((c) => {
+					if (c.type === "input_text") return true;
+					if (c.type === "input_image") return model.input.includes("image");
+					if ((c as any).type === "input_video") return model.input.includes("video");
+					if ((c as any).type === "input_audio") return model.input.includes("audio");
+					return true;
+				});
 				if (filteredContent.length === 0) continue;
 				messages.push({
 					role: "user",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -152,8 +152,14 @@ export interface ThinkingContent {
 
 export interface ImageContent {
 	type: "image";
-	data: string; // base64 encoded image data
-	mimeType: string; // e.g., "image/jpeg", "image/png"
+	data: string; // base64 encoded media data
+	/**
+	 * Media MIME type. Historically image/jpeg, image/png, etc., but also accepts
+	 * video/* and audio/* for providers that support multimodal input beyond still
+	 * images (e.g. Gemma 3/4, Gemini, GPT-4o). Providers map this to the correct
+	 * content-part shape based on the prefix.
+	 */
+	mimeType: string;
 }
 
 export interface ToolCall {
@@ -318,7 +324,7 @@ export interface Model<TApi extends Api> {
 	provider: Provider;
 	baseUrl: string;
 	reasoning: boolean;
-	input: ("text" | "image")[];
+	input: ("text" | "image" | "video" | "audio")[];
 	cost: {
 		input: number; // $/million tokens
 		output: number; // $/million tokens

--- a/packages/ai/test/ollama-gemma4-multimodal.integration.test.ts
+++ b/packages/ai/test/ollama-gemma4-multimodal.integration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration test: route video/audio content parts through the openai-completions
+ * provider to a locally-running Ollama instance serving Gemma 4. Skipped unless
+ * OLLAMA_INTEGRATION=1 is set so it never fires in CI.
+ *
+ * Prereq: `ollama pull gemma4` and `ollama serve` on localhost:11434.
+ */
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.js";
+import { convertMessages } from "../src/providers/openai-completions.js";
+import type { Context, Model, OpenAICompletionsCompat } from "../src/types.js";
+
+const RUN = process.env.OLLAMA_INTEGRATION === "1";
+const OLLAMA_HOST = process.env.OLLAMA_HOST ?? "http://localhost:11434";
+const GEMMA_MODEL = process.env.OLLAMA_GEMMA_MODEL ?? "gemma4:26b";
+
+const compat: Required<OpenAICompletionsCompat> = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: false,
+	reasoningEffortMap: {},
+	supportsUsageInStreaming: false,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	supportsStrictMode: false,
+};
+
+// 1x1 red PNG (smallest valid PNG)
+const RED_PIXEL_PNG =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+function buildModel(input: ("text" | "image" | "video" | "audio")[]): Model<"openai-completions"> {
+	const base = getModel("openai", "gpt-4o-mini");
+	return { ...base, api: "openai-completions", input };
+}
+
+describe.skipIf(!RUN)("Ollama Gemma 4 multimodal integration", () => {
+	it("builds a video_url content part that Ollama accepts without schema error", async () => {
+		const model = buildModel(["text", "video"]);
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "one word response please: ok" },
+						// Small fake mp4 payload — Gemma 4 may reject the content, but we
+						// only assert the request shape is forwarded through without the
+						// gateway returning a schema-validation 4xx on the content part.
+						{ type: "image", data: "AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDE=", mimeType: "video/mp4" },
+					],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		const params = convertMessages(model, context, compat);
+
+		const res = await fetch(`${OLLAMA_HOST}/v1/chat/completions`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ model: GEMMA_MODEL, messages: params, max_tokens: 16 }),
+		});
+
+		const text = await res.text();
+		// Ollama returns 200 OK with a response body even if the model can't consume the
+		// media payload; what we're ruling out is a 400 "unknown content part type".
+		expect(res.status, `ollama response: ${text}`).toBeLessThan(500);
+		if (res.status === 400) {
+			expect(text.toLowerCase()).not.toContain("unknown content");
+			expect(text.toLowerCase()).not.toContain("invalid type");
+		}
+	}, 60_000);
+
+	it("image_url still works end-to-end (regression guard)", async () => {
+		const model = buildModel(["text", "image"]);
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "What color is this? answer with one word" },
+						{ type: "image", data: RED_PIXEL_PNG, mimeType: "image/png" },
+					],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		const params = convertMessages(model, context, compat);
+
+		const res = await fetch(`${OLLAMA_HOST}/v1/chat/completions`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ model: GEMMA_MODEL, messages: params, max_tokens: 64 }),
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as any;
+		// Gemma 4 via Ollama may emit output in either `content` or `reasoning` depending
+		// on how the server routes thinking blocks. Accept either — what we're asserting
+		// is that the image_url content part was consumed and produced a response.
+		const msg = body?.choices?.[0]?.message;
+		const reply = (msg?.content ?? "") + (msg?.reasoning ?? "");
+		expect(reply.length).toBeGreaterThan(0);
+	}, 180_000);
+});

--- a/packages/ai/test/openai-completions-multimodal-mimetypes.test.ts
+++ b/packages/ai/test/openai-completions-multimodal-mimetypes.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.js";
+import { convertMessages } from "../src/providers/openai-completions.js";
+import type { Context, Model, OpenAICompletionsCompat } from "../src/types.js";
+
+const compat: Required<OpenAICompletionsCompat> = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	reasoningEffortMap: {},
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	supportsStrictMode: true,
+};
+
+function buildMultimodalModel(input: ("text" | "image" | "video" | "audio")[]): Model<"openai-completions"> {
+	const base = getModel("openai", "gpt-4o-mini");
+	return {
+		...base,
+		api: "openai-completions",
+		input,
+	};
+}
+
+describe("openai-completions content-part mapping by mimeType", () => {
+	const now = Date.now();
+
+	it("maps video/* mimeTypes to video_url content parts", () => {
+		const model = buildMultimodalModel(["text", "video"]);
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "What happens in this clip?" },
+						{ type: "image", data: "ZmFrZQ==", mimeType: "video/mp4" },
+					],
+					timestamp: now,
+				},
+			],
+		};
+
+		const params = convertMessages(model, context, compat);
+		const userMsg = params.find((p) => p.role === "user");
+		expect(userMsg).toBeDefined();
+		const parts = userMsg!.content as any[];
+		expect(parts.some((p) => p.type === "video_url")).toBe(true);
+		const videoPart = parts.find((p) => p.type === "video_url");
+		expect(videoPart.video_url.url).toBe("data:video/mp4;base64,ZmFrZQ==");
+	});
+
+	it("maps audio/* mimeTypes to audio_url content parts", () => {
+		const model = buildMultimodalModel(["text", "audio"]);
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "Transcribe this." },
+						{ type: "image", data: "ZmFrZQ==", mimeType: "audio/wav" },
+					],
+					timestamp: now,
+				},
+			],
+		};
+
+		const params = convertMessages(model, context, compat);
+		const userMsg = params.find((p) => p.role === "user");
+		const parts = userMsg!.content as any[];
+		expect(parts.some((p) => p.type === "audio_url")).toBe(true);
+		const audioPart = parts.find((p) => p.type === "audio_url");
+		expect(audioPart.audio_url.url).toBe("data:audio/wav;base64,ZmFrZQ==");
+	});
+
+	it("still maps image/* mimeTypes to image_url content parts", () => {
+		const model = buildMultimodalModel(["text", "image"]);
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "Describe." },
+						{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+					],
+					timestamp: now,
+				},
+			],
+		};
+
+		const params = convertMessages(model, context, compat);
+		const userMsg = params.find((p) => p.role === "user");
+		const parts = userMsg!.content as any[];
+		expect(parts.some((p) => p.type === "image_url")).toBe(true);
+	});
+
+	it("filters out video_url when model does not declare video capability", () => {
+		const model = buildMultimodalModel(["text"]);
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "Hello" },
+						{ type: "image", data: "ZmFrZQ==", mimeType: "video/mp4" },
+					],
+					timestamp: now,
+				},
+			],
+		};
+
+		const params = convertMessages(model, context, compat);
+		const userMsg = params.find((p) => p.role === "user");
+		const parts = userMsg!.content as any[];
+		expect(parts.some((p) => p.type === "video_url")).toBe(false);
+		expect(parts.some((p) => p.type === "text")).toBe(true);
+	});
+
+	it("filters out audio_url when model does not declare audio capability", () => {
+		const model = buildMultimodalModel(["text", "image"]);
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "Hello" },
+						{ type: "image", data: "ZmFrZQ==", mimeType: "audio/wav" },
+					],
+					timestamp: now,
+				},
+			],
+		};
+
+		const params = convertMessages(model, context, compat);
+		const userMsg = params.find((p) => p.role === "user");
+		const parts = userMsg!.content as any[];
+		expect(parts.some((p) => p.type === "audio_url")).toBe(false);
+	});
+
+	it("mixed media: passes through only declared capabilities", () => {
+		const model = buildMultimodalModel(["text", "image", "video", "audio"]);
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "All three" },
+						{ type: "image", data: "aW1n", mimeType: "image/png" },
+						{ type: "image", data: "dmlk", mimeType: "video/webm" },
+						{ type: "image", data: "YXVk", mimeType: "audio/mpeg" },
+					],
+					timestamp: now,
+				},
+			],
+		};
+
+		const params = convertMessages(model, context, compat);
+		const userMsg = params.find((p) => p.role === "user");
+		const parts = userMsg!.content as any[];
+		expect(parts.filter((p) => p.type === "image_url")).toHaveLength(1);
+		expect(parts.filter((p) => p.type === "video_url")).toHaveLength(1);
+		expect(parts.filter((p) => p.type === "audio_url")).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Summary
- Extends the existing `images` array to carry any media by MIME type — no new fields, backward compatible with all existing callers.
- `openai-completions` and `openai-responses` providers now route parts by mimeType prefix:
  - `image/*` → `image_url` / `input_image` (existing)
  - `video/*` → `video_url` / `input_video` (new)
  - `audio/*` → `audio_url` / `input_audio` (new)
- `Model.input` widened to `("text" | "image" | "video" | "audio")[]`; content filter drops video/audio parts for models that don't declare the capability (same pattern as the existing image filter).

## Why
Closes #3200. Screenpipe embeds Pi as its chat backend and users want to ask questions about their screen-recording clips. Gemma 4 (and similar multimodal models) running on vLLM/Ollama accept `video_url`/`audio_url` content parts via the OpenAI-compatible API — Pi just needs to pass them through. The OpenAI SDK forwards unknown part types unchanged, so this works transparently on OpenAI-compatible gateways (vLLM, Ollama, LMDeploy, etc.).

## Tests
- **Unit** (`test/openai-completions-multimodal-mimetypes.test.ts`): 6 tests covering the mapping for each prefix + capability filtering. Run with `npm test`.
- **Integration** (`test/ollama-gemma4-multimodal.integration.test.ts`): 2 tests against a local Ollama Gemma 4. Opt-in — only run when `OLLAMA_INTEGRATION=1` is set, so CI is unaffected. Verifies `video_url` is accepted without a schema-validation error and that `image_url` still produces a real response (regression guard).
  - Tested locally against `gemma4:26b` on Ollama 11434 — both pass.

## Test plan
- [x] Unit tests pass (`npm test` in `packages/ai`)
- [x] Integration tests pass against local Ollama Gemma 4 (`OLLAMA_INTEGRATION=1 npm test`)
- [x] Existing image-related tests (`openai-completions-tool-result-images`, etc.) still pass — no regression
- [x] Full workspace build passes (`npm run build` at root)