### PR TITLE
fix(providers): sanitize tool schemas for Claude models via Google Code Assist proxy

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -7,6 +7,52 @@ import type { Context, ImageContent, Model, StopReason, TextContent, Tool } from
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { transformMessages } from "./transform-messages.js";
 
+function cleanJsonSchemaForAnthropic(obj: any): any {
+    if (!obj || typeof obj !== "object") return obj;
+    if (Array.isArray(obj)) return obj.map(cleanJsonSchemaForAnthropic);
+
+    let result: any = {};
+    for (const [k, v] of Object.entries(obj)) {
+        if (k === "$schema") continue;
+        if (k === "const") {
+            result["enum"] = [v];
+        } else {
+            result[k] = cleanJsonSchemaForAnthropic(v);
+        }
+    }
+
+    if (result.anyOf && Array.isArray(result.anyOf)) {
+        if (result.anyOf.length === 0) {
+            delete result.anyOf;
+        } else {
+            const isAllEnum = result.anyOf.every((item: any) => item && item.enum && Array.isArray(item.enum));
+            if (isAllEnum) {
+                const combinedEnum: any[] = [];
+                for (const item of result.anyOf) {
+                    combinedEnum.push(...item.enum);
+                }
+                if (!result.type && result.anyOf[0] && result.anyOf[0].type) {
+                    result.type = result.anyOf[0].type;
+                } else if (!result.type) {
+                    result.type = typeof combinedEnum[0] === "string" ? "string" : "number";
+                }
+                delete result.anyOf;
+                result.enum = combinedEnum;
+            } else {
+                delete result.anyOf;
+                result.description = (result.description ? result.description + " " : "") + "(Note: Any valid JSON type is accepted here due to schema constraints)";
+                delete result.type;
+            }
+        }
+    }
+
+    if (result.oneOf) delete result.oneOf;
+    if (result.allOf) delete result.allOf;
+
+    return result;
+}
+
+
 type GoogleApiType = "google-generative-ai" | "google-gemini-cli" | "google-vertex";
 
 /**
@@ -251,6 +297,9 @@ export function convertTools(
 	tools: Tool[],
 	useParameters = false,
 ): { functionDeclarations: Record<string, unknown>[] }[] | undefined {
+	if (useParameters) {
+		tools = tools.map(t => ({...t, parameters: cleanJsonSchemaForAnthropic(t.parameters)}));
+	}
 	if (tools.length === 0) return undefined;
 	return [
 		{


### PR DESCRIPTION
**Issue**
When invoking Claude models through the Antigravity provider (Google Cloud Code Assist proxy), the API rejects requests containing certain JSON Schema properties within tool definitions. This leads to `400 Bad Request` errors during tool execution. The failures stem from two distinct parsing limitations across the request pipeline:

1. The Google Cloud Code Assist proxy fails to parse `const` keywords nested inside `anyOf` arrays (e.g., generated by TypeBox unions), throwing `Unknown name "const"`.
2. The downstream Anthropic API strictly enforces JSON Schema Draft 2020-12 for its `input_schema`. It explicitly rejects legacy `$schema` declarations (such as `draft-07` injected by MCP servers) and entirely forbids `anyOf`, `oneOf`, and `allOf` constraints.

This severely limits compatibility with standard MCP tools (like the GitHub server) and internal tools relying on TypeBox-generated schemas.

**Solution**
This PR introduces a schema sanitizer (`cleanJsonSchemaForAnthropic`) in `google-shared.js` that recursively transforms tool parameters into an Anthropic-compliant format. 

The sanitization logic ensures structural compatibility by:
- Stripping explicit `$schema` directives to prevent versioning conflicts.
- Converting `{ "const": "value" }` to the semantically equivalent `{ "enum": ["value"] }`, bypassing the proxy's parsing limitations.
- Flattening `anyOf` arrays that contain only `enum` objects into a single, unified `enum` array.
- Dropping `anyOf` constraints for mixed-type unions, falling back to an untyped field while appending a functional note to the parameter's `description` to guide the model.
- Removing unsupported `oneOf` and `allOf` keys.

**Impact & Safety**
The sanitization is strictly guarded behind the `useParameters` flag. It only executes when mapping tools for Claude models. Gemini models (`useParameters = false`) bypass this logic entirely and continue to receive the fully intact `parametersJsonSchema` payload, ensuring no degradation in schema strictness for natively supported models.

**Testing**
- Verified against GitHub MCP server tools (which inject `draft-07`).
- Verified against internal `pi-lens` and `interactive_shell` tools (which heavily utilize TypeBox unions/enums).
- Confirmed Gemini models continue to process the unaltered original schemas.
