### PR TITLE
feat(amazon-bedrock): conditionally omit maxTokens from inferenceConfig to avoid quota waste

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -182,7 +182,10 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				modelId: model.id,
 				messages: convertMessages(context, model, cacheRetention),
 				system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
-				inferenceConfig: { maxTokens: options.maxTokens, temperature: options.temperature },
+				inferenceConfig: {
+					...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
+					...(options.temperature !== undefined && { temperature: options.temperature }),
+				},
 				toolConfig: convertToolConfig(context.tools, options.toolChoice),
 				additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
 				...(options.requestMetadata !== undefined && { requestMetadata: options.requestMetadata }),

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -3,7 +3,7 @@ import type { Api, Model, SimpleStreamOptions, StreamOptions, ThinkingBudgets, T
 export function buildBaseOptions(model: Model<Api>, options?: SimpleStreamOptions, apiKey?: string): StreamOptions {
 	return {
 		temperature: options?.temperature,
-		maxTokens: options?.maxTokens || Math.min(model.maxTokens, 32000),
+		maxTokens: options?.maxTokens ?? (model.maxTokens > 0 ? Math.min(model.maxTokens, 32000) : undefined),
 		signal: options?.signal,
 		apiKey: apiKey || options?.apiKey,
 		cacheRetention: options?.cacheRetention,


### PR DESCRIPTION
## Problem

The Bedrock provider always sends `maxTokens` in `inferenceConfig`, even when the caller doesn't set it. Combined with `buildBaseOptions` defaulting to `Math.min(model.maxTokens, 32000)`, this creates two issues:

### 1. Token quota waste from aggressive reservation

Bedrock's [token burndown mechanism](https://docs.aws.amazon.com/bedrock/latest/userguide/quotas-token-burndown.html) reserves `input_tokens + max_tokens` from your TPM quota **at request start**. For Claude 3.7+ models, output tokens have a **5x burndown rate**.

With `maxTokens=32000` (current default cap):
- **Initial TPM reservation:** `input_tokens + 32,000`
- **Typical 1K-output response:** `input_tokens + 5,000` (actual)
- **Wasted reservation:** ~27,000 tokens of TPM capacity per request

This directly reduces concurrent request throughput and causes premature `ThrottlingException` on on-demand quotas.

### 2. Bug: `||` vs `??` treats explicit `maxTokens: 0` as falsy

```typescript
// Before: explicit 0 falls through to the default
maxTokens: options?.maxTokens || Math.min(model.maxTokens, 32000)
```

This means a caller setting `maxTokens: 0` to indicate "let the model decide" gets 32000 instead.

## Fix

**`simple-options.ts`:**
- Use `??` instead of `||` so explicit `0` is preserved
- Return `undefined` when `model.maxTokens` is `0` (unset/unknown), signaling "no preference"

```typescript
maxTokens: options?.maxTokens ?? (model.maxTokens > 0 ? Math.min(model.maxTokens, 32000) : undefined),
```

**`amazon-bedrock.ts`:**
- Conditionally spread `maxTokens` and `temperature` into `inferenceConfig` only when defined
- When omitted, Bedrock uses the model's internal default (typically ~4096 for Claude)

```typescript
inferenceConfig: {
  ...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
  ...(options.temperature !== undefined && { temperature: options.temperature }),
},
```

## Behavior change

| Scenario | Before | After |
|----------|--------|-------|
| Caller sets `maxTokens: 8192` | Sends 8192 | Sends 8192 (no change) |
| Caller sets `maxTokens: 0` | Sends 32000 (bug) | Sends 0 |
| `model.maxTokens > 0`, caller omits | Sends `min(model.maxTokens, 32000)` | Same (no change) |
| `model.maxTokens = 0`, caller omits | Sends 0 | Omits from request (model default) |
| Thinking enabled | `adjustMaxTokensForThinking` always sets explicit value | Same (no change) |

The thinking path (`adjustMaxTokensForThinking`) always produces an explicit `maxTokens`, so thinking-enabled requests are unaffected.

## Context

- Bedrock's `inferenceConfig.maxTokens` is [optional in the Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html)
- AWS SDK omits `undefined` properties during serialization
- Downstream consumers (OpenClaw's Bedrock discovery) set `model.maxTokens` from their own defaults — when those are wrong or conservative, omitting is better than passing a bad value
- Related: openclaw/openclaw#65952 (discovery hardcodes `DEFAULT_MAX_TOKENS = 4096`)

Fixes #3399