### PR TITLE
fix(extensions): exclude test/spec files from extension discovery

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -466,7 +466,11 @@ function readPiManifest(packageJsonPath: string): PiManifest | null {
 }
 
 function isExtensionFile(name: string): boolean {
-	return name.endsWith(".ts") || name.endsWith(".js");
+	return (name.endsWith(".ts") || name.endsWith(".js")) &&
+		!name.endsWith(".test.ts") &&
+		!name.endsWith(".spec.ts") &&
+		!name.endsWith(".test.js") &&
+		!name.endsWith(".spec.js");
 }
 
 /**


### PR DESCRIPTION
## Problem

The `isExtensionFile()` function in `loader.ts` currently matches **any** `.ts` or `.js` file, including test files like `*.test.ts` and `*.spec.ts`. When such files are placed in the `extensions/` directory, pi attempts to load them as extensions and crashes with:

```
Error: Failed to load extension ...: Extension does not export a valid factory function
```

This blocks pi from starting if any test file exists in the extensions directory.

## Fix

Exclude files ending with:
- `.test.ts`
- `.spec.ts`  
- `.test.js`
- `.spec.js`

from extension discovery in `isExtensionFile()`.

### Before
```ts
function isExtensionFile(name: string): boolean {
	return name.endsWith(".ts") || name.endsWith(".js");
}
```

### After
```ts
function isExtensionFile(name: string): boolean {
	return (name.endsWith(".ts") || name.endsWith(".js")) &&
		!name.endsWith(".test.ts") &&
		!name.endsWith(".spec.ts") &&
		!name.endsWith(".test.js") &&
		!name.endsWith(".spec.js");
}
```

## Testing

Verified locally with pi 0.70.5 — applied the equivalent fix to the compiled `loader.js` in both `@mariozechner/pi-coding-agent` and `openclaw` installations. Both launch cleanly after the fix.