### PR TITLE
fix(coding-agent): detect Windows pnpm global installs under .pnpm

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -33,7 +33,12 @@ export function detectInstallMethod(): InstallMethod {
 
 	const resolvedPath = `${__dirname}\0${process.execPath || ""}`.toLowerCase();
 
-	if (resolvedPath.includes("/pnpm/") || resolvedPath.includes("/.pnpm/") || resolvedPath.includes("\\pnpm\\")) {
+	if (
+		resolvedPath.includes("/pnpm/") ||
+		resolvedPath.includes("/.pnpm/") ||
+		resolvedPath.includes("\\pnpm\\") ||
+		resolvedPath.includes("\\.pnpm\\")
+	) {
 		return "pnpm";
 	}
 	if (resolvedPath.includes("/yarn/") || resolvedPath.includes("/.yarn/") || resolvedPath.includes("\\yarn\\")) {

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { detectInstallMethod, getUpdateInstruction } from "../src/config.js";
+
+const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
+
+function setExecPath(value: string): void {
+	Object.defineProperty(process, "execPath", {
+		value,
+		configurable: true,
+	});
+}
+
+afterEach(() => {
+	if (execPathDescriptor) {
+		Object.defineProperty(process, "execPath", execPathDescriptor);
+	}
+});
+
+describe("detectInstallMethod", () => {
+	test("detects pnpm from Windows .pnpm install paths", () => {
+		setExecPath(
+			"C:\\Users\\Admin\\Documents\\pnpm-repository\\global\\5\\.pnpm\\@mariozechner+pi-coding-agent@0.67.68\\node_modules\\@mariozechner\\pi-coding-agent\\dist\\cli.js",
+		);
+
+		expect(detectInstallMethod()).toBe("pnpm");
+		expect(getUpdateInstruction("@mariozechner/pi-coding-agent")).toBe(
+			"Run: pnpm install -g @mariozechner/pi-coding-agent",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
On Windows, `detectInstallMethod()` can miss pnpm global installs because it checks for `\\pnpm\\` but not the common pnpm store segment `\\.pnpm\\`.

When that happens, pi falls back to `unknown` and shows the wrong update instruction:

```text
Run: npm install -g @mariozechner/pi-coding-agent
```

for installations that were actually done with pnpm.

## Reproduction
1. Install pi globally with pnpm on Windows.
2. Open pi from that install.
3. Trigger the update notification path.
4. Observe that the suggested update command is `npm install -g ...` instead of `pnpm install -g ...`.

Example install path from a real repro:

```text
C:\Users\Admin\Documents\pnpm-repository\global\5\.pnpm\@mariozechner+pi-coding-agent@0.67.68\node_modules\@mariozechner\pi-coding-agent\dist\cli.js
```

## Root cause
`packages/coding-agent/src/config.ts` currently detects pnpm with these path fragments:

- `/pnpm/`
- `/.pnpm/`
- `\\pnpm\\`

The Windows-specific `.pnpm` segment (`\\.pnpm\\`) is not included, so the install method can be misdetected as `unknown`.

## Fix
Add `\\.pnpm\\` to the pnpm path detection logic.

Also add a regression test covering a Windows pnpm global install path.

## Validation
Test added:

```bash
cd packages/coding-agent
npm test -- test/config.test.ts
```

## Scope
This is a minimal bugfix only. It does not change the broader install-method detection strategy.