### PR TITLE
fix(coding-agent): escape exported image data

### DIFF
--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -881,7 +881,7 @@
           const images = getResultImages();
           if (images.length === 0) return '';
           return '<div class="tool-images">' +
-            images.map(img => `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${img.data}" class="tool-image" />`).join('') +
+            images.map(img => `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${escapeHtml(img.data || '')}" class="tool-image" />`).join('') +
             '</div>';
         };
 
@@ -1148,7 +1148,7 @@
               if (images.length > 0) {
                 html += '<div class="message-images">';
                 for (const img of images) {
-                  html += `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${img.data}" class="message-image" />`;
+                  html += `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${escapeHtml(img.data || '')}" class="message-image" />`;
                 }
                 html += '</div>';
               }

--- a/packages/coding-agent/test/export-html-xss.test.ts
+++ b/packages/coding-agent/test/export-html-xss.test.ts
@@ -25,4 +25,10 @@ describe("export HTML markdown link sanitization", () => {
 		expect(templateJs).not.toMatch(/\$\{img\.mimeType\}/);
 		expect(templateJs).toMatch(/escapeHtml\(img\.mimeType/);
 	});
+
+	it("escapes image data attributes", () => {
+		// Image data is embedded in src attributes and must not allow attribute breakout.
+		expect(templateJs).not.toMatch(/;base64,\$\{img\.data\}"/);
+		expect(templateJs).toMatch(/;base64,\$\{escapeHtml\(img\.data \|\| (?:''|"")\)\}"/);
+	});
 });


### PR DESCRIPTION
Escapes exported image base64 data before interpolating it into HTML `src` attributes.

This covers both export paths that render inline images:
- tool-result images
- user message images

Fixes #3811.

## Testing

- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/export-html-xss.test.ts`
- `npm run check`
