### PR TITLE
feat(ai): add Claude 4.7 full family support (Sonnet, Haiku)

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -456,7 +456,7 @@ function handleContentBlockStop(
 }
 
 /**
- * Check if the model supports adaptive thinking (Opus 4.6+, Sonnet 4.6).
+ * Check if the model supports adaptive thinking (Claude 4.6+).
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
 	return (
@@ -465,7 +465,11 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 		modelId.includes("opus-4-7") ||
 		modelId.includes("opus-4.7") ||
 		modelId.includes("sonnet-4-6") ||
-		modelId.includes("sonnet-4.6")
+		modelId.includes("sonnet-4.6") ||
+		modelId.includes("sonnet-4-7") ||
+		modelId.includes("sonnet-4.7") ||
+		modelId.includes("haiku-4-7") ||
+		modelId.includes("haiku-4.7")
 	);
 }
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -467,18 +467,29 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 };
 
 /**
- * Check if a model supports adaptive thinking (Opus 4.6+, Sonnet 4.6)
+ * Check if a model supports adaptive thinking (Claude 4.6+)
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
-	// Adaptive-thinking model IDs (with or without date suffix)
 	return (
 		modelId.includes("opus-4-6") ||
 		modelId.includes("opus-4.6") ||
 		modelId.includes("opus-4-7") ||
 		modelId.includes("opus-4.7") ||
 		modelId.includes("sonnet-4-6") ||
-		modelId.includes("sonnet-4.6")
+		modelId.includes("sonnet-4.6") ||
+		modelId.includes("sonnet-4-7") ||
+		modelId.includes("sonnet-4.7") ||
+		modelId.includes("haiku-4-7") ||
+		modelId.includes("haiku-4.7")
 	);
+}
+
+/**
+ * Check if a model belongs to the Claude 4.7 family.
+ * Claude 4.7 rejects temperature, top_p, and top_k parameters.
+ */
+function isClaude47(modelId: string): boolean {
+	return modelId.includes("4-7") || modelId.includes("4.7");
 }
 
 /**
@@ -679,8 +690,8 @@ function buildParams(
 		];
 	}
 
-	// Temperature is incompatible with extended thinking (adaptive or budget-based).
-	if (options?.temperature !== undefined && !options?.thinkingEnabled) {
+	// Temperature is incompatible with extended thinking and with Claude 4.7 models.
+	if (options?.temperature !== undefined && !options?.thinkingEnabled && !isClaude47(model.id)) {
 		params.temperature = options.temperature;
 	}
 


### PR DESCRIPTION
## Summary
- Add Claude Sonnet 4.7 and Haiku 4.7 to `supportsAdaptiveThinking()` in both Anthropic and Bedrock providers
- Add `isClaude47()` helper function for Claude 4.7 model family detection
- Guard temperature parameter in `buildParams()` — Claude 4.7 rejects temperature/top_p/top_k with 400 error
- Extends the existing Claude 4.7 Opus support to the full model family

## Test plan
- [ ] Verify Sonnet 4.7 and Haiku 4.7 are detected by `supportsAdaptiveThinking()`
- [ ] Verify `isClaude47()` matches all 4.7 variants (opus, sonnet, haiku, dated)
- [ ] Verify temperature is NOT sent for any Claude 4.7 model
- [ ] Verify temperature IS still sent for non-4.7 models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>