### PR TITLE
feat(tui): add img2sixel sixel support

### DIFF
--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -248,7 +248,7 @@ md.setText("Updated markdown");
 
 ### Image
 
-Renders images in supported terminals (Kitty, iTerm2, Ghostty, WezTerm).
+Renders images in supported terminals (Kitty, iTerm2, Ghostty, WezTerm, and terminals that report SIXEL support).
 
 ```typescript
 const image = new Image(

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added SIXEL image rendering support for terminals that report SIXEL support, using `img2sixel` (libsixel), including runtime capability probing, automatic backend selection, and `PI_TUI_IMAGE_PROTOCOL` / `PI_TUI_SIXEL_ENCODER` overrides.
+
 ## [0.69.0] - 2026-04-22
 
 ### Added

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -10,7 +10,7 @@ Minimal terminal UI framework with differential rendering and synchronized outpu
 - **Component-based**: Simple Component interface with render() method
 - **Theme Support**: Components accept theme interfaces for customizable styling
 - **Built-in Components**: Text, TruncatedText, Input, Editor, Markdown, Loader, SelectList, SettingsList, Spacer, Image, Box, Container
-- **Inline Images**: Renders images in terminals that support Kitty or iTerm2 graphics protocols
+- **Inline Images**: Renders images in terminals that support Kitty, iTerm2, or SIXEL graphics protocols
 - **Autocomplete Support**: File paths and slash commands
 
 ## Quick Start
@@ -487,7 +487,7 @@ const spacer = new Spacer(2); // 2 empty lines (default: 1)
 
 ### Image
 
-Renders images inline for terminals that support the Kitty graphics protocol (Kitty, Ghostty, WezTerm) or iTerm2 inline images. Falls back to a text placeholder on unsupported terminals.
+Renders images inline for terminals that support the Kitty graphics protocol (Kitty, Ghostty, WezTerm), iTerm2 inline images, or SIXEL output. Falls back to a text placeholder on unsupported terminals or when no SIXEL encoder is available.
 
 ```typescript
 interface ImageTheme {
@@ -510,6 +510,8 @@ tui.addChild(image);
 ```
 
 Supported formats: PNG, JPEG, GIF, WebP. Dimensions are parsed from the image headers automatically.
+
+SIXEL rendering uses an external `img2sixel` encoder (libsixel). `pi-tui` auto-detects `img2sixel`, or you can point it at a specific binary with `PI_TUI_SIXEL_ENCODER=/path/to/img2sixel`. When Kitty and iTerm2 are not available, `pi-tui` probes the terminal at startup and enables SIXEL automatically only if the terminal reports support. You can still force or disable a specific image backend with `PI_TUI_IMAGE_PROTOCOL=kitty|iterm2|sixel|none`.
 
 ## Autocomplete
 
@@ -765,3 +767,23 @@ Set `PI_TUI_WRITE_LOG` to capture the raw ANSI stream written to stdout.
 ```bash
 PI_TUI_WRITE_LOG=/tmp/tui-ansi.log npx tsx test/chat-simple.ts
 ```
+
+### Image protocol overrides
+
+`pi-tui` detects Kitty and iTerm2 image support automatically. When no native image protocol is available, it probes the terminal for SIXEL support and uses it automatically when `img2sixel` is available. You can still override image detection with these environment variables:
+
+```bash
+# Force a specific image backend
+PI_TUI_IMAGE_PROTOCOL=sixel
+PI_TUI_IMAGE_PROTOCOL=kitty
+PI_TUI_IMAGE_PROTOCOL=iterm2
+PI_TUI_IMAGE_PROTOCOL=none
+
+# Use a specific SIXEL encoder binary
+PI_TUI_SIXEL_ENCODER=/path/to/img2sixel
+```
+
+Notes:
+- SIXEL auto-detection uses the terminal's DA1 capability response and requires an external `img2sixel` encoder (libsixel).
+- Kitty and iTerm2 remain preferred over SIXEL when their native protocols are available.
+- tmux/screen still default to image rendering off unless you explicitly override the protocol.

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -71,6 +71,7 @@ export {
 	detectCapabilities,
 	encodeITerm2,
 	encodeKitty,
+	encodeSixel,
 	getCapabilities,
 	getCellDimensions,
 	getGifDimensions,

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -1,4 +1,9 @@
-export type ImageProtocol = "kitty" | "iterm2" | null;
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export type ImageProtocol = "kitty" | "iterm2" | "sixel" | null;
 
 export interface TerminalCapabilities {
 	images: ImageProtocol;
@@ -24,7 +29,12 @@ export interface ImageRenderOptions {
 	imageId?: number;
 }
 
+interface SixelEncoder {
+	command: string;
+}
+
 let cachedCapabilities: TerminalCapabilities | null = null;
+let cachedSixelEncoder: SixelEncoder | null | undefined;
 
 // Default cell dimensions - updated by TUI when terminal responds to query
 let cellDimensions: CellDimensions = { widthPx: 9, heightPx: 18 };
@@ -37,51 +47,80 @@ export function setCellDimensions(dims: CellDimensions): void {
 	cellDimensions = dims;
 }
 
+function getImageProtocolOverride(): ImageProtocol | "none" | undefined {
+	const value = process.env.PI_TUI_IMAGE_PROTOCOL?.trim().toLowerCase();
+	if (!value || value === "auto") {
+		return undefined;
+	}
+	if (value === "kitty" || value === "iterm2" || value === "sixel") {
+		return value;
+	}
+	if (value === "none" || value === "off" || value === "false") {
+		return "none";
+	}
+	return undefined;
+}
+
+function isTmuxOrScreen(term: string, env: NodeJS.ProcessEnv = process.env): boolean {
+	return !!env.TMUX || term.startsWith("tmux") || term.startsWith("screen");
+}
+
 export function detectCapabilities(): TerminalCapabilities {
 	const termProgram = process.env.TERM_PROGRAM?.toLowerCase() || "";
 	const term = process.env.TERM?.toLowerCase() || "";
 	const colorTerm = process.env.COLORTERM?.toLowerCase() || "";
+	const imageProtocolOverride = getImageProtocolOverride();
+	const trueColor = colorTerm === "truecolor" || colorTerm === "24bit";
+
+	let images: ImageProtocol = null;
+	let hyperlinks = false;
+	let terminalTrueColor = trueColor;
+
+	if (process.env.KITTY_WINDOW_ID || termProgram === "kitty") {
+		images = "kitty";
+		hyperlinks = true;
+		terminalTrueColor = true;
+	} else if (termProgram === "ghostty" || term.includes("ghostty") || process.env.GHOSTTY_RESOURCES_DIR) {
+		images = "kitty";
+		hyperlinks = true;
+		terminalTrueColor = true;
+	} else if (process.env.WEZTERM_PANE || termProgram === "wezterm") {
+		images = "kitty";
+		hyperlinks = true;
+		terminalTrueColor = true;
+	} else if (process.env.ITERM_SESSION_ID || termProgram === "iterm.app") {
+		images = "iterm2";
+		hyperlinks = true;
+		terminalTrueColor = true;
+	} else if (process.env.WT_SESSION) {
+		hyperlinks = true;
+		terminalTrueColor = true;
+	} else if (termProgram === "vscode") {
+		hyperlinks = true;
+		terminalTrueColor = true;
+	} else if (termProgram === "alacritty") {
+		hyperlinks = true;
+		terminalTrueColor = true;
+	}
 
 	// tmux and screen swallow OSC 8 by default (passthrough is opt-in and wraps
 	// sequences differently). Force hyperlinks off whenever we detect them, even
 	// when the outer terminal would otherwise support OSC 8. Image protocols are
-	// also unreliable under tmux/screen, so leave `images: null` for safety.
-	const inTmuxOrScreen = !!process.env.TMUX || term.startsWith("tmux") || term.startsWith("screen");
+	// also unreliable under tmux/screen, so leave `images: null` for safety unless
+	// the user explicitly overrides the image protocol.
+	const inTmuxOrScreen = isTmuxOrScreen(term);
 	if (inTmuxOrScreen) {
-		const trueColor = colorTerm === "truecolor" || colorTerm === "24bit";
-		return { images: null, trueColor, hyperlinks: false };
+		hyperlinks = false;
+		if (imageProtocolOverride === undefined) {
+			images = null;
+		}
 	}
 
-	if (process.env.KITTY_WINDOW_ID || termProgram === "kitty") {
-		return { images: "kitty", trueColor: true, hyperlinks: true };
+	if (imageProtocolOverride !== undefined) {
+		images = imageProtocolOverride === "none" ? null : imageProtocolOverride;
 	}
 
-	if (termProgram === "ghostty" || term.includes("ghostty") || process.env.GHOSTTY_RESOURCES_DIR) {
-		return { images: "kitty", trueColor: true, hyperlinks: true };
-	}
-
-	if (process.env.WEZTERM_PANE || termProgram === "wezterm") {
-		return { images: "kitty", trueColor: true, hyperlinks: true };
-	}
-
-	if (process.env.ITERM_SESSION_ID || termProgram === "iterm.app") {
-		return { images: "iterm2", trueColor: true, hyperlinks: true };
-	}
-
-	if (termProgram === "vscode") {
-		return { images: null, trueColor: true, hyperlinks: true };
-	}
-
-	if (termProgram === "alacritty") {
-		return { images: null, trueColor: true, hyperlinks: true };
-	}
-
-	// Unknown terminal: be conservative. OSC 8 is rendered invisibly as "just
-	// text" on terminals that swallow it, which means the URL disappears from
-	// the rendered output. Default to the legacy `text (url)` behavior unless we
-	// have positively identified a hyperlink-capable terminal above.
-	const trueColor = colorTerm === "truecolor" || colorTerm === "24bit";
-	return { images: null, trueColor, hyperlinks: false };
+	return { images, trueColor: terminalTrueColor, hyperlinks };
 }
 
 export function getCapabilities(): TerminalCapabilities {
@@ -93,6 +132,7 @@ export function getCapabilities(): TerminalCapabilities {
 
 export function resetCapabilitiesCache(): void {
 	cachedCapabilities = null;
+	cachedSixelEncoder = undefined;
 }
 
 /** Override the cached capabilities. Useful in tests to exercise both code paths. */
@@ -102,14 +142,28 @@ export function setCapabilities(caps: TerminalCapabilities): void {
 
 const KITTY_PREFIX = "\x1b_G";
 const ITERM2_PREFIX = "\x1b]1337;File=";
+const SIXEL_PREFIX = "\x1bP";
+const SIXEL_START_PATTERN = /\x1bP(?:[0-9;]*)q/;
+const PRIMARY_DEVICE_ATTRIBUTES_PATTERN = /^\x1b\[\??([0-9;]*)c$/;
+const SIXEL_ENCODER_CHECK_TIMEOUT_MS = 1000;
+const SIXEL_ENCODE_TIMEOUT_MS = 5000;
 
 export function isImageLine(line: string): boolean {
 	// Fast path: sequence at line start (single-row images)
-	if (line.startsWith(KITTY_PREFIX) || line.startsWith(ITERM2_PREFIX)) {
+	if (
+		line.startsWith(KITTY_PREFIX) ||
+		line.startsWith(ITERM2_PREFIX) ||
+		(line.startsWith(SIXEL_PREFIX) && SIXEL_START_PATTERN.test(line))
+	) {
 		return true;
 	}
+
 	// Slow path: sequence elsewhere (multi-row images have cursor-up prefix)
-	return line.includes(KITTY_PREFIX) || line.includes(ITERM2_PREFIX);
+	return (
+		line.includes(KITTY_PREFIX) ||
+		line.includes(ITERM2_PREFIX) ||
+		(line.includes(SIXEL_PREFIX) && SIXEL_START_PATTERN.test(line))
+	);
 }
 
 /**
@@ -204,6 +258,106 @@ export function encodeITerm2(
 	}
 
 	return `\x1b]1337;File=${params.join(";")}:${base64Data}\x07`;
+}
+
+function detectSixelEncoder(): SixelEncoder | null {
+	if (cachedSixelEncoder !== undefined) {
+		return cachedSixelEncoder;
+	}
+
+	const explicitCommand = process.env.PI_TUI_SIXEL_ENCODER?.trim();
+	if (explicitCommand) {
+		const encoder: SixelEncoder = { command: explicitCommand };
+		const check = spawnSync(encoder.command, ["-V"], {
+			encoding: "utf8",
+			timeout: SIXEL_ENCODER_CHECK_TIMEOUT_MS,
+		});
+		cachedSixelEncoder = check.error || check.status !== 0 ? null : encoder;
+		return cachedSixelEncoder;
+	}
+
+	const encoder: SixelEncoder = { command: "img2sixel" };
+	const check = spawnSync(encoder.command, ["-V"], {
+		encoding: "utf8",
+		timeout: SIXEL_ENCODER_CHECK_TIMEOUT_MS,
+	});
+	cachedSixelEncoder = check.error || check.status !== 0 ? null : encoder;
+	return cachedSixelEncoder;
+}
+
+function buildSixelArgs(inputPath: string, columns: number, rows: number, preserveAspectRatio: boolean): string[] {
+	const dims = getCellDimensions();
+	const widthPx = Math.max(1, Math.round(columns * dims.widthPx));
+	const heightPx = Math.max(1, Math.round(rows * dims.heightPx));
+	const args = ["-w", `${widthPx}px`];
+	if (!preserveAspectRatio) {
+		args.push("-h", `${heightPx}px`);
+	}
+	args.push(inputPath);
+	return args;
+}
+
+export function shouldAutoDetectSixel(caps: TerminalCapabilities = getCapabilities()): boolean {
+	if (getImageProtocolOverride() !== undefined) {
+		return false;
+	}
+	if (caps.images) {
+		return false;
+	}
+	const term = process.env.TERM?.toLowerCase() || "";
+	if (isTmuxOrScreen(term)) {
+		return false;
+	}
+	return detectSixelEncoder() !== null;
+}
+
+export function parsePrimaryDeviceAttributesSixelSupport(response: string): boolean | null {
+	const match = response.match(PRIMARY_DEVICE_ATTRIBUTES_PATTERN);
+	if (!match) {
+		return null;
+	}
+	return match[1].split(";").some((param) => param === "4");
+}
+
+export function encodeSixel(
+	base64Data: string,
+	options: {
+		columns?: number;
+		rows?: number;
+		preserveAspectRatio?: boolean;
+	} = {},
+): string | null {
+	const encoder = detectSixelEncoder();
+	if (!encoder) {
+		return null;
+	}
+
+	const columns = Math.max(1, options.columns ?? 80);
+	const rows = Math.max(1, options.rows ?? 24);
+	const preserveAspectRatio = options.preserveAspectRatio ?? true;
+	const tempDir = mkdtempSync(join(tmpdir(), "pi-tui-sixel-"));
+	const inputPath = join(tempDir, "image.bin");
+
+	try {
+		writeFileSync(inputPath, Buffer.from(base64Data, "base64"));
+		const result = spawnSync(encoder.command, buildSixelArgs(inputPath, columns, rows, preserveAspectRatio), {
+			encoding: "utf8",
+			maxBuffer: 20 * 1024 * 1024,
+			timeout: SIXEL_ENCODE_TIMEOUT_MS,
+		});
+
+		if (result.error || result.status !== 0 || !result.stdout) {
+			return null;
+		}
+
+		const sequence = result.stdout.replace(/[\r\n]+$/, "");
+		if (!SIXEL_START_PATTERN.test(sequence)) {
+			return null;
+		}
+		return sequence;
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
 }
 
 export function calculateImageRows(
@@ -388,13 +542,25 @@ export function renderImage(
 		return { sequence, rows };
 	}
 
+	if (caps.images === "sixel") {
+		const sequence = encodeSixel(base64Data, {
+			columns: maxWidth,
+			rows,
+			preserveAspectRatio: options.preserveAspectRatio,
+		});
+		if (!sequence) {
+			return null;
+		}
+		return { sequence, rows };
+	}
+
 	return null;
 }
 
 /**
  * Wrap text in an OSC 8 hyperlink sequence.
  * The text is rendered as a clickable hyperlink in terminals that support OSC 8
- * (Ghostty, Kitty, WezTerm, iTerm2, VSCode, and others).
+ * (Ghostty, Kitty, WezTerm, iTerm2, VSCode, Windows Terminal, and others).
  * In terminals that do not support OSC 8, the escape sequences are ignored
  * and only the plain text is displayed.
  *

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -8,7 +8,14 @@ import * as path from "node:path";
 import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.js";
 import type { Terminal } from "./terminal.js";
-import { getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
+import {
+	getCapabilities,
+	isImageLine,
+	parsePrimaryDeviceAttributesSixelSupport,
+	setCapabilities,
+	setCellDimensions,
+	shouldAutoDetectSixel,
+} from "./terminal-image.js";
 import { extractSegments, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.js";
 
 /**
@@ -228,6 +235,7 @@ export class TUI extends Container {
 	private renderTimer: NodeJS.Timeout | undefined;
 	private lastRenderAt = 0;
 	private static readonly MIN_RENDER_INTERVAL_MS = 16;
+	private static readonly SIXEL_PROBE_TIMEOUT_MS = 2000;
 	private cursorRow = 0; // Logical cursor row (end of rendered content)
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1";
@@ -236,6 +244,9 @@ export class TUI extends Container {
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
 	private fullRedrawCount = 0;
 	private stopped = false;
+	private pendingSixelProbe = false;
+	private acceptLateSixelProbeResponse = false;
+	private sixelProbeTimer: NodeJS.Timeout | undefined;
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
@@ -422,6 +433,7 @@ export class TUI extends Container {
 			() => this.requestRender(),
 		);
 		this.terminal.hideCursor();
+		this.querySixelSupport();
 		this.queryCellSize();
 		this.requestRender();
 	}
@@ -437,6 +449,26 @@ export class TUI extends Container {
 		this.inputListeners.delete(listener);
 	}
 
+	private querySixelSupport(): void {
+		if (!shouldAutoDetectSixel()) {
+			return;
+		}
+		this.pendingSixelProbe = true;
+		this.acceptLateSixelProbeResponse = false;
+		this.sixelProbeTimer = setTimeout(() => {
+			this.sixelProbeTimer = undefined;
+			if (!this.pendingSixelProbe) {
+				return;
+			}
+			// Keep a short late-response window until the first non-probe input.
+			this.pendingSixelProbe = false;
+			this.acceptLateSixelProbeResponse = true;
+		}, TUI.SIXEL_PROBE_TIMEOUT_MS);
+		// Query terminal capabilities via DA1. Response format is typically
+		// CSI ? <device> ; <extension> ; ... c, where extension code 4 indicates SIXEL.
+		this.terminal.write("\x1b[c");
+	}
+
 	private queryCellSize(): void {
 		// Only query if terminal supports images (cell size is only used for image rendering)
 		if (!getCapabilities().images) {
@@ -449,6 +481,12 @@ export class TUI extends Container {
 
 	stop(): void {
 		this.stopped = true;
+		if (this.sixelProbeTimer) {
+			clearTimeout(this.sixelProbeTimer);
+			this.sixelProbeTimer = undefined;
+		}
+		this.pendingSixelProbe = false;
+		this.acceptLateSixelProbeResponse = false;
 		if (this.renderTimer) {
 			clearTimeout(this.renderTimer);
 			this.renderTimer = undefined;
@@ -536,8 +574,8 @@ export class TUI extends Container {
 			data = current;
 		}
 
-		// Consume terminal cell size responses without blocking unrelated input.
-		if (this.consumeCellSizeResponse(data)) {
+		// Consume terminal capability responses without blocking unrelated input.
+		if (this.consumeSixelSupportResponse(data) || this.consumeCellSizeResponse(data)) {
 			return;
 		}
 
@@ -571,6 +609,38 @@ export class TUI extends Container {
 			this.focusedComponent.handleInput(data);
 			this.requestRender();
 		}
+	}
+
+	private consumeSixelSupportResponse(data: string): boolean {
+		if (!this.pendingSixelProbe && !this.acceptLateSixelProbeResponse) {
+			return false;
+		}
+
+		const sixelSupport = parsePrimaryDeviceAttributesSixelSupport(data);
+		if (sixelSupport === null) {
+			if (this.acceptLateSixelProbeResponse) {
+				this.acceptLateSixelProbeResponse = false;
+			}
+			return false;
+		}
+
+		if (this.sixelProbeTimer) {
+			clearTimeout(this.sixelProbeTimer);
+			this.sixelProbeTimer = undefined;
+		}
+		this.pendingSixelProbe = false;
+		this.acceptLateSixelProbeResponse = false;
+
+		if (!sixelSupport) {
+			return true;
+		}
+
+		const capabilities = getCapabilities();
+		setCapabilities({ ...capabilities, images: "sixel" });
+		this.queryCellSize();
+		this.invalidate();
+		this.requestRender();
+		return true;
 	}
 
 	private consumeCellSizeResponse(data: string): boolean {

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -3,8 +3,21 @@
  */
 
 import assert from "node:assert";
-import { describe, it } from "node:test";
-import { detectCapabilities, hyperlink, isImageLine } from "../src/terminal-image.js";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+	detectCapabilities,
+	hyperlink,
+	isImageLine,
+	parsePrimaryDeviceAttributesSixelSupport,
+	renderImage,
+	resetCapabilitiesCache,
+	setCapabilities,
+	setCellDimensions,
+	shouldAutoDetectSixel,
+} from "../src/terminal-image.js";
 
 const ENV_KEYS = [
 	"TERM",
@@ -15,6 +28,12 @@ const ENV_KEYS = [
 	"GHOSTTY_RESOURCES_DIR",
 	"WEZTERM_PANE",
 	"ITERM_SESSION_ID",
+	"WT_SESSION",
+	"WSL_DISTRO_NAME",
+	"WSL_INTEROP",
+	"WSLENV",
+	"PI_TUI_IMAGE_PROTOCOL",
+	"PI_TUI_SIXEL_ENCODER",
 ] as const;
 
 function withEnv(overrides: Record<string, string | undefined>, fn: () => void): void {
@@ -23,6 +42,7 @@ function withEnv(overrides: Record<string, string | undefined>, fn: () => void):
 		saved[key] = process.env[key];
 		delete process.env[key];
 	}
+	resetCapabilitiesCache();
 	try {
 		for (const [k, v] of Object.entries(overrides)) {
 			if (v === undefined) delete process.env[k];
@@ -34,8 +54,54 @@ function withEnv(overrides: Record<string, string | undefined>, fn: () => void):
 			if (saved[key] === undefined) delete process.env[key];
 			else process.env[key] = saved[key];
 		}
+		resetCapabilitiesCache();
 	}
 }
+
+function createFakeSixelEncoder(
+	baseName = "fake-img2sixel",
+	versionExitCode = 0,
+): { path: string; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "pi-tui-sixel-test-"));
+	const programPath = join(dir, `${baseName}.js`);
+	writeFileSync(
+		programPath,
+		`const args = process.argv.slice(2);
+const versionExitCode = ${versionExitCode};
+if (args.includes("--version") || args.includes("-V")) {
+	if (versionExitCode !== 0) {
+		process.stderr.write("fake encoder version check failed\\n");
+		process.exit(versionExitCode);
+	}
+	process.stdout.write("fake encoder 1.0\\n");
+	process.exit(0);
+}
+process.stdout.write("\\x1bPqMOCK:" + args.join("|") + "\\x1b\\\\\\n");
+`,
+	);
+
+	if (process.platform === "win32") {
+		const wrapperPath = join(dir, `${baseName}.cmd`);
+		writeFileSync(wrapperPath, `@echo off\r\n"${process.execPath}" "${programPath}" %*\r\n`);
+		return {
+			path: wrapperPath,
+			cleanup: () => rmSync(dir, { recursive: true, force: true }),
+		};
+	}
+
+	const wrapperPath = join(dir, baseName);
+	writeFileSync(wrapperPath, `#!/bin/sh\nexec "${process.execPath}" "${programPath}" "$@"\n`);
+	chmodSync(wrapperPath, 0o755);
+	return {
+		path: wrapperPath,
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+afterEach(() => {
+	resetCapabilitiesCache();
+	setCellDimensions({ widthPx: 9, heightPx: 18 });
+});
 
 describe("isImageLine", () => {
 	describe("iTerm2 image protocol", () => {
@@ -86,6 +152,23 @@ describe("isImageLine", () => {
 			// Kitty protocol adds padding to escape sequences
 			const kittyWithPadding = "  \x1b_Ga=T,f=100...\x1b\\\x1b_Gm=i=1;\x1b\\  ";
 			assert.strictEqual(isImageLine(kittyWithPadding), true);
+		});
+	});
+
+	describe("SIXEL image protocol", () => {
+		it("should detect SIXEL image escape sequence at start of line", () => {
+			const sixelImageLine = "\x1bPq~~@@~~\x1b\\";
+			assert.strictEqual(isImageLine(sixelImageLine), true);
+		});
+
+		it("should detect SIXEL image escape sequence with parameters", () => {
+			const sixelImageLine = "\x1bP0;0;0q#0;2;0;0;0-~~\x1b\\";
+			assert.strictEqual(isImageLine(sixelImageLine), true);
+		});
+
+		it("should detect SIXEL image escape sequence after cursor movement", () => {
+			const sixelImageLine = "\x1b[4A\x1bPq#0~~~~\x1b\\";
+			assert.strictEqual(isImageLine(sixelImageLine), true);
 		});
 	});
 
@@ -151,6 +234,11 @@ describe("isImageLine", () => {
 		it("should not detect images in lines with partial Kitty sequences", () => {
 			// Similar prefix but missing the complete sequence
 			const partialSequence = "Some text with _G but missing ESC at start";
+			assert.strictEqual(isImageLine(partialSequence), false);
+		});
+
+		it("should not detect images in lines with partial SIXEL sequences", () => {
+			const partialSequence = "Some text with \x1bP but missing the q introducer";
 			assert.strictEqual(isImageLine(partialSequence), false);
 		});
 
@@ -244,10 +332,133 @@ describe("detectCapabilities", () => {
 		});
 	});
 
-	it("enables hyperlinks for VSCode", () => {
+	it("keeps Windows Terminal on text fallback until runtime SIXEL probing succeeds", () => {
+		withEnv({ WT_SESSION: "1" }, () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.hyperlinks, true);
+			assert.strictEqual(caps.images, null);
+		});
+	});
+
+	it("keeps VSCode on text fallback until runtime SIXEL probing succeeds", () => {
+		withEnv({ TERM_PROGRAM: "vscode", WSL_DISTRO_NAME: "Ubuntu" }, () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.hyperlinks, true);
+			assert.strictEqual(caps.images, null);
+		});
+	});
+
+	it("allows PI_TUI_IMAGE_PROTOCOL to force SIXEL", () => {
+		withEnv({ PI_TUI_IMAGE_PROTOCOL: "sixel" }, () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.images, "sixel");
+		});
+	});
+
+	it("allows PI_TUI_IMAGE_PROTOCOL to disable images", () => {
+		withEnv({ WT_SESSION: "1", PI_TUI_IMAGE_PROTOCOL: "none" }, () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.hyperlinks, true);
+			assert.strictEqual(caps.images, null);
+		});
+	});
+
+	it("probes SIXEL support only when no image protocol is already selected", () => {
+		const encoder = createFakeSixelEncoder();
+		try {
+			withEnv({ PI_TUI_SIXEL_ENCODER: encoder.path }, () => {
+				const caps = detectCapabilities();
+				assert.strictEqual(caps.images, null);
+				assert.strictEqual(shouldAutoDetectSixel(caps), true);
+			});
+		} finally {
+			encoder.cleanup();
+		}
+	});
+
+	it("does not probe SIXEL under tmux by default", () => {
+		const encoder = createFakeSixelEncoder();
+		try {
+			withEnv({ PI_TUI_SIXEL_ENCODER: encoder.path, TERM: "tmux-256color" }, () => {
+				const caps = detectCapabilities();
+				assert.strictEqual(caps.images, null);
+				assert.strictEqual(shouldAutoDetectSixel(caps), false);
+			});
+		} finally {
+			encoder.cleanup();
+		}
+	});
+
+	it("does not probe SIXEL when encoder health check exits non-zero", () => {
+		const encoder = createFakeSixelEncoder("fake-img2sixel-failing", 1);
+		try {
+			withEnv({ PI_TUI_SIXEL_ENCODER: encoder.path }, () => {
+				const caps = detectCapabilities();
+				assert.strictEqual(caps.images, null);
+				assert.strictEqual(shouldAutoDetectSixel(caps), false);
+			});
+		} finally {
+			encoder.cleanup();
+		}
+	});
+
+	it("enables hyperlinks for VSCode outside Windows and WSL", () => {
 		withEnv({ TERM_PROGRAM: "vscode" }, () => {
 			const caps = detectCapabilities();
 			assert.strictEqual(caps.hyperlinks, true);
+			assert.strictEqual(caps.images, null);
+		});
+	});
+});
+
+describe("parsePrimaryDeviceAttributesSixelSupport", () => {
+	it("detects SIXEL support from DA1 responses", () => {
+		assert.strictEqual(parsePrimaryDeviceAttributesSixelSupport("\x1b[?62;4;22c"), true);
+		assert.strictEqual(parsePrimaryDeviceAttributesSixelSupport("\x1b[?1;2c"), false);
+	});
+
+	it("returns null for non-DA1 responses", () => {
+		assert.strictEqual(parsePrimaryDeviceAttributesSixelSupport("\x1b[6;20;10t"), null);
+	});
+});
+
+describe("renderImage", () => {
+	it("renders SIXEL output via img2sixel", () => {
+		const encoder = createFakeSixelEncoder();
+		try {
+			withEnv({ PI_TUI_SIXEL_ENCODER: encoder.path }, () => {
+				setCapabilities({ images: "sixel", trueColor: true, hyperlinks: true });
+				setCellDimensions({ widthPx: 10, heightPx: 20 });
+				const result = renderImage(
+					Buffer.from("fake").toString("base64"),
+					{ widthPx: 200, heightPx: 100 },
+					{
+						maxWidthCells: 20,
+					},
+				);
+
+				assert.ok(result);
+				assert.strictEqual(result.rows, 5);
+				assert.ok(result.sequence.startsWith("\x1bPqMOCK:"));
+				assert.ok(result.sequence.includes("-w|200px|"));
+				assert.ok(!result.sequence.includes("|-h|"));
+			});
+		} finally {
+			encoder.cleanup();
+		}
+	});
+
+	it("falls back when SIXEL encoder is unavailable", () => {
+		withEnv({ PI_TUI_SIXEL_ENCODER: "/definitely/not/present/pi-tui-sixel-encoder" }, () => {
+			setCapabilities({ images: "sixel", trueColor: true, hyperlinks: true });
+			const result = renderImage(
+				Buffer.from("fake").toString("base64"),
+				{ widthPx: 200, heightPx: 100 },
+				{
+					maxWidthCells: 20,
+				},
+			);
+			assert.strictEqual(result, null);
 		});
 	});
 });

--- a/packages/tui/test/tui-cell-size-input.test.ts
+++ b/packages/tui/test/tui-cell-size-input.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
-import { getCellDimensions, resetCapabilitiesCache, setCellDimensions } from "../src/terminal-image.js";
+import {
+	getCapabilities,
+	getCellDimensions,
+	resetCapabilitiesCache,
+	setCellDimensions,
+} from "../src/terminal-image.js";
 import { type Component, TUI } from "../src/tui.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
 
@@ -41,6 +49,91 @@ function withImageTerminal<T>(fn: () => T): T {
 	}
 }
 
+function withUnknownTerminal<T>(encoderPath: string, fn: () => T): T;
+function withUnknownTerminal<T>(encoderPath: string, fn: () => Promise<T>): Promise<T>;
+function withUnknownTerminal<T>(encoderPath: string, fn: () => T | Promise<T>): T | Promise<T> {
+	const previous = {
+		TERM_PROGRAM: process.env.TERM_PROGRAM,
+		TERM: process.env.TERM,
+		TMUX: process.env.TMUX,
+		GHOSTTY_RESOURCES_DIR: process.env.GHOSTTY_RESOURCES_DIR,
+		KITTY_WINDOW_ID: process.env.KITTY_WINDOW_ID,
+		WEZTERM_PANE: process.env.WEZTERM_PANE,
+		ITERM_SESSION_ID: process.env.ITERM_SESSION_ID,
+		WT_SESSION: process.env.WT_SESSION,
+		PI_TUI_IMAGE_PROTOCOL: process.env.PI_TUI_IMAGE_PROTOCOL,
+		PI_TUI_SIXEL_ENCODER: process.env.PI_TUI_SIXEL_ENCODER,
+	};
+
+	delete process.env.TERM_PROGRAM;
+	delete process.env.TERM;
+	delete process.env.TMUX;
+	delete process.env.GHOSTTY_RESOURCES_DIR;
+	delete process.env.KITTY_WINDOW_ID;
+	delete process.env.WEZTERM_PANE;
+	delete process.env.ITERM_SESSION_ID;
+	delete process.env.WT_SESSION;
+	delete process.env.PI_TUI_IMAGE_PROTOCOL;
+	process.env.PI_TUI_SIXEL_ENCODER = encoderPath;
+	resetCapabilitiesCache();
+
+	const restore = (): void => {
+		for (const [key, value] of Object.entries(previous)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		resetCapabilitiesCache();
+	};
+
+	try {
+		const result = fn();
+		if (result instanceof Promise) {
+			return result.finally(restore);
+		}
+		restore();
+		return result;
+	} catch (error) {
+		restore();
+		throw error;
+	}
+}
+
+function createFakeSixelEncoder(baseName = "fake-img2sixel"): { path: string; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "pi-tui-sixel-test-"));
+	const programPath = join(dir, `${baseName}.js`);
+	writeFileSync(
+		programPath,
+		`const args = process.argv.slice(2);
+if (args.includes("--version") || args.includes("-V")) {
+	process.stdout.write("fake encoder 1.0\\n");
+	process.exit(0);
+}
+process.stdout.write("\\x1bPqMOCK:" + args.join("|") + "\\x1b\\\\\\n");
+`,
+	);
+
+	if (process.platform === "win32") {
+		const wrapperPath = join(dir, `${baseName}.cmd`);
+		writeFileSync(wrapperPath, `@echo off\r\n"${process.execPath}" "${programPath}" %*\r\n`);
+		return {
+			path: wrapperPath,
+			cleanup: () => rmSync(dir, { recursive: true, force: true }),
+		};
+	}
+
+	const wrapperPath = join(dir, baseName);
+	writeFileSync(wrapperPath, `#!/bin/sh\nexec "${process.execPath}" "${programPath}" "$@"\n`);
+	chmodSync(wrapperPath, 0o755);
+	return {
+		path: wrapperPath,
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe("TUI cell size responses", () => {
 	it("forwards bare escape even when a cell size query was sent at startup", () => {
 		withImageTerminal(() => {
@@ -77,5 +170,80 @@ describe("TUI cell size responses", () => {
 			assert.deepStrictEqual(recorder.inputs, ["q"]);
 			tui.stop();
 		});
+	});
+
+	it("consumes DA1 SIXEL responses and enables the SIXEL backend", () => {
+		const encoder = createFakeSixelEncoder();
+		try {
+			withUnknownTerminal(encoder.path, () => {
+				const terminal = new VirtualTerminal(80, 24);
+				const tui = new TUI(terminal);
+				const recorder = new InputRecorder();
+
+				tui.setFocus(recorder);
+				tui.start();
+				assert.strictEqual(getCapabilities().images, null);
+
+				terminal.sendInput("\x1b[?62;4;22c");
+				assert.deepStrictEqual(recorder.inputs, []);
+				assert.strictEqual(getCapabilities().images, "sixel");
+
+				terminal.sendInput("q");
+				assert.deepStrictEqual(recorder.inputs, ["q"]);
+				tui.stop();
+			});
+		} finally {
+			encoder.cleanup();
+		}
+	});
+
+	it("keeps SIXEL probe active long enough for higher-latency DA1 responses", async () => {
+		const encoder = createFakeSixelEncoder();
+		try {
+			await withUnknownTerminal(encoder.path, async () => {
+				const terminal = new VirtualTerminal(80, 24);
+				const tui = new TUI(terminal);
+				const recorder = new InputRecorder();
+
+				tui.setFocus(recorder);
+				tui.start();
+				assert.strictEqual(getCapabilities().images, null);
+
+				await sleep(500);
+				terminal.sendInput("\x1b[?62;4;22c");
+				assert.deepStrictEqual(recorder.inputs, []);
+				assert.strictEqual(getCapabilities().images, "sixel");
+
+				tui.stop();
+			});
+		} finally {
+			encoder.cleanup();
+		}
+	});
+
+	it("consumes late DA1 SIXEL responses that arrive after the probe timeout", async () => {
+		const encoder = createFakeSixelEncoder();
+		try {
+			await withUnknownTerminal(encoder.path, async () => {
+				const terminal = new VirtualTerminal(80, 24);
+				const tui = new TUI(terminal);
+				const recorder = new InputRecorder();
+
+				tui.setFocus(recorder);
+				tui.start();
+				assert.strictEqual(getCapabilities().images, null);
+
+				await sleep(2200);
+				terminal.sendInput("\x1b[?62;4;22c");
+				assert.deepStrictEqual(recorder.inputs, []);
+				assert.strictEqual(getCapabilities().images, "sixel");
+
+				terminal.sendInput("q");
+				assert.deepStrictEqual(recorder.inputs, ["q"]);
+				tui.stop();
+			});
+		} finally {
+			encoder.cleanup();
+		}
 	});
 });


### PR DESCRIPTION
## Problem

My main motivation for this PR is that Inline images don't work currently in Windows Terminal (or VS Code embedded Terminal on Windows). However, I learned that images are supported via Sixel in the Windows Terminal app as of 1.22 ([relevant changelog](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-22-release/)) and in VS Code's terminal as long as you enable the following settings

```json
  "terminal.integrated.enableImages": true,
  "terminal.integrated.gpuAcceleration": "on",
  "terminal.integrated.windowsUseConptyDll": true,
```

Sixel is also supported in a few other terminals that pi doesn't currently support - https://www.arewesixelyet.com/

## Solution

Added [sixel](https://github.com/saitoha/libsixel) (img2sixel specifically) when we detect sixel is supported. It does require a 3rd party install:

```bash
# ubuntu
$ sudo apt install libsixel-bin
```

## Testing

### Automated

```bash
$ cd packages/tui && node --test --import tsx test/terminal-image.test.ts
```

### Manual

Ran `npm install`, `npm run build`, then `./pi-test.sh` and the following:

<img width="2775" height="1426" alt="image" src="https://github.com/user-attachments/assets/701cb412-537a-466d-a51d-409cbe81d752" />