### PR TITLE
feat(ai): add Claude 4.7 full family support and fix temperature handling

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -456,7 +456,7 @@ function handleContentBlockStop(
 }
 
 /**
- * Check if the model supports adaptive thinking (Opus 4.6+, Sonnet 4.6).
+ * Check if the model supports adaptive thinking (Claude 4.6+).
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
 	return (
@@ -465,7 +465,11 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 		modelId.includes("opus-4-7") ||
 		modelId.includes("opus-4.7") ||
 		modelId.includes("sonnet-4-6") ||
-		modelId.includes("sonnet-4.6")
+		modelId.includes("sonnet-4.6") ||
+		modelId.includes("sonnet-4-7") ||
+		modelId.includes("sonnet-4.7") ||
+		modelId.includes("haiku-4-7") ||
+		modelId.includes("haiku-4.7")
 	);
 }
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -467,18 +467,29 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 };
 
 /**
- * Check if a model supports adaptive thinking (Opus 4.6+, Sonnet 4.6)
+ * Check if a model supports adaptive thinking (Claude 4.6+)
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
-	// Adaptive-thinking model IDs (with or without date suffix)
 	return (
 		modelId.includes("opus-4-6") ||
 		modelId.includes("opus-4.6") ||
 		modelId.includes("opus-4-7") ||
 		modelId.includes("opus-4.7") ||
 		modelId.includes("sonnet-4-6") ||
-		modelId.includes("sonnet-4.6")
+		modelId.includes("sonnet-4.6") ||
+		modelId.includes("sonnet-4-7") ||
+		modelId.includes("sonnet-4.7") ||
+		modelId.includes("haiku-4-7") ||
+		modelId.includes("haiku-4.7")
 	);
+}
+
+/**
+ * Check if a model belongs to the Claude 4.7 family.
+ * Claude 4.7 rejects temperature, top_p, and top_k parameters.
+ */
+function isClaude47(modelId: string): boolean {
+	return modelId.includes("4-7") || modelId.includes("4.7");
 }
 
 /**
@@ -679,8 +690,8 @@ function buildParams(
 		];
 	}
 
-	// Temperature is incompatible with extended thinking (adaptive or budget-based).
-	if (options?.temperature !== undefined && !options?.thinkingEnabled) {
+	// Temperature is incompatible with extended thinking and with Claude 4.7 models.
+	if (options?.temperature !== undefined && !options?.thinkingEnabled && !isClaude47(model.id)) {
 		params.temperature = options.temperature;
 	}
 


### PR DESCRIPTION
## Summary

The Claude 4.7 model family (Opus, Sonnet, Haiku) uses adaptive thinking exclusively and rejects `temperature`, `top_p`, and `top_k` parameters — the API returns a **400 error** even when extended thinking is disabled.

This PR:

- **Adds Sonnet 4.7 and Haiku 4.7** to `supportsAdaptiveThinking()` in both `anthropic` and `amazon-bedrock` providers. Opus 4.7 was already present but Sonnet and Haiku were missing, causing them to fall through to budget-based thinking (which 4.7 models also don't support).

- **Introduces `isClaude47()` helper** in the anthropic provider to detect 4.7 family models using a simple `"4-7"` / `"4.7"` substring match. This is intentionally broad to cover future model IDs (e.g. date-suffixed variants like `claude-sonnet-4-7-20260501`).

- **Guards temperature in `buildParams()`** so it is never sent to 4.7 models, even when `thinkingEnabled` is false. Without this guard, any non-thinking API call with a temperature value fails with a 400 error.

## Changes

| File | Change |
|------|--------|
| `packages/ai/src/providers/anthropic.ts` | Add sonnet/haiku 4.7 to `supportsAdaptiveThinking()`, add `isClaude47()`, guard temperature |
| `packages/ai/src/providers/amazon-bedrock.ts` | Add sonnet/haiku 4.7 to `supportsAdaptiveThinking()` |

## Test plan

- [x] Existing `supports-xhigh.test.ts` continues to pass (Opus 4.7 path unchanged)
- [x] Verified no false positives from `isClaude47()` pattern against `models.generated.ts`
- [x] Verified `top_p`/`top_k` are not sent by the anthropic provider (only temperature needed guarding)
- [ ] Manual verification with Claude 4.7 Sonnet API call with temperature (should no longer 400)