### PR TITLE
test(coding-agent): fix showLoadedResources mocks

### DIFF
--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -175,7 +175,10 @@ describe("InteractiveMode.showLoadedResources", () => {
 			},
 			session: {
 				promptTemplates: [],
-				extensionRunner: undefined,
+				extensionRunner: {
+					getCommandDiagnostics: () => [],
+					getShortcutDiagnostics: () => [],
+				},
 				resourceLoader: {
 					getPathMetadata: () => new Map(),
 					getAgentsFiles: () => ({ agentsFiles: options.contextFiles ?? [] }),


### PR DESCRIPTION
Hello! Noticed that the tests were failing and so had kimi investigate, bisect and fix them.

Session: https://pi.dev/session/#8258d177995c02b2e641c20b6e29acb7

------

<details><summary>Summary by Kimi K2.5:</summary>
<p>

Fixes failing tests in `packages/coding-agent/test/interactive-mode-status.test.ts` introduced by commit `32a305cb`.

## Problem

The `showLoadedResources` tests mock `this.session` but leave `extensionRunner` as `undefined`. The `InteractiveMode.showLoadedResources()` method calls `this.session.extensionRunner.getCommandDiagnostics()` and `getShortcutDiagnostics()` without optional chaining, causing:

```
Cannot read properties of undefined (reading 'getCommandDiagnostics')
```

## Changes

**File:** `packages/coding-agent/test/interactive-mode-status.test.ts`

Added mock methods to the `extensionRunner` object:
- `getCommandDiagnostics: () => []`
- `getShortcutDiagnostics: () => []`

## Verification

- `npm run check` passes
- `./test.sh` passes (all 16 tests in interactive-mode-status.test.ts now pass)

## Regression Note

This fixes a regression from commit `32a305cb` ("disambiguate compact extension labels") which added new tests but omitted these required mocks.

</p>
</details>