### PR TITLE
fix(coding-agent): resolve symlinks in session paths for parent-child matching

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -6,6 +6,7 @@ import {
 	closeSync,
 	existsSync,
 	mkdirSync,
+	realpathSync,
 	openSync,
 	readdirSync,
 	readFileSync,
@@ -547,6 +548,14 @@ function getSessionModifiedDate(entries: FileEntry[], header: SessionHeader, sta
 }
 
 async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
+	// Resolve symlinks so session paths are canonical — this ensures
+	// parentSession matching works across different symlink trees
+	// (e.g. multiple config profiles sharing a sessions directory).
+	try {
+		filePath = realpathSync(filePath);
+	} catch {
+		// If realpath fails (broken symlink, etc.), use the original path
+	}
 	try {
 		const content = await readFile(filePath, "utf8");
 		const entries: FileEntry[] = [];
@@ -595,7 +604,14 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 		}
 
 		const cwd = typeof (header as SessionHeader).cwd === "string" ? (header as SessionHeader).cwd : "";
-		const parentSessionPath = (header as SessionHeader).parentSession;
+		let parentSessionPath = (header as SessionHeader).parentSession;
+		if (parentSessionPath) {
+			try {
+				parentSessionPath = realpathSync(parentSessionPath);
+			} catch {
+				// Keep original path if symlink target doesn't exist
+			}
+		}
 
 		const modified = getSessionModifiedDate(entries, header as SessionHeader, stats.mtime);
 


### PR DESCRIPTION
`buildSessionTree()` matches parent-child relationships by exact string equality on `session.path`. When session directories are symlinked (e.g. multiple profiles sharing a sessions directory via `PI_CODING_AGENT_DIR`), the same file produces different path strings, and fork relationships break in `/resume`.

Resolves `filePath` and `parentSessionPath` with `realpathSync()` inside `buildSessionInfo()` so all paths are canonical before comparison. Both calls are wrapped in try/catch to fall back to the original path if the symlink target doesn't exist.

closes #3364
