### PR TITLE
docs: render logo in black on light-mode READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 <p align="center">
   <a href="https://pi.dev">
-    <img src="https://pi.dev/logo.svg" alt="pi logo" width="128">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://pi.dev/logo.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/buckets/julien-c/my-training-bucket/resolve/pi-logo-dark.svg">
+      <img alt="pi logo" src="https://pi.dev/logo.svg" width="128">
+    </picture>
   </a>
 </p>
 <p align="center">

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -1,6 +1,10 @@
 <p align="center">
   <a href="https://pi.dev">
-    <img src="https://pi.dev/logo.svg" alt="pi logo" width="128">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://pi.dev/logo.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/buckets/julien-c/my-training-bucket/resolve/pi-logo-dark.svg">
+      <img alt="pi logo" src="https://pi.dev/logo.svg" width="128">
+    </picture>
   </a>
 </p>
 <p align="center">


### PR DESCRIPTION
Fixing this current issue in light mode:


<img width="4336" height="2804" alt="image" src="https://github.com/user-attachments/assets/b0efd0f2-8d1a-419b-8d13-c902fbe633aa" />

## Summary
- Wrap the logo `<img>` in a `<picture>` so GitHub picks the right variant per color scheme: the existing white `pi.dev/logo.svg` for dark mode, and a new black variant for light mode (currently the white logo is invisible on a light background).
- The black variant is hosted at `https://huggingface.co/buckets/julien-c/my-training-bucket/resolve/pi-logo-dark.svg` — happy to move it elsewhere if you prefer (e.g. commit it to the repo or host it on pi.dev as `logo-dark.svg`).

Why a `<picture>` instead of a CSS filter? GitHub's markdown sanitizer strips `style` attributes and inline `<svg>`, so the two-file `<picture>` pattern is the only reliable theme-aware approach.

## Test plan
- [ ] Verify both READMEs render correctly in GitHub light mode (logo visible / black)
- [ ] Verify both READMEs render correctly in GitHub dark mode (logo visible / white)