### PR TITLE
add pre-wrap to tool outputs in web share page

### DIFF
--- a/packages/coding-agent/src/core/export-html/template.css
+++ b/packages/coding-agent/src/core/export-html/template.css
@@ -510,6 +510,7 @@
       margin: 0;
       padding: 0;
       line-height: var(--line-height);
+      white-space: pre-wrap;
     }
 
     .tool-output pre {


### PR DESCRIPTION
The .output-preview and .output-full elements in the exported/shared session HTML were missing white-space: pre-wrap, causing tool output to collapse whitespace instead of preserving formatting.

| Before | After |
| --- | --- |
| <img width="776" height="558" alt="Screenshot 2026-04-19 at 9 44 55 PM" src="https://github.com/user-attachments/assets/2129fb62-5441-4e61-b62c-23920fdc1ee7" /> | <img width="952" height="590" alt="Screenshot 2026-04-19 at 9 45 02 PM" src="https://github.com/user-attachments/assets/a7b624c6-6b3b-413d-96cd-21c2196766e5" /> |




