### PR TITLE
fix(coding-agent): coerce stringified JSON edits in edit tool

### DIFF
--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -92,14 +92,24 @@ function prepareEditArguments(input: unknown): EditToolInput {
 		return input as EditToolInput;
 	}
 
-	const args = input as LegacyEditToolInput;
-	if (typeof args.oldText !== "string" || typeof args.newText !== "string") {
-		return input as EditToolInput;
+	const args = input as Record<string, unknown>;
+
+	// Some models (Opus 4.6, GLM-5.1) send edits as a JSON string instead of an array
+	if (typeof args.edits === "string") {
+		try {
+			const parsed = JSON.parse(args.edits);
+			if (Array.isArray(parsed)) args.edits = parsed;
+		} catch {}
 	}
 
-	const edits = Array.isArray(args.edits) ? [...args.edits] : [];
-	edits.push({ oldText: args.oldText, newText: args.newText });
-	const { oldText: _oldText, newText: _newText, ...rest } = args;
+	const legacy = args as LegacyEditToolInput;
+	if (typeof legacy.oldText !== "string" || typeof legacy.newText !== "string") {
+		return args as EditToolInput;
+	}
+
+	const edits = Array.isArray(legacy.edits) ? [...legacy.edits] : [];
+	edits.push({ oldText: legacy.oldText, newText: legacy.newText });
+	const { oldText: _oldText, newText: _newText, ...rest } = legacy;
 	return { ...rest, edits } as EditToolInput;
 }
 

--- a/packages/coding-agent/test/edit-tool-legacy-input.test.ts
+++ b/packages/coding-agent/test/edit-tool-legacy-input.test.ts
@@ -88,3 +88,29 @@ describe("edit tool prepareArguments", () => {
 		expect(await readFile(filePath, "utf8")).toBe("after\n");
 	});
 });
+
+describe("edit tool stringified edits", () => {
+	it("parses edits from a JSON string", () => {
+		const definition = createEditToolDefinition(process.cwd());
+		const prepared = definition.prepareArguments!({
+			path: "file.txt",
+			edits: JSON.stringify([{ oldText: "a", newText: "b" }]),
+		});
+		expect(prepared).toEqual({
+			path: "file.txt",
+			edits: [{ oldText: "a", newText: "b" }],
+		});
+	});
+
+	it("leaves edits alone when the string is not valid JSON", () => {
+		const definition = createEditToolDefinition(process.cwd());
+		const prepared = definition.prepareArguments!({
+			path: "file.txt",
+			edits: "not json",
+		});
+		expect(prepared).toEqual({
+			path: "file.txt",
+			edits: "not json",
+		});
+	});
+});


### PR DESCRIPTION
Follow-up to #3336 per @badlogic's feedback — moved from validation layer to `prepareArguments` on the edit tool definition.

Models like Opus 4.6 and GLM-5.1 send `edits` as a JSON string instead of an array. AJV rejects it, the model panics, falls back to `sed` and Python, chaos ensues.

Parses stringified `edits` back into a real array in `prepareEditArguments`, before validation runs.
