### PR TITLE
fix(ai): honor Fireworks Anthropic tool compat

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed OpenAI-compatible prompt cache tests to cover proxies that explicitly disable long cache retention.
+- Fixed Fireworks Anthropic-compatible requests with tools by omitting unsupported per-tool `eager_input_streaming` and `cache_control` fields.
 - Stopped sending `tools: []` on OpenAI-compatible, Anthropic, OpenAI Responses, OpenAI Codex Responses, and Azure OpenAI Responses requests when no tools are active (e.g. `pi --no-tools`). DashScope/Aliyun Qwen (OpenAI-compatible) rejects empty tools arrays with `"[] is too short - 'tools'"` (HTTP 400); the field is now omitted unless the conversation has tool history (the existing LiteLLM/Anthropic-proxy workaround).
 - Fixed `supportsXhigh()` to recognize DeepSeek V4 Pro, preserving `xhigh` reasoning requests so they map to DeepSeek's `max` effort ([#3662](https://github.com/badlogic/pi-mono/issues/3662))
 - Fixed OpenAI-compatible DeepSeek V4 model replay to include empty `reasoning_content` on assistant messages when needed, preventing OpenRouter DeepSeek V4 sessions from failing after responses without reasoning deltas ([#3668](https://github.com/badlogic/pi-mono/issues/3668))

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -72,6 +72,12 @@ const EAGER_TOOL_INPUT_STREAMING_UNSUPPORTED_ANTHROPIC_MODELS = new Set([
 	"github-copilot:claude-sonnet-4.5",
 ]);
 
+const FIREWORKS_ANTHROPIC_COMPAT: AnthropicMessagesCompat = {
+	supportsEagerToolInputStreaming: false,
+	supportsFineGrainedToolStreamingBeta: false,
+	supportsToolCacheControl: false,
+};
+
 function getAnthropicMessagesCompat(provider: string, modelId: string): AnthropicMessagesCompat | undefined {
 	return EAGER_TOOL_INPUT_STREAMING_UNSUPPORTED_ANTHROPIC_MODELS.has(`${provider}:${modelId}`)
 		? { supportsEagerToolInputStreaming: false }
@@ -502,6 +508,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					provider: "fireworks",
 					// Fireworks Anthropic-compatible API - SDK appends /v1/messages
 					baseUrl: "https://api.fireworks.ai/inference",
+					compat: FIREWORKS_ANTHROPIC_COMPAT,
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
 					cost: {

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -2794,6 +2794,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2811,6 +2812,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2828,6 +2830,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2845,6 +2848,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2862,6 +2866,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2879,6 +2884,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2896,6 +2902,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2913,6 +2920,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2930,6 +2938,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2947,6 +2956,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: false,
 			input: ["text"],
 			cost: {
@@ -2964,6 +2974,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -2981,6 +2992,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -2998,6 +3010,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -3015,6 +3028,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -3032,6 +3046,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -3049,6 +3064,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -3066,6 +3082,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -3083,6 +3100,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "fireworks",
 			baseUrl: "https://api.fireworks.ai/inference",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsFineGrainedToolStreamingBeta":false,"supportsToolCacheControl":false},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -7125,6 +7143,40 @@ export const MODELS = {
 			contextWindow: 1050000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-responses">,
+		"gpt-5.5": {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-responses",
+			provider: "opencode",
+			baseUrl: "https://opencode.ai/zen/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 5,
+				output: 30,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 1050000,
+			maxTokens: 130000,
+		} satisfies Model<"openai-responses">,
+		"gpt-5.5-pro": {
+			id: "gpt-5.5-pro",
+			name: "GPT-5.5 Pro",
+			api: "openai-responses",
+			provider: "opencode",
+			baseUrl: "https://opencode.ai/zen/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 30,
+				output: 180,
+				cacheRead: 30,
+				cacheWrite: 0,
+			},
+			contextWindow: 1050000,
+			maxTokens: 128000,
+		} satisfies Model<"openai-responses">,
 		"hy3-preview-free": {
 			id: "hy3-preview-free",
 			name: "Hy3 preview Free",
@@ -7297,6 +7349,42 @@ export const MODELS = {
 		} satisfies Model<"anthropic-messages">,
 	},
 	"opencode-go": {
+		"deepseek-v4-flash": {
+			id: "deepseek-v4-flash",
+			name: "DeepSeek V4 Flash",
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			compat: {"requiresReasoningContentOnAssistantMessages":true},
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 0.14,
+				output: 0.28,
+				cacheRead: 0.028,
+				cacheWrite: 0,
+			},
+			contextWindow: 1000000,
+			maxTokens: 384000,
+		} satisfies Model<"openai-completions">,
+		"deepseek-v4-pro": {
+			id: "deepseek-v4-pro",
+			name: "DeepSeek V4 Pro",
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			compat: {"requiresReasoningContentOnAssistantMessages":true},
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 1.74,
+				output: 3.48,
+				cacheRead: 0.145,
+				cacheWrite: 0,
+			},
+			contextWindow: 1000000,
+			maxTokens: 384000,
+		} satisfies Model<"openai-completions">,
 		"glm-5": {
 			id: "glm-5",
 			name: "GLM-5",
@@ -8301,7 +8389,7 @@ export const MODELS = {
 				cacheRead: 0.024999999999999998,
 				cacheWrite: 0.08333333333333334,
 			},
-			contextWindow: 1048576,
+			contextWindow: 1000000,
 			maxTokens: 8192,
 		} satisfies Model<"openai-completions">,
 		"google/gemini-2.0-flash-lite-001": {
@@ -10106,6 +10194,40 @@ export const MODELS = {
 			contextWindow: 1050000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-completions">,
+		"openai/gpt-5.5": {
+			id: "openai/gpt-5.5",
+			name: "OpenAI: GPT-5.5",
+			api: "openai-completions",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 5,
+				output: 30,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 1050000,
+			maxTokens: 128000,
+		} satisfies Model<"openai-completions">,
+		"openai/gpt-5.5-pro": {
+			id: "openai/gpt-5.5-pro",
+			name: "OpenAI: GPT-5.5 Pro",
+			api: "openai-completions",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 30,
+				output: 180,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 1050000,
+			maxTokens: 128000,
+		} satisfies Model<"openai-completions">,
 		"openai/gpt-audio": {
 			id: "openai/gpt-audio",
 			name: "OpenAI: GPT Audio",
@@ -10778,9 +10900,9 @@ export const MODELS = {
 			reasoning: false,
 			input: ["text"],
 			cost: {
-				input: 0.15,
+				input: 0.14,
 				output: 0.7999999999999999,
-				cacheRead: 0.11,
+				cacheRead: 0.09,
 				cacheWrite: 0,
 			},
 			contextWindow: 262144,
@@ -11698,11 +11820,11 @@ export const MODELS = {
 			cost: {
 				input: 0.3,
 				output: 0.8999999999999999,
-				cacheRead: 0,
+				cacheRead: 0.049999999999999996,
 				cacheWrite: 0,
 			},
 			contextWindow: 131072,
-			maxTokens: 131072,
+			maxTokens: 24000,
 		} satisfies Model<"openai-completions">,
 		"z-ai/glm-4.7": {
 			id: "z-ai/glm-4.7",
@@ -12499,7 +12621,7 @@ export const MODELS = {
 			cost: {
 				input: 0.14,
 				output: 0.28,
-				cacheRead: 0.014,
+				cacheRead: 0.028,
 				cacheWrite: 0,
 			},
 			contextWindow: 1000000,
@@ -13795,6 +13917,40 @@ export const MODELS = {
 				cacheWrite: 0,
 			},
 			contextWindow: 1050000,
+			maxTokens: 128000,
+		} satisfies Model<"anthropic-messages">,
+		"openai/gpt-5.5": {
+			id: "openai/gpt-5.5",
+			name: "GPT 5.5",
+			api: "anthropic-messages",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://ai-gateway.vercel.sh",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 5,
+				output: 30,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 1000000,
+			maxTokens: 128000,
+		} satisfies Model<"anthropic-messages">,
+		"openai/gpt-5.5-pro": {
+			id: "openai/gpt-5.5-pro",
+			name: "GPT 5.5 Pro",
+			api: "anthropic-messages",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://ai-gateway.vercel.sh",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 30,
+				output: 180,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 1000000,
 			maxTokens: 128000,
 		} satisfies Model<"anthropic-messages">,
 		"openai/gpt-oss-20b": {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -166,6 +166,8 @@ const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
 function getAnthropicCompat(model: Model<"anthropic-messages">): Required<AnthropicMessagesCompat> {
 	return {
 		supportsEagerToolInputStreaming: model.compat?.supportsEagerToolInputStreaming ?? true,
+		supportsFineGrainedToolStreamingBeta: model.compat?.supportsFineGrainedToolStreamingBeta ?? true,
+		supportsToolCacheControl: model.compat?.supportsToolCacheControl ?? true,
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
 	};
 }
@@ -878,10 +880,12 @@ function buildParams(
 	}
 
 	if (context.tools && context.tools.length > 0) {
+		const compat = getAnthropicCompat(model);
 		params.tools = convertTools(
 			context.tools,
 			isOAuthToken,
-			getAnthropicCompat(model).supportsEagerToolInputStreaming,
+			compat.supportsEagerToolInputStreaming,
+			compat.supportsToolCacheControl,
 			cacheControl,
 		);
 	}
@@ -1106,13 +1110,17 @@ function convertMessages(
 }
 
 function shouldUseFineGrainedToolStreamingBeta(model: Model<"anthropic-messages">, context: Context): boolean {
-	return !!context.tools?.length && !getAnthropicCompat(model).supportsEagerToolInputStreaming;
+	const compat = getAnthropicCompat(model);
+	return (
+		!!context.tools?.length && !compat.supportsEagerToolInputStreaming && compat.supportsFineGrainedToolStreamingBeta
+	);
 }
 
 function convertTools(
 	tools: Tool[],
 	isOAuthToken: boolean,
 	supportsEagerToolInputStreaming: boolean,
+	supportsToolCacheControl: boolean,
 	cacheControl?: CacheControlEphemeral,
 ): Anthropic.Messages.Tool[] {
 	if (!tools) return [];
@@ -1129,7 +1137,9 @@ function convertTools(
 				properties: schema.properties ?? {},
 				required: schema.required ?? [],
 			},
-			...(cacheControl && index === tools.length - 1 ? { cache_control: cacheControl } : {}),
+			...(cacheControl && supportsToolCacheControl && index === tools.length - 1
+				? { cache_control: cacheControl }
+				: {}),
 		};
 	});
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -331,6 +331,10 @@ export interface AnthropicMessagesCompat {
 	 * Default: true.
 	 */
 	supportsEagerToolInputStreaming?: boolean;
+	/** Whether the provider supports the legacy fine-grained tool streaming beta header when `supportsEagerToolInputStreaming` is false. Default: true. */
+	supportsFineGrainedToolStreamingBeta?: boolean;
+	/** Whether the provider accepts Anthropic `cache_control` markers on tool definitions. Default: true. */
+	supportsToolCacheControl?: boolean;
 	/** Whether the provider supports Anthropic long cache retention (`cache_control.ttl: "1h"`). Default: true. */
 	supportsLongCacheRetention?: boolean;
 }

--- a/packages/ai/test/anthropic-eager-tool-input-compat.test.ts
+++ b/packages/ai/test/anthropic-eager-tool-input-compat.test.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from "node:net";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { streamAnthropic } from "../src/providers/anthropic.js";
-import type { Context, Model, Tool } from "../src/types.js";
+import type { CacheRetention, Context, Model, Tool } from "../src/types.js";
 
 interface CapturedRequest {
 	headers: IncomingMessage["headers"];
@@ -55,6 +55,7 @@ function writeEmptySseResponse(response: ServerResponse): void {
 async function captureAnthropicRequest(
 	compat: Model<"anthropic-messages">["compat"],
 	context: Context,
+	cacheRetention: CacheRetention = "none",
 ): Promise<CapturedRequest> {
 	let capturedRequest: CapturedRequest | undefined;
 
@@ -72,7 +73,7 @@ async function captureAnthropicRequest(
 	try {
 		const stream = streamAnthropic(createModel(`http://127.0.0.1:${address.port}`, compat), context, {
 			apiKey: "test-key",
-			cacheRetention: "none",
+			cacheRetention,
 		});
 
 		for await (const event of stream) {
@@ -113,10 +114,26 @@ describe("Anthropic eager tool input streaming compatibility", () => {
 		expect(request.headers["anthropic-beta"]).toBe("fine-grained-tool-streaming-2025-05-14");
 	});
 
+	it("does not send the legacy fine-grained tool streaming beta when disabled", async () => {
+		const request = await captureAnthropicRequest(
+			{ supportsEagerToolInputStreaming: false, supportsFineGrainedToolStreamingBeta: false },
+			createContext(),
+		);
+
+		expect(getFirstTool(request.body).eager_input_streaming).toBeUndefined();
+		expect(request.headers["anthropic-beta"]).toBeUndefined();
+	});
+
 	it("does not send the legacy fine-grained tool streaming beta when there are no tools", async () => {
 		const request = await captureAnthropicRequest({ supportsEagerToolInputStreaming: false }, createContext([]));
 
 		expect(request.body.tools).toBeUndefined();
 		expect(request.headers["anthropic-beta"]).toBeUndefined();
+	});
+
+	it("omits tool cache control when disabled", async () => {
+		const request = await captureAnthropicRequest({ supportsToolCacheControl: false }, createContext(), "short");
+
+		expect(getFirstTool(request.body).cache_control).toBeUndefined();
 	});
 });

--- a/packages/ai/test/fireworks-models.test.ts
+++ b/packages/ai/test/fireworks-models.test.ts
@@ -20,6 +20,11 @@ describe("Fireworks models", () => {
 		expect(model.api).toBe("anthropic-messages");
 		expect(model.provider).toBe("fireworks");
 		expect(model.baseUrl).toBe("https://api.fireworks.ai/inference");
+		expect(model.compat).toEqual({
+			supportsEagerToolInputStreaming: false,
+			supportsFineGrainedToolStreamingBeta: false,
+			supportsToolCacheControl: false,
+		});
 		expect(model.reasoning).toBe(true);
 		expect(model.input).toEqual(["text", "image"]);
 		expect(model.contextWindow).toBe(262000);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed coding-agent test expectations for current default models and missing-auth guidance.
+- Fixed Fireworks tool-enabled requests by honoring Anthropic compatibility flags for unsupported tool streaming and tool cache-control fields.
 
 ## [0.70.2] - 2026-04-24
 

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -274,7 +274,7 @@ Behavior notes:
 
 For providers or proxies using `api: "anthropic-messages"`, use `compat.supportsEagerToolInputStreaming` to control Anthropic fine-grained tool streaming compatibility.
 
-By default pi sends per-tool `eager_input_streaming: true`. If a proxy or Anthropic-compatible backend rejects that field, set `supportsEagerToolInputStreaming` to `false`. Pi will omit `tools[].eager_input_streaming` and send the legacy `fine-grained-tool-streaming-2025-05-14` beta header for tool-enabled requests instead.
+By default pi sends per-tool `eager_input_streaming: true`. If a proxy or Anthropic-compatible backend rejects that field, set `supportsEagerToolInputStreaming` to `false`. Pi will omit `tools[].eager_input_streaming` and send the legacy `fine-grained-tool-streaming-2025-05-14` beta header for tool-enabled requests instead. If the backend also rejects that beta header or Anthropic `cache_control` markers on tool definitions, set `supportsFineGrainedToolStreamingBeta` or `supportsToolCacheControl` to `false`.
 
 ```json
 {
@@ -285,6 +285,8 @@ By default pi sends per-tool `eager_input_streaming: true`. If a proxy or Anthro
       "apiKey": "ANTHROPIC_PROXY_KEY",
       "compat": {
         "supportsEagerToolInputStreaming": false,
+        "supportsFineGrainedToolStreamingBeta": false,
+        "supportsToolCacheControl": false,
         "supportsLongCacheRetention": true
       },
       "models": [
@@ -301,7 +303,9 @@ By default pi sends per-tool `eager_input_streaming: true`. If a proxy or Anthro
 
 | Field | Description |
 |-------|-------------|
-| `supportsEagerToolInputStreaming` | Whether the provider accepts per-tool `eager_input_streaming`. Default: `true`. Set to `false` to omit that field and use the legacy fine-grained tool streaming beta header on tool-enabled requests. |
+| `supportsEagerToolInputStreaming` | Whether the provider accepts per-tool `eager_input_streaming`. Default: `true`. Set to `false` to omit that field and use the legacy fine-grained tool streaming beta header on tool-enabled requests unless `supportsFineGrainedToolStreamingBeta` is also `false`. |
+| `supportsFineGrainedToolStreamingBeta` | Whether the provider accepts the legacy fine-grained tool streaming beta header when `supportsEagerToolInputStreaming` is `false`. Default: `true`. |
+| `supportsToolCacheControl` | Whether the provider accepts Anthropic `cache_control` markers on tool definitions. Default: `true`. |
 | `supportsLongCacheRetention` | Whether the provider accepts Anthropic long cache retention (`cache_control.ttl: "1h"`) when cache retention is `long`. Default: `true`. |
 
 ## OpenAI Compatibility

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -123,6 +123,8 @@ const OpenAIResponsesCompatSchema = Type.Object({
 
 const AnthropicMessagesCompatSchema = Type.Object({
 	supportsEagerToolInputStreaming: Type.Optional(Type.Boolean()),
+	supportsFineGrainedToolStreamingBeta: Type.Optional(Type.Boolean()),
+	supportsToolCacheControl: Type.Optional(Type.Boolean()),
 	supportsLongCacheRetention: Type.Optional(Type.Boolean()),
 });
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -432,7 +432,7 @@ describe("ModelRegistry", () => {
 			expect(compat?.cacheControlFormat).toBe("anthropic");
 		});
 
-		test("compat schema accepts Anthropic eager tool input streaming flag", () => {
+		test("compat schema accepts Anthropic tool compatibility flags", () => {
 			writeRawModelsJson({
 				demo: {
 					baseUrl: "https://example.com",
@@ -440,6 +440,8 @@ describe("ModelRegistry", () => {
 					api: "anthropic-messages",
 					compat: {
 						supportsEagerToolInputStreaming: false,
+						supportsFineGrainedToolStreamingBeta: false,
+						supportsToolCacheControl: false,
 					},
 					models: [
 						{
@@ -459,6 +461,8 @@ describe("ModelRegistry", () => {
 
 			expect(registry.getError()).toBeUndefined();
 			expect(compat?.supportsEagerToolInputStreaming).toBe(false);
+			expect(compat?.supportsFineGrainedToolStreamingBeta).toBe(false);
+			expect(compat?.supportsToolCacheControl).toBe(false);
 		});
 
 		test("compat schema accepts long cache retention flag", () => {


### PR DESCRIPTION
## Problem

Using the built-in fireworks API provider resulted in the following errors (using any FW model):

<img width="2351" height="507" alt="image" src="https://github.com/user-attachments/assets/de41b186-d8a1-4c4d-8150-d6ad1cc16380" />

## (Proposed) Solution

I worked with pi and reviewed the [Anthropic Messages](https://docs.fireworks.ai/tools-sdks/anthropic-compatibility#differences-from-anthropic) API from Fireworks, and determined that we were sending along params that were unsupported, so we made it explicit that Fireworks didn't support `eager_input_streaming` and `cache_control`.

## Testing

```bash
npm run build
export FIREWORKS_API_KEY="fw***"
./pi-test.sh
# Choose a fireworks model
Testing succeeds without the error messages
```

## Notes

I had previously had pi build a fireworks provider for me as an extension that did work. It used the `openai-completions` api - not anthropic. So that's an option but felt like a bigger change. Also, cool if you'd rather tell Fireworks to fix/change something on their side, vs deal with it in pi.