### PR TITLE
fix(ai): preserve DeepSeek reasoning after tool results

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Stopped sending `tools: []` on OpenAI-compatible, Anthropic, OpenAI Responses, OpenAI Codex Responses, and Azure OpenAI Responses requests when no tools are active (e.g. `pi --no-tools`). DashScope/Aliyun Qwen (OpenAI-compatible) rejects empty tools arrays with `"[] is too short - 'tools'"` (HTTP 400); the field is now omitted unless the conversation has tool history (the existing LiteLLM/Anthropic-proxy workaround).
 - Fixed `supportsXhigh()` to recognize DeepSeek V4 Pro, preserving `xhigh` reasoning requests so they map to DeepSeek's `max` effort ([#3662](https://github.com/badlogic/pi-mono/issues/3662))
 - Fixed OpenAI-compatible DeepSeek V4 model replay to include empty `reasoning_content` on assistant messages when needed, preventing OpenRouter DeepSeek V4 sessions from failing after responses without reasoning deltas ([#3668](https://github.com/badlogic/pi-mono/issues/3668))
+- Fixed OpenAI-compatible DeepSeek V4 model replay to preserve prior thinking as `reasoning_content` on assistant follow-up messages after tool results.
 
 ## [0.70.2] - 2026-04-24
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -723,6 +723,7 @@ export function convertMessages(
 	}
 
 	let lastRole: string | null = null;
+	let lastReasoningContent: string | undefined;
 
 	for (let i = 0; i < transformedMessages.length; i++) {
 		const msg = transformedMessages[i];
@@ -769,6 +770,7 @@ export function convertMessages(
 				role: "assistant",
 				content: compat.requiresAssistantAfterToolResult ? "" : null,
 			};
+			const requiresReasoningContent = compat.requiresReasoningContentOnAssistantMessages && model.reasoning;
 
 			const assistantTextParts = msg.content
 				.filter(isTextContentBlock)
@@ -786,6 +788,13 @@ export function convertMessages(
 				.filter(isThinkingContentBlock)
 				.filter((block) => block.thinking.trim().length > 0);
 			if (nonEmptyThinkingBlocks.length > 0) {
+				const reasoningContent = nonEmptyThinkingBlocks
+					.map((block) => sanitizeSurrogates(block.thinking))
+					.join("\n");
+				if (requiresReasoningContent) {
+					(assistantMsg as { reasoning_content?: string }).reasoning_content = reasoningContent;
+					lastReasoningContent = reasoningContent;
+				}
 				if (compat.requiresThinkingAsText) {
 					// Convert thinking blocks to plain text (no tags to avoid model mimicking them)
 					const thinkingText = nonEmptyThinkingBlocks
@@ -805,7 +814,7 @@ export function convertMessages(
 					// Use the signature from the first thinking block if available (for llama.cpp server + gpt-oss)
 					const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
 					if (signature && signature.length > 0) {
-						(assistantMsg as any)[signature] = nonEmptyThinkingBlocks.map((block) => block.thinking).join("\n");
+						(assistantMsg as any)[signature] = reasoningContent;
 					}
 				}
 			} else if (assistantText.length > 0) {
@@ -815,6 +824,9 @@ export function convertMessages(
 				// NVIDIA NIM) to mirror the content-block structure literally in their
 				// output, producing recursive nesting like [{'type':'text','text':'[{...}]'}].
 				assistantMsg.content = assistantText;
+				if (requiresReasoningContent && lastRole === "toolResult" && lastReasoningContent) {
+					(assistantMsg as { reasoning_content?: string }).reasoning_content = lastReasoningContent;
+				}
 			}
 
 			const toolCalls = msg.content.filter(isToolCallBlock);
@@ -840,10 +852,17 @@ export function convertMessages(
 				if (reasoningDetails.length > 0) {
 					(assistantMsg as any).reasoning_details = reasoningDetails;
 				}
+				if (
+					requiresReasoningContent &&
+					lastRole === "toolResult" &&
+					lastReasoningContent &&
+					(assistantMsg as { reasoning_content?: string }).reasoning_content === undefined
+				) {
+					(assistantMsg as { reasoning_content?: string }).reasoning_content = lastReasoningContent;
+				}
 			}
 			if (
-				compat.requiresReasoningContentOnAssistantMessages &&
-				model.reasoning &&
+				requiresReasoningContent &&
 				(assistantMsg as { reasoning_content?: string }).reasoning_content === undefined
 			) {
 				(assistantMsg as { reasoning_content?: string }).reasoning_content = "";

--- a/packages/ai/test/openai-completions-deepseek-reasoning-content.test.ts
+++ b/packages/ai/test/openai-completions-deepseek-reasoning-content.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages } from "../src/providers/openai-completions.js";
+import type {
+	AssistantMessage,
+	Context,
+	Model,
+	OpenAICompletionsCompat,
+	ToolResultMessage,
+	Usage,
+} from "../src/types.js";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const compat = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	reasoningEffortMap: {},
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresReasoningContentOnAssistantMessages: true,
+	thinkingFormat: "deepseek",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	zaiToolStream: false,
+	supportsStrictMode: true,
+	cacheControlFormat: undefined,
+	sendSessionAffinityHeaders: false,
+	supportsLongCacheRetention: true,
+} satisfies Required<Omit<OpenAICompletionsCompat, "cacheControlFormat">> & {
+	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+};
+
+interface AssistantReplayMessage {
+	role: "assistant";
+	content?: unknown;
+	reasoning_content?: string;
+	tool_calls?: unknown;
+}
+
+function buildModel(): Model<"openai-completions"> {
+	return {
+		id: "deepseek-v4-flash",
+		name: "DeepSeek V4 Flash",
+		api: "openai-completions",
+		provider: "deepseek",
+		baseUrl: "https://api.deepseek.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+		compat,
+	};
+}
+
+function buildAssistant(content: AssistantMessage["content"], timestamp: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-completions",
+		provider: "deepseek",
+		model: "deepseek-v4-flash",
+		usage: emptyUsage,
+		stopReason: "stop",
+		timestamp,
+	};
+}
+
+function buildToolResult(timestamp: number): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "tool-1",
+		toolName: "read",
+		content: [{ type: "text", text: "tool result" }],
+		isError: false,
+		timestamp,
+	};
+}
+
+describe("openai-completions DeepSeek reasoning_content replay", () => {
+	it("replays prior thinking as reasoning_content across a tool-result follow-up assistant message", () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Inspect the file", timestamp: 1 },
+				buildAssistant(
+					[
+						{
+							type: "thinking",
+							thinking: "I should inspect the file before answering.",
+							thinkingSignature: "reasoning_content",
+						},
+						{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "notes.md" } },
+					],
+					2,
+				),
+				buildToolResult(3),
+				buildAssistant([{ type: "text", text: "The file contains project notes." }], 4),
+				{ role: "user", content: "Continue", timestamp: 5 },
+			],
+		};
+
+		const messages = convertMessages(buildModel(), context, compat);
+		const toolCallingAssistant = messages[1] as AssistantReplayMessage;
+		const followUpAssistant = messages[3] as AssistantReplayMessage;
+
+		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "tool", "assistant", "user"]);
+		expect(toolCallingAssistant.reasoning_content).toBe("I should inspect the file before answering.");
+		expect(toolCallingAssistant.tool_calls).toBeDefined();
+		expect(followUpAssistant).toMatchObject({
+			role: "assistant",
+			content: "The file contains project notes.",
+			reasoning_content: "I should inspect the file before answering.",
+		});
+	});
+
+	it("does not replay stale reasoning after an ordinary user turn", () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Think first", timestamp: 1 },
+				buildAssistant(
+					[
+						{ type: "thinking", thinking: "Initial reasoning.", thinkingSignature: "reasoning_content" },
+						{ type: "text", text: "Visible answer." },
+					],
+					2,
+				),
+				{ role: "user", content: "New request", timestamp: 3 },
+				buildAssistant([{ type: "text", text: "New visible answer without thinking." }], 4),
+			],
+		};
+
+		const messages = convertMessages(buildModel(), context, compat);
+		const nextAssistant = messages[3] as AssistantReplayMessage;
+
+		expect(nextAssistant).toMatchObject({
+			role: "assistant",
+			content: "New visible answer without thinking.",
+			reasoning_content: "",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This completes the DeepSeek V4 Chat Completions replay fix for tool-result continuations.

When `requiresReasoningContentOnAssistantMessages` is enabled, assistant messages with thinking blocks now serialize that thinking into `reasoning_content` and cache it. If the next assistant message follows a `toolResult` and has no new thinking blocks, it reuses the cached reasoning content instead of falling through to the empty-string fallback.

This preserves the existing empty `reasoning_content` fallback for ordinary assistant messages without thinking, so stale reasoning is not replayed across normal user turns.

## Why

DeepSeek V4 can reject multi-turn thinking-mode sessions with:

```text
The `reasoning_content` in the thinking mode must be passed back to the API.
```

The previous fix added the DeepSeek compat flag and empty replay fallback, but a tool-use transcript can contain:

```text
assistant(thinking + tool_call) -> toolResult -> assistant(text) -> user
```

The post-tool assistant message belongs to the same reasoning chain but does not carry a new thinking block. Sending `reasoning_content: ""` there can still lose the required replay state.

## Changes

- Preserve non-empty assistant thinking as `reasoning_content` for providers that require it.
- Reuse the last preserved reasoning content on assistant follow-up messages immediately after `toolResult`.
- Keep the empty-string fallback for assistant messages without reasoning outside that tool-result continuation case.
- Add a focused DeepSeek regression test covering both the tool-result continuation and stale-reasoning non-replay cases.
- Add a changelog entry under `packages/ai`.

## Checks

- `cd packages/ai && npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-completions-deepseek-reasoning-content.test.ts`
- `npx biome check --error-on-warnings packages/ai/src/providers/openai-completions.ts packages/ai/test/openai-completions-deepseek-reasoning-content.test.ts packages/ai/CHANGELOG.md`
- `npx tsgo --noEmit`
- `npm run check`

For this fresh checkout, `npm run check` needed generated local workspace declarations first:

```text
npx tsgo -p packages/ai/tsconfig.build.json
npx tsgo -p packages/agent/tsconfig.build.json
npx tsc -p packages/web-ui/tsconfig.build.json
```
