### PR TITLE
test(coding-agent): update stale mocks and fix /clone expectation

### DIFF
--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -450,6 +450,7 @@ describe("AgentSession concurrent prompt guard", () => {
 					systemPrompt: string,
 					systemPromptOptions: BuildSystemPromptOptions,
 				) => Promise<undefined>;
+				invalidate: (message?: string) => void;
 			};
 		};
 		sessionWithRunner._extensionRunner = {
@@ -466,6 +467,7 @@ describe("AgentSession concurrent prompt guard", () => {
 			},
 			emitInput: async () => ({ action: "continue" }),
 			emitBeforeAgentStart: async () => undefined,
+			invalidate: () => {},
 		};
 
 		await session.prompt("hi");
@@ -590,6 +592,7 @@ describe("AgentSession concurrent prompt guard", () => {
 					systemPrompt: string,
 					systemPromptOptions: BuildSystemPromptOptions,
 				) => Promise<undefined>;
+				invalidate: (message?: string) => void;
 			};
 		};
 		sessionWithRunner._extensionRunner = {
@@ -601,6 +604,7 @@ describe("AgentSession concurrent prompt guard", () => {
 			},
 			emitInput: async () => ({ action: "continue" }),
 			emitBeforeAgentStart: async () => undefined,
+			invalidate: () => {},
 		};
 
 		await session.prompt("hi");

--- a/packages/coding-agent/test/interactive-mode-clone-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-clone-command.test.ts
@@ -6,7 +6,6 @@ type CloneCommandContext = {
 	runtimeHost: {
 		fork: (entryId: string, options?: { position?: "before" | "at" }) => Promise<{ cancelled: boolean }>;
 	};
-	handleRuntimeSessionChange: () => Promise<void>;
 	renderCurrentSessionState: () => void;
 	editor: { setText: (text: string) => void };
 	showStatus: (message: string) => void;
@@ -23,7 +22,6 @@ const interactiveModePrototype = InteractiveMode.prototype as unknown as Interac
 describe("InteractiveMode /clone", () => {
 	it("clones the current leaf into a new session", async () => {
 		const fork = vi.fn(async () => ({ cancelled: false }));
-		const handleRuntimeSessionChange = vi.fn(async () => {});
 		const renderCurrentSessionState = vi.fn();
 		const setText = vi.fn();
 		const showStatus = vi.fn();
@@ -33,7 +31,6 @@ describe("InteractiveMode /clone", () => {
 		const context: CloneCommandContext = {
 			sessionManager: { getLeafId: () => "leaf-123" },
 			runtimeHost: { fork },
-			handleRuntimeSessionChange,
 			renderCurrentSessionState,
 			editor: { setText },
 			showStatus,
@@ -44,7 +41,6 @@ describe("InteractiveMode /clone", () => {
 		await interactiveModePrototype.handleCloneCommand.call(context);
 
 		expect(fork).toHaveBeenCalledWith("leaf-123", { position: "at" });
-		expect(handleRuntimeSessionChange).toHaveBeenCalled();
 		expect(renderCurrentSessionState).toHaveBeenCalled();
 		expect(setText).toHaveBeenCalledWith("");
 		expect(showStatus).toHaveBeenCalledWith("Cloned to new session");
@@ -60,7 +56,6 @@ describe("InteractiveMode /clone", () => {
 		const context: CloneCommandContext = {
 			sessionManager: { getLeafId: () => null },
 			runtimeHost: { fork },
-			handleRuntimeSessionChange: vi.fn(async () => {}),
 			renderCurrentSessionState: vi.fn(),
 			editor: { setText: vi.fn() },
 			showStatus,

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -16,7 +16,8 @@ describe("InteractiveMode compaction events", () => {
 			showError: vi.fn(),
 			showStatus: vi.fn(),
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
-			ui: { requestRender: vi.fn() },
+			settingsManager: { getShowTerminalProgress: () => false },
+			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
 		};
 
 		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -27,6 +27,7 @@ type FakeRuntimeHost = {
 	fork: ReturnType<typeof vi.fn>;
 	switchSession: ReturnType<typeof vi.fn>;
 	dispose: ReturnType<typeof vi.fn>;
+	setRebindSession: ReturnType<typeof vi.fn>;
 };
 
 function createAssistantMessage(options?: {
@@ -81,6 +82,7 @@ function createRuntimeHost(assistantMessage: AssistantMessage): FakeRuntimeHost 
 		dispose: vi.fn(async () => {
 			await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
 		}),
+		setRebindSession: vi.fn(),
 	};
 }
 

--- a/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
@@ -147,6 +147,7 @@ function createRuntimeHost(options: { withAuth: boolean; responseDelayMs: number
 		switchSession: vi.fn(async () => ({ cancelled: true })),
 		fork: vi.fn(async () => ({ cancelled: true, selectedText: "" })),
 		dispose: vi.fn(async () => {}),
+		setRebindSession: vi.fn(),
 	} as unknown as AgentSessionRuntime;
 
 	return {


### PR DESCRIPTION
## Summary

Mocks in 5 test files hadn't kept up with recent source additions, producing 10 vitest failures on `main`. Noticed while the CI run on #3607 hit these same failures — they reproduce on a clean `main` checkout.

## Fixes

- `test/print-mode.test.ts` — `FakeRuntimeHost` missing `setRebindSession` (added to `AgentSessionRuntime` and now called by `runPrintMode`)
- `test/rpc-prompt-response-semantics.test.ts` — same
- `test/agent-session-concurrent.test.ts` — both `_extensionRunner` mocks missing `invalidate` (called from `agent-session.ts:726` during session rebind)
- `test/interactive-mode-compaction.test.ts` — `fakeThis` missing `settingsManager.getShowTerminalProgress` and `ui.terminal.setProgress` (the `compaction_end` branch now consults the setting after 8cc046f8)
- `test/interactive-mode-clone-command.test.ts` — removed stale `handleRuntimeSessionChange` expectation; `handleCloneCommand` has never called it since d554409b introduced `/clone`, and the other `fork` call sites in `interactive-mode.ts` also don't

## Testing

Before: `Test Files 5 failed | 95 passed | 7 skipped (107)` / `Tests 10 failed | 1030 passed | 47 skipped (1087)`

After: `Test Files 100 passed | 7 skipped (107)` / `Tests 1040 passed | 47 skipped (1087)`

- `npm run check` passes
- vitest full suite clean (1040 / 0 / 47)

Test-only; no source changes.