### PR TITLE
fix(amazon-bedrock): pass model.baseUrl as endpoint to BedrockRuntimeClient

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -115,6 +115,12 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 			profile: options.profile,
 		};
 
+		// Pass custom endpoint when the model has a non-default baseUrl.
+		// This enables VPC endpoints, proxy setups, and custom routing.
+		if (model.baseUrl) {
+			config.endpoint = model.baseUrl;
+		}
+
 		// Resolve bearer token for Bedrock API key auth.
 		const bearerToken = options.bearerToken || process.env.AWS_BEARER_TOKEN_BEDROCK || undefined;
 		const useBearerToken = bearerToken !== undefined && process.env.AWS_BEDROCK_SKIP_AUTH !== "1";


### PR DESCRIPTION
## Problem

`BedrockRuntimeClient` is constructed without the `endpoint` option, so `model.baseUrl` is silently ignored. Custom Bedrock endpoints — VPC endpoints, proxy setups, custom routing — never take effect. Requests always go to the default regional endpoint.

```typescript
// Current: baseUrl is never used
const config: BedrockRuntimeClientConfig = {
  profile: options.profile,
};
// ...
const client = new BedrockRuntimeClient(config);
```

This affects enterprise users behind VPC endpoints who configure a custom `baseUrl` in their provider config.

## Fix

Pass `model.baseUrl` as the `endpoint` config when set:

```typescript
const config: BedrockRuntimeClientConfig = {
  profile: options.profile,
};

if (model.baseUrl) {
  config.endpoint = model.baseUrl;
}
```

When `baseUrl` is not set (the default), the SDK falls back to the standard regional endpoint constructed from the `region` config, preserving existing behavior.

## Changes

| File | Change |
|------|--------|
| `packages/ai/src/providers/amazon-bedrock.ts` | +6 lines — pass `model.baseUrl` as `endpoint` |

## Testing

- Default path (no custom baseUrl): no behavior change, SDK uses regional endpoint
- Custom baseUrl: endpoint is now correctly passed to the client

Fixes openclaw/openclaw#47899