### PR TITLE
fix(ai): drop unpaired reasoning items when replaying assistant history

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -171,7 +171,18 @@ export function convertResponsesMessages<TApi extends Api>(
 				if (block.type === "thinking") {
 					if (block.thinkingSignature) {
 						const reasoningItem = JSON.parse(block.thinkingSignature) as ResponseReasoningItem;
-						output.push(reasoningItem);
+						// Azure Responses API requires every reasoning item (rs_*) to be
+						// followed by its paired message/function_call in the same turn,
+						// otherwise it returns 400 "reasoning was provided without its
+						// required following item". Only replay the reasoning item when
+						// a pairable follower exists in this assistant turn.
+						const blockIdx = msg.content.indexOf(block);
+						const hasFollower = msg.content
+							.slice(blockIdx + 1)
+							.some((b) => b.type === "text" || b.type === "toolCall");
+						if (hasFollower) {
+							output.push(reasoningItem);
+						}
 					}
 				} else if (block.type === "text") {
 					const textBlock = block as TextContent;


### PR DESCRIPTION
## Problem

When replaying assistant history to the Azure OpenAI Responses API, multi-turn requests intermittently fail with:

```
400 Item 'rs_xxx' of type 'reasoning' was provided without its required following item.
```

This happens when a previous assistant turn contained a `thinking` block (with `thinkingSignature`) that was **not** followed by a paired `text` message or `toolCall` in that same turn — for example, when the model emitted only reasoning summaries and then stopped, or when downstream post-processing stripped the text/toolCall block but left the thinking block intact.

`convertResponsesMessages` currently pushes the reasoning item unconditionally, which violates the Azure Responses API invariant that every `rs_*` item must be immediately followed by its paired `message` or `function_call` item in the same assistant turn.

Related: #2118 (same pairing-validation family, opposite direction: `function_call` without `reasoning`).

## Fix

Before pushing the parsed reasoning item, check whether the remainder of `msg.content` contains a `text` or `toolCall` block. If not, drop the reasoning item for that turn. Azure treats the replayed assistant message as complete without it, and the request validates.

This is conservative: we never fabricate pairings, we only omit an item that would otherwise guarantee a 400.

## Test

Reproduced against `gpt-5.4-pro` on Azure (api-version `2025-04-01-preview`) with a conversation containing an assistant turn whose only content block is `thinking`. Before the patch: deterministic 400 on the next turn. After the patch: request succeeds.
