### PR TITLE
Allow per-model request config

### DIFF
--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -191,6 +191,10 @@ If your command is slow, expensive, rate-limited, or should keep using a previou
 | `id` | Yes | — | Model identifier (passed to the API) |
 | `name` | No | `id` | Human-readable model label. Used for matching (`--model` patterns) and shown in model details/status text. |
 | `api` | No | provider's `api` | Override provider's API for this model |
+| `baseUrl` | No | provider's `baseUrl` | Override provider endpoint for this model |
+| `apiKey` | No | provider's `apiKey` | Override provider API key for this model |
+| `headers` | No | none | Extra request headers for this model |
+| `authHeader` | No | provider's `authHeader` | Override auth header behavior for this model |
 | `reasoning` | No | `false` | Supports extended thinking |
 | `input` | No | `["text"]` | Input types: `["text"]` or `["text", "image"]` |
 | `contextWindow` | No | `128000` | Context window size in tokens |

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -139,6 +139,8 @@ const ModelDefinitionSchema = Type.Object({
 	name: Type.Optional(Type.String({ minLength: 1 })),
 	api: Type.Optional(Type.String({ minLength: 1 })),
 	baseUrl: Type.Optional(Type.String({ minLength: 1 })),
+	apiKey: Type.Optional(Type.String({ minLength: 1 })),
+	authHeader: Type.Optional(Type.Boolean()),
 	reasoning: Type.Optional(Type.Boolean()),
 	input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
 	cost: Type.Optional(
@@ -315,7 +317,7 @@ export const clearApiKeyCache = clearConfigValueCache;
 export class ModelRegistry {
 	private models: Model<Api>[] = [];
 	private providerRequestConfigs: Map<string, ProviderRequestConfig> = new Map();
-	private modelRequestHeaders: Map<string, Record<string, string>> = new Map();
+	private modelRequestConfigs: Map<string, ProviderRequestConfig> = new Map();
 	private registeredProviders: Map<string, ProviderConfigInput> = new Map();
 	private loadError: string | undefined = undefined;
 
@@ -339,7 +341,7 @@ export class ModelRegistry {
 	 */
 	refresh(): void {
 		this.providerRequestConfigs.clear();
-		this.modelRequestHeaders.clear();
+		this.modelRequestConfigs.clear();
 		this.loadError = undefined;
 
 		// Ensure dynamic API/OAuth registrations are rebuilt from current provider state.
@@ -474,7 +476,7 @@ export class ModelRegistry {
 				if (providerConfig.modelOverrides) {
 					modelOverrides.set(providerName, new Map(Object.entries(providerConfig.modelOverrides)));
 					for (const [modelId, modelOverride] of Object.entries(providerConfig.modelOverrides)) {
-						this.storeModelHeaders(providerName, modelId, modelOverride.headers);
+						this.storeModelRequestConfig(providerName, modelId, modelOverride);
 					}
 				}
 			}
@@ -508,12 +510,22 @@ export class ModelRegistry {
 					);
 				}
 			} else if (!isBuiltIn) {
-				// Non-built-in providers with custom models require endpoint + auth.
+				// Non-built-in providers with custom models require endpoint + auth at provider or model level.
 				if (!providerConfig.baseUrl) {
-					throw new Error(`Provider ${providerName}: "baseUrl" is required when defining custom models.`);
+					const modelWithoutBaseUrl = models.find((modelDef) => !modelDef.baseUrl);
+					if (modelWithoutBaseUrl) {
+						throw new Error(
+							`Provider ${providerName}, model ${modelWithoutBaseUrl.id}: "baseUrl" is required when provider "baseUrl" is not set.`,
+						);
+					}
 				}
 				if (!providerConfig.apiKey) {
-					throw new Error(`Provider ${providerName}: "apiKey" is required when defining custom models.`);
+					const modelWithoutApiKey = models.find((modelDef) => !modelDef.apiKey);
+					if (modelWithoutApiKey) {
+						throw new Error(
+							`Provider ${providerName}, model ${modelWithoutApiKey.id}: "apiKey" is required when provider "apiKey" is not set.`,
+						);
+					}
 				}
 			}
 			// Built-in providers with custom models: baseUrl/apiKey/api are optional,
@@ -569,7 +581,7 @@ export class ModelRegistry {
 				if (!baseUrl) continue;
 
 				const compat = mergeCompat(providerConfig.compat, modelDef.compat);
-				this.storeModelHeaders(providerName, modelDef.id, modelDef.headers);
+				this.storeModelRequestConfig(providerName, modelDef.id, modelDef);
 
 				const defaultCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 				models.push({
@@ -619,8 +631,10 @@ export class ModelRegistry {
 	 * Get API key for a model.
 	 */
 	hasConfiguredAuth(model: Model<Api>): boolean {
+		const modelConfig = this.modelRequestConfigs.get(this.getModelRequestKey(model.provider, model.id));
 		return (
 			this.authStorage.hasAuth(model.provider) ||
+			modelConfig?.apiKey !== undefined ||
 			this.providerRequestConfigs.get(model.provider)?.apiKey !== undefined
 		);
 	}
@@ -648,13 +662,26 @@ export class ModelRegistry {
 		});
 	}
 
-	private storeModelHeaders(providerName: string, modelId: string, headers?: Record<string, string>): void {
+	private storeModelRequestConfig(
+		providerName: string,
+		modelId: string,
+		config: {
+			apiKey?: string;
+			headers?: Record<string, string>;
+			authHeader?: boolean;
+		},
+	): void {
 		const key = this.getModelRequestKey(providerName, modelId);
-		if (!headers || Object.keys(headers).length === 0) {
-			this.modelRequestHeaders.delete(key);
+		if (!config.apiKey && !config.headers && !config.authHeader) {
+			this.modelRequestConfigs.delete(key);
 			return;
 		}
-		this.modelRequestHeaders.set(key, headers);
+
+		this.modelRequestConfigs.set(key, {
+			apiKey: config.apiKey,
+			headers: config.headers,
+			authHeader: config.authHeader,
+		});
 	}
 
 	/**
@@ -663,25 +690,27 @@ export class ModelRegistry {
 	async getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth> {
 		try {
 			const providerConfig = this.providerRequestConfigs.get(model.provider);
+			const modelConfig = this.modelRequestConfigs.get(this.getModelRequestKey(model.provider, model.id));
 			const apiKeyFromAuthStorage = await this.authStorage.getApiKey(model.provider, { includeFallback: false });
 			const apiKey =
 				apiKeyFromAuthStorage ??
+				(modelConfig?.apiKey
+					? resolveConfigValueOrThrow(modelConfig.apiKey, `API key for model "${model.provider}/${model.id}"`)
+					: undefined) ??
 				(providerConfig?.apiKey
 					? resolveConfigValueOrThrow(providerConfig.apiKey, `API key for provider "${model.provider}"`)
 					: undefined);
 
 			const providerHeaders = resolveHeadersOrThrow(providerConfig?.headers, `provider "${model.provider}"`);
-			const modelHeaders = resolveHeadersOrThrow(
-				this.modelRequestHeaders.get(this.getModelRequestKey(model.provider, model.id)),
-				`model "${model.provider}/${model.id}"`,
-			);
+			const modelHeaders = resolveHeadersOrThrow(modelConfig?.headers, `model "${model.provider}/${model.id}"`);
 
 			let headers =
 				model.headers || providerHeaders || modelHeaders
 					? { ...model.headers, ...providerHeaders, ...modelHeaders }
 					: undefined;
 
-			if (providerConfig?.authHeader) {
+			const useAuthHeader = modelConfig?.authHeader ?? providerConfig?.authHeader;
+			if (useAuthHeader) {
 				if (!apiKey) {
 					return { ok: false, error: `No API key found for "${model.provider}"` };
 				}
@@ -712,8 +741,15 @@ export class ModelRegistry {
 		}
 
 		const providerApiKey = this.providerRequestConfigs.get(provider)?.apiKey;
-		if (!providerApiKey) {
+		const hasModelApiKey = [...this.modelRequestConfigs.entries()].some(
+			([key, config]) => key.startsWith(`${provider}:`) && config.apiKey,
+		);
+		if (!providerApiKey && !hasModelApiKey) {
 			return authStatus;
+		}
+
+		if (!providerApiKey) {
+			return { configured: true, source: "models_json_key" };
 		}
 
 		if (providerApiKey.startsWith("!")) {
@@ -805,10 +841,20 @@ export class ModelRegistry {
 		}
 
 		if (!config.baseUrl) {
-			throw new Error(`Provider ${providerName}: "baseUrl" is required when defining models.`);
+			const modelWithoutBaseUrl = config.models.find((modelDef) => !modelDef.baseUrl);
+			if (modelWithoutBaseUrl) {
+				throw new Error(
+					`Provider ${providerName}, model ${modelWithoutBaseUrl.id}: "baseUrl" is required when provider "baseUrl" is not set.`,
+				);
+			}
 		}
 		if (!config.apiKey && !config.oauth) {
-			throw new Error(`Provider ${providerName}: "apiKey" or "oauth" is required when defining models.`);
+			const modelWithoutApiKey = config.models.find((modelDef) => !modelDef.apiKey);
+			if (modelWithoutApiKey) {
+				throw new Error(
+					`Provider ${providerName}, model ${modelWithoutApiKey.id}: "apiKey" is required when provider "apiKey" or "oauth" is not set.`,
+				);
+			}
 		}
 
 		for (const modelDef of config.models) {
@@ -851,14 +897,14 @@ export class ModelRegistry {
 			// Parse and add new models
 			for (const modelDef of config.models) {
 				const api = modelDef.api || config.api;
-				this.storeModelHeaders(providerName, modelDef.id, modelDef.headers);
+				this.storeModelRequestConfig(providerName, modelDef.id, modelDef);
 
 				this.models.push({
 					id: modelDef.id,
 					name: modelDef.name,
 					api: api as Api,
 					provider: providerName,
-					baseUrl: config.baseUrl!,
+					baseUrl: modelDef.baseUrl ?? config.baseUrl!,
 					reasoning: modelDef.reasoning,
 					input: modelDef.input as ("text" | "image")[],
 					cost: modelDef.cost,
@@ -906,6 +952,8 @@ export interface ProviderConfigInput {
 		name: string;
 		api?: Api;
 		baseUrl?: string;
+		apiKey?: string;
+		authHeader?: boolean;
 		reasoning: boolean;
 		input: ("text" | "image")[];
 		cost: { input: number; output: number; cacheRead: number; cacheWrite: number };

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -527,6 +527,117 @@ describe("ModelRegistry", () => {
 			expect(glm5?.baseUrl).toBe("https://opencode.ai/zen/go/v1");
 		});
 
+		test("non-built-in provider accepts endpoint and apiKey entirely at model level", async () => {
+			writeRawModelsJson({
+				"mixed-provider": {
+					models: [
+						{
+							id: "model-a",
+							api: "openai-responses",
+							baseUrl: "https://model-a.test/v1",
+							apiKey: "KEY_A",
+							reasoning: true,
+							input: ["text", "image"],
+							contextWindow: 272000,
+							maxTokens: 128000,
+						},
+						{
+							id: "model-b",
+							api: "google-generative-ai",
+							baseUrl: "https://model-b.test/v1beta",
+							apiKey: "KEY_B",
+							headers: { "User-Agent": "ModelBClient/1.0" },
+							reasoning: true,
+							input: ["text", "image"],
+							contextWindow: 1048576,
+							maxTokens: 65536,
+						},
+					],
+				},
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			expect(registry.getError()).toBeUndefined();
+
+			const modelA = registry.find("mixed-provider", "model-a");
+			const modelB = registry.find("mixed-provider", "model-b");
+
+			expect(modelA?.baseUrl).toBe("https://model-a.test/v1");
+			expect(modelA?.api).toBe("openai-responses");
+			expect(modelB?.baseUrl).toBe("https://model-b.test/v1beta");
+			expect(modelB?.api).toBe("google-generative-ai");
+			expect(
+				registry
+					.getAvailable()
+					.filter((m) => m.provider === "mixed-provider")
+					.map((m) => m.id),
+			).toEqual(["model-a", "model-b"]);
+
+			expect(await registry.getApiKeyAndHeaders(modelA!)).toEqual({ ok: true, apiKey: "KEY_A" });
+			expect(await registry.getApiKeyAndHeaders(modelB!)).toEqual({
+				ok: true,
+				apiKey: "KEY_B",
+				headers: { "User-Agent": "ModelBClient/1.0" },
+			});
+		});
+
+		test("model-level apiKey overrides provider-level apiKey", async () => {
+			writeRawModelsJson({
+				"mixed-provider": {
+					baseUrl: "https://provider.test/v1",
+					apiKey: "PROVIDER_KEY",
+					api: "openai-completions",
+					models: [
+						{
+							id: "model-a",
+							apiKey: "MODEL_A_KEY",
+							reasoning: false,
+							input: ["text"],
+						},
+						{
+							id: "model-b",
+							reasoning: false,
+							input: ["text"],
+						},
+					],
+				},
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const modelA = registry.find("mixed-provider", "model-a");
+			const modelB = registry.find("mixed-provider", "model-b");
+
+			expect(await registry.getApiKeyAndHeaders(modelA!)).toEqual({ ok: true, apiKey: "MODEL_A_KEY" });
+			expect(await registry.getApiKeyAndHeaders(modelB!)).toEqual({ ok: true, apiKey: "PROVIDER_KEY" });
+		});
+
+		test("model-level authHeader uses model apiKey", async () => {
+			writeRawModelsJson({
+				custom: {
+					models: [
+						{
+							id: "model-a",
+							api: "openai-completions",
+							baseUrl: "https://example.com/v1",
+							apiKey: "MODEL_A_KEY",
+							authHeader: true,
+							reasoning: false,
+							input: ["text"],
+						},
+					],
+				},
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const model = registry.find("custom", "model-a");
+
+			expect(await registry.getApiKeyAndHeaders(model!)).toEqual({
+				ok: true,
+				apiKey: "MODEL_A_KEY",
+				headers: { Authorization: "Bearer MODEL_A_KEY" },
+			});
+		});
+
 		test("modelOverrides still apply when provider also defines models", () => {
 			writeRawModelsJson({
 				openrouter: {
@@ -1005,6 +1116,49 @@ describe("ModelRegistry", () => {
 					"custom-a",
 					"custom-b",
 				]);
+			});
+
+			test("dynamic provider accepts model-level baseUrl and apiKey", async () => {
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				registry.registerProvider("mixed-provider", {
+					api: "openai-completions",
+					models: [
+						{
+							id: "model-a",
+							name: "Model A",
+							api: "openai-responses",
+							baseUrl: "https://model-a.test/v1",
+							apiKey: "KEY_A",
+							reasoning: true,
+							input: ["text", "image"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 272000,
+							maxTokens: 128000,
+						},
+						{
+							id: "model-b",
+							name: "Model B",
+							api: "google-generative-ai",
+							baseUrl: "https://model-b.test/v1beta",
+							apiKey: "KEY_B",
+							reasoning: true,
+							input: ["text", "image"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 1048576,
+							maxTokens: 65536,
+						},
+					],
+				});
+				registry.refresh();
+
+				const modelA = registry.find("mixed-provider", "model-a");
+				const modelB = registry.find("mixed-provider", "model-b");
+
+				expect(modelA?.baseUrl).toBe("https://model-a.test/v1");
+				expect(modelB?.baseUrl).toBe("https://model-b.test/v1beta");
+				expect(await registry.getApiKeyAndHeaders(modelA!)).toEqual({ ok: true, apiKey: "KEY_A" });
+				expect(await registry.getApiKeyAndHeaders(modelB!)).toEqual({ ok: true, apiKey: "KEY_B" });
 			});
 
 			test("baseUrl-only override keeps custom provider models after refresh", () => {


### PR DESCRIPTION
What do you want to change?

Make custom model config more flexible. Allow `baseUrl`, `apiKey`, `headers`, and `authHeader` on individual `models[]` entries in `models.json`, not just on the provider.

Why?

Right now one provider name effectively shares one endpoint/key setup. Some gateways expose different API formats or endpoints under the same service, so users have to split them into fake provider names just to configure them. That makes `/model` noisier and less accurate.

How?

Keep provider-level values as defaults. If a model defines its own `baseUrl`, `apiKey`, `headers`, or `authHeader`, use that for that model. Existing configs keep working.
