### PR TITLE
Fix typo: 'teh' → 'the' in test-sessions.ts

### DIFF
--- a/packages/web-ui/src/utils/test-sessions.ts
+++ b/packages/web-ui/src/utils/test-sessions.ts
@@ -463,7 +463,7 @@ export const longSession = {
 			content: [
 				{
 					type: "text",
-					text: "you managed to enter the text in teh text area, but click is not possible because the app thinks no text has been entered yet",
+					text: "you managed to enter the text in the text area, but click is not possible because the app thinks no text has been entered yet",
 				},
 			],
 		},


### PR DESCRIPTION
## Summary
Fix typo in test data where 'teh' should be corrected to 'the'.

## Changes
- Corrected typo in test message: 'in teh text area' → 'in the text area'

## Files Changed
- packages/web-ui/src/utils/test-sessions.ts (line 466)