### PR TITLE
fix(ai): disable unsupported Anthropic fields for opencode minimax-m2.5-free

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -574,7 +574,13 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 						cacheRead: m.cost?.cache_read || 0,
 						cacheWrite: m.cost?.cache_write || 0,
 					},
-					...(compat ? { compat } : {}),
+					// Fix #3779: opencode's minimax-m2.5-free does not support eager tool streaming or cache control
+					...(modelId === "minimax-m2.5-free" ? {
+						compat: {
+							supportsEagerToolInputStreaming: false,
+							supportsLongCacheRetention: false
+						}
+					} : compat ? { compat } : {}),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 				});

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -7216,6 +7216,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "opencode",
 			baseUrl: "https://opencode.ai/zen",
+			compat: {"supportsEagerToolInputStreaming":false,"supportsLongCacheRetention":false},
 			reasoning: true,
 			input: ["text"],
 			cost: {


### PR DESCRIPTION
The opencode minimax-m2.5-free model returns 400 on every request with default pi config.

issue：https://github.com/badlogic/pi-mono/issues/3779

### Root cause
The model entry in models.generated.ts has no compat block, so supportsEagerToolInputStreaming and supportsLongCacheRetention both default to true. 

The Anthropic provider sends:
  tools[*].eager_input_streaming: true
  tools[N].cache_control: {"type": "ephemeral"}

opencode Zen rejects both:
  Error from provider: 2 request validation errors:
  Extra inputs are not permitted, field: 'tools[0].cache_control';
  Extra inputs are not permitted, field: 'tools[0].eager_input_streaming'

### Fix
Add compat flags for this model only. In generate-models.ts, one inline check (same pattern as the existing k2p5 special case).
Regenerated models.generated.ts picks up the compat block. No other models touched.

### Verification
- curl against opencode API: with fields → 400, without → clean response
- ./test.sh: 545 tests, all pass

<img width="899" height="438" alt="image" src="https://github.com/user-attachments/assets/ec5abf90-3637-4fca-91ff-b9a176a90096" />


Happy to adjust based on feedback