### PR TITLE
fix(ai): preserve actual reasoning_content on DeepSeek assistant replay

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -785,6 +785,23 @@ export function convertMessages(
 			const nonEmptyThinkingBlocks = msg.content
 				.filter(isThinkingContentBlock)
 				.filter((block) => block.thinking.trim().length > 0);
+
+			// When the endpoint requires reasoning_content on replayed assistant messages
+			// (e.g. DeepSeek), carry the prior turn's actual reasoning rather than relying
+			// on the empty-string fallback below. DeepSeek docs require the prior turn's
+			// reasoning to be passed back on tool-call turns; sending the real text
+			// preserves reasoning continuity across multi-turn sessions.
+			// https://api-docs.deepseek.com/guides/thinking_mode
+			if (
+				compat.requiresReasoningContentOnAssistantMessages &&
+				model.reasoning &&
+				nonEmptyThinkingBlocks.length > 0
+			) {
+				(assistantMsg as { reasoning_content?: string }).reasoning_content = nonEmptyThinkingBlocks
+					.map((block) => sanitizeSurrogates(block.thinking))
+					.join("\n");
+			}
+
 			if (nonEmptyThinkingBlocks.length > 0) {
 				if (compat.requiresThinkingAsText) {
 					// Convert thinking blocks to plain text (no tags to avoid model mimicking them)

--- a/packages/ai/test/deepseek-reasoning-content.test.ts
+++ b/packages/ai/test/deepseek-reasoning-content.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.js";
+import { streamSimple } from "../src/stream.js";
+import type { AssistantMessage, Context, Model } from "../src/types.js";
+
+interface DeepSeekCapturedPayload {
+	messages: Array<{
+		role: string;
+		content?: unknown;
+		reasoning_content?: string;
+		tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>;
+	}>;
+}
+
+async function capturePayload(context: Context): Promise<DeepSeekCapturedPayload> {
+	const model = getModel("deepseek", "deepseek-v4-pro") as Model<"openai-completions">;
+	const captureModel: Model<"openai-completions"> = {
+		...model,
+		baseUrl: "http://127.0.0.1:9",
+	};
+
+	let captured: DeepSeekCapturedPayload | undefined;
+	const s = streamSimple(captureModel, context, {
+		apiKey: "fake-key",
+		onPayload: (payload) => {
+			captured = payload as DeepSeekCapturedPayload;
+			return payload;
+		},
+	});
+
+	await s.result();
+
+	if (!captured) {
+		throw new Error("Expected payload to be captured before request failure");
+	}
+
+	return captured;
+}
+
+function makeAssistantMsg(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-completions",
+		provider: "deepseek",
+		model: "deepseek-v4-pro",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("DeepSeek reasoning_content round-trip on assistant history", () => {
+	it("carries the actual thinking text when the prior assistant turn had reasoning", async () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "hi", timestamp: Date.now() },
+				makeAssistantMsg([
+					{ type: "thinking", thinking: "Let me ponder this carefully." },
+					{ type: "text", text: "Hello!" },
+				]),
+				{ role: "user", content: "continue", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capturePayload(context);
+		const asst = payload.messages.find((m) => m.role === "assistant");
+
+		expect(asst).toBeDefined();
+		expect(asst?.reasoning_content).toBe("Let me ponder this carefully.");
+	});
+
+	it("joins multiple thinking blocks with newline", async () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "hi", timestamp: Date.now() },
+				makeAssistantMsg([
+					{ type: "thinking", thinking: "First thought." },
+					{ type: "thinking", thinking: "Second thought." },
+					{ type: "text", text: "Done." },
+				]),
+				{ role: "user", content: "continue", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capturePayload(context);
+		const asst = payload.messages.find((m) => m.role === "assistant");
+
+		expect(asst?.reasoning_content).toBe("First thought.\nSecond thought.");
+	});
+
+	it("filters empty / whitespace-only thinking blocks before joining", async () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "hi", timestamp: Date.now() },
+				makeAssistantMsg([
+					{ type: "thinking", thinking: "" },
+					{ type: "thinking", thinking: "   " },
+					{ type: "thinking", thinking: "Real thought." },
+					{ type: "text", text: "OK." },
+				]),
+				{ role: "user", content: "continue", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capturePayload(context);
+		const asst = payload.messages.find((m) => m.role === "assistant");
+
+		expect(asst?.reasoning_content).toBe("Real thought.");
+	});
+
+	it("falls back to empty string when the prior assistant turn had tool_calls but no thinking (the 400-producing case)", async () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "search for something", timestamp: Date.now() },
+				makeAssistantMsg([
+					{
+						type: "toolCall",
+						id: "call_xyz",
+						name: "search",
+						arguments: { query: "hi" },
+					},
+				]),
+				{
+					role: "toolResult",
+					toolCallId: "call_xyz",
+					toolName: "search",
+					content: [{ type: "text", text: "ok" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+				{ role: "user", content: "continue", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capturePayload(context);
+		const asst = payload.messages.find((m) => m.role === "assistant");
+
+		expect(asst).toBeDefined();
+		expect(asst?.reasoning_content).toBe("");
+		expect(asst?.tool_calls?.[0]?.id).toBe("call_xyz");
+	});
+
+	it("falls back to empty string when prior assistant turn has text but no thinking", async () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "hi", timestamp: Date.now() },
+				makeAssistantMsg([{ type: "text", text: "Just text, no reasoning this turn." }]),
+				{ role: "user", content: "continue", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capturePayload(context);
+		const asst = payload.messages.find((m) => m.role === "assistant");
+
+		expect(asst?.reasoning_content).toBe("");
+	});
+});


### PR DESCRIPTION
Closes #3655

## Summary

When `requiresReasoningContentOnAssistantMessages` is set on an OpenAI-compatible completions provider (currently auto-detected for DeepSeek), carry the prior turn's actual reasoning in the replayed `reasoning_content` field rather than always sending an empty string.

The existing empty-string fallback (packages/ai/src/providers/openai-completions.ts, ~line 844) is retained: it still fills `""` for turns with no prior thinking, satisfying DeepSeek's "must be present" constraint on tool-call turns.

## Why

DeepSeek's thinking-mode docs require the prior turn's `reasoning_content` to be round-tripped on tool-call turns or the server returns 400. `main` already handles the 400 via the empty-string fallback; this PR adds the missing half — sending the real reasoning when the model produced it — so the documented multi-turn reasoning continuity is preserved rather than discarded.

## Change

- `packages/ai/src/providers/openai-completions.ts` — one new early `if` (~5 lines of logic) ahead of the existing `nonEmptyThinkingBlocks.length > 0` branch. Gated on `compat.requiresReasoningContentOnAssistantMessages && model.reasoning && nonEmptyThinkingBlocks.length > 0`. Writes joined `sanitizeSurrogates(block.thinking)` to `assistantMsg.reasoning_content`.
- Existing fallback and the `requiresThinkingAsText` / signature branches are unchanged.

## Tests

`packages/ai/test/deepseek-reasoning-content.test.ts` — 5 vitest cases using the existing `onPayload` capture pattern (cf. `anthropic-thinking-disable.test.ts`):

1. actual thinking round-trip
2. multiple thinking blocks joined with `\n`
3. empty / whitespace-only blocks filtered
4. fallback to `""` when prior tool-call turn had no thinking (the 400-producing case)
5. fallback to `""` for plain-text turns

Local verification: all 5 new cases pass; all other `openai-completions-*.test.ts` tests pass.

Note: following CONTRIBUTING, I opened #3655 describing the change first — wait on `lgtm` before expecting review here.
