### PR TITLE
feat(ai): add optimizeImage hook to StreamOptions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `optimizeImage` callback to `StreamOptions`, allowing callers to compress, resize, or re-encode `ImageContent` blocks before they are sent to the provider. Applied automatically to all images in user and toolResult messages. No-op when not provided.
+
 ## [0.67.68] - 2026-04-17
 
 ### Fixed

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -11,6 +11,8 @@ import type {
 	SimpleStreamOptions,
 	StreamOptions,
 } from "./types.js";
+import { AssistantMessageEventStream as AssistantMessageEventStreamClass } from "./utils/event-stream.js";
+import { optimizeContextImages } from "./utils/optimize-context-images.js";
 
 export { getEnvApiKey } from "./env-api-keys.js";
 
@@ -28,7 +30,12 @@ export function stream<TApi extends Api>(
 	options?: ProviderStreamOptions,
 ): AssistantMessageEventStream {
 	const provider = resolveApiProvider(model.api);
-	return provider.stream(model, context, options as StreamOptions);
+	if (!options?.optimizeImage) {
+		return provider.stream(model, context, options as StreamOptions);
+	}
+	return wrapWithImageOptimization(context, options as StreamOptions, (ctx) =>
+		provider.stream(model, ctx, options as StreamOptions),
+	);
 }
 
 export async function complete<TApi extends Api>(
@@ -46,7 +53,10 @@ export function streamSimple<TApi extends Api>(
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
 	const provider = resolveApiProvider(model.api);
-	return provider.streamSimple(model, context, options);
+	if (!options?.optimizeImage) {
+		return provider.streamSimple(model, context, options);
+	}
+	return wrapWithImageOptimization(context, options, (ctx) => provider.streamSimple(model, ctx, options));
 }
 
 export async function completeSimple<TApi extends Api>(
@@ -56,4 +66,55 @@ export async function completeSimple<TApi extends Api>(
 ): Promise<AssistantMessage> {
 	const s = streamSimple(model, context, options);
 	return s.result();
+}
+
+/**
+ * Wrap a provider stream call with image optimization.
+ * Optimizes images in the context before delegating to the provider,
+ * then forwards all events from the inner stream to the outer stream.
+ */
+function wrapWithImageOptimization(
+	context: Context,
+	options: StreamOptions,
+	createInnerStream: (optimizedContext: Context) => AssistantMessageEventStream,
+): AssistantMessageEventStream {
+	const outer = new AssistantMessageEventStreamClass();
+
+	queueMicrotask(async () => {
+		try {
+			const optimizedContext = await optimizeContextImages(context, options);
+			const inner = createInnerStream(optimizedContext);
+			for await (const event of inner) {
+				outer.push(event);
+			}
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			const errorMsg: AssistantMessage = {
+				role: "assistant",
+				content: [],
+				api: "" as Api,
+				provider: "",
+				model: "",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "error",
+				errorMessage: `Image optimization failed: ${errorMessage}`,
+				timestamp: Date.now(),
+			};
+			outer.push({
+				type: "error",
+				reason: "error",
+				error: errorMsg,
+			});
+			outer.end(errorMsg);
+		}
+	});
+
+	return outer;
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -113,6 +113,17 @@ export interface StreamOptions {
 	 * For example, Anthropic uses `user_id` for abuse tracking and rate limiting.
 	 */
 	metadata?: Record<string, unknown>;
+	/**
+	 * Optional image optimizer called before sending images to the provider.
+	 * Receives an ImageContent block and returns an optimized version (e.g.,
+	 * PNG-to-JPEG conversion, re-encoding at lower quality, resizing).
+	 * Applied to all ImageContent blocks in context messages before the
+	 * provider sees them. If not provided, images are sent as-is.
+	 *
+	 * The optimizer runs once per ImageContent block per stream/complete call.
+	 * Returning the input unchanged is safe and skips replacement.
+	 */
+	optimizeImage?: (image: ImageContent) => ImageContent | Promise<ImageContent>;
 }
 
 export type ProviderStreamOptions = StreamOptions & Record<string, unknown>;

--- a/packages/ai/src/utils/optimize-context-images.ts
+++ b/packages/ai/src/utils/optimize-context-images.ts
@@ -1,0 +1,67 @@
+import type { Context, ImageContent, Message, StreamOptions } from "../types.js";
+
+/**
+ * Apply the `optimizeImage` callback from StreamOptions to all ImageContent
+ * blocks in the context messages. Returns a new Context with optimized images
+ * if any were transformed, or the original context if nothing changed.
+ */
+export async function optimizeContextImages(context: Context, options?: StreamOptions): Promise<Context> {
+	const optimizer = options?.optimizeImage;
+	if (!optimizer) return context;
+
+	let changed = false;
+	const optimizedMessages: Message[] = [];
+
+	for (const msg of context.messages) {
+		if (msg.role === "user") {
+			if (typeof msg.content === "string") {
+				optimizedMessages.push(msg);
+				continue;
+			}
+			const optimizedContent = await optimizeContentArray(msg.content, optimizer);
+			if (optimizedContent !== msg.content) {
+				optimizedMessages.push({ ...msg, content: optimizedContent });
+				changed = true;
+			} else {
+				optimizedMessages.push(msg);
+			}
+		} else if (msg.role === "toolResult") {
+			const optimizedContent = await optimizeContentArray(msg.content, optimizer);
+			if (optimizedContent !== msg.content) {
+				optimizedMessages.push({ ...msg, content: optimizedContent });
+				changed = true;
+			} else {
+				optimizedMessages.push(msg);
+			}
+		} else {
+			optimizedMessages.push(msg);
+		}
+	}
+
+	if (!changed) return context;
+	return { ...context, messages: optimizedMessages };
+}
+
+type ContentItem = { type: "text"; text: string } | ImageContent;
+
+async function optimizeContentArray(
+	content: ContentItem[],
+	optimizer: (image: ImageContent) => ImageContent | Promise<ImageContent>,
+): Promise<ContentItem[]> {
+	let changed = false;
+	const result: ContentItem[] = [];
+
+	for (const item of content) {
+		if (item.type === "image") {
+			const optimized = await optimizer(item);
+			if (optimized !== item) {
+				changed = true;
+			}
+			result.push(optimized);
+		} else {
+			result.push(item);
+		}
+	}
+
+	return changed ? result : content;
+}

--- a/packages/ai/test/optimize-image.test.ts
+++ b/packages/ai/test/optimize-image.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { complete, fauxAssistantMessage, registerFauxProvider, stream } from "../src/index.js";
+import type { AssistantMessageEvent, Context, ImageContent } from "../src/types.js";
+
+async function collectEvents(streamResult: ReturnType<typeof stream>): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of streamResult) {
+		events.push(event);
+	}
+	return events;
+}
+
+const registrations: Array<{ unregister: () => void }> = [];
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) {
+		registration.unregister();
+	}
+});
+
+describe("optimizeImage", () => {
+	it("transforms images in user messages before sending to provider", async () => {
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+
+		const seenContexts: Context[] = [];
+		registration.setResponses([
+			(context) => {
+				seenContexts.push(context);
+				return fauxAssistantMessage("ok");
+			},
+		]);
+
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "look at this" },
+						{ type: "image", data: "AAAA", mimeType: "image/png" },
+					],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		await complete(registration.getModel(), context, {
+			optimizeImage: (_img) => ({
+				type: "image",
+				data: "BBBB",
+				mimeType: "image/jpeg",
+			}),
+		});
+
+		expect(seenContexts).toHaveLength(1);
+		const userMsg = seenContexts[0].messages[0];
+		expect(userMsg.role).toBe("user");
+		if (userMsg.role === "user" && Array.isArray(userMsg.content)) {
+			const imageBlock = userMsg.content.find((c): c is ImageContent => c.type === "image");
+			expect(imageBlock).toBeDefined();
+			expect(imageBlock!.data).toBe("BBBB");
+			expect(imageBlock!.mimeType).toBe("image/jpeg");
+		}
+	});
+
+	it("transforms images in toolResult messages", async () => {
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+
+		const seenContexts: Context[] = [];
+		registration.setResponses([
+			(context) => {
+				seenContexts.push(context);
+				return fauxAssistantMessage("ok");
+			},
+		]);
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "run tool", timestamp: Date.now() },
+				{
+					...fauxAssistantMessage("calling tool"),
+					content: [{ type: "toolCall", id: "tc-1", name: "screenshot", arguments: {} }],
+					stopReason: "toolUse",
+				},
+				{
+					role: "toolResult",
+					toolCallId: "tc-1",
+					toolName: "screenshot",
+					content: [
+						{ type: "text", text: "screenshot taken" },
+						{ type: "image", data: "ORIGINAL", mimeType: "image/png" },
+					],
+					isError: false,
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		await complete(registration.getModel(), context, {
+			optimizeImage: (_img) => ({
+				type: "image",
+				data: "COMPRESSED",
+				mimeType: "image/jpeg",
+			}),
+		});
+
+		expect(seenContexts).toHaveLength(1);
+		const toolResult = seenContexts[0].messages[2];
+		expect(toolResult.role).toBe("toolResult");
+		if (toolResult.role === "toolResult") {
+			const imageBlock = toolResult.content.find((c): c is ImageContent => c.type === "image");
+			expect(imageBlock).toBeDefined();
+			expect(imageBlock!.data).toBe("COMPRESSED");
+			expect(imageBlock!.mimeType).toBe("image/jpeg");
+		}
+	});
+
+	it("does not modify context when no optimizeImage is provided", async () => {
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+
+		const seenContexts: Context[] = [];
+		registration.setResponses([
+			(context) => {
+				seenContexts.push(context);
+				return fauxAssistantMessage("ok");
+			},
+		]);
+
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "look" },
+						{ type: "image", data: "ORIGINAL", mimeType: "image/png" },
+					],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		await complete(registration.getModel(), context);
+
+		expect(seenContexts).toHaveLength(1);
+		const userMsg = seenContexts[0].messages[0];
+		if (userMsg.role === "user" && Array.isArray(userMsg.content)) {
+			const imageBlock = userMsg.content.find((c): c is ImageContent => c.type === "image");
+			expect(imageBlock!.data).toBe("ORIGINAL");
+		}
+	});
+
+	it("does not modify the original context object", async () => {
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+		registration.setResponses([fauxAssistantMessage("ok")]);
+
+		const originalImage: ImageContent = { type: "image", data: "ORIGINAL", mimeType: "image/png" };
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "text", text: "look" }, originalImage],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		await complete(registration.getModel(), context, {
+			optimizeImage: () => ({ type: "image", data: "CHANGED", mimeType: "image/jpeg" }),
+		});
+
+		// Original context must be untouched
+		expect(originalImage.data).toBe("ORIGINAL");
+		expect(originalImage.mimeType).toBe("image/png");
+		const userMsg = context.messages[0];
+		if (userMsg.role === "user" && Array.isArray(userMsg.content)) {
+			expect(userMsg.content[1]).toBe(originalImage);
+		}
+	});
+
+	it("supports async optimizeImage callbacks", async () => {
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+
+		const seenContexts: Context[] = [];
+		registration.setResponses([
+			(context) => {
+				seenContexts.push(context);
+				return fauxAssistantMessage("ok");
+			},
+		]);
+
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "image", data: "SYNC", mimeType: "image/png" }],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		await complete(registration.getModel(), context, {
+			optimizeImage: async (_img) => {
+				await new Promise((r) => setTimeout(r, 10));
+				return { type: "image", data: "ASYNC", mimeType: "image/jpeg" };
+			},
+		});
+
+		const userMsg = seenContexts[0].messages[0];
+		if (userMsg.role === "user" && Array.isArray(userMsg.content)) {
+			expect((userMsg.content[0] as ImageContent).data).toBe("ASYNC");
+		}
+	});
+
+	it("skips optimization when no images are present", async () => {
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+
+		let optimizerCalled = false;
+		const seenContexts: Context[] = [];
+		registration.setResponses([
+			(context) => {
+				seenContexts.push(context);
+				return fauxAssistantMessage("ok");
+			},
+		]);
+
+		const context: Context = {
+			messages: [{ role: "user", content: "just text", timestamp: Date.now() }],
+		};
+
+		await complete(registration.getModel(), context, {
+			optimizeImage: (img) => {
+				optimizerCalled = true;
+				return img;
+			},
+		});
+
+		expect(optimizerCalled).toBe(false);
+		expect(seenContexts[0].messages[0]).toBe(context.messages[0]);
+	});
+
+	it("preserves text blocks alongside optimized images", async () => {
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+
+		const seenContexts: Context[] = [];
+		registration.setResponses([
+			(context) => {
+				seenContexts.push(context);
+				return fauxAssistantMessage("ok");
+			},
+		]);
+
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "first" },
+						{ type: "image", data: "IMG1", mimeType: "image/png" },
+						{ type: "text", text: "second" },
+						{ type: "image", data: "IMG2", mimeType: "image/png" },
+					],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		await complete(registration.getModel(), context, {
+			optimizeImage: (img) => ({ ...img, data: `${img.data}_OPT`, mimeType: "image/jpeg" }),
+		});
+
+		const userMsg = seenContexts[0].messages[0];
+		if (userMsg.role === "user" && Array.isArray(userMsg.content)) {
+			expect(userMsg.content).toEqual([
+				{ type: "text", text: "first" },
+				{ type: "image", data: "IMG1_OPT", mimeType: "image/jpeg" },
+				{ type: "text", text: "second" },
+				{ type: "image", data: "IMG2_OPT", mimeType: "image/jpeg" },
+			]);
+		}
+	});
+
+	it("emits error event when optimizeImage throws", async () => {
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+		registration.setResponses([fauxAssistantMessage("should not reach")]);
+
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "image", data: "BAD", mimeType: "image/png" }],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		const events = await collectEvents(
+			stream(registration.getModel(), context, {
+				optimizeImage: () => {
+					throw new Error("compression failed");
+				},
+			}),
+		);
+
+		expect(events).toHaveLength(1);
+		expect(events[0].type).toBe("error");
+		if (events[0].type === "error") {
+			expect(events[0].error.errorMessage).toContain("compression failed");
+		}
+	});
+
+	it("works with streamSimple via completeSimple path", async () => {
+		const { completeSimple } = await import("../src/stream.js");
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+
+		const seenContexts: Context[] = [];
+		registration.setResponses([
+			(context) => {
+				seenContexts.push(context);
+				return fauxAssistantMessage("ok");
+			},
+		]);
+
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "image", data: "RAW", mimeType: "image/png" }],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		await completeSimple(registration.getModel(), context, {
+			optimizeImage: (_img) => ({ type: "image", data: "OPTIMIZED", mimeType: "image/jpeg" }),
+		});
+
+		const userMsg = seenContexts[0].messages[0];
+		if (userMsg.role === "user" && Array.isArray(userMsg.content)) {
+			expect((userMsg.content[0] as ImageContent).data).toBe("OPTIMIZED");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Add an optional `optimizeImage` callback to `StreamOptions` that lets callers compress, resize, or re-encode `ImageContent` blocks before they reach the provider. Applied automatically to all images in user and toolResult messages. No-op when not provided.

## Motivation

Currently all `ImageContent` is sent as-is to providers. Large PNG screenshots (several MB) get base64-encoded and sent directly, increasing request payload size and network latency. Callers have no unified way to optimize images at the pi-ai layer -- coding-agent has its own resize logic in `image-resize.ts`, but other consumers (mom, web-ui, SDK users) get no optimization.

This hook lets any caller inject their preferred image processing (sharp, photon-node, Canvas API, etc.) without adding native dependencies to pi-ai.

## Changes

- `packages/ai/src/types.ts` -- Add `optimizeImage` field to `StreamOptions`
- `packages/ai/src/stream.ts` -- Apply optimizer before delegating to provider in `stream()` and `streamSimple()`
- `packages/ai/src/utils/optimize-context-images.ts` -- Utility that walks context messages and applies the callback to each `ImageContent`
- `packages/ai/test/optimize-image.test.ts` -- 9 tests covering user messages, toolResult messages, async callbacks, error handling, immutability, and streamSimple path
- `packages/ai/CHANGELOG.md` -- Added entry under `[Unreleased]`

## Design decisions

- Zero new dependencies, pi-ai stays browser-compatible
- Optional hook, default behavior unchanged
- Original context object is never mutated
- If optimizer returns the same reference, context copy is skipped
- If optimizer throws, error is surfaced as a stream error event

## Usage

```typescript
await complete(model, context, {
  optimizeImage: async (img) => {
    const buf = Buffer.from(img.data, "base64");
    const compressed = await sharp(buf).jpeg({ quality: 85 }).toBuffer();
    return { type: "image", data: compressed.toString("base64"), mimeType: "image/jpeg" };
  },
});
