### PR TITLE
docs(coding-agent): fix promptGuidelines examples to name tools explicitly

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1105,6 +1105,8 @@ Use `pi.setActiveTools()` to enable or disable tools (including dynamically adde
 
 Use `promptSnippet` to opt a custom tool into a one-line entry in `Available tools`, and `promptGuidelines` to append tool-specific bullets to the default `Guidelines` section when the tool is active.
 
+**Important:** `promptGuidelines` bullets are appended flat to the `Guidelines` section with no tool name prefix. Each guideline must name the tool it refers to — avoid "Use this tool when..." because the LLM cannot tell which tool "this" means. Write "Use my_tool when..." instead.
+
 See [dynamic-tools.ts](../examples/extensions/dynamic-tools.ts) for a full example.
 
 ```typescript
@@ -1116,7 +1118,7 @@ pi.registerTool({
   label: "My Tool",
   description: "What this tool does",
   promptSnippet: "Summarize or transform text according to action",
-  promptGuidelines: ["Use this tool when the user asks to summarize previously generated text."],
+  promptGuidelines: ["Use my_tool when the user asks to summarize previously generated text."],
   parameters: Type.Object({
     action: StringEnum(["list", "add"] as const),
     text: Type.Optional(Type.String()),
@@ -1542,6 +1544,8 @@ Use `promptSnippet` for a short one-line entry in the `Available tools` section 
 
 Use `promptGuidelines` to add tool-specific bullets to the default system prompt `Guidelines` section. These bullets are included only while the tool is active (for example, after `pi.setActiveTools([...])`).
 
+**Important:** `promptGuidelines` bullets are appended flat to the `Guidelines` section with no tool name prefix or grouping. Each guideline must name the tool it refers to — avoid "Use this tool when..." because the LLM cannot tell which tool "this" means. Write "Use my_tool when..." instead.
+
 Note: Some models are idiots and include the @ prefix in tool path arguments. Built-in tools strip a leading @ before resolving paths. If your custom tool accepts a path, normalize a leading @ as well.
 
 If your custom tool mutates files, use `withFileMutationQueue()` so it participates in the same per-file queue as built-in `edit` and `write`. This matters because tool calls run in parallel by default. Without the queue, two tools can read the same old file contents, compute different updates, and then whichever write lands last overwrites the other.
@@ -1587,7 +1591,7 @@ pi.registerTool({
   description: "What this tool does (shown to LLM)",
   promptSnippet: "List or add items in the project todo list",
   promptGuidelines: [
-    "Use this tool for todo planning instead of direct file edits when the user asks for a task list."
+    "Use my_tool for todo planning instead of direct file edits when the user asks for a task list."
   ],
   parameters: Type.Object({
     action: StringEnum(["list", "add"] as const),  // Use StringEnum for Google compatibility

--- a/packages/coding-agent/examples/extensions/dynamic-tools.ts
+++ b/packages/coding-agent/examples/extensions/dynamic-tools.ts
@@ -35,7 +35,7 @@ export default function dynamicToolsExtension(pi: ExtensionAPI) {
 			label,
 			description: `Echo a message with prefix: ${prefix}`,
 			promptSnippet: `Echo back user-provided text with ${prefix.trim()} prefix`,
-			promptGuidelines: ["Use this tool when the user asks for exact echo output."],
+			promptGuidelines: ["Use echo_session when the user asks for exact echo output."],
 			parameters: ECHO_PARAMS,
 			async execute(_toolCallId, params) {
 				return {


### PR DESCRIPTION
Hello! Noticed some inconsistencies when looking at the behaviour of adding `promptGuidelines` to the system prompt, which confused agents both when writing the guidelines and using the tools mentioned in the guideline.

I also looked at the history of this change (first in addition to the tool description when it was added to the system prompt and not used in replacement), and shouldn't we have the tool prompt guidelines with the tool definitions/params in the system prompt by default?

------

<details><summary>Summary by glm-5.1:</summary>
<p>

## Summary

`promptGuidelines` bullets are appended flat to the `Guidelines` section with no tool name prefix or grouping. Using "Use this tool when..." is ambiguous because the LLM cannot tell which tool "this" refers to.

## Changes

**`packages/coding-agent/docs/extensions.md`**
- Added an **Important** note in two locations (basic and advanced `registerTool` sections) explaining that each guideline must name the tool it refers to
- Replaced `promptGuidelines` examples using "Use this tool when..." with explicit tool names ("Use my_tool when..." and "Use my_tool for...")

**`packages/coding-agent/examples/extensions/dynamic-tools.ts`**
- Changed `promptGuidelines` from `"Use this tool when the user asks for exact echo output."` to `"Use echo_session when the user asks for exact echo output."` so the example matches the documented best practice

</p>
</details>