### PR TITLE
fix(coding-agent): retry on http2 'request did not get a response' errors

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2414,8 +2414,8 @@ export class AgentSession {
 		if (isContextOverflow(message, contextWindow)) return false;
 
 		const err = message.errorMessage;
-		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), fetch failed, request ended without sending chunks, terminated, retry delay exceeded
-		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|timed? out|timeout|terminated|retry delay/i.test(
+		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), fetch failed, request ended without sending chunks, terminated, retry delay exceeded, http2 stream closed with no response
+		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|timed? out|timeout|terminated|retry delay|http2 request did not get a response/i.test(
 			err,
 		);
 	}


### PR DESCRIPTION
Hello and thanks for the awesome product!

I've been lately running into a bunch of errors like `http2 request did not get a response` when working with AWS Bedrock. They look like this in the terminal and I have to manually nudge the agent to continue working:

<img width="1138" height="418" alt="image" src="https://github.com/user-attachments/assets/c77ed0c3-e6ce-4d52-b45e-5d2976a0397e" />

I thought it would be nice to handle them automatically.

Cheers!