### PR TITLE
Capture resolved model from OpenAI-compatible stream chunks

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -206,6 +206,9 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,
 				// and each chunk in a streamed completion carries the same id.
 				output.responseId ||= chunk.id;
+				if (typeof chunk.model === "string") {
+					output.model = chunk.model;
+				}
 				if (chunk.usage) {
 					output.usage = parseChunkUsage(chunk.usage, model);
 				}


### PR DESCRIPTION
## Summary\n\nCapture the resolved model returned by OpenAI-compatible streaming chunks when the provider includes a top-level `model` field.\n\nThis matters for OpenRouter `auto` routing: the request model is `auto`, but OpenRouter streams chunks whose top-level `model` contains the concrete model that served the generation. Without copying that field into `output.model`, pi persists assistant messages as `model: auto`, losing the actual model provenance.\n\n## Change\n\nInside `streamOpenAICompletions`, after capturing `chunk.id`, copy `chunk.model` into the assistant output when present:\n\n```ts\nif (typeof chunk.model === "string") {\n  output.model = chunk.model;\n}\n```\n\n## Verification\n\nI verified OpenRouter streaming with a raw `model: auto` request. The SSE chunks included a top-level resolved model, for example:\n\n```text\nmodels ['anthropic/claude-4.6-opus-20260205']\ntext ok\n```\n\nI then applied the same change locally to the installed built artifact and ran pi in a fresh isolated session:\n\n```bash\npi --provider openrouter --model auto \\n  --no-extensions --no-skills --no-prompt-templates --no-context-files --no-tools \\n  --session-dir <tempdir> \\n  -p "Reply exactly: ok"\n```\n\nBefore this change, the assistant message persisted `model: auto`. After the change, the session JSONL persisted the resolved model:\n\n```text\nprovider: openrouter\nmodel: anthropic/claude-4.6-opus-20260205\ntext: ok\n```\n\n## Notes\n\nThis should be safe for other OpenAI-compatible providers: if they do not include `chunk.model`, behavior is unchanged.