### PR TITLE
fix(openai-completions): inject empty reasoning_content for DeepSeek tool-call history

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -470,6 +470,7 @@ function buildParams(
 	cacheRetention: CacheRetention = resolveCacheRetention(options?.cacheRetention),
 ) {
 	const messages = convertMessages(model, context, compat);
+	injectDeepSeekReasoningContent(messages, model);
 	const cacheControl = getCompatCacheControl(compat, cacheRetention);
 
 	const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
@@ -568,6 +569,33 @@ function buildParams(
 	}
 
 	return params;
+}
+
+/**
+ * DeepSeek V4 thinking mode requires reasoning_content to be passed back
+ * in assistant tool-call history. If missing, the API returns 400:
+ * "The reasoning_content in the thinking mode must be passed back to the API."
+ *
+ * An empty string is a safe fallback (verified against the live API).
+ */
+function injectDeepSeekReasoningContent(
+	messages: ChatCompletionMessageParam[],
+	model: Model<"openai-completions">,
+): void {
+	if (model.provider !== "deepseek" && !model.baseUrl?.includes?.("deepseek.com")) {
+		return;
+	}
+	for (const msg of messages) {
+		if (msg.role !== "assistant") continue;
+		const assistant = msg as ChatCompletionAssistantMessageParam & {
+			reasoning_content?: string;
+			tool_calls?: Array<{ function?: { arguments?: string; name?: string }; id?: string; type?: string }>;
+		};
+		// Only inject for messages that carry tool_calls and lack reasoning_content
+		if (!assistant.tool_calls || assistant.tool_calls.length === 0) continue;
+		if (assistant.reasoning_content !== undefined) continue;
+		assistant.reasoning_content = "";
+	}
 }
 
 function mapReasoningEffort(


### PR DESCRIPTION
## Problem

In pi-ai `buildParams`, `convertMessages` does not generate a `reasoning_content` field for assistant tool-call messages. DeepSeek V4 thinking mode requires this field to be passed back, otherwise the API returns a 400 error:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

## Fix

After `convertMessages` in `buildParams`, check DeepSeek model assistant tool-call messages for missing `reasoning_content`. When absent, inject an empty string `""` (verified safe against the live DeepSeek API → 200 OK).

Only applied to models with `provider=deepseek` or `baseUrl` containing `deepseek.com`.

## Verification

- Production live test: 0 errors after applying the patch

## Related

Companion fix in openclaw: https://github.com/snowzlm/openclaw/pull/4