### PR TITLE
feat(ai): allow overriding oauth callback bind host

### DIFF
--- a/packages/ai/src/utils/oauth/anthropic.ts
+++ b/packages/ai/src/utils/oauth/anthropic.ts
@@ -28,7 +28,7 @@ const decode = (s: string) => atob(s);
 const CLIENT_ID = decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl");
 const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
 const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
-const CALLBACK_HOST = "127.0.0.1";
+const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 const CALLBACK_PORT = 53692;
 const CALLBACK_PATH = "/callback";
 const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;

--- a/packages/ai/src/utils/oauth/google-antigravity.ts
+++ b/packages/ai/src/utils/oauth/google-antigravity.ts
@@ -15,6 +15,8 @@ type AntigravityCredentials = OAuthCredentials & {
 	projectId: string;
 };
 
+const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
+
 let _createServer: typeof import("node:http").createServer | null = null;
 let _httpImportPromise: Promise<void> | null = null;
 if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
@@ -110,7 +112,7 @@ async function startCallbackServer(): Promise<CallbackServerInfo> {
 			reject(err);
 		});
 
-		server.listen(51121, "127.0.0.1", () => {
+		server.listen(51121, CALLBACK_HOST, () => {
 			resolve({
 				server,
 				cancelWait: () => {

--- a/packages/ai/src/utils/oauth/google-gemini-cli.ts
+++ b/packages/ai/src/utils/oauth/google-gemini-cli.ts
@@ -15,6 +15,8 @@ type GeminiCredentials = OAuthCredentials & {
 	projectId: string;
 };
 
+const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
+
 let _createServer: typeof import("node:http").createServer | null = null;
 let _httpImportPromise: Promise<void> | null = null;
 if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
@@ -102,7 +104,7 @@ async function startCallbackServer(): Promise<CallbackServerInfo> {
 			reject(err);
 		});
 
-		server.listen(8085, "127.0.0.1", () => {
+		server.listen(8085, CALLBACK_HOST, () => {
 			resolve({
 				server,
 				cancelWait: () => {

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -21,6 +21,7 @@ import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
 import { generatePKCE } from "./pkce.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from "./types.js";
 
+const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
@@ -248,7 +249,7 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 
 	return new Promise((resolve) => {
 		server
-			.listen(1455, "127.0.0.1", () => {
+			.listen(1455, CALLBACK_HOST, () => {
 				resolve({
 					close: () => server.close(),
 					cancelWait: () => {
@@ -259,7 +260,7 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 			})
 			.on("error", (err: NodeJS.ErrnoException) => {
 				console.error(
-					"[openai-codex] Failed to bind http://127.0.0.1:1455 (",
+					`[openai-codex] Failed to bind http://${CALLBACK_HOST}:1455 (`,
 					err.code,
 					") Falling back to manual paste.",
 				);


### PR DESCRIPTION
Closes #3396.

Adds a `CALLBACK_HOST` constant to each of the four OAuth providers in `packages/ai/src/utils/oauth/`, read from `PI_OAUTH_CALLBACK_HOST` with `127.0.0.1` as the default. The hardcoded `"127.0.0.1"` in each `server.listen(...)` now uses the constant. Default behavior unchanged.
