### PR TITLE
fix(bedrock): guard against empty content blocks after sanitization

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -597,11 +597,11 @@ function convertMessages(
 					role: ConversationRole.USER,
 					content:
 						typeof m.content === "string"
-							? [{ text: sanitizeSurrogates(m.content) }]
+							? [{ text: sanitizeSurrogates(m.content) || " " }]
 							: m.content.map((c) => {
 									switch (c.type) {
 										case "text":
-											return { text: sanitizeSurrogates(c.text) };
+											const sanitized = sanitizeSurrogates(c.text); if (!sanitized || sanitized.trim().length === 0) return { text: " " }; return { text: sanitized };
 										case "image":
 											return { image: createImageBlock(c.mimeType, c.data) };
 										default:
@@ -685,7 +685,7 @@ function convertMessages(
 						content: m.content.map((c) =>
 							c.type === "image"
 								? { image: createImageBlock(c.mimeType, c.data) }
-								: { text: sanitizeSurrogates(c.text) },
+								: { text: sanitizeSurrogates(c.text) || " " },
 						),
 						status: m.isError ? ToolResultStatus.ERROR : ToolResultStatus.SUCCESS,
 					},
@@ -701,7 +701,7 @@ function convertMessages(
 							content: nextMsg.content.map((c) =>
 								c.type === "image"
 									? { image: createImageBlock(c.mimeType, c.data) }
-									: { text: sanitizeSurrogates(c.text) },
+									: { text: sanitizeSurrogates(c.text) || " " },
 							),
 							status: nextMsg.isError ? ToolResultStatus.ERROR : ToolResultStatus.SUCCESS,
 						},


### PR DESCRIPTION
## Problem

AWS Bedrock's Converse API strictly validates that all message content blocks are non-empty. When `sanitizeSurrogates()` produces an empty string (e.g., from Unicode-only content, aborted failover responses, or compacted conversation history), the Bedrock API returns:

```
Validation error: The content field in the Message object at messages.X is empty.
Add a ContentBlock object to the content field and try again.
```

This error is intermittent and depends on conversation history content. Other providers (Anthropic direct, OpenAI) are more tolerant of empty content.

## Root Cause

The `convertMessages()` function in `amazon-bedrock.ts` has three locations where empty text can slip through to the Bedrock API:

1. **User messages** (string content path): `sanitizeSurrogates(m.content)` can produce an empty string
2. **User messages** (content array path): text blocks with empty `c.text` after sanitization pass through
3. **Tool results**: `sanitizeSurrogates(c.text)` can produce empty text with no fallback

Note: Assistant messages already have proper filtering (`if (c.text.trim().length === 0) continue` and `if (contentBlocks.length === 0) continue`).

## Fix

- **User messages (string)**: Fallback to single space `" "` if sanitized content is empty
- **User messages (text blocks)**: Return space placeholder for empty text after sanitization
- **Tool results**: Fallback to space for empty text content (cannot be skipped as they must match tool_use IDs)

## Testing

- Verified with `amazon-bedrock/global.anthropic.claude-opus-4-7`
- Verified with `amazon-bedrock/global.anthropic.claude-opus-4-6-v1`
- Reproduces reliably with conversations containing compacted/aborted history

Fixes: openclaw/openclaw#30117