### PR TITLE
feat(ai): add xhigh reasoning support for DeepSeek V4 Pro

### DIFF
--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -51,6 +51,7 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
  * Supported today:
  * - GPT-5.2 / GPT-5.3 / GPT-5.4 / GPT-5.5 model families
  * - Opus 4.6+ models (xhigh maps to adaptive effort "max" on Anthropic-compatible providers)
+ * - DeepSeek V4 Pro (xhigh maps to reasoning effort "max" via the deepseek thinking format)
  */
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
 	if (
@@ -68,6 +69,10 @@ export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
 		model.id.includes("opus-4-7") ||
 		model.id.includes("opus-4.7")
 	) {
+		return true;
+	}
+
+	if (model.id.includes("deepseek-v4-pro")) {
 		return true;
 	}
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -669,7 +669,7 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 
 /**
  * Map ThinkingLevel to Anthropic effort levels for adaptive thinking.
- * Note: effort "max" is only valid on Opus 4.6, while Opus 4.7 supports "xhigh".
+ * Note: effort "max" is only valid on Opus 4.6 and DeepSeek V4 Pro, while Opus 4.7 supports "xhigh".
  */
 function mapThinkingLevelToEffort(level: SimpleStreamOptions["reasoning"], modelId: string): AnthropicEffort {
 	switch (level) {
@@ -687,6 +687,9 @@ function mapThinkingLevelToEffort(level: SimpleStreamOptions["reasoning"], model
 			}
 			if (modelId.includes("opus-4-7") || modelId.includes("opus-4.7")) {
 				return "xhigh";
+			}
+			if (modelId.includes("deepseek-v4-pro")) {
+				return "max";
 			}
 			return "high";
 		default:

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -31,4 +31,34 @@ describe("supportsXhigh", () => {
 		expect(model).toBeDefined();
 		expect(supportsXhigh(model!)).toBe(true);
 	});
+
+	it("returns true for DeepSeek V4 Pro on native deepseek provider (openai-completions API)", () => {
+		const model = getModel("deepseek", "deepseek-v4-pro");
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(true);
+	});
+
+	it("returns true for DeepSeek V4 Pro on openrouter (openai-completions API)", () => {
+		const model = getModel("openrouter", "deepseek/deepseek-v4-pro");
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(true);
+	});
+
+	it("returns true for DeepSeek V4 Pro on vercel-ai-gateway (anthropic-messages API)", () => {
+		const model = getModel("vercel-ai-gateway", "deepseek/deepseek-v4-pro");
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(true);
+	});
+
+	it("returns false for DeepSeek V4 Flash (does not support max effort)", () => {
+		const model = getModel("deepseek", "deepseek-v4-flash");
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(false);
+	});
+
+	it("returns false for older DeepSeek models (bedrock)", () => {
+		const model = getModel("amazon-bedrock", "deepseek.v3.2");
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(false);
+	});
 });


### PR DESCRIPTION
## Motivation

DeepSeek V4 Pro supports `reasoning_effort=max` for complex agent workloads ([API docs](https://api-docs.deepseek.com/guides/thinking_mode)). The existing `reasoningEffortMap` in model compat already maps `xhigh` → `max`, but `supportsXhigh()` did not recognize DeepSeek model IDs, so `xhigh` was silently clamped to `high` at two points:

- `openai-completions.ts`: `clampReasoning("xhigh")` → `"high"`
- `main.ts`: `effectiveThinking = "high"`

DeepSeek V4 Flash does **not** support max effort, so only `deepseek-v4-pro` IDs are recognized.

## Changes

**`supportsXhigh()` in `models.ts`:** returns `true` for model IDs containing `deepseek-v4-pro`.

**`mapThinkingLevelToEffort()` in `anthropic.ts`:** maps `xhigh` → `"max"` for DeepSeek V4 Pro models routed through vercel-ai-gateway (anthropic-messages API).

**`supports-xhigh.test.ts`:** 5 new tests covering V4 Pro on all three providers (deepseek, openrouter, vercel-ai-gateway), V4 Flash (false), and older bedrock models (false).

## Verification

```
npx vitest --run test/supports-xhigh.test.ts  # 11 tests pass
npx biome check --error-on-warnings .          # clean
```
