### PR TITLE
feat(coding-agent): add images.maxWidthCells setting for terminal image display width

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -111,6 +111,7 @@ When a provider requests a retry delay longer than `maxDelayMs` (e.g., Google's 
 | `terminal.clearOnShrink` | boolean | `false` | Clear empty rows when content shrinks (can cause flicker) |
 | `images.autoResize` | boolean | `true` | Resize images to 2000x2000 max |
 | `images.blockImages` | boolean | `false` | Block all images from being sent to LLM |
+| `images.maxWidthCells` | number | `60` | Maximum image display width in terminal columns |
 
 ### Shell
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -30,6 +30,7 @@ export interface TerminalSettings {
 export interface ImageSettings {
 	autoResize?: boolean; // default: true (resize images to 2000x2000 max for better model compatibility)
 	blockImages?: boolean; // default: false - when true, prevents all images from being sent to LLM providers
+	maxWidthCells?: number; // default: 60 - max terminal columns for inline image display
 }
 
 export interface ThinkingBudgetsSettings {
@@ -899,6 +900,19 @@ export class SettingsManager {
 		}
 		this.globalSettings.images.blockImages = blocked;
 		this.markModified("images", "blockImages");
+		this.save();
+	}
+
+	getImageMaxWidthCells(): number {
+		return this.settings.images?.maxWidthCells ?? 60;
+	}
+
+	setImageMaxWidthCells(width: number): void {
+		if (!this.globalSettings.images) {
+			this.globalSettings.images = {};
+		}
+		this.globalSettings.images.maxWidthCells = width;
+		this.markModified("images", "maxWidthCells");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -33,6 +33,7 @@ export interface SettingsConfig {
 	showImages: boolean;
 	autoResizeImages: boolean;
 	blockImages: boolean;
+	imageMaxWidthCells: number;
 	enableSkillCommands: boolean;
 	steeringMode: "all" | "one-at-a-time";
 	followUpMode: "all" | "one-at-a-time";
@@ -58,6 +59,7 @@ export interface SettingsCallbacks {
 	onShowImagesChange: (enabled: boolean) => void;
 	onAutoResizeImagesChange: (enabled: boolean) => void;
 	onBlockImagesChange: (blocked: boolean) => void;
+	onImageMaxWidthCellsChange: (width: number) => void;
 	onEnableSkillCommandsChange: (enabled: boolean) => void;
 	onSteeringModeChange: (mode: "all" | "one-at-a-time") => void;
 	onFollowUpModeChange: (mode: "all" | "one-at-a-time") => void;
@@ -313,9 +315,19 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
-		// Skill commands toggle (insert after block-images)
+		// Image max width toggle (insert after block-images)
 		const blockImagesIndex = items.findIndex((item) => item.id === "block-images");
 		items.splice(blockImagesIndex + 1, 0, {
+			id: "image-max-width",
+			label: "Image display width",
+			description: "Maximum image width in terminal columns",
+			currentValue: String(config.imageMaxWidthCells),
+			values: ["30", "40", "50", "60", "80", "100", "120", "150", "180"],
+		});
+
+		// Skill commands toggle (insert after image-max-width)
+		const imageMaxWidthIndex = items.findIndex((item) => item.id === "image-max-width");
+		items.splice(imageMaxWidthIndex + 1, 0, {
 			id: "skill-commands",
 			label: "Skill commands",
 			description: "Register skills as /skill:name commands",
@@ -383,6 +395,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "block-images":
 						callbacks.onBlockImagesChange(newValue === "true");
+						break;
+					case "image-max-width":
+						callbacks.onImageMaxWidthCellsChange(parseInt(newValue, 10));
 						break;
 					case "skill-commands":
 						callbacks.onEnableSkillCommandsChange(newValue === "true");

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -7,6 +7,7 @@ import { theme } from "../theme/theme.js";
 
 export interface ToolExecutionOptions {
 	showImages?: boolean;
+	maxWidthCells?: number;
 }
 
 export class ToolExecutionComponent extends Container {
@@ -23,6 +24,7 @@ export class ToolExecutionComponent extends Container {
 	private args: any;
 	private expanded = false;
 	private showImages: boolean;
+	private maxWidthCells: number;
 	private isPartial = true;
 	private toolDefinition?: ToolDefinition<any, any>;
 	private builtInToolDefinition?: ToolDefinition<any, any>;
@@ -54,6 +56,7 @@ export class ToolExecutionComponent extends Container {
 		this.toolDefinition = toolDefinition;
 		this.builtInToolDefinition = createAllToolDefinitions(cwd)[toolName as ToolName];
 		this.showImages = options.showImages ?? true;
+		this.maxWidthCells = options.maxWidthCells ?? 60;
 		this.ui = ui;
 		this.cwd = cwd;
 
@@ -205,6 +208,14 @@ export class ToolExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
+	setMaxWidthCells(width: number): void {
+		this.maxWidthCells = width;
+		for (const img of this.imageComponents) {
+			img.invalidate();
+		}
+		this.updateDisplay();
+	}
+
 	override invalidate(): void {
 		super.invalidate();
 		this.updateDisplay();
@@ -312,7 +323,7 @@ export class ToolExecutionComponent extends Container {
 						imageData,
 						imageMimeType,
 						{ fallbackColor: (s: string) => theme.fg("toolOutput", s) },
-						{ maxWidthCells: 60 },
+						{ maxWidthCells: this.maxWidthCells },
 					);
 					this.imageComponents.push(imageComponent);
 					this.addChild(imageComponent);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2633,6 +2633,7 @@ export class InteractiveMode {
 									content.arguments,
 									{
 										showImages: this.settingsManager.getShowImages(),
+										maxWidthCells: this.settingsManager.getImageMaxWidthCells(),
 									},
 									this.getRegisteredToolDefinition(content.name),
 									this.ui,
@@ -2701,6 +2702,7 @@ export class InteractiveMode {
 						event.args,
 						{
 							showImages: this.settingsManager.getShowImages(),
+							maxWidthCells: this.settingsManager.getImageMaxWidthCells(),
 						},
 						this.getRegisteredToolDefinition(event.toolName),
 						this.ui,
@@ -3031,7 +3033,10 @@ export class InteractiveMode {
 							content.name,
 							content.id,
 							content.arguments,
-							{ showImages: this.settingsManager.getShowImages() },
+							{
+								showImages: this.settingsManager.getShowImages(),
+								maxWidthCells: this.settingsManager.getImageMaxWidthCells(),
+							},
 							this.getRegisteredToolDefinition(content.name),
 							this.ui,
 							this.sessionManager.getCwd(),
@@ -3652,6 +3657,7 @@ export class InteractiveMode {
 					showImages: this.settingsManager.getShowImages(),
 					autoResizeImages: this.settingsManager.getImageAutoResize(),
 					blockImages: this.settingsManager.getBlockImages(),
+					imageMaxWidthCells: this.settingsManager.getImageMaxWidthCells(),
 					enableSkillCommands: this.settingsManager.getEnableSkillCommands(),
 					steeringMode: this.session.steeringMode,
 					followUpMode: this.session.followUpMode,
@@ -3689,6 +3695,14 @@ export class InteractiveMode {
 					},
 					onBlockImagesChange: (blocked) => {
 						this.settingsManager.setBlockImages(blocked);
+					},
+					onImageMaxWidthCellsChange: (width) => {
+						this.settingsManager.setImageMaxWidthCells(width);
+						for (const child of this.chatContainer.children) {
+							if (child instanceof ToolExecutionComponent) {
+								child.setMaxWidthCells(width);
+							}
+						}
 					},
 					onEnableSkillCommandsChange: (enabled) => {
 						this.settingsManager.setEnableSkillCommands(enabled);

--- a/packages/coding-agent/test/image-max-width.test.ts
+++ b/packages/coding-agent/test/image-max-width.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { SettingsManager } from "../src/core/settings-manager.js";
+
+describe("images.maxWidthCells setting", () => {
+	it("should default to 60", () => {
+		const manager = SettingsManager.inMemory({});
+		expect(manager.getImageMaxWidthCells()).toBe(60);
+	});
+
+	it("should return configured value", () => {
+		const manager = SettingsManager.inMemory({ images: { maxWidthCells: 120 } });
+		expect(manager.getImageMaxWidthCells()).toBe(120);
+	});
+
+	it("should persist via setImageMaxWidthCells", () => {
+		const manager = SettingsManager.inMemory({});
+		expect(manager.getImageMaxWidthCells()).toBe(60);
+
+		manager.setImageMaxWidthCells(100);
+		expect(manager.getImageMaxWidthCells()).toBe(100);
+
+		manager.setImageMaxWidthCells(30);
+		expect(manager.getImageMaxWidthCells()).toBe(30);
+	});
+
+	it("should coexist with other image settings", () => {
+		const manager = SettingsManager.inMemory({
+			images: { autoResize: true, blockImages: false, maxWidthCells: 80 },
+		});
+		expect(manager.getImageAutoResize()).toBe(true);
+		expect(manager.getBlockImages()).toBe(false);
+		expect(manager.getImageMaxWidthCells()).toBe(80);
+	});
+
+	it("should not affect other image settings when changed", () => {
+		const manager = SettingsManager.inMemory({
+			images: { autoResize: false, blockImages: true },
+		});
+
+		manager.setImageMaxWidthCells(150);
+		expect(manager.getImageAutoResize()).toBe(false);
+		expect(manager.getBlockImages()).toBe(true);
+		expect(manager.getImageMaxWidthCells()).toBe(150);
+	});
+});


### PR DESCRIPTION
## Summary

- Add `images.maxWidthCells` setting (default: 60) to control max width of inline images in terminal columns
- Configurable via `/settings` → "Image display width" or directly in `settings.json`
- Changing the setting live-updates all already-rendered images in the current session

## Motivation

Image display width was hardcoded at 60 columns. On wide terminals this makes images unnecessarily small, especially charts and plots. The `Image` component already supported `maxWidthCells` as a constructor option — this PR wires it to a user-facing setting.

## Changes

- **settings-manager.ts** — `ImageSettings.maxWidthCells` + getter/setter
- **tool-execution.ts** — accepts `maxWidthCells` option, `setMaxWidthCells()` for live updates
- **interactive-mode.ts** — passes setting to all `ToolExecutionComponent` instantiations
- **settings-selector.ts** — "Image display width" in `/settings` UI (30–180)
- **docs/settings.md** — documents the new setting
- **test/image-max-width.test.ts** — 5 tests for default, persistence, coexistence with other image settings