### PR TITLE
fix(coding-agent): tear down extension UI on shutdown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed crash on `/quit` when an extension registers a custom footer whose `render()` accesses `ctx`, by tearing down extension-provided UI before invalidating the extension runner during shutdown ([#3595](https://github.com/badlogic/pi-mono/issues/3595))
 - Fixed `ctx.ui.setWorkingMessage()` to persist across loader recreation, matching the behavior of `ctx.ui.setWorkingIndicator()` ([#3566](https://github.com/badlogic/pi-mono/issues/3566))
 - Fixed coding-agent `fs.watch` error handling for theme and git-footer watchers to retry after transient watcher failures such as `EMFILE`, avoiding startup crashes in large repos ([#3564](https://github.com/badlogic/pi-mono/issues/3564))
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3174,6 +3174,7 @@ export class InteractiveMode {
 		if (this.isShuttingDown) return;
 		this.isShuttingDown = true;
 		this.unregisterSignalHandlers();
+		this.resetExtensionUI();
 		await this.runtimeHost.dispose();
 
 		// Wait for any pending renders to complete


### PR DESCRIPTION
Custom footers registered via ctx.ui.setFooter(...) whose render() closure touched ctx would crash pi on /quit: runtimeHost.dispose() invalidates the extension runner before the TUI stops rendering, so any still-attached footer render tick hit assertActive() and threw.

Call resetExtensionUI() before runtimeHost.dispose() in the interactive shutdown path, matching the rebindCurrentSession() pattern. This disposes the custom footer (clearing its interval) and detaches it from the TUI tree before the runner goes stale.

closes #3595