### PR TITLE
feat(coding-agent): add persistModelChanges setting for session-only model selection

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -17,6 +17,7 @@ Edit directly or use `/settings` for common options.
 |---------|------|---------|-------------|
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
+| `persistModelChanges` | boolean | `true` | When `true`, picking a model via `/model` or cycling with Ctrl+P updates `defaultProvider`/`defaultModel` in settings.json. Set to `false` to keep model switches session-only. |
 | `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1396,7 +1396,7 @@ export class AgentSession {
 		const thinkingLevel = this._getThinkingLevelForModelSwitch();
 		this.agent.state.model = model;
 		this.sessionManager.appendModelChange(model.provider, model.id);
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		this.settingsManager.maybePersistDefaultModel(model.provider, model.id);
 
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(thinkingLevel);
@@ -1433,7 +1433,7 @@ export class AgentSession {
 		// Apply model
 		this.agent.state.model = next.model;
 		this.sessionManager.appendModelChange(next.model.provider, next.model.id);
-		this.settingsManager.setDefaultModelAndProvider(next.model.provider, next.model.id);
+		this.settingsManager.maybePersistDefaultModel(next.model.provider, next.model.id);
 
 		// Apply thinking level.
 		// - Explicit scoped model thinking level overrides current session level
@@ -1461,7 +1461,7 @@ export class AgentSession {
 		const thinkingLevel = this._getThinkingLevelForModelSwitch();
 		this.agent.state.model = nextModel;
 		this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
-		this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+		this.settingsManager.maybePersistDefaultModel(nextModel.provider, nextModel.id);
 
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(thinkingLevel);

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -67,6 +67,7 @@ export interface Settings {
 	lastChangelogVersion?: string;
 	defaultProvider?: string;
 	defaultModel?: string;
+	persistModelChanges?: boolean; // default: true - when false, /model and Ctrl+P cycling are session-only
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 	transport?: TransportSetting; // default: "sse"
 	steeringMode?: "all" | "one-at-a-time";
@@ -578,6 +579,29 @@ export class SettingsManager {
 		this.markModified("defaultProvider");
 		this.markModified("defaultModel");
 		this.save();
+	}
+
+	getPersistModelChanges(): boolean {
+		return this.settings.persistModelChanges ?? true;
+	}
+
+	setPersistModelChanges(value: boolean): void {
+		this.globalSettings.persistModelChanges = value;
+		this.markModified("persistModelChanges");
+		this.save();
+	}
+
+	/**
+	 * Persist the current model/provider as the new default for future sessions,
+	 * unless the user has opted out via `persistModelChanges: false`.
+	 *
+	 * Call this from flows where the user is picking a model for the current
+	 * session (e.g. `/model`, Ctrl+P cycling). Use `setDefaultModelAndProvider`
+	 * directly when the user explicitly asks to set a new default.
+	 */
+	maybePersistDefaultModel(provider: string, modelId: string): void {
+		if (!this.getPersistModelChanges()) return;
+		this.setDefaultModelAndProvider(provider, modelId);
 	}
 
 	getSteeringMode(): "all" | "one-at-a-time" {

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -327,8 +327,8 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private handleSelect(model: Model<any>): void {
-		// Save as new default
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		// Save as new default (no-op when persistModelChanges is disabled)
+		this.settingsManager.maybePersistDefaultModel(model.provider, model.id);
 		this.onSelectCallback(model);
 	}
 

--- a/packages/coding-agent/test/agent-session-persist-model-changes.test.ts
+++ b/packages/coding-agent/test/agent-session-persist-model-changes.test.ts
@@ -1,0 +1,76 @@
+import { Agent } from "@mariozechner/pi-agent-core";
+import { getModel } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { createTestResourceLoader } from "./utilities.js";
+
+const modelA = getModel("anthropic", "claude-sonnet-4-5")!;
+const modelB = getModel("anthropic", "claude-3-5-haiku-latest")!;
+
+function createSession(opts: { persistModelChanges?: boolean } = {}) {
+	const settingsManager = SettingsManager.inMemory({
+		defaultProvider: modelA.provider,
+		defaultModel: modelA.id,
+		...(opts.persistModelChanges !== undefined ? { persistModelChanges: opts.persistModelChanges } : {}),
+	});
+	const authStorage = AuthStorage.inMemory();
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	const session = new AgentSession({
+		agent: new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: modelA,
+				systemPrompt: "You are a helpful assistant.",
+				tools: [],
+				thinkingLevel: "off",
+			},
+		}),
+		sessionManager: SessionManager.inMemory(),
+		settingsManager,
+		cwd: process.cwd(),
+		modelRegistry: ModelRegistry.inMemory(authStorage),
+		resourceLoader: createTestResourceLoader(),
+		scopedModels: [{ model: modelA }, { model: modelB }],
+	});
+	return { session, settingsManager };
+}
+
+describe("AgentSession persistModelChanges", () => {
+	it("persists model changes to settings by default", async () => {
+		const { session, settingsManager } = createSession();
+		try {
+			await session.setModel(modelB);
+			expect(settingsManager.getDefaultProvider()).toBe(modelB.provider);
+			expect(settingsManager.getDefaultModel()).toBe(modelB.id);
+
+			await session.cycleModel();
+			expect(settingsManager.getDefaultProvider()).toBe(modelA.provider);
+			expect(settingsManager.getDefaultModel()).toBe(modelA.id);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("keeps settings untouched when persistModelChanges is false", async () => {
+		const { session, settingsManager } = createSession({ persistModelChanges: false });
+		try {
+			await session.setModel(modelB);
+			expect(session.model?.id).toBe(modelB.id);
+			// Settings retain the original default.
+			expect(settingsManager.getDefaultProvider()).toBe(modelA.provider);
+			expect(settingsManager.getDefaultModel()).toBe(modelA.id);
+
+			await session.cycleModel();
+			expect(session.model?.id).toBe(modelA.id);
+			// Still untouched.
+			expect(settingsManager.getDefaultProvider()).toBe(modelA.provider);
+			expect(settingsManager.getDefaultModel()).toBe(modelA.id);
+		} finally {
+			session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -155,6 +155,75 @@ describe("SettingsManager", () => {
 		});
 	});
 
+	describe("persistModelChanges", () => {
+		it("defaults to true (preserves existing auto-persist behavior)", () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getPersistModelChanges()).toBe(true);
+		});
+
+		it("reflects the configured value from settings.json", () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ persistModelChanges: false }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getPersistModelChanges()).toBe(false);
+		});
+
+		it("maybePersistDefaultModel writes defaultProvider/defaultModel when enabled", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.maybePersistDefaultModel("anthropic", "claude-opus-4-5");
+			await manager.flush();
+
+			const saved = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(saved.defaultProvider).toBe("anthropic");
+			expect(saved.defaultModel).toBe("claude-opus-4-5");
+			expect(saved.theme).toBe("dark");
+		});
+
+		it("maybePersistDefaultModel is a no-op when persistModelChanges is false", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(
+				settingsPath,
+				JSON.stringify({
+					persistModelChanges: false,
+					defaultProvider: "anthropic",
+					defaultModel: "claude-sonnet-4-20250514",
+				}),
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.maybePersistDefaultModel("openai", "gpt-5");
+			await manager.flush();
+
+			const saved = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(saved.defaultProvider).toBe("anthropic");
+			expect(saved.defaultModel).toBe("claude-sonnet-4-20250514");
+			expect(saved.persistModelChanges).toBe(false);
+			// In-memory model stays as-is (the method is a pure no-op when disabled).
+			expect(manager.getDefaultProvider()).toBe("anthropic");
+			expect(manager.getDefaultModel()).toBe("claude-sonnet-4-20250514");
+		});
+
+		it("setDefaultModelAndProvider still persists even when persistModelChanges is false", async () => {
+			// Explicit API for "make this my new default" must keep working, e.g. for a /settings
+			// action or custom extension, regardless of the auto-persist preference.
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ persistModelChanges: false }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setDefaultModelAndProvider("openai", "gpt-5");
+			await manager.flush();
+
+			const saved = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(saved.defaultProvider).toBe("openai");
+			expect(saved.defaultModel).toBe("gpt-5");
+			expect(saved.persistModelChanges).toBe(false);
+		});
+	});
+
 	describe("reload", () => {
 		it("should reload global settings from disk", async () => {
 			const settingsPath = join(agentDir, "settings.json");


### PR DESCRIPTION
Adds a persistModelChanges setting (default: true, preserving current behavior). Set to false to keep /model selections and Ctrl+P cycling session-only instead of overwriting defaultProvider/defaultModel in settings.json.

Motivation: picking a different model for a single task shouldn't silently change the long-term default.
