### PR TITLE
feat(coding-agent): show double-press hint in the footer

### DIFF
--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -89,6 +89,7 @@ export class FooterDataProvider {
 	private static readonly WATCH_DEBOUNCE_MS = 500;
 
 	private extensionStatuses = new Map<string, string>();
+	private hint: string | undefined = undefined;
 	private cachedBranch: string | null | undefined = undefined;
 	private gitPaths: GitPaths | null | undefined = undefined;
 	private headWatcher: FSWatcher | null = null;
@@ -122,6 +123,14 @@ export class FooterDataProvider {
 		return this.extensionStatuses;
 	}
 
+	/**
+	 * Transient hint text (e.g. "Press Ctrl-C again to exit"). Custom footers
+	 * can opt in by reading this and rendering it in place of the pwd line.
+	 */
+	getHint(): string | undefined {
+		return this.hint;
+	}
+
 	/** Subscribe to git branch changes. Returns unsubscribe function. */
 	onBranchChange(callback: () => void): () => void {
 		this.branchChangeCallbacks.add(callback);
@@ -140,6 +149,11 @@ export class FooterDataProvider {
 	/** Internal: clear extension statuses */
 	clearExtensionStatuses(): void {
 		this.extensionStatuses.clear();
+	}
+
+	/** Internal: set or clear the transient hint */
+	setHint(text: string | undefined): void {
+		this.hint = text;
 	}
 
 	/** Number of unique providers with available models (for footer display) */
@@ -350,5 +364,5 @@ export class FooterDataProvider {
 /** Read-only view for extensions - excludes setExtensionStatus, setAvailableProviderCount and dispose */
 export type ReadonlyFooterDataProvider = Pick<
 	FooterDataProvider,
-	"getGitBranch" | "getExtensionStatuses" | "getAvailableProviderCount" | "onBranchChange"
+	"getGitBranch" | "getExtensionStatuses" | "getHint" | "getAvailableProviderCount" | "onBranchChange"
 >;

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -201,8 +201,9 @@ export class FooterComponent implements Component {
 		const remainder = statsLine.slice(statsLeft.length); // padding + rightSide
 		const dimRemainder = theme.fg("dim", remainder);
 
-		const pwdLine = truncateToWidth(theme.fg("dim", pwd), width, theme.fg("dim", "..."));
-		const lines = [pwdLine, dimStatsLeft + dimRemainder];
+		const firstLineText = this.footerData.getHint() ?? pwd;
+		const firstLine = truncateToWidth(theme.fg("dim", firstLineText), width, theme.fg("dim", "..."));
+		const lines = [firstLine, dimStatsLeft + dimRemainder];
 
 		// Add extension statuses on a single line, sorted by key alphabetically
 		const extensionStatuses = this.footerData.getExtensionStatuses();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -249,6 +249,11 @@ export class InteractiveMode {
 	private lastStatusSpacer: Spacer | undefined = undefined;
 	private lastStatusText: Text | undefined = undefined;
 
+	// Transient hint for the footer (e.g. "Press Ctrl-C again to exit").
+	// State lives on footerDataProvider so custom footers can opt in by reading
+	// `footerData.getHint()` in their own render().
+	private hintTimer: ReturnType<typeof setTimeout> | undefined = undefined;
+
 	// Streaming message tracking
 	private streamingComponent: AssistantMessageComponent | undefined = undefined;
 	private streamingMessage: AssistantMessage | undefined = undefined;
@@ -2328,6 +2333,7 @@ export class InteractiveMode {
 				if (action !== "none") {
 					const now = Date.now();
 					if (now - this.lastEscapeTime < 500) {
+						this.clearHint();
 						if (action === "tree") {
 							this.showTreeSelector();
 						} else {
@@ -2336,6 +2342,7 @@ export class InteractiveMode {
 						this.lastEscapeTime = 0;
 					} else {
 						this.lastEscapeTime = now;
+						this.showTransientHint(`Press Esc again to open /${action}`, 500);
 					}
 				}
 			}
@@ -2954,6 +2961,26 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	/**
+	 * Show a transient hint in the footer's first line (replaces pwd), auto-clearing
+	 * after ttlMs. Used for double-press cues (e.g. "Press Ctrl-C again to exit").
+	 */
+	private showTransientHint(message: string, ttlMs: number): void {
+		if (this.hintTimer) clearTimeout(this.hintTimer);
+		this.footerDataProvider.setHint(message);
+		this.ui.requestRender();
+		this.hintTimer = setTimeout(() => this.clearHint(), ttlMs);
+	}
+
+	private clearHint(): void {
+		if (this.hintTimer) {
+			clearTimeout(this.hintTimer);
+			this.hintTimer = undefined;
+		}
+		this.footerDataProvider.setHint(undefined);
+		this.ui.requestRender();
+	}
+
 	private addMessageToChat(message: AgentMessage, options?: { populateHistory?: boolean }): void {
 		switch (message.role) {
 			case "bashExecution": {
@@ -3164,6 +3191,7 @@ export class InteractiveMode {
 		} else {
 			this.clearEditor();
 			this.lastSigintTime = now;
+			this.showTransientHint("Press Ctrl-C again to exit", 500);
 		}
 	}
 

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -63,6 +63,7 @@ function createFooterData(providerCount: number): ReadonlyFooterDataProvider {
 	const provider = {
 		getGitBranch: () => "main",
 		getExtensionStatuses: () => new Map<string, string>(),
+		getHint: () => undefined,
 		getAvailableProviderCount: () => providerCount,
 		onBranchChange: (callback: () => void) => {
 			void callback;


### PR DESCRIPTION
## Summary

Add a dim hint in the footer when one of pi's two-press mechanics has a pending window. Both currently have invisible 500ms windows — nothing tells the user the first press registered or that a second will do something different. Matches node REPL's cue pattern: `(To exit, press Ctrl+C again or Ctrl+D or type .exit)`.

- First Ctrl-C (clear editor): `Press Ctrl-C again to exit` for 500ms
- First Esc on empty editor (with double-escape-action set): `Press Esc again to open /{tree|fork}` for 500ms
- Both auto-clear after the window, or immediately when the second press takes the action

## How

Hint state lives on `FooterDataProvider` (new `setHint` / `getHint`, `getHint` added to `ReadonlyFooterDataProvider`). The default footer replaces its pwd line with the hint for the duration — no layout jump, stats/model row stays visible. Custom footers installed via `ctx.ui.setFooter` can opt in by reading `footerData.getHint()` in their own render.

## Changes

- `src/core/footer-data-provider.ts` — new `hint` slot, `getHint` / `setHint`; `ReadonlyFooterDataProvider` widened to expose `getHint`
- `src/modes/interactive/components/footer.ts` — renders `footerData.getHint() ?? pwd` for the first line
- `src/modes/interactive/interactive-mode.ts` — `showTransientHint(msg, ttlMs)` and `clearHint()`; called from `handleCtrlC` and the empty-editor Esc branch. `clearHint()` runs immediately when the second press takes the action so the hint doesn't linger into the opened selector
- `test/footer-width.test.ts` — mock provider updated for the widened type

## Testing

- `npm run check` passes
- `./test.sh` passes (560 / 560)
- Manually verified in tmux: hint replaces pwd on first Ctrl-C / Esc, auto-clears after 500ms, clears immediately on the second press, stats row untouched throughout