### PR TITLE
fix(ai): replace stale OpenRouter Llama 4 Maverick test model with Llama 4 Scout

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenRouter Meta tests by switching `meta-llama/llama-4-maverick` to `meta-llama/llama-4-scout` to avoid type-check failures from model-catalog drift.
+
 ## [0.67.68] - 2026-04-17
 
 ### Fixed

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -527,8 +527,8 @@ describe("Context overflow error handling", () => {
 		}, 120000);
 
 		// Meta/Llama backend
-		it("meta-llama/llama-4-maverick via OpenRouter - should detect overflow via isContextOverflow", async () => {
-			const model = getModel("openrouter", "meta-llama/llama-4-maverick");
+		it("meta-llama/llama-4-scout via OpenRouter - should detect overflow via isContextOverflow", async () => {
+			const model = getModel("openrouter", "meta-llama/llama-4-scout");
 			const result = await testContextOverflow(model, process.env.OPENROUTER_API_KEY!);
 			logResult(result);
 

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -514,10 +514,10 @@ describe("totalTokens field", () => {
 		);
 
 		it(
-			"meta-llama/llama-4-maverick - should return totalTokens equal to sum of components",
+			"meta-llama/llama-4-scout - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("openrouter", "meta-llama/llama-4-maverick");
+				const llm = getModel("openrouter", "meta-llama/llama-4-scout");
 
 				console.log(`\nOpenRouter / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.OPENROUTER_API_KEY });


### PR DESCRIPTION
- Switch OpenRouter Meta test model from `meta-llama/llama-4-maverick` to `meta-llama/llama-4-scout` in `packages/ai` tests.
- Testing: Check CI
- The goal was to address this failure on CI

| CI |
| ------------- |
| <img width="800" height="auto" alt="CleanShot 2026-04-19 at 14 38 00@2x" src="https://github.com/user-attachments/assets/b6b70b0a-dbbc-4475-86c7-85eeac23cf54" /> |

**Q:** is this the "correct way" how those "drifts" are generally approached here? I've seen [this commit](https://github.com/badlogic/pi-mono/commit/18c7ab8a475bb1cf9a9233a3cdd87c7b369523e4#diff-9300104eb2972544fa9f1810f19f4c40ecc6c39afbff7d62c8d13a01a3bed67d), so that's why my first thought was to just pick a different model. 