### PR TITLE
fix(coding-agent): sanitize markdown links in exported session HTML

### DIFF
--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -881,7 +881,7 @@
           const images = getResultImages();
           if (images.length === 0) return '';
           return '<div class="tool-images">' +
-            images.map(img => `<img src="data:${img.mimeType};base64,${img.data}" class="tool-image" />`).join('') +
+            images.map(img => `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${img.data}" class="tool-image" />`).join('') +
             '</div>';
         };
 
@@ -1148,7 +1148,7 @@
               if (images.length > 0) {
                 html += '<div class="message-images">';
                 for (const img of images) {
-                  html += `<img src="data:${img.mimeType};base64,${img.data}" class="message-image" />`;
+                  html += `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${img.data}" class="message-image" />`;
                 }
                 html += '</div>';
               }
@@ -1491,6 +1491,32 @@
           }
         },
         renderer: {
+          // Sanitize link URLs to prevent javascript:/vbscript:/data: XSS
+          link(token) {
+            const href = (token.href || '').trim();
+            if (/^\s*(javascript|vbscript|data):/i.test(href)) {
+              return this.parser.parseInline(token.tokens);
+            }
+            let out = '<a href="' + escapeHtml(href) + '"';
+            if (token.title) {
+              out += ' title="' + escapeHtml(token.title) + '"';
+            }
+            out += '>' + this.parser.parseInline(token.tokens) + '</a>';
+            return out;
+          },
+          // Sanitize image src URLs
+          image(token) {
+            const href = (token.href || '').trim();
+            if (/^\s*(javascript|vbscript|data):/i.test(href)) {
+              return escapeHtml(token.text || '');
+            }
+            let out = '<img src="' + escapeHtml(href) + '" alt="' + escapeHtml(token.text || '') + '"';
+            if (token.title) {
+              out += ' title="' + escapeHtml(token.title) + '"';
+            }
+            out += '>';
+            return out;
+          },
           // Code blocks: syntax highlight, no HTML escaping
           code(token) {
             const code = token.text;

--- a/packages/coding-agent/test/export-html-xss.test.ts
+++ b/packages/coding-agent/test/export-html-xss.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+
+describe("export HTML markdown link sanitization", () => {
+	const templateJs = readFileSync(new URL("../src/core/export-html/template.js", import.meta.url), "utf-8");
+
+	it("overrides the marked link renderer to block javascript: protocol", () => {
+		// The custom link renderer must check for dangerous protocols
+		expect(templateJs).toMatch(/link\s*\(\s*token\s*\)/);
+		expect(templateJs).toMatch(/javascript/i);
+		expect(templateJs).toMatch(/vbscript/i);
+	});
+
+	it("overrides the marked image renderer to block javascript: protocol", () => {
+		expect(templateJs).toMatch(/image\s*\(\s*token\s*\)/);
+	});
+
+	it("escapes href attributes in the custom link renderer", () => {
+		// The link renderer must escape href values to prevent attribute breakout
+		expect(templateJs).toMatch(/escapeHtml\(href\)/);
+	});
+
+	it("escapes image mimeType attributes", () => {
+		// Image mimeType must be escaped to prevent attribute breakout
+		expect(templateJs).not.toMatch(/\$\{img\.mimeType\}/);
+		expect(templateJs).toMatch(/escapeHtml\(img\.mimeType/);
+	});
+});


### PR DESCRIPTION
## Summary

Sanitize markdown link and image URLs in exported/shared session HTML to prevent XSS via `javascript:`, `vbscript:`, and `data:` protocol links.

## Problem

`template.js` uses marked v15.0.4, which removed built-in URL sanitization. The marked config overrides `code`, `codespan`, `html`, and `tag` renderers, but links and images use the default renderer — which passes `href` values through verbatim.

This means markdown like `[click here](javascript:alert(document.cookie))` in any user or assistant message renders as a clickable XSS link in the exported HTML. Anyone viewing a shared session can be affected.

**Proof:** `npx marked@15.0.4 -s '[click](javascript:alert(1))'` → `<a href="javascript:alert(1)">click</a>`

Four injection points exist where `safeMarkedParse()` renders unsanitized markdown:
- User message text (line 1160)
- Assistant message text blocks (line 1171) — most concerning, since prompt injection could cause an LLM to embed malicious links
- Branch summaries (line 1228)
- Custom entry content (line 1235)

## Fix

- Add custom `link` renderer that blocks `javascript:`, `vbscript:`, and `data:` protocols and escapes all `href`/`title` attributes
- Add custom `image` renderer with the same protocol filtering and attribute escaping
- Escape `img.mimeType` in session image rendering to prevent attribute breakout from crafted session JSONL
- Add regression tests

## Testing

Regression test: `packages/coding-agent/test/export-html-xss.test.ts` — verifies the template contains protocol sanitization for links, images, and mimeType escaping.

Fixes #3531
