### PR TITLE
fix(coding-agent): clear tree navigation busy state on cancel

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2709,71 +2709,80 @@ export class AgentSession {
 			label,
 		};
 
-		// Set up abort controller for summarization
-		this._branchSummaryAbortController = new AbortController();
+		// Set up abort controller for the hook and optional branch summarization phase.
+		const branchSummaryAbortController = new AbortController();
+		this._branchSummaryAbortController = branchSummaryAbortController;
+		const clearBranchSummaryAbortController = () => {
+			if (this._branchSummaryAbortController === branchSummaryAbortController) {
+				this._branchSummaryAbortController = undefined;
+			}
+		};
 		let extensionSummary: { summary: string; details?: unknown } | undefined;
 		let fromExtension = false;
-
-		// Emit session_before_tree event
-		if (this._extensionRunner.hasHandlers("session_before_tree")) {
-			const result = (await this._extensionRunner.emit({
-				type: "session_before_tree",
-				preparation,
-				signal: this._branchSummaryAbortController.signal,
-			})) as SessionBeforeTreeResult | undefined;
-
-			if (result?.cancel) {
-				return { cancelled: true };
-			}
-
-			if (result?.summary && options.summarize) {
-				extensionSummary = result.summary;
-				fromExtension = true;
-			}
-
-			// Allow extensions to override instructions and label
-			if (result?.customInstructions !== undefined) {
-				customInstructions = result.customInstructions;
-			}
-			if (result?.replaceInstructions !== undefined) {
-				replaceInstructions = result.replaceInstructions;
-			}
-			if (result?.label !== undefined) {
-				label = result.label;
-			}
-		}
-
-		// Run default summarizer if needed
 		let summaryText: string | undefined;
 		let summaryDetails: unknown;
-		if (options.summarize && entriesToSummarize.length > 0 && !extensionSummary) {
-			const model = this.model!;
-			const { apiKey, headers } = await this._getRequiredRequestAuth(model);
-			const branchSummarySettings = this.settingsManager.getBranchSummarySettings();
-			const result = await generateBranchSummary(entriesToSummarize, {
-				model,
-				apiKey,
-				headers,
-				signal: this._branchSummaryAbortController.signal,
-				customInstructions,
-				replaceInstructions,
-				reserveTokens: branchSummarySettings.reserveTokens,
-			});
-			this._branchSummaryAbortController = undefined;
-			if (result.aborted) {
-				return { cancelled: true, aborted: true };
+
+		try {
+			// Emit session_before_tree event
+			if (this._extensionRunner.hasHandlers("session_before_tree")) {
+				const result = (await this._extensionRunner.emit({
+					type: "session_before_tree",
+					preparation,
+					signal: branchSummaryAbortController.signal,
+				})) as SessionBeforeTreeResult | undefined;
+
+				if (result?.cancel) {
+					return { cancelled: true };
+				}
+
+				if (result?.summary && options.summarize) {
+					extensionSummary = result.summary;
+					fromExtension = true;
+				}
+
+				// Allow extensions to override instructions and label
+				if (result?.customInstructions !== undefined) {
+					customInstructions = result.customInstructions;
+				}
+				if (result?.replaceInstructions !== undefined) {
+					replaceInstructions = result.replaceInstructions;
+				}
+				if (result?.label !== undefined) {
+					label = result.label;
+				}
 			}
-			if (result.error) {
-				throw new Error(result.error);
+
+			// Run default summarizer if needed
+			if (options.summarize && entriesToSummarize.length > 0 && !extensionSummary) {
+				const model = this.model!;
+				const { apiKey, headers } = await this._getRequiredRequestAuth(model);
+				const branchSummarySettings = this.settingsManager.getBranchSummarySettings();
+				const result = await generateBranchSummary(entriesToSummarize, {
+					model,
+					apiKey,
+					headers,
+					signal: branchSummaryAbortController.signal,
+					customInstructions,
+					replaceInstructions,
+					reserveTokens: branchSummarySettings.reserveTokens,
+				});
+				if (result.aborted) {
+					return { cancelled: true, aborted: true };
+				}
+				if (result.error) {
+					throw new Error(result.error);
+				}
+				summaryText = result.summary;
+				summaryDetails = {
+					readFiles: result.readFiles || [],
+					modifiedFiles: result.modifiedFiles || [],
+				};
+			} else if (extensionSummary) {
+				summaryText = extensionSummary.summary;
+				summaryDetails = extensionSummary.details;
 			}
-			summaryText = result.summary;
-			summaryDetails = {
-				readFiles: result.readFiles || [],
-				modifiedFiles: result.modifiedFiles || [],
-			};
-		} else if (extensionSummary) {
-			summaryText = extensionSummary.summary;
-			summaryDetails = extensionSummary.details;
+		} finally {
+			clearBranchSummaryAbortController();
 		}
 
 		// Determine the new leaf position based on target type

--- a/packages/coding-agent/test/agent-session-tree-navigation.test.ts
+++ b/packages/coding-agent/test/agent-session-tree-navigation.test.ts
@@ -10,7 +10,44 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { API_KEY, createTestSession, type TestSessionContext } from "./utilities.js";
+import { API_KEY, buildTestTree, createTestSession, type TestSessionContext } from "./utilities.js";
+
+describe("AgentSession tree navigation extension cancellation", () => {
+	let ctx: TestSessionContext;
+
+	beforeEach(() => {
+		ctx = createTestSession({ inMemory: true });
+	});
+
+	afterEach(() => {
+		ctx.cleanup();
+	});
+
+	it("clears branch-summary busy state when a session_before_tree extension cancels navigation", async () => {
+		const { session, sessionManager } = ctx;
+		const ids = buildTestTree(sessionManager, {
+			messages: [
+				{ role: "user", text: "first" },
+				{ role: "assistant", text: "first response" },
+				{ role: "user", text: "second" },
+				{ role: "assistant", text: "second response" },
+			],
+		});
+		const leafBefore = sessionManager.getLeafId();
+
+		const runner = {
+			hasHandlers: (eventType: string) => eventType === "session_before_tree",
+			emit: async () => ({ cancel: true }),
+		};
+		(session as unknown as { _extensionRunner: typeof runner })._extensionRunner = runner;
+
+		const result = await session.navigateTree(ids.get("first")!, { summarize: false });
+
+		expect(result).toEqual({ cancelled: true });
+		expect(session.isCompacting).toBe(false);
+		expect(sessionManager.getLeafId()).toBe(leafBefore);
+	});
+});
 
 describe.skipIf(!API_KEY)("AgentSession tree navigation e2e", () => {
 	let ctx: TestSessionContext;


### PR DESCRIPTION
Fixes #3688

## Summary

- clear the branch-summary busy controller when `/tree` navigation is cancelled by `session_before_tree`
- scope that controller to the hook + optional branch summarization phase
- add a regression test for extension cancellation leaving `session.isCompacting` false

## Validation

```bash
npx biome check --write packages/coding-agent/src/core/agent-session.ts packages/coding-agent/test/agent-session-tree-navigation.test.ts
git diff --check -- packages/coding-agent/src/core/agent-session.ts packages/coding-agent/test/agent-session-tree-navigation.test.ts
npx tsgo --noEmit
```
