### PR TITLE
fix(coding-agent): show item count instead of line count in config scroll indicator

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/config-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector.ts
@@ -348,7 +348,10 @@ class ResourceList implements Component, Focusable {
 
 		// Scroll indicator
 		if (startIndex > 0 || endIndex < this.filteredItems.length) {
-			lines.push(theme.fg("dim", `  (${this.selectedIndex + 1}/${this.filteredItems.length})`));
+			const itemCount = this.filteredItems.filter((e) => e.type === "item").length;
+			const currentItemIndex =
+				this.filteredItems.slice(0, this.selectedIndex).filter((e) => e.type === "item").length + 1;
+			lines.push(theme.fg("dim", `  (${currentItemIndex}/${itemCount})`));
 		}
 
 		return lines;


### PR DESCRIPTION
Hello! Noticed this small inconsistency while working on #3818

### Before (see xx/24)


https://github.com/user-attachments/assets/b0c23cbe-5fa6-4e18-90f9-a6f0ac0db245

### After (see xx/13)

https://github.com/user-attachments/assets/a52ef1ea-ae4d-426a-aab2-c21f7e9f4046

Let me know if you need additional changes!

------

<details><summary>Summary by zai-org/GLM-5.1:</summary>
<p>

## What changed

In `pi config`, the scroll indicator showed line position/total lines instead of item position/total items. This happened because the flat list includes group headers and subgroup headers alongside actual resource items, so the counts were inflated by non-selectable header rows.

**File:** `packages/coding-agent/src/modes/interactive/components/config-selector.ts`

**Before:** `  (8/15)` — counts all flat entries (headers + items)
**After:** `  (5/12)` — counts only `type === "item"` entries

## Why

The `ResourceList` component uses a flat array of `FlatEntry` objects that includes group headers, subgroup headers, and items. The scroll indicator was using `this.selectedIndex` (position in the flat array) and `this.filteredItems.length` (total flat entries), which gave the impression there were more items than actually exist and that the cursor was at a different position than perceived.

The fix filters to only count entries of `type === "item"` for both the current item index and the total count.

</p>
</details>