### PR TITLE
fix(coding-agent): close temp file fd after late truncation in bash executor

### DIFF
--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -110,15 +110,18 @@ export async function executeBashWithOperations(
 			signal: options?.signal,
 		});
 
-		if (tempFileStream) {
-			tempFileStream.end();
-		}
-
 		const fullOutput = outputChunks.join("");
 		const truncationResult = truncateTail(fullOutput);
 		if (truncationResult.truncated) {
 			ensureTempFile();
 		}
+
+		// Close temp file if it was opened (either during streaming or late truncation).
+		// Must be called AFTER ensureTempFile() to cover the late-open case.
+		if (tempFileStream) {
+			tempFileStream.end();
+		}
+
 		const cancelled = options?.signal?.aborted ?? false;
 
 		return {
@@ -129,16 +132,17 @@ export async function executeBashWithOperations(
 			fullOutputPath: tempFilePath,
 		};
 	} catch (err) {
-		if (tempFileStream) {
-			tempFileStream.end();
-		}
-
 		// Check if it was an abort
 		if (options?.signal?.aborted) {
 			const fullOutput = outputChunks.join("");
 			const truncationResult = truncateTail(fullOutput);
 			if (truncationResult.truncated) {
 				ensureTempFile();
+			}
+
+			// Close temp file if it was opened (either during streaming or late truncation).
+			if (tempFileStream) {
+				tempFileStream.end();
 			}
 			return {
 				output: truncationResult.truncated ? truncationResult.content : fullOutput,


### PR DESCRIPTION
## Summary

Fixed a file descriptor leak in `bash-executor.ts` that caused `EBADF` / `EMFILE` errors after prolonged use.

## Root Cause

In `executeBashWithOperations`, when a bash command produces output that exceeds the **line limit** (2000 lines) but not the **byte limit** (50KB), the temp file stream was opened but never closed.

`tempFileStream.end()` was called before `ensureTempFile()`. When the byte-limit path hadn't triggered in `onData`, the stream was still `undefined` at that point, making it a no-op. The stream created by `ensureTempFile()` then leaked.

## Fix

Move `tempFileStream.end()` after `ensureTempFile()` in both the normal (`try`) and aborted (`catch`) paths, so the late-opened stream is always closed.

Fixes #3786.