### PR TITLE
fix: handle undefined model when restoring sessions

### DIFF
--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,6 +1,35 @@
 import { MODELS } from "./models.generated.js";
 import type { Api, KnownProvider, Model, Usage } from "./types.js";
 
+/**
+ * Validates that a model object is properly defined with required fields.
+ * Throws a descriptive error if validation fails.
+ * @param model The model to validate
+ * @param context Description of where the validation is happening (e.g., function name)
+ * @param suggestion Optional suggestion for how to fix the issue
+ * @throws Error if model is undefined or missing required fields
+ */
+export function validateModel<TApi extends Api>(
+	model: Model<TApi> | undefined,
+	context: string,
+	suggestion?: string,
+): asserts model is Model<TApi> {
+	if (!model) {
+		const baseMessage = `${context}: model is undefined.`;
+		const defaultSuggestion =
+			"This may happen when restoring a session with a provider/model that no longer exists in models.json.";
+		throw new Error(
+			suggestion ? `${baseMessage} ${suggestion}` : `${baseMessage} ${defaultSuggestion}`,
+		);
+	}
+	if (!model.id) {
+		throw new Error(
+			`${context}: model.id is undefined for provider "${model.provider}". ` +
+				"This indicates an invalid model configuration.",
+		);
+	}
+}
+
 const modelRegistry: Map<string, Map<string, Model<Api>>> = new Map();
 
 // Initialize registry from MODELS on module load
@@ -54,6 +83,8 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
  * - Opus 4.6+ models (xhigh maps to adaptive effort "max" on Anthropic-compatible providers)
  */
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
+	validateModel(model, "supportsXhigh");
+
 	if (
 		model.id.includes("gpt-5.2") ||
 		model.id.includes("gpt-5.3") ||

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -21,7 +21,7 @@ import {
 	ToolResultStatus,
 } from "@aws-sdk/client-bedrock-runtime";
 import type { DocumentType } from "@smithy/types";
-import { calculateCost } from "../models.js";
+import { calculateCost, validateModel } from "../models.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -89,6 +89,8 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 	context: Context,
 	options: BedrockOptions = {},
 ): AssistantMessageEventStream => {
+	validateModel(model, "streamBedrock");
+
 	const stream = new AssistantMessageEventStream();
 
 	(async () => {
@@ -313,6 +315,8 @@ export const streamSimpleBedrock: StreamFunction<"bedrock-converse-stream", Simp
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream => {
+	validateModel(model, "streamSimpleBedrock");
+
 	const base = buildBaseOptions(model, options, undefined);
 	if (!options?.reasoning) {
 		return streamBedrock(model, context, { ...base, reasoning: undefined } satisfies BedrockOptions);

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Content, ThinkingConfig } from "@google/genai";
-import { calculateCost } from "../models.js";
+import { calculateCost, validateModel } from "../models.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -323,6 +323,8 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 	context: Context,
 	options?: GoogleGeminiCliOptions,
 ): AssistantMessageEventStream => {
+	validateModel(model, "streamGoogleGeminiCli");
+
 	const stream = new AssistantMessageEventStream();
 
 	(async () => {

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -7,7 +7,7 @@ import {
 	type ThinkingConfig,
 	ThinkingLevel,
 } from "@google/genai";
-import { calculateCost } from "../models.js";
+import { calculateCost, validateModel } from "../models.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -65,6 +65,8 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 	context: Context,
 	options?: GoogleVertexOptions,
 ): AssistantMessageEventStream => {
+	validateModel(model, "streamGoogleVertex");
+
 	const stream = new AssistantMessageEventStream();
 
 	(async () => {

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -5,7 +5,7 @@ import {
 	type ThinkingConfig,
 } from "@google/genai";
 import { getEnvApiKey } from "../env-api-keys.js";
-import { calculateCost } from "../models.js";
+import { calculateCost, validateModel } from "../models.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -50,6 +50,8 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 	context: Context,
 	options?: GoogleOptions,
 ): AssistantMessageEventStream => {
+	validateModel(model, "streamGoogle");
+
 	const stream = new AssistantMessageEventStream();
 
 	(async () => {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -11,7 +11,7 @@ import type {
 	ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
 import { getEnvApiKey } from "../env-api-keys.js";
-import { calculateCost, supportsXhigh } from "../models.js";
+import { calculateCost, supportsXhigh, validateModel } from "../models.js";
 import type {
 	AssistantMessage,
 	CacheRetention,
@@ -1018,6 +1018,12 @@ function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"] | str
  * Returns a fully resolved OpenAICompletionsCompat object with all fields set.
  */
 function detectCompat(model: Model<"openai-completions">): ResolvedOpenAICompletionsCompat {
+	validateModel(
+		model,
+		"detectCompat",
+		"Try running with --no-session or clear the session directory.",
+	);
+
 	const provider = model.provider;
 	const baseUrl = model.baseUrl;
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1,6 +1,7 @@
 import "./providers/register-builtins.js";
 
 import { getApiProvider } from "./api-registry.js";
+import { validateModel } from "./models.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -27,6 +28,7 @@ export function stream<TApi extends Api>(
 	context: Context,
 	options?: ProviderStreamOptions,
 ): AssistantMessageEventStream {
+	validateModel(model, "stream");
 	const provider = resolveApiProvider(model.api);
 	return provider.stream(model, context, options as StreamOptions);
 }
@@ -45,6 +47,7 @@ export function streamSimple<TApi extends Api>(
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
+	validateModel(model, "streamSimple");
 	const provider = resolveApiProvider(model.api);
 	return provider.streamSimple(model, context, options);
 }

--- a/packages/ai/test/models-validation.test.ts
+++ b/packages/ai/test/models-validation.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { validateModel, supportsXhigh } from "../src/models.js";
+import type { Api, Model } from "../src/types.js";
+
+describe("validateModel", () => {
+	const validModel: Model<"openai-completions"> = {
+		id: "gpt-4o",
+		name: "GPT-4o",
+		api: "openai-completions",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 2.5, output: 10, cacheRead: 1.25, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16384,
+	};
+
+	describe("should throw descriptive error when model is undefined", () => {
+		it("throws with default suggestion", () => {
+			expect(() => validateModel(undefined, "testContext")).toThrow(
+				'testContext: model is undefined. This may happen when restoring a session with a provider/model that no longer exists in models.json.',
+			);
+		});
+
+		it("throws with custom suggestion", () => {
+			expect(() =>
+				validateModel(undefined, "detectCompat", "Try running with --no-session"),
+			).toThrow('detectCompat: model is undefined. Try running with --no-session');
+		});
+	});
+
+	describe("should throw descriptive error when model.id is undefined", () => {
+		it("throws with provider info", () => {
+			const invalidModel = { ...validModel, id: undefined } as unknown as Model<Api>;
+			expect(() => validateModel(invalidModel, "testContext")).toThrow(
+				'testContext: model.id is undefined for provider "openai". This indicates an invalid model configuration.',
+			);
+		});
+	});
+
+	describe("should not throw when model is valid", () => {
+		it("passes validation with valid model", () => {
+			expect(() => validateModel(validModel, "testContext")).not.toThrow();
+		});
+	});
+});
+
+describe("supportsXhigh with validation", () => {
+	it("should throw error when model is undefined", () => {
+		expect(() => supportsXhigh(undefined as unknown as Model<Api>)).toThrow(
+			'supportsXhigh: model is undefined. This may happen when restoring a session with a provider/model that no longer exists in models.json.',
+		);
+	});
+
+	it("should throw error when model.id is undefined", () => {
+		const invalidModel = {
+			provider: "test-provider",
+			id: undefined,
+		} as unknown as Model<Api>;
+		expect(() => supportsXhigh(invalidModel)).toThrow(
+			'supportsXhigh: model.id is undefined for provider "test-provider". This indicates an invalid model configuration.',
+		);
+	});
+
+	it("should work correctly with valid model", () => {
+		const validModel: Model<Api> = {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-completions",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 16384,
+		};
+		expect(supportsXhigh(validModel)).toBe(true);
+	});
+});

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -212,10 +212,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			model = restoredModel;
 		}
 		if (!model) {
-			modelFallbackMessage =
-				`Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId} ` +
-				`(model no longer exists or has been renamed). ` +
-				`Use --no-session to start a fresh session, or update models.json to include this model.`;
+			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;
 		}
 	}
 

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -212,7 +212,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			model = restoredModel;
 		}
 		if (!model) {
-			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;
+			modelFallbackMessage =
+				`Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId} ` +
+				`(model no longer exists or has been renamed). ` +
+				`Use --no-session to start a fresh session, or update models.json to include this model.`;
 		}
 	}
 


### PR DESCRIPTION
## Problem
Restoring a session fails with `Cannot read properties of undefined (reading 'startsWith')` when the referenced provider/model no longer exists in `models.json` (e.g., after renaming a provider).

## Solution
1. **API level**: Validate model exists in `stream.ts` entry points
2. **Provider level**: Add defensive checks in all providers accessing `model.id`

## Changes
- Add `validateModel()` helper with TypeScript asserts guard
- Add validation in `stream()`, `streamSimple()`, and provider functions
- Return clear error message suggesting `--no-session` flag

## Testing
- Added `packages/ai/test/models-validation.test.ts`