### PR TITLE
fix(coding-agent): route remaining hardcoded pi branding through APP_NAME

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -4,7 +4,6 @@
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"piConfig": {
-		"name": "pi",
 		"configDir": ".pi"
 	},
 	"bin": {

--- a/packages/coding-agent/src/bun/cli.ts
+++ b/packages/coding-agent/src/bun/cli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-process.title = "pi";
+import { APP_NAME } from "../config.js";
+
+process.title = APP_NAME;
 process.emitWarning = (() => {}) as typeof process.emitWarning;
 
 await import("./register-bedrock.js");

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -5,12 +5,13 @@
  *
  * Test with: npx tsx src/cli-new.ts [args...]
  */
-process.title = "pi";
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+import { APP_NAME } from "./config.js";
+import { main } from "./main.js";
+
+process.title = APP_NAME;
 process.env.PI_CODING_AGENT = "true";
 process.emitWarning = (() => {}) as typeof process.emitWarning;
-
-import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
-import { main } from "./main.js";
 
 setGlobalDispatcher(new EnvHttpProxyAgent());
 

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -184,7 +184,9 @@ export function getBundledInteractiveAssetPath(name: string): string {
 
 const pkg = JSON.parse(readFileSync(getPackageJsonPath(), "utf-8"));
 
-export const APP_NAME: string = pkg.piConfig?.name || "pi";
+const piConfigName: string | undefined = pkg.piConfig?.name;
+export const APP_NAME: string = piConfigName || "pi";
+export const APP_TITLE: string = piConfigName ? APP_NAME : "π";
 export const CONFIG_DIR_NAME: string = pkg.piConfig?.configDir || ".pi";
 export const VERSION: string = pkg.version;
 

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -21,7 +21,7 @@ import * as _bundledPiTui from "@mariozechner/pi-tui";
 import * as _bundledTypebox from "typebox";
 import * as _bundledTypeboxCompile from "typebox/compile";
 import * as _bundledTypeboxValue from "typebox/value";
-import { getAgentDir, isBunBinary } from "../../config.js";
+import { CONFIG_DIR_NAME, getAgentDir, isBunBinary } from "../../config.js";
 // NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
 // avoiding a circular dependency. Extensions can import from @mariozechner/pi-coding-agent.
 import * as _bundledPiCodingAgent from "../../index.js";
@@ -576,8 +576,8 @@ export async function discoverAndLoadExtensions(
 		}
 	};
 
-	// 1. Project-local extensions: cwd/.pi/extensions/
-	const localExtDir = path.join(cwd, ".pi", "extensions");
+	// 1. Project-local extensions: cwd/${CONFIG_DIR_NAME}/extensions/
+	const localExtDir = path.join(cwd, CONFIG_DIR_NAME, "extensions");
 	addPaths(discoverExtensionsInDir(localExtDir));
 
 	// 2. Global extensions: agentDir/extensions/

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -1,3 +1,4 @@
+import { APP_NAME } from "../config.js";
 import type { SourceInfo } from "./source-info.js";
 
 export type SlashCommandSource = "extension" | "prompt" | "skill";
@@ -35,5 +36,5 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "compact", description: "Manually compact the session context" },
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
-	{ name: "quit", description: "Quit pi" },
+	{ name: "quit", description: `Quit ${APP_NAME}` },
 ];

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -41,6 +41,7 @@ import {
 import { spawn, spawnSync } from "child_process";
 import {
 	APP_NAME,
+	APP_TITLE,
 	getAgentDir,
 	getAuthPath,
 	getDebugLogPath,
@@ -637,9 +638,9 @@ export class InteractiveMode {
 		const cwdBasename = path.basename(this.sessionManager.getCwd());
 		const sessionName = this.sessionManager.getSessionName();
 		if (sessionName) {
-			this.ui.terminal.setTitle(`π - ${sessionName} - ${cwdBasename}`);
+			this.ui.terminal.setTitle(`${APP_TITLE} - ${sessionName} - ${cwdBasename}`);
 		} else {
-			this.ui.terminal.setTitle(`π - ${cwdBasename}`);
+			this.ui.terminal.setTitle(`${APP_TITLE} - ${cwdBasename}`);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Route four remaining hardcoded `"pi"` / `".pi"` / `"π"` strings through `APP_NAME` / `CONFIG_DIR_NAME`
- Add `APP_TITLE` export for the one site (terminal tab title) that has a pi/rebranded distinction
- No behavior change for pi itself

## Changes

- `src/core/slash-commands.ts` — `/quit` description uses `APP_NAME`
- `src/cli.ts`, `src/bun/cli.ts` — `process.title` uses `APP_NAME` (what `ps` / Activity Monitor show)
- `src/core/extensions/loader.ts` — project-local extensions dir uses `CONFIG_DIR_NAME` instead of hardcoded `.pi` (small bug: `piConfig.configDir` was ignored here)
- `src/modes/interactive/interactive-mode.ts` — terminal tab title uses new `APP_TITLE`

## `APP_TITLE`

Terminal title is the one site where pi wants `π` but rebranded consumers want their own name. Rather than a new `piConfig` field, `APP_TITLE` keys off whether `piConfig.name` is explicitly set:

```ts
// src/config.ts
const piConfigName: string | undefined = pkg.piConfig?.name;
export const APP_NAME: string = piConfigName || "pi";
export const APP_TITLE: string = piConfigName ? APP_NAME : "π";
```

For the discriminator to work, pi's `package.json` drops the redundant `"name": "pi"` from its `piConfig`. The `|| "pi"` fallback in `config.ts:187` made that line a no-op for `APP_NAME`, so `APP_NAME === "pi"` before and after — the removal just makes presence of `piConfig.name` a reliable "has been rebranded" signal.

## Out of scope

Two items from my follow-up comment on #3476 have env-var workarounds:
- Update instruction URL — `PI_SKIP_VERSION_CHECK=1` disables the whole check
- Default share viewer URL — `PI_SHARE_VIEWER_URL` overrides

## Testing

- `npm run check` passes
- `./test.sh` passes (560 / 560)

Fixes #3476