### PR TITLE
Forward per-session cwd through SimpleStreamOptions

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -108,6 +108,12 @@ export interface AgentOptions {
 	transport?: Transport;
 	maxRetryDelayMs?: number;
 	toolExecution?: ToolExecutionMode;
+	/**
+	 * Optional working directory, forwarded to the stream function on every
+	 * request via {@link AgentLoopConfig}. Providers that do not spawn
+	 * subprocesses ignore this; see {@link SimpleStreamOptions.cwd}.
+	 */
+	cwd?: string;
 }
 
 class PendingMessageQueue {
@@ -186,6 +192,8 @@ export class Agent {
 	public maxRetryDelayMs?: number;
 	/** Tool execution strategy for assistant messages that contain multiple tool calls. */
 	public toolExecution: ToolExecutionMode;
+	/** Optional working directory forwarded to the stream function. */
+	public cwd?: string;
 
 	constructor(options: AgentOptions = {}) {
 		this._state = createMutableAgentState(options.initialState);
@@ -204,6 +212,7 @@ export class Agent {
 		this.transport = options.transport ?? "sse";
 		this.maxRetryDelayMs = options.maxRetryDelayMs;
 		this.toolExecution = options.toolExecution ?? "parallel";
+		this.cwd = options.cwd;
 	}
 
 	/**
@@ -413,6 +422,7 @@ export class Agent {
 			model: this._state.model,
 			reasoning: this._state.thinkingLevel === "off" ? undefined : this._state.thinkingLevel,
 			sessionId: this.sessionId,
+			cwd: this.cwd,
 			onPayload: this.onPayload,
 			onResponse: this.onResponse,
 			transport: this.transport,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -122,6 +122,20 @@ export interface SimpleStreamOptions extends StreamOptions {
 	reasoning?: ThinkingLevel;
 	/** Custom token budgets for thinking levels (token-based providers only) */
 	thinkingBudgets?: ThinkingBudgets;
+	/**
+	 * Optional working directory.
+	 *
+	 * Most providers ignore this — built-in HTTP providers do not spawn
+	 * subprocesses. Custom providers (e.g. adapters that delegate to an
+	 * external SDK or CLI which executes tools on the host filesystem) should
+	 * use this as the cwd for that subprocess when provided.
+	 *
+	 * This exists so multi-session hosts (e.g. a server that runs many agent
+	 * sessions in one OS process) can pass each session's cwd through to the
+	 * provider without relying on `process.cwd()`, which is a single global
+	 * value and races across concurrent sessions.
+	 */
+	cwd?: string;
 }
 
 // Generic StreamFunction with typed options.

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -326,6 +326,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			});
 		},
 		sessionId: sessionManager.getSessionId(),
+		cwd: sessionManager.getCwd(),
 		transformContext: async (messages) => {
 			const runner = extensionRunnerRef.current;
 			if (!runner) return messages;


### PR DESCRIPTION
Adds an optional `cwd` field to `SimpleStreamOptions` so custom providers that spawn subprocesses (or delegate to an external SDK/CLI that executes tools on the host filesystem) can use the caller-supplied working directory instead of falling back to `process.cwd()`.

Threads it through the agent loop (`AgentOptions` -> `Agent` -> `AgentLoopConfig`) and populates it in the coding-agent SDK from `sessionManager.getCwd()`, so each session's provider invocation carries its own cwd.

Built-in HTTP providers are unchanged — they don't spawn subprocesses and ignore the new field. The motivation is multi-session hosts (a single Node process running many agent sessions concurrently) where `process.cwd()` is a global racing across sessions.