### PR TITLE
Pi coding agent live pager

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added an opt-in interactive response pager for oversized assistant turns, with configurable vi-style navigation keys.
 - Added `ctx.ui.setWorkingVisible()` so extensions can hide the built-in interactive working loader row without reserving layout space, plus a border-status editor example that moves working state into a custom editor border ([#3674](https://github.com/badlogic/pi-mono/issues/3674))
 
 ### Fixed

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -142,6 +142,8 @@ The interface from top to bottom:
 - **Editor** - Where you type; border color indicates thinking level
 - **Footer** - Working directory, session name, total token/cache usage, cost, context usage, current model
 
+Enable `terminal.responsePager` to pause oversized turn output in a live pager that keeps the main page stable while showing the latest streaming lines at the bottom.
+
 The editor can be temporarily replaced by other UI, like built-in `/settings` or custom UI from extensions (e.g., a Q&A tool that lets the user answer model questions in a structured format). [Extensions](#extensions) can also replace the editor, add widgets above/below it, a status line, custom footer, or overlays.
 
 ### Editor

--- a/packages/coding-agent/TODO.md
+++ b/packages/coding-agent/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+- Review the settings/config shape for the response pager before polishing this for upstream. The first pass uses a small terminal display setting so we can prove the end-to-end interaction first.
+- Explore richer pager navigation over assistant text, thinking blocks, and tool output as separate sections.
+- Consider copy-friendly tool output modes: no left margin, optional soft-wrap control, and preserving long lines for terminal selection.

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -122,6 +122,17 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.message.followUp` | `alt+enter` | Queue follow-up message |
 | `app.message.dequeue` | `alt+up` | Restore queued messages to editor |
 
+### Response Pager
+
+| Keybinding id | Default | Description |
+|--------|---------|-------------|
+| `app.pager.lineUp` | `up`, `k` | Scroll up one line |
+| `app.pager.lineDown` | `down`, `j` | Scroll down one line |
+| `app.pager.pageUp` | `pageUp`, `ctrl+b` | Scroll up one page |
+| `app.pager.pageDown` | `pageDown`, `ctrl+f`, `space` | Scroll down one page |
+| `app.pager.close` | `escape`, `q` | Close the pager |
+| `app.pager.continue` | `enter` | Close the pager and continue |
+
 ### Tree Navigation
 
 | Keybinding id | Default | Description |

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -47,7 +47,7 @@ Edit directly or use `/settings` for common options.
 | `editorPaddingX` | number | `0` | Horizontal padding for input editor (0-3) |
 | `autocompleteMaxVisible` | number | `5` | Max visible items in autocomplete dropdown (3-20) |
 | `showHardwareCursor` | boolean | `false` | Show terminal cursor |
-| `terminal.responsePager` | boolean | `false` | Pause oversized turn output in an interactive pager (includes the triggering prompt, assistant response, and tool output) |
+| `terminal.responsePager` | boolean | `false` | Pause oversized turn output in a live interactive pager that keeps the main page stable while showing the latest streaming lines at the bottom (includes the triggering prompt, assistant response, and tool output) |
 
 ### Compaction
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -47,6 +47,7 @@ Edit directly or use `/settings` for common options.
 | `editorPaddingX` | number | `0` | Horizontal padding for input editor (0-3) |
 | `autocompleteMaxVisible` | number | `5` | Max visible items in autocomplete dropdown (3-20) |
 | `showHardwareCursor` | boolean | `false` | Show terminal cursor |
+| `terminal.responsePager` | boolean | `false` | Pause oversized assistant turns in an interactive pager |
 
 ### Compaction
 
@@ -116,6 +117,7 @@ When a provider requests a retry delay longer than `retry.provider.maxRetryDelay
 | `terminal.showImages` | boolean | `true` | Show images in terminal (if supported) |
 | `terminal.imageWidthCells` | number | `60` | Preferred inline image width in terminal cells |
 | `terminal.clearOnShrink` | boolean | `false` | Clear empty rows when content shrinks (can cause flicker) |
+| `terminal.responsePager` | boolean | `false` | Pause oversized assistant turns in an interactive pager |
 | `images.autoResize` | boolean | `true` | Resize images to 2000x2000 max |
 | `images.blockImages` | boolean | `false` | Block all images from being sent to LLM |
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -47,7 +47,7 @@ Edit directly or use `/settings` for common options.
 | `editorPaddingX` | number | `0` | Horizontal padding for input editor (0-3) |
 | `autocompleteMaxVisible` | number | `5` | Max visible items in autocomplete dropdown (3-20) |
 | `showHardwareCursor` | boolean | `false` | Show terminal cursor |
-| `terminal.responsePager` | boolean | `false` | Pause oversized assistant turns in an interactive pager |
+| `terminal.responsePager` | boolean | `false` | Pause oversized turn output in an interactive pager (includes the triggering prompt, assistant response, and tool output) |
 
 ### Compaction
 

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -52,6 +52,12 @@ export interface AppKeybindings {
 	"app.tree.filter.all": true;
 	"app.tree.filter.cycleForward": true;
 	"app.tree.filter.cycleBackward": true;
+	"app.pager.lineUp": true;
+	"app.pager.lineDown": true;
+	"app.pager.pageUp": true;
+	"app.pager.pageDown": true;
+	"app.pager.close": true;
+	"app.pager.continue": true;
 }
 
 export type AppKeybinding = keyof AppKeybindings;
@@ -198,6 +204,30 @@ export const KEYBINDINGS = {
 	"app.tree.filter.cycleBackward": {
 		defaultKeys: "shift+ctrl+o",
 		description: "Tree filter: cycle backward",
+	},
+	"app.pager.lineUp": {
+		defaultKeys: ["up", "k"],
+		description: "Response pager: scroll up one line",
+	},
+	"app.pager.lineDown": {
+		defaultKeys: ["down", "j"],
+		description: "Response pager: scroll down one line",
+	},
+	"app.pager.pageUp": {
+		defaultKeys: ["pageUp", "ctrl+b"],
+		description: "Response pager: scroll up one page",
+	},
+	"app.pager.pageDown": {
+		defaultKeys: ["pageDown", "ctrl+f", "space"],
+		description: "Response pager: scroll down one page",
+	},
+	"app.pager.close": {
+		defaultKeys: ["escape", "q"],
+		description: "Response pager: close",
+	},
+	"app.pager.continue": {
+		defaultKeys: "enter",
+		description: "Response pager: continue",
 	},
 } as const satisfies KeybindingDefinitions;
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -34,7 +34,7 @@ export interface TerminalSettings {
 	imageWidthCells?: number; // default: 60 (preferred inline image width in terminal cells)
 	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
 	showTerminalProgress?: boolean; // default: false (OSC 9;4 terminal progress indicators)
-	responsePager?: boolean; // default: false (pause oversized assistant turns in an interactive pager)
+	responsePager?: boolean; // default: false (pause oversized turn output in a live stable pager)
 }
 
 export interface ImageSettings {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -34,6 +34,7 @@ export interface TerminalSettings {
 	imageWidthCells?: number; // default: 60 (preferred inline image width in terminal cells)
 	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
 	showTerminalProgress?: boolean; // default: false (OSC 9;4 terminal progress indicators)
+	responsePager?: boolean; // default: false (pause oversized assistant turns in an interactive pager)
 }
 
 export interface ImageSettings {
@@ -955,6 +956,20 @@ export class SettingsManager {
 		}
 		this.globalSettings.terminal.showTerminalProgress = enabled;
 		this.markModified("terminal", "showTerminalProgress");
+		this.save();
+	}
+
+	getResponsePagerEnabled(): boolean {
+		// TODO: Review the final config shape before polishing this feature for upstream.
+		return this.settings.terminal?.responsePager ?? process.env.PI_RESPONSE_PAGER === "1";
+	}
+
+	setResponsePagerEnabled(enabled: boolean): void {
+		if (!this.globalSettings.terminal) {
+			this.globalSettings.terminal = {};
+		}
+		this.globalSettings.terminal.responsePager = enabled;
+		this.markModified("terminal", "responsePager");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/response-pager.ts
+++ b/packages/coding-agent/src/modes/interactive/components/response-pager.ts
@@ -4,11 +4,16 @@ import type { KeybindingsManager } from "../../../core/keybindings.js";
 import type { Theme } from "../theme/theme.js";
 import { keyText } from "./keybinding-hints.js";
 
+const preferredLiveTailHeight = 4;
+const minRowsForLiveTail = 10;
+
 export class ResponsePagerComponent implements Component {
 	private scrollOffset = 0;
+	private visibleContentHeight = 1;
 
 	constructor(
-		private readonly lines: string[],
+		private lines: string[],
+		private liveTailEnabled: boolean,
 		private readonly keybindings: KeybindingsManager,
 		private readonly getTerminalRows: () => number,
 		private readonly theme: Theme,
@@ -18,7 +23,11 @@ export class ResponsePagerComponent implements Component {
 
 	render(width: number): string[] {
 		const height = Math.max(5, this.getTerminalRows());
-		const contentHeight = Math.max(1, height - 3);
+		const liveTailHeight = this.getLiveTailHeight(height);
+		const liveTailSeparatorHeight = liveTailHeight > 0 ? 1 : 0;
+		const contentHeight = Math.max(1, height - 2 - liveTailSeparatorHeight - liveTailHeight);
+		this.visibleContentHeight = contentHeight;
+
 		const maxOffset = Math.max(0, this.lines.length - contentHeight);
 		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxOffset));
 
@@ -38,15 +47,17 @@ export class ResponsePagerComponent implements Component {
 			`${keyText("app.pager.continue")} continue`,
 		].join(" · ");
 
-		return [
-			this.fitLine(this.theme.fg("accent", this.theme.bold(title)), width),
-			...visible,
-			this.fitLine(this.theme.fg("dim", help), width),
-		];
+		const rendered = [this.fitLine(this.theme.fg("accent", this.theme.bold(title)), width), ...visible];
+		if (liveTailHeight > 0) {
+			rendered.push(this.fitLine(this.theme.fg("dim", "─ Live output ─"), width));
+			rendered.push(...this.lines.slice(-liveTailHeight).map((line) => this.fitLine(line, width)));
+		}
+		rendered.push(this.fitLine(this.theme.fg("dim", help), width));
+		return rendered;
 	}
 
 	handleInput(data: string): void {
-		const pageSize = Math.max(1, this.getTerminalRows() - 4);
+		const pageSize = Math.max(1, this.visibleContentHeight - 1);
 		if (this.keybindings.matches(data, "app.pager.close") || this.keybindings.matches(data, "app.pager.continue")) {
 			this.onClose();
 			return;
@@ -71,12 +82,23 @@ export class ResponsePagerComponent implements Component {
 	invalidate(): void {}
 
 	private scrollBy(delta: number): void {
-		const contentHeight = Math.max(1, this.getTerminalRows() - 3);
-		const maxOffset = Math.max(0, this.lines.length - contentHeight);
+		const maxOffset = Math.max(0, this.lines.length - this.visibleContentHeight);
 		const nextOffset = Math.max(0, Math.min(this.scrollOffset + delta, maxOffset));
 		if (nextOffset === this.scrollOffset) return;
 		this.scrollOffset = nextOffset;
 		this.onChange();
+	}
+
+	setLines(lines: string[], liveTailEnabled: boolean): void {
+		this.lines = lines;
+		this.liveTailEnabled = liveTailEnabled;
+		this.onChange();
+	}
+
+	private getLiveTailHeight(height: number): number {
+		if (!this.liveTailEnabled) return 0;
+		if (height < minRowsForLiveTail) return 0;
+		return Math.min(preferredLiveTailHeight, Math.max(0, this.lines.length - 1));
 	}
 
 	private fitLine(line: string, width: number): string {

--- a/packages/coding-agent/src/modes/interactive/components/response-pager.ts
+++ b/packages/coding-agent/src/modes/interactive/components/response-pager.ts
@@ -1,0 +1,86 @@
+import type { Component } from "@mariozechner/pi-tui";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import type { KeybindingsManager } from "../../../core/keybindings.js";
+import type { Theme } from "../theme/theme.js";
+import { keyText } from "./keybinding-hints.js";
+
+export class ResponsePagerComponent implements Component {
+	private scrollOffset = 0;
+
+	constructor(
+		private readonly lines: string[],
+		private readonly keybindings: KeybindingsManager,
+		private readonly getTerminalRows: () => number,
+		private readonly theme: Theme,
+		private readonly onClose: () => void,
+		private readonly onChange: () => void,
+	) {}
+
+	render(width: number): string[] {
+		const height = Math.max(5, this.getTerminalRows());
+		const contentHeight = Math.max(1, height - 3);
+		const maxOffset = Math.max(0, this.lines.length - contentHeight);
+		this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxOffset));
+
+		const start = this.scrollOffset;
+		const end = Math.min(this.lines.length, start + contentHeight);
+		const visible = this.lines.slice(start, end).map((line) => this.fitLine(line, width));
+		while (visible.length < contentHeight) {
+			visible.push("");
+		}
+
+		const position = `${Math.min(end, this.lines.length)}/${this.lines.length}`;
+		const title = ` Response pager ${position} `;
+		const help = [
+			`${keyText("app.pager.lineUp")}/${keyText("app.pager.lineDown")} line`,
+			`${keyText("app.pager.pageUp")}/${keyText("app.pager.pageDown")} page`,
+			`${keyText("app.pager.close")} close`,
+			`${keyText("app.pager.continue")} continue`,
+		].join(" · ");
+
+		return [
+			this.fitLine(this.theme.fg("accent", this.theme.bold(title)), width),
+			...visible,
+			this.fitLine(this.theme.fg("dim", help), width),
+		];
+	}
+
+	handleInput(data: string): void {
+		const pageSize = Math.max(1, this.getTerminalRows() - 4);
+		if (this.keybindings.matches(data, "app.pager.close") || this.keybindings.matches(data, "app.pager.continue")) {
+			this.onClose();
+			return;
+		}
+		if (this.keybindings.matches(data, "app.pager.lineUp")) {
+			this.scrollBy(-1);
+			return;
+		}
+		if (this.keybindings.matches(data, "app.pager.lineDown")) {
+			this.scrollBy(1);
+			return;
+		}
+		if (this.keybindings.matches(data, "app.pager.pageUp")) {
+			this.scrollBy(-pageSize);
+			return;
+		}
+		if (this.keybindings.matches(data, "app.pager.pageDown")) {
+			this.scrollBy(pageSize);
+		}
+	}
+
+	invalidate(): void {}
+
+	private scrollBy(delta: number): void {
+		const contentHeight = Math.max(1, this.getTerminalRows() - 3);
+		const maxOffset = Math.max(0, this.lines.length - contentHeight);
+		const nextOffset = Math.max(0, Math.min(this.scrollOffset + delta, maxOffset));
+		if (nextOffset === this.scrollOffset) return;
+		this.scrollOffset = nextOffset;
+		this.onChange();
+	}
+
+	private fitLine(line: string, width: number): string {
+		if (visibleWidth(line) <= width) return line;
+		return truncateToWidth(line, width, "");
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -53,6 +53,7 @@ export interface SettingsConfig {
 	quietStartup: boolean;
 	clearOnShrink: boolean;
 	showTerminalProgress: boolean;
+	responsePager: boolean;
 }
 
 export interface SettingsCallbacks {
@@ -79,6 +80,7 @@ export interface SettingsCallbacks {
 	onQuietStartupChange: (enabled: boolean) => void;
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onShowTerminalProgressChange: (enabled: boolean) => void;
+	onResponsePagerChange: (enabled: boolean) => void;
 	onCancel: () => void;
 }
 
@@ -384,6 +386,16 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
+		// Response pager toggle (insert after terminal-progress)
+		const terminalProgressIndex = items.findIndex((item) => item.id === "terminal-progress");
+		items.splice(terminalProgressIndex + 1, 0, {
+			id: "response-pager",
+			label: "Response pager",
+			description: "Pause oversized assistant turns in an interactive pager",
+			currentValue: config.responsePager ? "true" : "false",
+			values: ["true", "false"],
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -454,6 +466,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "terminal-progress":
 						callbacks.onShowTerminalProgressChange(newValue === "true");
+						break;
+					case "response-pager":
+						callbacks.onResponsePagerChange(newValue === "true");
 						break;
 				}
 			},

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -105,6 +105,7 @@ import { keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.js";
 import { LoginDialogComponent } from "./components/login-dialog.js";
 import { ModelSelectorComponent } from "./components/model-selector.js";
 import { type AuthSelectorProvider, OAuthSelectorComponent } from "./components/oauth-selector.js";
+import { ResponsePagerComponent } from "./components/response-pager.js";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.js";
 import { SessionSelectorComponent } from "./components/session-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
@@ -289,6 +290,9 @@ export class InteractiveMode {
 
 	// Thinking block visibility state
 	private hideThinkingBlock = false;
+
+	// Response pager state
+	private turnStartChildIndex: number | undefined = undefined;
 
 	// Skill commands: command name -> skill file path
 	private skillCommands = new Map<string, string>();
@@ -2659,6 +2663,49 @@ export class InteractiveMode {
 		});
 	}
 
+	private maybeShowResponsePager(): void {
+		if (!this.settingsManager.getResponsePagerEnabled()) return;
+		if (this.ui.hasOverlay()) return;
+		if (this.turnStartChildIndex === undefined) return;
+
+		const width = this.ui.terminal.columns;
+		const height = this.ui.terminal.rows;
+		const turnComponents = this.chatContainer.children.slice(this.turnStartChildIndex);
+		const lines = turnComponents.flatMap((component) => component.render(width));
+		if (lines.length === 0) return;
+
+		const bottomChromeLines = [
+			...this.pendingMessagesContainer.render(width),
+			...this.statusContainer.render(width),
+			...this.widgetContainerAbove.render(width),
+			...this.editorContainer.render(width),
+			...this.widgetContainerBelow.render(width),
+			...this.footer.render(width),
+		].length;
+		const availableResponseLines = Math.max(1, height - bottomChromeLines);
+		if (lines.length <= availableResponseLines) return;
+
+		let handle: OverlayHandle | undefined;
+		const close = () => {
+			handle?.hide();
+			handle = undefined;
+		};
+		const pager = new ResponsePagerComponent(
+			lines,
+			this.keybindings,
+			() => this.ui.terminal.rows,
+			theme,
+			close,
+			() => this.ui.requestRender(),
+		);
+		handle = this.ui.showOverlay(pager, {
+			anchor: "top-left",
+			width: "100%",
+			maxHeight: "100%",
+			margin: 0,
+		});
+	}
+
 	private async handleEvent(event: AgentSessionEvent): Promise<void> {
 		if (!this.isInitialized) {
 			await this.init();
@@ -2668,6 +2715,7 @@ export class InteractiveMode {
 
 		switch (event.type) {
 			case "agent_start":
+				this.turnStartChildIndex = this.chatContainer.children.length;
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(true);
 				}
@@ -2861,6 +2909,8 @@ export class InteractiveMode {
 
 				await this.checkShutdownRequested();
 
+				this.maybeShowResponsePager();
+				this.turnStartChildIndex = undefined;
 				this.ui.requestRender();
 				break;
 
@@ -3788,6 +3838,7 @@ export class InteractiveMode {
 					quietStartup: this.settingsManager.getQuietStartup(),
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
 					showTerminalProgress: this.settingsManager.getShowTerminalProgress(),
+					responsePager: this.settingsManager.getResponsePagerEnabled(),
 				},
 				{
 					onAutoCompactChange: (enabled) => {
@@ -3900,6 +3951,9 @@ export class InteractiveMode {
 					},
 					onShowTerminalProgressChange: (enabled) => {
 						this.settingsManager.setShowTerminalProgress(enabled);
+					},
+					onResponsePagerChange: (enabled) => {
+						this.settingsManager.setResponsePagerEnabled(enabled);
 					},
 					onCancel: () => {
 						done();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -293,6 +293,9 @@ export class InteractiveMode {
 
 	// Response pager state
 	private turnStartChildIndex: number | undefined = undefined;
+	private responsePagerComponent: ResponsePagerComponent | undefined = undefined;
+	private responsePagerHandle: OverlayHandle | undefined = undefined;
+	private responsePagerDismissedForTurn = false;
 
 	// Skill commands: command name -> skill file path
 	private skillCommands = new Map<string, string>();
@@ -2663,10 +2666,11 @@ export class InteractiveMode {
 		});
 	}
 
-	private maybeShowResponsePager(): void {
+	private maybeShowResponsePager(liveTailEnabled = true): void {
 		if (!this.settingsManager.getResponsePagerEnabled()) return;
-		if (this.ui.hasOverlay()) return;
+		if (this.responsePagerDismissedForTurn) return;
 		if (this.turnStartChildIndex === undefined) return;
+		if (this.ui.hasOverlay() && !this.responsePagerComponent) return;
 
 		const width = this.ui.terminal.columns;
 		const height = this.ui.terminal.rows;
@@ -2683,27 +2687,37 @@ export class InteractiveMode {
 			...this.footer.render(width),
 		].length;
 		const availableResponseLines = Math.max(1, height - bottomChromeLines);
-		if (lines.length <= availableResponseLines) return;
+		if (lines.length <= availableResponseLines) {
+			this.hideResponsePager(false);
+			return;
+		}
 
-		let handle: OverlayHandle | undefined;
-		const close = () => {
-			handle?.hide();
-			handle = undefined;
-		};
-		const pager = new ResponsePagerComponent(
-			lines,
-			this.keybindings,
-			() => this.ui.terminal.rows,
-			theme,
-			close,
-			() => this.ui.requestRender(),
-		);
-		handle = this.ui.showOverlay(pager, {
-			anchor: "top-left",
-			width: "100%",
-			maxHeight: "100%",
-			margin: 0,
-		});
+		if (!this.responsePagerComponent) {
+			this.responsePagerComponent = new ResponsePagerComponent(
+				lines,
+				liveTailEnabled,
+				this.keybindings,
+				() => this.ui.terminal.rows,
+				theme,
+				() => this.hideResponsePager(),
+				() => this.ui.requestRender(),
+			);
+			this.responsePagerHandle = this.ui.showOverlay(this.responsePagerComponent, {
+				anchor: "top-left",
+				width: "100%",
+				maxHeight: "100%",
+				margin: 0,
+			});
+		} else {
+			this.responsePagerComponent.setLines(lines, liveTailEnabled);
+		}
+	}
+
+	private hideResponsePager(dismissForTurn = true): void {
+		this.responsePagerHandle?.hide();
+		this.responsePagerHandle = undefined;
+		this.responsePagerComponent = undefined;
+		this.responsePagerDismissedForTurn = dismissForTurn;
 	}
 
 	private async handleEvent(event: AgentSessionEvent): Promise<void> {
@@ -2715,7 +2729,9 @@ export class InteractiveMode {
 
 		switch (event.type) {
 			case "agent_start":
+				this.hideResponsePager(false);
 				this.turnStartChildIndex = this.chatContainer.children.length;
+				this.responsePagerDismissedForTurn = false;
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(true);
 				}
@@ -2759,8 +2775,10 @@ export class InteractiveMode {
 				} else if (event.message.role === "user") {
 					this.addMessageToChat(event.message);
 					this.updatePendingMessagesDisplay();
+					this.maybeShowResponsePager();
 					this.ui.requestRender();
 				} else if (event.message.role === "assistant") {
+					this.maybeShowResponsePager();
 					this.streamingComponent = new AssistantMessageComponent(
 						undefined,
 						this.hideThinkingBlock,
@@ -2770,6 +2788,7 @@ export class InteractiveMode {
 					this.streamingMessage = event.message;
 					this.chatContainer.addChild(this.streamingComponent);
 					this.streamingComponent.updateContent(this.streamingMessage);
+					this.maybeShowResponsePager();
 					this.ui.requestRender();
 				}
 				break;
@@ -2805,6 +2824,7 @@ export class InteractiveMode {
 							}
 						}
 					}
+					this.maybeShowResponsePager();
 					this.ui.requestRender();
 				}
 				break;
@@ -2845,6 +2865,7 @@ export class InteractiveMode {
 					this.streamingMessage = undefined;
 					this.footer.invalidate();
 				}
+				this.maybeShowResponsePager();
 				this.ui.requestRender();
 				break;
 
@@ -2868,6 +2889,7 @@ export class InteractiveMode {
 					this.pendingTools.set(event.toolCallId, component);
 				}
 				component.markExecutionStarted();
+				this.maybeShowResponsePager();
 				this.ui.requestRender();
 				break;
 			}
@@ -2876,6 +2898,7 @@ export class InteractiveMode {
 				const component = this.pendingTools.get(event.toolCallId);
 				if (component) {
 					component.updateResult({ ...event.partialResult, isError: false }, true);
+					this.maybeShowResponsePager();
 					this.ui.requestRender();
 				}
 				break;
@@ -2886,6 +2909,7 @@ export class InteractiveMode {
 				if (component) {
 					component.updateResult({ ...event.result, isError: event.isError });
 					this.pendingTools.delete(event.toolCallId);
+					this.maybeShowResponsePager();
 					this.ui.requestRender();
 				}
 				break;
@@ -2909,7 +2933,7 @@ export class InteractiveMode {
 
 				await this.checkShutdownRequested();
 
-				this.maybeShowResponsePager();
+				this.maybeShowResponsePager(false);
 				this.turnStartChildIndex = undefined;
 				this.ui.requestRender();
 				break;

--- a/packages/coding-agent/test/response-pager.test.ts
+++ b/packages/coding-agent/test/response-pager.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.js";
+import { ResponsePagerComponent } from "../src/modes/interactive/components/response-pager.js";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.js";
+
+function mainViewportLines(rendered: string[]): string[] {
+	const liveOutputIndex = rendered.findIndex((line) => line.includes("Live output"));
+	return rendered.slice(1, liveOutputIndex);
+}
+
+function liveTailLines(rendered: string[]): string[] {
+	const liveOutputIndex = rendered.findIndex((line) => line.includes("Live output"));
+	return rendered.slice(liveOutputIndex + 1, -1);
+}
+
+describe("ResponsePagerComponent", () => {
+	test("keeps the main viewport stable while appended lines appear in the live tail", () => {
+		initTheme("dark");
+		const component = new ResponsePagerComponent(
+			["one", "two", "three", "four", "five", "six"],
+			true,
+			new KeybindingsManager(),
+			() => 12,
+			theme,
+			() => {},
+			() => {},
+		);
+
+		expect(mainViewportLines(component.render(80))).toEqual(["one", "two", "three", "four", "five"]);
+
+		component.setLines(["one", "two", "three", "four", "five", "six", "seven"], true);
+		expect(mainViewportLines(component.render(80))).toEqual(["one", "two", "three", "four", "five"]);
+		expect(liveTailLines(component.render(80))).toEqual(["four", "five", "six", "seven"]);
+
+		component.handleInput("j");
+		expect(mainViewportLines(component.render(80))).toEqual(["two", "three", "four", "five", "six"]);
+
+		component.setLines(["one", "two", "three", "four", "five", "six", "seven", "eight"], true);
+		expect(mainViewportLines(component.render(80))).toEqual(["two", "three", "four", "five", "six"]);
+		expect(liveTailLines(component.render(80))).toEqual(["five", "six", "seven", "eight"]);
+	});
+
+	test("drops the live tail after streaming ends", () => {
+		initTheme("dark");
+		const component = new ResponsePagerComponent(
+			["one", "two", "three", "four", "five", "six", "seven"],
+			true,
+			new KeybindingsManager(),
+			() => 12,
+			theme,
+			() => {},
+			() => {},
+		);
+
+		expect(component.render(80).some((line) => line.includes("Live output"))).toBe(true);
+
+		component.setLines(["one", "two", "three", "four", "five", "six", "seven"], false);
+		expect(component.render(80).some((line) => line.includes("Live output"))).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Makes the opt-in interactive response pager live while a turn is still streaming.

When enabled, Pi opens the pager as soon as the current turn grows beyond the available terminal space. The main reading viewport stays stable, while a small live-output tail at the bottom shows the latest streaming lines until the turn finishes.

## Motivation

Long responses and tool-heavy turns can quickly push the beginning of the answer out of view while the model is still streaming. The pager should enter reading mode as soon as the current turn becomes too large, instead of waiting for the user to recover context from terminal scrollback.

For these turns, the desired UX is:

- The user can start reading the beginning of the turn immediately.
- The main pager viewport does not jump as new output arrives.
- The user can still see recent streaming progress in a small live tail.
- Once the turn completes, the live tail disappears because it duplicates the final lines in the pager.

## What changed

- Response pager now opens during a turn once rendered turn output exceeds available terminal space.

- The pager keeps the main viewport stable while new lines are appended.

- Added a 4-line live-output tail while the turn is streaming.

- Removed the live-output tail at `agent_end`, leaving only the final pageable turn output.

- Closing or continuing the pager dismisses it for the rest of the current turn.

- Updated docs to describe the live stable-pager behavior.

- Added regression coverage for:
  - stable main viewport while lines append,
  - live tail showing latest lines,
  - live tail disappearing after streaming ends.

## Behavior

At `agent_start`, interactive mode records the current chat position. As user, assistant, and tool components are added or updated, it renders the components added during the current turn and compares their rendered line count to the available terminal space after accounting for:

- pending messages,
- status rows,
- widgets above/below the editor,
- editor,
- footer.

If the turn exceeds the available response space, Pi opens or updates the pager overlay.

While the turn is active:

- the main pager viewport remains anchored where it was,
- the bottom live-output section shows the latest 4 rendered lines,
- manual scrolling changes only the main viewport.

When the turn ends:

- Pi updates the pager one final time,
- disables the live-output section,
- keeps the final turn content available in the pager.

## Notes / follow-up ideas

This keeps the live tail fixed at 4 lines for now. That matches the current target of showing roughly 3-5 recent streaming lines without adding config/API surface before the UX settles.

Future iterations could improve the feature by:

- tuning the live-tail height after dogfooding,
- making the live-tail height proportional to terminal height,
- adding hierarchy-aware navigation across assistant text, thinking blocks, and tool output,
- exposing section jumps for tool calls or thinking blocks.

## Testing

- Ran targeted test:

  ```bash
  cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/response-pager.test.ts
  ```

- Ran:

  ```bash
  npm run check
  ```
