### PR TITLE
fix(coding-agent): add OpenRouter attrib headers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenRouter request attribution to include Pi app headers (`HTTP-Referer: https://pi.dev`, `X-OpenRouter-Title: pi`, `X-OpenRouter-Categories: cli-agent`) so Pi usage can be attributed in OpenRouter rankings ([#3414](https://github.com/badlogic/pi-mono/issues/3414))
+
 ## [0.67.68] - 2026-04-17
 
 ## [0.67.67] - 2026-04-17

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -9,6 +9,7 @@ import { DefaultResourceLoader, type DefaultResourceLoaderOptions, type Resource
 import { type CreateAgentSessionResult, createAgentSession } from "./sdk.js";
 import type { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
+import { isInstallTelemetryEnabled } from "./telemetry.js";
 import type { Tool } from "./tools/index.js";
 
 /**
@@ -133,7 +134,11 @@ export async function createAgentSessionServices(
 	const agentDir = options.agentDir ?? getAgentDir();
 	const authStorage = options.authStorage ?? AuthStorage.create(join(agentDir, "auth.json"));
 	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
-	const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, join(agentDir, "models.json"));
+	const modelRegistry =
+		options.modelRegistry ??
+		ModelRegistry.create(authStorage, join(agentDir, "models.json"), {
+			isTelemetryEnabled: () => isInstallTelemetryEnabled(settingsManager),
+		});
 	const resourceLoader = new DefaultResourceLoader({
 		...(options.resourceLoaderOptions ?? {}),
 		cwd,

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -283,6 +283,10 @@ function applyModelOverride(model: Model<Api>, override: ModelOverride): Model<A
 /** Clear the config value command cache. Exported for testing. */
 export const clearApiKeyCache = clearConfigValueCache;
 
+export interface ModelRegistryOptions {
+	isTelemetryEnabled?: () => boolean;
+}
+
 /**
  * Model registry - loads and manages models, resolves API keys via AuthStorage.
  */
@@ -292,20 +296,27 @@ export class ModelRegistry {
 	private modelRequestHeaders: Map<string, Record<string, string>> = new Map();
 	private registeredProviders: Map<string, ProviderConfigInput> = new Map();
 	private loadError: string | undefined = undefined;
+	private readonly telemetryEnabledResolver: () => boolean;
 
 	private constructor(
 		readonly authStorage: AuthStorage,
 		private modelsJsonPath: string | undefined,
+		options: ModelRegistryOptions = {},
 	) {
+		this.telemetryEnabledResolver = options.isTelemetryEnabled ?? (() => true);
 		this.loadModels();
 	}
 
-	static create(authStorage: AuthStorage, modelsJsonPath: string = join(getAgentDir(), "models.json")): ModelRegistry {
-		return new ModelRegistry(authStorage, modelsJsonPath);
+	static create(
+		authStorage: AuthStorage,
+		modelsJsonPath: string = join(getAgentDir(), "models.json"),
+		options: ModelRegistryOptions = {},
+	): ModelRegistry {
+		return new ModelRegistry(authStorage, modelsJsonPath, options);
 	}
 
-	static inMemory(authStorage: AuthStorage): ModelRegistry {
-		return new ModelRegistry(authStorage, undefined);
+	static inMemory(authStorage: AuthStorage, options: ModelRegistryOptions = {}): ModelRegistry {
+		return new ModelRegistry(authStorage, undefined, options);
 	}
 
 	/**
@@ -648,9 +659,22 @@ export class ModelRegistry {
 				`model "${model.provider}/${model.id}"`,
 			);
 
+			const openRouterAttributionHeaders: Record<string, string> | undefined =
+				this.telemetryEnabledResolver() &&
+				// Users can configure custom provider names in models.json
+				// while still routing requests through OpenRouter endpoints,
+				// so need to check both.
+				(model.provider === "openrouter" || model.baseUrl.includes("openrouter.ai"))
+					? {
+							"HTTP-Referer": "https://pi.dev",
+							"X-OpenRouter-Title": "pi",
+							"X-OpenRouter-Categories": "cli-agent",
+						}
+					: undefined;
+
 			let headers =
-				model.headers || providerHeaders || modelHeaders
-					? { ...model.headers, ...providerHeaders, ...modelHeaders }
+				openRouterAttributionHeaders || model.headers || providerHeaders || modelHeaders
+					? { ...openRouterAttributionHeaders, ...model.headers, ...providerHeaders, ...modelHeaders }
 					: undefined;
 
 			if (providerConfig?.authHeader) {

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -13,6 +13,7 @@ import type { ResourceLoader } from "./resource-loader.js";
 import { DefaultResourceLoader } from "./resource-loader.js";
 import { getDefaultSessionDir, SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
+import { isInstallTelemetryEnabled } from "./telemetry.js";
 import { time } from "./timings.js";
 import {
 	allTools,
@@ -175,9 +176,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const authPath = options.agentDir ? join(agentDir, "auth.json") : undefined;
 	const modelsPath = options.agentDir ? join(agentDir, "models.json") : undefined;
 	const authStorage = options.authStorage ?? AuthStorage.create(authPath);
-	const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, modelsPath);
-
 	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
+	const modelRegistry =
+		options.modelRegistry ??
+		ModelRegistry.create(authStorage, modelsPath, {
+			isTelemetryEnabled: () => isInstallTelemetryEnabled(settingsManager),
+		});
 	const sessionManager = options.sessionManager ?? SessionManager.create(cwd, getDefaultSessionDir(cwd, agentDir));
 
 	if (!resourceLoader) {

--- a/packages/coding-agent/src/core/telemetry.ts
+++ b/packages/coding-agent/src/core/telemetry.ts
@@ -1,0 +1,13 @@
+import type { SettingsManager } from "./settings-manager.js";
+
+function isTruthyEnvFlag(value: string | undefined): boolean {
+	if (!value) return false;
+	return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
+}
+
+export function isInstallTelemetryEnabled(
+	settingsManager: SettingsManager,
+	telemetryEnv: string | undefined = process.env.PI_TELEMETRY,
+): boolean {
+	return telemetryEnv !== undefined ? isTruthyEnvFlag(telemetryEnv) : settingsManager.getEnableInstallTelemetry();
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -65,6 +65,7 @@ import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../cor
 import { type SessionContext, SessionManager } from "../../core/session-manager.js";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
 import type { SourceInfo } from "../../core/source-info.js";
+import { isInstallTelemetryEnabled } from "../../core/telemetry.js";
 import type { TruncationResult } from "../../core/tools/truncate.js";
 import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/changelog.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
@@ -152,11 +153,6 @@ const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
 
 function isAnthropicSubscriptionAuthKey(apiKey: string | undefined): boolean {
 	return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
-}
-
-function isTruthyEnvFlag(value: string | undefined): boolean {
-	if (!value) return false;
-	return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
 }
 
 function isUnknownModel(model: Model<any> | undefined): boolean {
@@ -844,10 +840,7 @@ export class InteractiveMode {
 			return;
 		}
 
-		const telemetryEnv = process.env.PI_TELEMETRY;
-		const telemetryEnabled =
-			telemetryEnv !== undefined ? isTruthyEnvFlag(telemetryEnv) : this.settingsManager.getEnableInstallTelemetry();
-		if (!telemetryEnabled) {
+		if (!isInstallTelemetryEnabled(this.settingsManager)) {
 			return;
 		}
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -758,6 +758,80 @@ describe("ModelRegistry", () => {
 		});
 	});
 
+	describe("OpenRouter attribution headers", () => {
+		test("adds default attribution headers for OpenRouter models", async () => {
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const openRouterModel = registry.getAll().find((m) => m.provider === "openrouter");
+			expect(openRouterModel).toBeDefined();
+
+			const auth = await registry.getApiKeyAndHeaders(openRouterModel!);
+			expect(auth.ok).toBe(true);
+			if (auth.ok) {
+				expect(auth.headers?.["HTTP-Referer"]).toBe("https://pi.dev");
+				expect(auth.headers?.["X-OpenRouter-Title"]).toBe("pi");
+				expect(auth.headers?.["X-OpenRouter-Categories"]).toBe("cli-agent");
+			}
+		});
+
+		test("does not add attribution headers for non-OpenRouter models", async () => {
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const openAi = registry.getAll().find((m) => m.provider === "openai");
+			expect(openAi).toBeDefined();
+
+			const auth = await registry.getApiKeyAndHeaders(openAi!);
+			expect(auth.ok).toBe(true);
+			if (auth.ok) {
+				expect(auth.headers?.["HTTP-Referer"]).toBeUndefined();
+				expect(auth.headers?.["X-OpenRouter-Title"]).toBeUndefined();
+				expect(auth.headers?.["X-OpenRouter-Categories"]).toBeUndefined();
+			}
+		});
+
+		test("does not add default attribution headers when telemetry is disabled", async () => {
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath, {
+				isTelemetryEnabled: () => false,
+			});
+			const openRouterModel = registry.getAll().find((m) => m.provider === "openrouter");
+			expect(openRouterModel).toBeDefined();
+
+			const auth = await registry.getApiKeyAndHeaders(openRouterModel!);
+			expect(auth.ok).toBe(true);
+			if (auth.ok) {
+				expect(auth.headers?.["HTTP-Referer"]).toBeUndefined();
+				expect(auth.headers?.["X-OpenRouter-Title"]).toBeUndefined();
+				expect(auth.headers?.["X-OpenRouter-Categories"]).toBeUndefined();
+			}
+		});
+
+		test("allows models.json headers to override default attribution headers", async () => {
+			writeRawModelsJson({
+				openrouter: {
+					modelOverrides: {
+						"anthropic/claude-sonnet-4": {
+							headers: {
+								"HTTP-Referer": "https://override.example",
+								"X-OpenRouter-Title": "override-title",
+								"X-OpenRouter-Categories": "custom-category",
+							},
+						},
+					},
+				},
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const model = registry.find("openrouter", "anthropic/claude-sonnet-4");
+			expect(model).toBeDefined();
+
+			const auth = await registry.getApiKeyAndHeaders(model!);
+			expect(auth.ok).toBe(true);
+			if (auth.ok) {
+				expect(auth.headers?.["HTTP-Referer"]).toBe("https://override.example");
+				expect(auth.headers?.["X-OpenRouter-Title"]).toBe("override-title");
+				expect(auth.headers?.["X-OpenRouter-Categories"]).toBe("custom-category");
+			}
+		});
+	});
+
 	describe("dynamic provider lifecycle", () => {
 		test("failed registerProvider does not persist invalid streamSimple config", () => {
 			const registry = ModelRegistry.create(authStorage, modelsJsonPath);


### PR DESCRIPTION
closes #3414

We set OpenRouter attribution headers for Pi as per OpenRouter docs (https://openrouter.ai/docs/app-attribution). To respect user privacy, we only do this if telemetry is enabled. To make that work we add a `ModelRegistryOptions` which we use to thread through reading of the telemetry config. Please let me know if this change is undesirable.