### PR TITLE
fix(coding-agent): await native clipboard before emitting OSC 52

### DIFF
--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -18,20 +18,29 @@ function copyToX11Clipboard(options: NativeClipboardExecOptions): void {
 }
 
 export async function copyToClipboard(text: string): Promise<void> {
-	// Always emit OSC 52 - works over SSH/mosh, harmless locally
-	const encoded = Buffer.from(text).toString("base64");
-	process.stdout.write(`\x1b]52;c;${encoded}\x07`);
-
+	// Await the native addon to completion *before* emitting OSC 52. If OSC 52
+	// is emitted first, the outer terminal (tmux with set-clipboard on, iTerm2,
+	// Ghostty, etc.) may write NSPasteboard concurrently with the native
+	// addon's tokio worker, which panics the addon on macOS with
+	// `writeObjects failed` (kPasteboardSyncErr). Sequential is safe. OSC 52
+	// still fires afterward so SSH/mosh sessions (where native writes the
+	// wrong machine's clipboard) reach the user's real terminal.
+	let nativeOk = false;
 	try {
 		if (clipboard) {
 			await clipboard.setText(text);
-			return;
+			nativeOk = true;
 		}
 	} catch {
-		// Fall through to platform-specific clipboard tools.
+		// Native failed. Fall through to OSC 52 + platform-specific tools.
 	}
 
-	// Also try native tools (best effort for local sessions)
+	const encoded = Buffer.from(text).toString("base64");
+	process.stdout.write(`\x1b]52;c;${encoded}\x07`);
+
+	if (nativeOk) return;
+
+	// Also try platform-specific shell tools (best effort for local sessions)
 	const p = platform();
 	const options: NativeClipboardExecOptions = { input: text, timeout: 5000, stdio: ["pipe", "ignore", "ignore"] };
 

--- a/packages/coding-agent/test/clipboard-order.test.ts
+++ b/packages/coding-agent/test/clipboard-order.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Track call order across stdout writes and native setText.
+const calls: { kind: "native" | "osc52" | "pbcopy"; at: number }[] = [];
+
+vi.mock("../src/utils/clipboard-native.js", () => ({
+	clipboard: {
+		setText: vi.fn(async (_text: string) => {
+			// Simulate native addon's NSPasteboard write taking a few ms.
+			await new Promise((r) => setTimeout(r, 5));
+			calls.push({ kind: "native", at: performance.now() });
+		}),
+	},
+}));
+
+vi.mock("child_process", () => ({
+	execSync: vi.fn((cmd: string) => {
+		if (cmd === "pbcopy") {
+			calls.push({ kind: "pbcopy", at: performance.now() });
+		}
+	}),
+	spawn: vi.fn(),
+}));
+
+vi.mock("../src/utils/clipboard-image.js", () => ({
+	isWaylandSession: () => false,
+}));
+
+let originalWrite: typeof process.stdout.write;
+
+beforeEach(() => {
+	calls.length = 0;
+	originalWrite = process.stdout.write.bind(process.stdout);
+	process.stdout.write = ((chunk: string) => {
+		if (typeof chunk === "string" && chunk.startsWith("\x1b]52;c;")) {
+			calls.push({ kind: "osc52", at: performance.now() });
+		}
+		return true;
+	}) as typeof process.stdout.write;
+});
+
+afterEach(() => {
+	process.stdout.write = originalWrite;
+	vi.clearAllMocks();
+});
+
+describe("copyToClipboard ordering", () => {
+	it("awaits native setText before emitting OSC 52 (no race)", async () => {
+		const { copyToClipboard } = await import("../src/utils/clipboard.js");
+		await copyToClipboard("hello");
+
+		const native = calls.findIndex((c) => c.kind === "native");
+		const osc52 = calls.findIndex((c) => c.kind === "osc52");
+		expect(native).toBeGreaterThanOrEqual(0);
+		expect(osc52).toBeGreaterThanOrEqual(0);
+		expect(native).toBeLessThan(osc52);
+	});
+
+	it("skips pbcopy when native succeeded (preserves original optimization)", async () => {
+		const { copyToClipboard } = await import("../src/utils/clipboard.js");
+		await copyToClipboard("hello");
+
+		expect(calls.some((c) => c.kind === "native")).toBe(true);
+		expect(calls.some((c) => c.kind === "pbcopy")).toBe(false);
+	});
+
+	it("still emits OSC 52 even when native succeeded (SSH/mosh correctness)", async () => {
+		const { copyToClipboard } = await import("../src/utils/clipboard.js");
+		await copyToClipboard("hello");
+
+		expect(calls.some((c) => c.kind === "osc52")).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

`copyToClipboard` now awaits the native clipboard addon to completion before emitting OSC 52, eliminating a race that panics the native addon on macOS. OSC 52 still fires unconditionally afterward so SSH/mosh sessions continue to reach the user's real terminal. Platform shell-tool fallback (`pbcopy`/`wl-copy`/`xclip`) is still skipped when the native write succeeded.

## Why

`/copy` can crash the agent with:

```
thread 'tokio-runtime-worker' panicked at src/lib.rs:33:22:
called `Result::unwrap()` on an `Err` value: "writeObjects failed"
```

The current flow emits OSC 52 *before* awaiting `clipboard.setText`. With `tmux set-clipboard on` (or an outer terminal like iTerm2/Ghostty forwarding OSC 52 directly), the terminal writes `NSPasteboard` in response to the escape, at the same time the native addon's tokio worker is also writing `NSPasteboard`. Two writers, one pasteboard, sync-cookie race → `kPasteboardBadItemErr` → `clipboard-rs` returns `Err("writeObjects failed")` → the addon's `.unwrap()` panics the whole Node process. A JS `try/catch` can't rescue a Rust `panic!`.

Reordering so the native write commits *before* OSC 52 is emitted makes the terminal's subsequent pasteboard write strictly sequential, eliminating the race.

## The `nativeOk` flag

A pure literal swap of the two blocks would either (a) keep the early `return` and skip OSC 52 on native success, regressing SSH→Mac (native writes the *remote* Mac's clipboard, and users relied on OSC 52 to reach their local terminal), or (b) drop the `return` and redundantly run `pbcopy` after every successful native write. The flag preserves both: OSC 52 fires unconditionally (correctness for SSH/mosh), platform shell tools skip when native succeeded (original optimization).

## Caveat

After a successful native write locally, OSC 52 still fires and the outer terminal will redundantly re-write `NSPasteboard` with the same content. Cosmetic: on Macs with aggressive clipboard managers this double-fires a change event. Not a race (sequential), not a crash.

## Tests

Added `packages/coding-agent/test/clipboard-order.test.ts` (vitest) covering:

1. Native awaited before OSC 52 emission
2. OSC 52 still emitted after native success (SSH/mosh correctness)
3. Platform shell tools skipped when native succeeded (original optimization)

All 8 clipboard-scoped tests pass (3 new + 5 existing `clipboard-image`).

## Related

This reorder only prevents the self-race through OSC 52. External concurrent writers (clipboard managers, Universal Clipboard, Handoff) can still trigger the same panic in the native addon. A companion PR on the upstream `@mariozechner/clipboard` addon propagates `set_text` errors through `napi::Result` instead of `.unwrap()`-ing them, which is the root-cause fix for the class of bug.
