### PR TITLE
fix: preserve thinking blocks for cross-model reasoning calls

### DIFF
--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -107,6 +107,10 @@ export function transformMessages<TApi extends Api>(
 					// Skip empty thinking blocks, convert others to plain text
 					if (!block.thinking || block.thinking.trim() === "") return [];
 					if (isSameModel) return block;
+					// For cross-model calls where the target model has reasoning enabled,
+					// preserve thinking blocks so convertMessages can include reasoning_content
+					// (e.g., DeepSeek requires reasoning_content to be echoed back)
+					if (model.reasoning) return block;
 					return {
 						type: "text" as const,
 						text: block.thinking,


### PR DESCRIPTION
DeepSeek V4 Pro (and other reasoning models like DeepSeek R1) require `reasoning_content` to be echoed back in assistant messages when thinking mode is active.

## Problem

`transformMessages()` converts cross-model thinking blocks to plain text (lines 108-116), which strips the `thinkingSignature` field. Later, `convertMessages()` in `openai-completions.ts` checks for `thinkingSignature` to set `reasoning_content` on the assistant message — but since it was stripped, the field is never set. This causes a 400 error:

```
The `reasoning_content` in the thinking mode must be passed back to the API
```

## Fix

Added a check for `model.reasoning` before converting thinking blocks to plain text. When the target model has reasoning enabled, thinking blocks are preserved so `convertMessages` can properly include `reasoning_content`.

## Testing

Verified with session data from OpenClaw using DeepSeek V4 Pro. Before the fix, all assistant messages were missing `reasoning_content`. After the fix, all bailian (reasoning) messages correctly include `reasoning_content` in the API request.

## Related

This is similar to how same-model thinking blocks are preserved (line 109: `if (isSameModel) return block`). The reasoning applies to cross-model calls too — any model with reasoning enabled needs to echo back the reasoning content.