### PR TITLE
fix(coding-agent): use browser-safe /share viewer shortcuts

### DIFF
--- a/packages/coding-agent/src/core/export-html/template.css
+++ b/packages/coding-agent/src/core/export-html/template.css
@@ -262,9 +262,23 @@
       margin-bottom: var(--line-height);
       display: flex;
       align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
       gap: 12px;
     }
 
+    .help-hint {
+      flex: 1 1 240px;
+    }
+
+    .help-actions {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .header-toggle-btn,
     .download-json-btn {
       font-size: 10px;
       padding: 2px 8px;
@@ -276,6 +290,7 @@
       font-family: inherit;
     }
 
+    .header-toggle-btn:hover,
     .download-json-btn:hover {
       background: var(--hover);
       border-color: var(--borderAccent);

--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -1291,8 +1291,12 @@
           <div class="header">
             <h1>Session: ${escapeHtml(header?.id || 'unknown')}</h1>
             <div class="help-bar">
-              <span>Ctrl+T toggle thinking · Ctrl+O toggle tools</span>
-              <button class="download-json-btn" onclick="downloadSessionJson()" title="Download session as JSONL">↓ JSONL</button>
+              <span class="help-hint">T toggle thinking · O toggle tools</span>
+              <div class="help-actions">
+                <button type="button" class="header-toggle-btn" data-action="toggle-thinking" title="Toggle thinking (T)">Toggle thinking</button>
+                <button type="button" class="header-toggle-btn" data-action="toggle-tools" title="Toggle tools (O)">Toggle tools</button>
+                <button type="button" class="download-json-btn" onclick="downloadSessionJson()" title="Download session as JSONL">↓ JSONL</button>
+              </div>
             </div>
             <div class="header-info">
               <div class="info-item"><span class="info-label">Date:</span><span class="info-value">${header?.timestamp ? new Date(header.timestamp).toLocaleString() : 'unknown'}</span></div>
@@ -1393,6 +1397,7 @@
         renderTree();
 
         document.getElementById('header-container').innerHTML = renderHeader();
+        attachHeaderHandlers();
 
         // Build messages using cached DOM nodes
         const messagesEl = document.getElementById('messages');
@@ -1672,6 +1677,20 @@
         });
       };
 
+      const attachHeaderHandlers = () => {
+        document.querySelector('[data-action="toggle-thinking"]')?.addEventListener('click', toggleThinking);
+        document.querySelector('[data-action="toggle-tools"]')?.addEventListener('click', toggleToolOutputs);
+      };
+
+      const isEditableTarget = (element) => {
+        if (!element) return false;
+        const tagName = element.tagName;
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT' || tagName === 'BUTTON') {
+          return true;
+        }
+        return element.isContentEditable || Boolean(element.closest?.('[contenteditable="true"]'));
+      };
+
       // Keyboard shortcuts
       document.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') {
@@ -1679,11 +1698,16 @@
           searchQuery = '';
           navigateTo(leafId, 'bottom');
         }
-        if (e.ctrlKey && e.key === 't') {
+
+        if (isEditableTarget(document.activeElement)) {
+          return;
+        }
+
+        const key = e.key.toLowerCase();
+        if (key === 't') {
           e.preventDefault();
           toggleThinking();
-        }
-        if (e.ctrlKey && e.key === 'o') {
+        } else if (key === 'o') {
           e.preventDefault();
           toggleToolOutputs();
         }


### PR DESCRIPTION
## Summary
- replace `/share` viewer browser-conflicting `Ctrl+T` / `Ctrl+O` hints with `T` / `O`
- add simple header toggle buttons for thinking and tool output
- keep shortcuts disabled while focus is in editable elements

## Validation
- `node --check packages/coding-agent/src/core/export-html/template.js`
- manual test of exported `/share` HTML in browser on Windows

## Notes
- `npm run check` is currently failing on latest `main` in unrelated workspace checks (`packages/web-ui` module resolution), not in these files

## Shared session

You can try here https://pi.dev/session/#ff293b16b4d35f1f7e27608db0b122d9

Fixes #3358
