### PR TITLE
fix(coding-agent): prevent large-output sanitize/render crashes

### DIFF
--- a/packages/coding-agent/src/core/tools/render-utils.ts
+++ b/packages/coding-agent/src/core/tools/render-utils.ts
@@ -4,6 +4,25 @@ import { getCapabilities, getImageDimensions, imageFallback } from "@mariozechne
 import stripAnsi from "strip-ansi";
 import { sanitizeBinaryOutput } from "../../utils/shell.js";
 
+const MAX_RENDER_TEXT_CHARS = 64 * 1024;
+const MAX_RENDER_OUTPUT_CHARS = 256 * 1024;
+const TRUNCATED_BLOCK_MARKER = "\n[truncated for display]";
+const TRUNCATED_TOTAL_MARKER = "\n[truncated total output for display]";
+
+function toSafeString(value: unknown): string {
+	if (typeof value === "string") {
+		return value;
+	}
+	if (value == null) {
+		return "";
+	}
+	try {
+		return String(value);
+	} catch {
+		return "";
+	}
+}
+
 export function shortenPath(path: unknown): string {
 	if (typeof path !== "string") return "";
 	const home = os.homedir();
@@ -36,7 +55,35 @@ export function getTextOutput(
 	const textBlocks = result.content.filter((c) => c.type === "text");
 	const imageBlocks = result.content.filter((c) => c.type === "image");
 
-	let output = textBlocks.map((c) => sanitizeBinaryOutput(stripAnsi(c.text || "")).replace(/\r/g, "")).join("\n");
+	let output = "";
+	let totalTruncated = false;
+	for (const block of textBlocks) {
+		if (totalTruncated) {
+			break;
+		}
+
+		let text = toSafeString(block.text);
+		if (text.length > MAX_RENDER_TEXT_CHARS) {
+			text = text.slice(0, MAX_RENDER_TEXT_CHARS) + TRUNCATED_BLOCK_MARKER;
+		}
+
+		const sanitized = sanitizeBinaryOutput(stripAnsi(text)).replace(/\r/g, "");
+		const segment = output.length > 0 ? `\n${sanitized}` : sanitized;
+		const remaining = MAX_RENDER_OUTPUT_CHARS - output.length;
+		if (remaining <= 0) {
+			output += TRUNCATED_TOTAL_MARKER;
+			totalTruncated = true;
+			break;
+		}
+		if (segment.length > remaining) {
+			output += sanitizeBinaryOutput(segment.slice(0, remaining));
+			output += TRUNCATED_TOTAL_MARKER;
+			totalTruncated = true;
+			break;
+		}
+
+		output += segment;
+	}
 
 	const caps = getCapabilities();
 	if (imageBlocks.length > 0 && (!caps.images || !showImages)) {

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -138,38 +138,60 @@ export function getShellEnv(): NodeJS.ProcessEnv {
  * - Control characters (except tab, newline, carriage return)
  * - Lone surrogates
  * - Unicode Format characters (crash string-width due to a bug)
- * - Characters with undefined code points
  */
-export function sanitizeBinaryOutput(str: string): string {
-	// Use Array.from to properly iterate over code points (not code units)
-	// This handles surrogate pairs correctly and catches edge cases where
-	// codePointAt() might return undefined
-	return Array.from(str)
-		.filter((char) => {
-			// Filter out characters that cause string-width to crash
-			// This includes:
-			// - Unicode format characters
-			// - Lone surrogates (already filtered by Array.from)
-			// - Control chars except \t \n \r
-			// - Characters with undefined code points
+export function sanitizeBinaryOutput(str: unknown): string {
+	if (str == null) {
+		return "";
+	}
 
-			const code = char.codePointAt(0);
+	let text: string;
+	if (typeof str === "string") {
+		text = str;
+	} else {
+		try {
+			text = String(str);
+		} catch {
+			return "";
+		}
+	}
 
-			// Skip if code point is undefined (edge case with invalid strings)
-			if (code === undefined) return false;
+	// Scan code units and accumulate safe segments without per-char arrays.
+	// This keeps memory bounded and avoids Array.from() failures on very large inputs.
+	let out = "";
+	let segmentStart = 0;
+	for (let i = 0; i < text.length; ) {
+		const code = text.charCodeAt(i);
+		let charLength = 1;
+		let shouldDrop = false;
 
-			// Allow tab, newline, carriage return
-			if (code === 0x09 || code === 0x0a || code === 0x0d) return true;
+		if (code >= 0xd800 && code <= 0xdbff) {
+			const next = i + 1 < text.length ? text.charCodeAt(i + 1) : -1;
+			if (next >= 0xdc00 && next <= 0xdfff) {
+				charLength = 2;
+			} else {
+				shouldDrop = true;
+			}
+		} else if (code >= 0xdc00 && code <= 0xdfff) {
+			shouldDrop = true;
+		} else {
+			const isAllowedWhitespace = code === 0x09 || code === 0x0a || code === 0x0d;
+			const isControl = code <= 0x1f;
+			const isDangerousFormat = code >= 0xfff9 && code <= 0xfffb;
+			shouldDrop = !isAllowedWhitespace && (isControl || isDangerousFormat);
+		}
 
-			// Filter out control characters (0x00-0x1F, except 0x09, 0x0a, 0x0x0d)
-			if (code <= 0x1f) return false;
+		if (shouldDrop) {
+			out += text.slice(segmentStart, i);
+			segmentStart = i + charLength;
+		}
+		i += charLength;
+	}
 
-			// Filter out Unicode format characters
-			if (code >= 0xfff9 && code <= 0xfffb) return false;
-
-			return true;
-		})
-		.join("");
+	if (segmentStart === 0) {
+		return text;
+	}
+	out += text.slice(segmentStart);
+	return out;
 }
 
 /**

--- a/packages/coding-agent/test/suite/regressions/3383-large-tool-output-render-crash.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3383-large-tool-output-render-crash.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeBinaryOutput } from "../../../src/utils/shell.js";
+
+describe("issue #3383 large tool output render crash", () => {
+	it("does not throw on very large text payloads", () => {
+		const huge = "a".repeat(2 ** 28);
+		expect(() => sanitizeBinaryOutput(huge)).not.toThrow();
+		expect(sanitizeBinaryOutput(huge).length).toBe(huge.length);
+	});
+
+	it("sanitizes control chars, lone surrogates, and dangerous format chars", () => {
+		const dirty = `A${String.fromCharCode(0)}B${String.fromCharCode(0xd800)}C\ufff9D\n\t\r`;
+		expect(sanitizeBinaryOutput(dirty)).toBe("ABCD\n\t\r");
+	});
+
+	it("accepts non-string values defensively", () => {
+		expect(sanitizeBinaryOutput(123)).toBe("123");
+		expect(sanitizeBinaryOutput(null)).toBe("");
+	});
+});


### PR DESCRIPTION
## Summary
- replace `sanitizeBinaryOutput()`'s `Array.from()` path with a code-unit scanner that preserves valid surrogate pairs, drops lone surrogates/control chars/`U+FFF9..U+FFFB`, and avoids per-character array allocation on very large strings
- harden `getTextOutput()` for interactive rendering with bounded display output:
  - per text block cap: `64 * 1024` chars + `[truncated for display]`
  - total accumulated output cap: `256 * 1024` chars + `[truncated total output for display]`
  - safe coercion for non-string `text` payloads before sanitization
- add issue regression test `test/suite/regressions/3383-large-tool-output-render-crash.test.ts`

## Validation
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/3383-large-tool-output-render-crash.test.ts` (from `packages/coding-agent/`)
- `npm run check` (repo root)

fixes #3383
