### PR TITLE
fix(coding-agent): preserve models when re-registering provider with overrides only

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -732,7 +732,7 @@ export class ModelRegistry {
 	registerProvider(providerName: string, config: ProviderConfigInput): void {
 		this.validateProviderConfig(providerName, config);
 		this.applyProviderConfig(providerName, config);
-		this.registeredProviders.set(providerName, config);
+		this.upsertRegisteredProvider(providerName, config);
 	}
 
 	/**
@@ -748,6 +748,25 @@ export class ModelRegistry {
 		if (!this.registeredProviders.has(providerName)) return;
 		this.registeredProviders.delete(providerName);
 		this.refresh();
+	}
+
+	/**
+	 * Upsert a provider config into registeredProviders.
+	 * If the provider is already registered, defined values in the incoming config
+	 * override existing ones; undefined values are preserved from the stored config.
+	 * If the provider is not registered, the incoming config is stored as-is.
+	 */
+	private upsertRegisteredProvider(providerName: string, config: ProviderConfigInput): void {
+		const existing = this.registeredProviders.get(providerName);
+		if (!existing) {
+			this.registeredProviders.set(providerName, config);
+			return;
+		}
+		for (const k of Object.keys(config) as (keyof ProviderConfigInput)[]) {
+			if (config[k] !== undefined) {
+				(existing as Record<string, unknown>)[k] = config[k];
+			}
+		}
 	}
 
 	private validateProviderConfig(providerName: string, config: ProviderConfigInput): void {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -6,7 +6,7 @@ import { getApiProvider } from "@mariozechner/pi-ai";
 import { getOAuthProvider } from "@mariozechner/pi-ai/oauth";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
-import { clearApiKeyCache, ModelRegistry } from "../src/core/model-registry.js";
+import { clearApiKeyCache, ModelRegistry, type ProviderConfigInput } from "../src/core/model-registry.js";
 
 describe("ModelRegistry", () => {
 	let tempDir: string;
@@ -32,11 +32,11 @@ describe("ModelRegistry", () => {
 		baseUrl: string,
 		models: Array<{ id: string; name?: string }>,
 		api: string = "anthropic-messages",
-	) {
+	): ProviderConfigInput {
 		return {
 			baseUrl,
 			apiKey: "TEST_KEY",
-			api,
+			api: api as Api,
 			models: models.map((m) => ({
 				id: m.id,
 				name: m.name ?? m.id,
@@ -951,6 +951,101 @@ describe("ModelRegistry", () => {
 					error instanceof Error && error.message === "custom streamSimple override";
 			}
 			expect(threwCustomOverrideAfterUnregister).toBe(false);
+		});
+
+		describe("dynamic provider override persistence", () => {
+			test("baseUrl-only override keeps built-in provider models after refresh", () => {
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				registry.registerProvider("anthropic", { baseUrl: "https://proxy.test/anthropic" });
+				registry.refresh();
+
+				const anthropicModels = getModelsForProvider(registry, "anthropic");
+				expect(anthropicModels.length).toBeGreaterThan(1);
+				expect(anthropicModels.every((m) => m.baseUrl === "https://proxy.test/anthropic")).toBe(true);
+			});
+
+			test("models-only override replaces built-in provider models after refresh", () => {
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				registry.registerProvider("anthropic", {
+					...providerConfig("https://custom.test/anthropic", [{ id: "custom-claude" }], "anthropic-messages"),
+					baseUrl: "https://custom.test/anthropic",
+				});
+				registry.refresh();
+
+				expect(getModelsForProvider(registry, "anthropic").map((m) => m.id)).toEqual(["custom-claude"]);
+				expect(registry.find("anthropic", "custom-claude")?.baseUrl).toBe("https://custom.test/anthropic");
+			});
+
+			test("models plus baseUrl override replaces built-in provider models after refresh", () => {
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				registry.registerProvider("anthropic", {
+					...providerConfig("https://custom.test/anthropic", [{ id: "custom-claude" }], "anthropic-messages"),
+					baseUrl: "https://custom.test/anthropic",
+				});
+				registry.registerProvider("anthropic", { baseUrl: "https://proxy.test/anthropic" });
+				registry.refresh();
+
+				expect(getModelsForProvider(registry, "anthropic").map((m) => m.id)).toEqual(["custom-claude"]);
+				expect(registry.find("anthropic", "custom-claude")?.baseUrl).toBe("https://proxy.test/anthropic");
+			});
+
+			test("models-only custom provider registration survives refresh", () => {
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				registry.registerProvider(
+					"custom-provider",
+					providerConfig("https://custom.test/v1", [{ id: "custom-a" }, { id: "custom-b" }], "openai-completions"),
+				);
+				registry.refresh();
+
+				expect(getModelsForProvider(registry, "custom-provider").map((m) => m.id)).toEqual([
+					"custom-a",
+					"custom-b",
+				]);
+			});
+
+			test("baseUrl-only override keeps custom provider models after refresh", () => {
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				registry.registerProvider(
+					"custom-provider",
+					providerConfig("https://custom.test/v1", [{ id: "custom-a" }, { id: "custom-b" }], "openai-completions"),
+				);
+				registry.registerProvider("custom-provider", { baseUrl: "https://proxy.test/custom" });
+				registry.refresh();
+
+				expect(getModelsForProvider(registry, "custom-provider").map((m) => m.id)).toEqual([
+					"custom-a",
+					"custom-b",
+				]);
+				expect(
+					getModelsForProvider(registry, "custom-provider").every(
+						(m) => m.baseUrl === "https://proxy.test/custom",
+					),
+				).toBe(true);
+			});
+
+			test("headers-only override keeps custom provider models after refresh", async () => {
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				registry.registerProvider(
+					"custom-provider",
+					providerConfig("https://custom.test/v1", [{ id: "custom-a" }, { id: "custom-b" }], "openai-completions"),
+				);
+				registry.registerProvider("custom-provider", { headers: { "x-proxy": "enabled" } });
+				registry.refresh();
+
+				const models = getModelsForProvider(registry, "custom-provider");
+				expect(models.map((m) => m.id)).toEqual(["custom-a", "custom-b"]);
+				expect(models.every((m) => m.baseUrl === "https://custom.test/v1")).toBe(true);
+				expect(await registry.getApiKeyAndHeaders(models[0])).toMatchObject({
+					ok: true,
+					headers: { "x-proxy": "enabled" },
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
Hello!

Noticed this edge case when overriding custom providers:
- Let's say an extension registers a provider asap, with baseURL, models and whatever else
- Then, another extension overrides that providers, but only updating its `baseURL`

According to the docs, it should only replace the baseURL and keep the existing models. However, currently, the override replaces the provider, loosing the models and the other configuration.

In this PR I upsert the providers on change instead of replacing them. I wasn't too sure about the shape the code should look like (see back and forth in the implementation between making a generic util or keeping it only in the model registry), but decide to keep it local. 

Let me know if you need/want changes!


Investigation: https://pi.dev/session/#8c0e991e423d658a4c85ab532055e873
Implementation: https://pi.dev/session/#5b7f4e0c5551f1b162038091f9169137


------

<details><summary>Summary by GLM-5.1:</summary>
<p>

## Problem

`registerProvider()` stored dynamic provider registrations in a single `Map<string, ProviderConfigInput>`, where each call overwrote the previous entry. This meant a models registration followed by a baseUrl/headers-only override lost the models in the stored config. After `refresh()`, only the override-only config was replayed, causing extension-provided models to disappear.

## Fix

Added `upsertRegisteredProvider()` that merges defined fields into the existing stored config instead of replacing it. Fields absent from the incoming config (undefined) are preserved from the stored config.

**Semantics preserved:**
- `models` provided in new config → replaces stored models
- no `models`, but `baseUrl`/`headers`/etc. → overrides existing config without deleting previously registered models
- `refresh()` can reconstruct the final state from `registeredProviders`

## Files changed

- `packages/coding-agent/src/core/model-registry.ts` — added `upsertRegisteredProvider()`, replaced `this.registeredProviders.set()` with upsert call, removed debug logging
- `packages/coding-agent/test/model-registry.test.ts` — added 6 regression tests under "dynamic provider override persistence" describe block

## Tests

3 previously-failing tests now pass:
- models plus baseUrl override replaces built-in provider models after refresh
- baseUrl-only override keeps custom provider models after refresh
- headers-only override keeps custom provider models after refresh

All 560 tests pass via `./test.sh`. Build passes via `npm run build`.

</p>
</details>