### PR TITLE
fix(coding-agent): repopulate editor prompt history on /reload

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/reload` dropping the editor's prompt history so Up-arrow no longer cycled previously submitted prompts ([#3667](https://github.com/badlogic/pi-mono/issues/3667))
+
 ## [0.70.2] - 2026-04-24
 
 ### Fixed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3186,10 +3186,10 @@ export class InteractiveMode {
 		});
 	}
 
-	private rebuildChatFromMessages(): void {
+	private rebuildChatFromMessages(options: { populateHistory?: boolean } = {}): void {
 		this.chatContainer.clear();
 		const context = this.sessionManager.buildSessionContext();
-		this.renderSessionContext(context);
+		this.renderSessionContext(context, options);
 	}
 
 	// =========================================================================
@@ -4778,7 +4778,9 @@ export class InteractiveMode {
 			this.setupAutocompleteProvider();
 			const runner = this.session.extensionRunner;
 			this.setupExtensionShortcuts(runner);
-			this.rebuildChatFromMessages();
+			// Repopulate the editor's prompt history from the existing session
+			// messages so Up-arrow still cycles prior prompts after /reload.
+			this.rebuildChatFromMessages({ populateHistory: true });
 			dismissReloadBox(this.editor as Component);
 			this.showLoadedResources({
 				force: false,

--- a/packages/coding-agent/test/suite/regressions/3667-reload-editor-history.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3667-reload-editor-history.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.js";
+
+describe("regression #3667: /reload repopulates editor prompt history", () => {
+	test("rebuildChatFromMessages forwards populateHistory to renderSessionContext", () => {
+		const sessionContext = { messages: [], entries: [] };
+		const fakeThis = {
+			chatContainer: { clear: vi.fn() },
+			sessionManager: { buildSessionContext: vi.fn().mockReturnValue(sessionContext) },
+			renderSessionContext: vi.fn(),
+		};
+
+		const rebuildChatFromMessages = Reflect.get(InteractiveMode.prototype, "rebuildChatFromMessages") as (
+			this: typeof fakeThis,
+			options?: { populateHistory?: boolean },
+		) => void;
+
+		rebuildChatFromMessages.call(fakeThis, { populateHistory: true });
+
+		expect(fakeThis.chatContainer.clear).toHaveBeenCalledTimes(1);
+		expect(fakeThis.renderSessionContext).toHaveBeenCalledTimes(1);
+		expect(fakeThis.renderSessionContext).toHaveBeenCalledWith(sessionContext, { populateHistory: true });
+	});
+
+	test("rebuildChatFromMessages defaults to not populating history for non-reload callers", () => {
+		const sessionContext = { messages: [], entries: [] };
+		const fakeThis = {
+			chatContainer: { clear: vi.fn() },
+			sessionManager: { buildSessionContext: vi.fn().mockReturnValue(sessionContext) },
+			renderSessionContext: vi.fn(),
+		};
+
+		const rebuildChatFromMessages = Reflect.get(InteractiveMode.prototype, "rebuildChatFromMessages") as (
+			this: typeof fakeThis,
+			options?: { populateHistory?: boolean },
+		) => void;
+
+		rebuildChatFromMessages.call(fakeThis);
+
+		expect(fakeThis.renderSessionContext).toHaveBeenCalledWith(sessionContext, {});
+	});
+
+	test("renderSessionContext calls editor.addToHistory for user messages when populateHistory is true", () => {
+		const addToHistory = vi.fn();
+		const userMessage = {
+			role: "user" as const,
+			content: [{ type: "text", text: "first prompt" }],
+		};
+		const fakeThis = {
+			pendingTools: { clear: vi.fn() },
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			chatContainer: { addChild: vi.fn() },
+			editor: { addToHistory },
+			getUserMessageText: vi.fn().mockReturnValue("first prompt"),
+			getMarkdownThemeWithSettings: vi.fn().mockReturnValue({}),
+			addMessageToChat: vi.fn(function (
+				this: typeof fakeThis,
+				message: unknown,
+				options?: { populateHistory?: boolean },
+			) {
+				// Reproduce the minimal branch we care about: user messages push to editor history
+				// when populateHistory is set. This mirrors the real addMessageToChat logic.
+				const msg = message as { role: string };
+				if (msg.role === "user" && options?.populateHistory) {
+					this.editor.addToHistory?.("first prompt");
+				}
+			}),
+			ui: { requestRender: vi.fn() },
+		};
+
+		const renderSessionContext = Reflect.get(InteractiveMode.prototype, "renderSessionContext") as (
+			this: typeof fakeThis,
+			sessionContext: { messages: unknown[] },
+			options?: { updateFooter?: boolean; populateHistory?: boolean },
+		) => void;
+
+		renderSessionContext.call(fakeThis, { messages: [userMessage] }, { populateHistory: true });
+
+		expect(addToHistory).toHaveBeenCalledTimes(1);
+		expect(addToHistory).toHaveBeenCalledWith("first prompt");
+	});
+
+	test("renderSessionContext does NOT call editor.addToHistory when populateHistory is false", () => {
+		const addToHistory = vi.fn();
+		const userMessage = {
+			role: "user" as const,
+			content: [{ type: "text", text: "first prompt" }],
+		};
+		const fakeThis = {
+			pendingTools: { clear: vi.fn() },
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			chatContainer: { addChild: vi.fn() },
+			editor: { addToHistory },
+			getUserMessageText: vi.fn().mockReturnValue("first prompt"),
+			getMarkdownThemeWithSettings: vi.fn().mockReturnValue({}),
+			addMessageToChat: vi.fn(function (
+				this: typeof fakeThis,
+				message: unknown,
+				options?: { populateHistory?: boolean },
+			) {
+				const msg = message as { role: string };
+				if (msg.role === "user" && options?.populateHistory) {
+					this.editor.addToHistory?.("first prompt");
+				}
+			}),
+			ui: { requestRender: vi.fn() },
+		};
+
+		const renderSessionContext = Reflect.get(InteractiveMode.prototype, "renderSessionContext") as (
+			this: typeof fakeThis,
+			sessionContext: { messages: unknown[] },
+			options?: { updateFooter?: boolean; populateHistory?: boolean },
+		) => void;
+
+		renderSessionContext.call(fakeThis, { messages: [userMessage] }, {});
+
+		expect(addToHistory).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Fixes #3667.

## What

`handleReloadCommand` rebuilt the chat via `rebuildChatFromMessages()`, which calls `renderSessionContext` without `populateHistory: true`. That's the only code path that pushes user messages into `editor.addToHistory`, so after `/reload` the editor's prompt-history ring was empty and Up-arrow no longer cycled previously submitted prompts.

## Fix

Add an opt-in `populateHistory` option to `rebuildChatFromMessages`, and pass it from `handleReloadCommand`. Other callers (compaction, thinking-block toggle, settings modal) keep their current default of not repopulating — those redraw paths don't own the editor history.

```diff
-	private rebuildChatFromMessages(): void {
+	private rebuildChatFromMessages(options: { populateHistory?: boolean } = {}): void {
 		this.chatContainer.clear();
 		const context = this.sessionManager.buildSessionContext();
-		this.renderSessionContext(context);
+		this.renderSessionContext(context, options);
 	}
```

```diff
 			this.setupExtensionShortcuts(runner);
-			this.rebuildChatFromMessages();
+			// Repopulate the editor's prompt history from the existing session
+			// messages so Up-arrow still cycles prior prompts after /reload.
+			this.rebuildChatFromMessages({ populateHistory: true });
 			dismissReloadBox(this.editor as Component);
```

## Tests

`packages/coding-agent/test/suite/regressions/3667-reload-editor-history.test.ts` uses the same `Reflect.get` + fake-`this` pattern as existing `InteractiveMode` tests. Four cases:

1. `rebuildChatFromMessages({ populateHistory: true })` forwards the flag to `renderSessionContext`.
2. `rebuildChatFromMessages()` defaults to `{}`, so non-reload callers keep their prior behavior.
3. `renderSessionContext` with `populateHistory: true` calls `editor.addToHistory` for user messages.
4. `renderSessionContext` without `populateHistory` does not call `editor.addToHistory`.

Verified the first two fail on `upstream/main` and pass on this branch; all four pass with the fix.

## Verification

- `npm run check` clean across the monorepo.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/3667-reload-editor-history.test.ts` → 4 passed.
- Manual: patched an installed `dist/modes/interactive/interactive-mode.js`, restarted pi, confirmed Up-arrow cycles pre-reload prompts after `/reload`. Reverted and re-confirmed the bug reproduced on the unpatched build. Noted in the issue thread.

## Changelog

Added an entry under `[Unreleased]` / `### Fixed` in `packages/coding-agent/CHANGELOG.md`.
