### PR TITLE
feat(coding-agent,tui): run slash commands from inline autocomplete

### DIFF
--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -13,6 +13,7 @@ export interface SlashCommandInfo {
 export interface BuiltinSlashCommand {
 	name: string;
 	description: string;
+	clearEditor?: boolean;
 }
 
 export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
@@ -20,21 +21,21 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "model", description: "Select model (opens selector UI)" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
-	{ name: "import", description: "Import and resume a session from a JSONL file" },
+	{ name: "import", description: "Import and resume a session from a JSONL file", clearEditor: true },
 	{ name: "share", description: "Share session as a secret GitHub gist" },
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{ name: "name", description: "Set session display name" },
 	{ name: "session", description: "Show session info and stats" },
 	{ name: "changelog", description: "Show changelog entries" },
 	{ name: "hotkeys", description: "Show all keyboard shortcuts" },
-	{ name: "fork", description: "Create a new fork from a previous user message" },
-	{ name: "clone", description: "Duplicate the current session at the current position" },
-	{ name: "tree", description: "Navigate session tree (switch branches)" },
+	{ name: "fork", description: "Create a new fork from a previous user message", clearEditor: true },
+	{ name: "clone", description: "Duplicate the current session at the current position", clearEditor: true },
+	{ name: "tree", description: "Navigate session tree (switch branches)", clearEditor: true },
 	{ name: "login", description: "Configure provider authentication" },
 	{ name: "logout", description: "Remove provider authentication" },
-	{ name: "new", description: "Start a new session" },
-	{ name: "compact", description: "Manually compact the session context" },
-	{ name: "resume", description: "Resume a different session" },
-	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
-	{ name: "quit", description: `Quit ${APP_NAME}` },
+	{ name: "new", description: "Start a new session", clearEditor: true },
+	{ name: "compact", description: "Manually compact the session context", clearEditor: true },
+	{ name: "resume", description: "Resume a different session", clearEditor: true },
+	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes", clearEditor: true },
+	{ name: "quit", description: `Quit ${APP_NAME}`, clearEditor: true },
 ];

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2467,7 +2467,7 @@ export class InteractiveMode {
 		return true;
 	}
 
-	private async dispatchSlashCommand(text: string, options: { clearEditor?: boolean } = {}): Promise<boolean> {
+	private async dispatchBuiltInSlashCommand(text: string, options: { clearEditor?: boolean } = {}): Promise<boolean> {
 		const run = (handler: () => void | Promise<void>) =>
 			this.runDispatchedSlashCommand(options.clearEditor === true, handler);
 
@@ -2556,7 +2556,7 @@ export class InteractiveMode {
 	private async dispatchAutocompleteSlashCommand(command: string): Promise<void> {
 		const clearEditor = this.shouldClearEditorForAutocompleteSlashCommand(command);
 		if (
-			await this.dispatchSlashCommand(command, {
+			await this.dispatchBuiltInSlashCommand(command, {
 				clearEditor,
 			})
 		)
@@ -2604,7 +2604,7 @@ export class InteractiveMode {
 			text = text.trim();
 			if (!text) return;
 
-			if (await this.dispatchSlashCommand(text, { clearEditor: true })) {
+			if (await this.dispatchBuiltInSlashCommand(text, { clearEditor: true })) {
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -243,6 +243,8 @@ export interface InteractiveModeOptions {
 	verbose?: boolean;
 }
 
+type InteractiveSlashCommand = SlashCommand & { clearEditor?: boolean };
+
 export class InteractiveMode {
 	private runtimeHost: AgentSessionRuntime;
 	private ui: TUI;
@@ -253,6 +255,7 @@ export class InteractiveMode {
 	private editor: EditorComponent;
 	private autocompleteProvider: AutocompleteProvider | undefined;
 	private autocompleteProviderWrappers: AutocompleteProviderFactory[] = [];
+	private autocompleteSlashCommandClearEditor = new Map<string, boolean>();
 	private fdPath: string | undefined;
 	private editorContainer: Container;
 	private footer: FooterComponent;
@@ -455,9 +458,10 @@ export class InteractiveMode {
 
 	private createBaseAutocompleteProvider(): AutocompleteProvider {
 		// Define commands for autocomplete
-		const slashCommands: SlashCommand[] = BUILTIN_SLASH_COMMANDS.map((command) => ({
+		const slashCommands: InteractiveSlashCommand[] = BUILTIN_SLASH_COMMANDS.map((command) => ({
 			name: command.name,
 			description: command.description,
+			...(command.clearEditor && { clearEditor: true }),
 		}));
 
 		const modelCommand = slashCommands.find((command) => command.name === "model");
@@ -492,7 +496,7 @@ export class InteractiveMode {
 		}
 
 		// Convert prompt templates to SlashCommand format for autocomplete
-		const templateCommands: SlashCommand[] = this.session.promptTemplates.map((cmd) => ({
+		const templateCommands: InteractiveSlashCommand[] = this.session.promptTemplates.map((cmd) => ({
 			name: cmd.name,
 			description: this.prefixAutocompleteDescription(cmd.description, cmd.sourceInfo),
 			...(cmd.argumentHint && { argumentHint: cmd.argumentHint }),
@@ -500,7 +504,7 @@ export class InteractiveMode {
 
 		// Convert extension commands to SlashCommand format
 		const builtinCommandNames = new Set(slashCommands.map((c) => c.name));
-		const extensionCommands: SlashCommand[] = this.session.extensionRunner
+		const extensionCommands: InteractiveSlashCommand[] = this.session.extensionRunner
 			.getRegisteredCommands()
 			.filter((cmd) => !builtinCommandNames.has(cmd.name))
 			.map((cmd) => ({
@@ -511,7 +515,7 @@ export class InteractiveMode {
 
 		// Build skill commands from session.skills (if enabled)
 		this.skillCommands.clear();
-		const skillCommandList: SlashCommand[] = [];
+		const skillCommandList: InteractiveSlashCommand[] = [];
 		if (this.settingsManager.getEnableSkillCommands()) {
 			for (const skill of this.session.resourceLoader.getSkills().skills) {
 				const commandName = `skill:${skill.name}`;
@@ -523,11 +527,12 @@ export class InteractiveMode {
 			}
 		}
 
-		return new CombinedAutocompleteProvider(
-			[...slashCommands, ...templateCommands, ...extensionCommands, ...skillCommandList],
-			this.sessionManager.getCwd(),
-			this.fdPath,
+		const allSlashCommands = [...slashCommands, ...templateCommands, ...extensionCommands, ...skillCommandList];
+		this.autocompleteSlashCommandClearEditor = new Map(
+			allSlashCommands.map((command) => [command.name, command.clearEditor === true]),
 		);
+
+		return new CombinedAutocompleteProvider(allSlashCommands, this.sessionManager.getCwd(), this.fdPath);
 	}
 
 	private setupAutocompleteProvider(): void {
@@ -2196,6 +2201,7 @@ export class InteractiveMode {
 
 			// Wire up callbacks from the default editor
 			newEditor.onSubmit = this.defaultEditor.onSubmit;
+			newEditor.onSlashCommand = this.defaultEditor.onSlashCommand;
 			newEditor.onChange = this.defaultEditor.onChange;
 
 			// Copy text from previous editor
@@ -2453,132 +2459,148 @@ export class InteractiveMode {
 		}
 	}
 
+	private async runDispatchedSlashCommand(clearEditor: boolean, handler: () => void | Promise<void>): Promise<true> {
+		if (clearEditor) {
+			this.editor.setText("");
+		}
+		await handler();
+		return true;
+	}
+
+	private async dispatchSlashCommand(text: string, options: { clearEditor?: boolean } = {}): Promise<boolean> {
+		const run = (handler: () => void | Promise<void>) =>
+			this.runDispatchedSlashCommand(options.clearEditor === true, handler);
+
+		if (text === "/settings") {
+			return run(() => this.showSettingsSelector());
+		}
+		if (text === "/scoped-models") {
+			return run(() => this.showModelsSelector());
+		}
+		if (text === "/model" || text.startsWith("/model ")) {
+			const searchTerm = text.startsWith("/model ") ? text.slice(7).trim() : undefined;
+			return run(() => this.handleModelCommand(searchTerm));
+		}
+		if (text === "/export" || text.startsWith("/export ")) {
+			return run(() => this.handleExportCommand(text));
+		}
+		if (text === "/import" || text.startsWith("/import ")) {
+			return run(() => this.handleImportCommand(text));
+		}
+		if (text === "/share") {
+			return run(() => this.handleShareCommand());
+		}
+		if (text === "/copy") {
+			return run(() => this.handleCopyCommand());
+		}
+		if (text === "/name" || text.startsWith("/name ")) {
+			return run(() => this.handleNameCommand(text));
+		}
+		if (text === "/session") {
+			return run(() => this.handleSessionCommand());
+		}
+		if (text === "/changelog") {
+			return run(() => this.handleChangelogCommand());
+		}
+		if (text === "/hotkeys") {
+			return run(() => this.handleHotkeysCommand());
+		}
+		if (text === "/fork") {
+			return run(() => this.showUserMessageSelector());
+		}
+		if (text === "/clone") {
+			return run(() => this.handleCloneCommand());
+		}
+		if (text === "/tree") {
+			return run(() => this.showTreeSelector());
+		}
+		if (text === "/login") {
+			return run(() => this.showOAuthSelector("login"));
+		}
+		if (text === "/logout") {
+			return run(() => this.showOAuthSelector("logout"));
+		}
+		if (text === "/new") {
+			return run(() => this.handleClearCommand());
+		}
+		if (text === "/compact" || text.startsWith("/compact ")) {
+			const customInstructions = text.startsWith("/compact ") ? text.slice(9).trim() : undefined;
+			return run(() => this.handleCompactCommand(customInstructions));
+		}
+		if (text === "/reload") {
+			return run(() => this.handleReloadCommand());
+		}
+		if (text === "/debug") {
+			return run(() => this.handleDebugCommand());
+		}
+		if (text === "/arminsayshi") {
+			return run(() => this.handleArminSaysHi());
+		}
+		if (text === "/dementedelves") {
+			return run(() => this.handleDementedDelves());
+		}
+		if (text === "/resume") {
+			return run(() => this.showSessionSelector());
+		}
+		if (text === "/quit") {
+			return run(() => this.shutdown());
+		}
+		return false;
+	}
+
+	private shouldClearEditorForAutocompleteSlashCommand(command: string): boolean {
+		const commandName = command.slice(1).split(/\s+/, 1)[0];
+		return this.autocompleteSlashCommandClearEditor.get(commandName) === true;
+	}
+
+	private async dispatchAutocompleteSlashCommand(command: string): Promise<void> {
+		const clearEditor = this.shouldClearEditorForAutocompleteSlashCommand(command);
+		if (
+			await this.dispatchSlashCommand(command, {
+				clearEditor,
+			})
+		)
+			return;
+
+		if (!command.startsWith("/")) return;
+		if (clearEditor) {
+			this.editor.setText("");
+		}
+
+		try {
+			if (this.session.isCompacting) {
+				if (this.isExtensionCommand(command)) {
+					await this.session.prompt(command);
+				} else {
+					this.queueCompactionMessage(command, "steer");
+				}
+				return;
+			}
+
+			if (this.session.isStreaming) {
+				await this.session.prompt(command, { streamingBehavior: "steer" });
+				this.updatePendingMessagesDisplay();
+				this.ui.requestRender();
+				return;
+			}
+
+			await this.session.prompt(command);
+		} catch (error: unknown) {
+			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+			this.showError(errorMessage);
+		}
+	}
+
 	private setupEditorSubmitHandler(): void {
+		this.defaultEditor.onSlashCommand = (command: string) => {
+			void this.dispatchAutocompleteSlashCommand(command);
+		};
+
 		this.defaultEditor.onSubmit = async (text: string) => {
 			text = text.trim();
 			if (!text) return;
 
-			// Handle commands
-			if (text === "/settings") {
-				this.showSettingsSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/scoped-models") {
-				this.editor.setText("");
-				await this.showModelsSelector();
-				return;
-			}
-			if (text === "/model" || text.startsWith("/model ")) {
-				const searchTerm = text.startsWith("/model ") ? text.slice(7).trim() : undefined;
-				this.editor.setText("");
-				await this.handleModelCommand(searchTerm);
-				return;
-			}
-			if (text === "/export" || text.startsWith("/export ")) {
-				await this.handleExportCommand(text);
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/import" || text.startsWith("/import ")) {
-				await this.handleImportCommand(text);
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/share") {
-				await this.handleShareCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/copy") {
-				await this.handleCopyCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/name" || text.startsWith("/name ")) {
-				this.handleNameCommand(text);
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/session") {
-				this.handleSessionCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/changelog") {
-				this.handleChangelogCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/hotkeys") {
-				this.handleHotkeysCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/fork") {
-				this.showUserMessageSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/clone") {
-				this.editor.setText("");
-				await this.handleCloneCommand();
-				return;
-			}
-			if (text === "/tree") {
-				this.showTreeSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/login") {
-				this.showOAuthSelector("login");
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/logout") {
-				this.showOAuthSelector("logout");
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/new") {
-				this.editor.setText("");
-				await this.handleClearCommand();
-				return;
-			}
-			if (text === "/compact" || text.startsWith("/compact ")) {
-				const customInstructions = text.startsWith("/compact ") ? text.slice(9).trim() : undefined;
-				this.editor.setText("");
-				await this.handleCompactCommand(customInstructions);
-				return;
-			}
-			if (text === "/reload") {
-				this.editor.setText("");
-				await this.handleReloadCommand();
-				return;
-			}
-			if (text === "/debug") {
-				this.handleDebugCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/arminsayshi") {
-				this.handleArminSaysHi();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/dementedelves") {
-				this.handleDementedDelves();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/resume") {
-				this.showSessionSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/quit") {
-				this.editor.setText("");
-				await this.shutdown();
+			if (await this.dispatchSlashCommand(text, { clearEditor: true })) {
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2567,6 +2567,10 @@ export class InteractiveMode {
 			this.editor.setText("");
 		}
 
+		// Built-in commands were handled above. Other slash commands may come
+		// from extensions, prompt templates, skills, or user input, so route them
+		// through the session prompt path with the same streaming/compaction rules
+		// as regular submitted input.
 		try {
 			if (this.session.isCompacting) {
 				if (this.isExtensionCommand(command)) {

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -402,14 +402,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const adjustedAfterCursor =
 			isQuotedPrefix && hasTrailingQuoteInItem && hasLeadingQuoteAfterCursor ? afterCursor.slice(1) : afterCursor;
 
-		// Backward-compatible fallback for callers that pass command items without a kind.
-		const isSlashCommand =
-			item.kind === "command" ||
-			(item.kind === undefined &&
-				prefix.startsWith("/") &&
-				!prefix.slice(1).includes("/") &&
-				(beforePrefix === "" || /\s$/.test(beforePrefix)));
-		if (isSlashCommand) {
+		if (item.kind === "command") {
 			// This is a command name completion
 			const newLine = `${beforePrefix}/${item.value} ${adjustedAfterCursor}`;
 			const newLines = [...lines];

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join } from "path";
 import { fuzzyFilter } from "./fuzzy.js";
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
+const SLASH_COMMAND_PREFIX_REGEX = /(?:^|\s)(\/\S*)$/;
 
 function toDisplayPath(value: string): string {
 	return value.replace(/\\/g, "/");
@@ -69,6 +70,11 @@ function findUnclosedQuoteStart(text: string): number | null {
 
 function isTokenStart(text: string, index: number): boolean {
 	return index === 0 || PATH_DELIMITERS.has(text[index - 1] ?? "");
+}
+
+// Extract a `/foo` command token when it starts the line or follows whitespace.
+export function extractSlashCommandPrefix(text: string): string | null {
+	return SLASH_COMMAND_PREFIX_REGEX.exec(text)?.[1] ?? null;
 }
 
 function extractQuotedPrefix(text: string): string | null {
@@ -216,10 +222,13 @@ async function walkDirectoryWithFd(
 	});
 }
 
+export type AutocompleteItemKind = "command" | "argument" | "file";
+
 export interface AutocompleteItem {
 	value: string;
 	label: string;
 	description?: string;
+	kind?: AutocompleteItemKind;
 }
 
 type Awaitable<T> = T | Promise<T>;
@@ -236,6 +245,7 @@ export interface SlashCommand {
 export interface AutocompleteSuggestions {
 	items: AutocompleteItem[];
 	prefix: string; // What we're matching against (e.g., "/" or "src/")
+	kind?: AutocompleteItemKind;
 }
 
 export interface AutocompleteProvider {
@@ -299,14 +309,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			return {
 				items: suggestions,
 				prefix: atPrefix,
+				kind: "file",
 			};
 		}
 
-		if (!options.force && textBeforeCursor.startsWith("/")) {
-			const spaceIndex = textBeforeCursor.indexOf(" ");
-
-			if (spaceIndex === -1) {
-				const prefix = textBeforeCursor.slice(1);
+		if (!options.force) {
+			const slashPrefix = extractSlashCommandPrefix(textBeforeCursor);
+			if (slashPrefix !== null) {
+				const prefix = slashPrefix.slice(1);
 				const commandItems = this.commands.map((cmd) => {
 					const name = "name" in cmd ? cmd.name : cmd.value;
 					const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
@@ -322,37 +332,43 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const filtered = fuzzyFilter(commandItems, prefix, (item) => item.name).map((item) => ({
 					value: item.name,
 					label: item.label,
+					kind: "command" as const,
 					...(item.description && { description: item.description }),
 				}));
 
-				if (filtered.length === 0) return null;
-
-				return {
-					items: filtered,
-					prefix: textBeforeCursor,
-				};
-			}
-
-			const commandName = textBeforeCursor.slice(1, spaceIndex);
-			const argumentText = textBeforeCursor.slice(spaceIndex + 1);
-
-			const command = this.commands.find((cmd) => {
-				const name = "name" in cmd ? cmd.name : cmd.value;
-				return name === commandName;
-			});
-			if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
+				if (filtered.length > 0) {
+					return {
+						items: filtered,
+						prefix: slashPrefix,
+						kind: "command",
+					};
+				}
 				return null;
 			}
 
-			const argumentSuggestions = await command.getArgumentCompletions(argumentText);
-			if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
-				return null;
-			}
+			// Argument completion is only offered when the slash command starts the line.
+			if (textBeforeCursor.startsWith("/")) {
+				const spaceIndex = textBeforeCursor.indexOf(" ");
+				if (spaceIndex !== -1) {
+					const commandName = textBeforeCursor.slice(1, spaceIndex);
+					const argumentText = textBeforeCursor.slice(spaceIndex + 1);
 
-			return {
-				items: argumentSuggestions,
-				prefix: argumentText,
-			};
+					const command = this.commands.find((cmd) => {
+						const name = "name" in cmd ? cmd.name : cmd.value;
+						return name === commandName;
+					});
+					if (command && "getArgumentCompletions" in command && command.getArgumentCompletions) {
+						const argumentSuggestions = await command.getArgumentCompletions(argumentText);
+						if (Array.isArray(argumentSuggestions) && argumentSuggestions.length > 0) {
+							return {
+								items: argumentSuggestions.map((item) => ({ ...item, kind: "argument" })),
+								prefix: argumentText,
+								kind: "argument",
+							};
+						}
+					}
+				}
+			}
 		}
 
 		const pathMatch = this.extractPathPrefix(textBeforeCursor, options.force ?? false);
@@ -366,6 +382,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return {
 			items: suggestions,
 			prefix: pathMatch,
+			kind: "file",
 		};
 	}
 
@@ -385,9 +402,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const adjustedAfterCursor =
 			isQuotedPrefix && hasTrailingQuoteInItem && hasLeadingQuoteAfterCursor ? afterCursor.slice(1) : afterCursor;
 
-		// Check if we're completing a slash command (prefix starts with "/" but NOT a file path)
-		// Slash commands are at the start of the line and don't contain path separators after the first /
-		const isSlashCommand = prefix.startsWith("/") && beforePrefix.trim() === "" && !prefix.slice(1).includes("/");
+		// Backward-compatible fallback for callers that pass command items without a kind.
+		const isSlashCommand =
+			item.kind === "command" ||
+			(item.kind === undefined &&
+				prefix.startsWith("/") &&
+				!prefix.slice(1).includes("/") &&
+				(beforePrefix === "" || /\s$/.test(beforePrefix)));
 		if (isSlashCommand) {
 			// This is a command name completion
 			const newLine = `${beforePrefix}/${item.value} ${adjustedAfterCursor}`;
@@ -418,25 +439,6 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				lines: newLines,
 				cursorLine,
 				cursorCol: beforePrefix.length + cursorOffset + suffix.length,
-			};
-		}
-
-		// Check if we're in a slash command context (beforePrefix contains "/command ")
-		const textBeforeCursor = currentLine.slice(0, cursorCol);
-		if (textBeforeCursor.includes("/") && textBeforeCursor.includes(" ")) {
-			// This is likely a command argument completion
-			const newLine = beforePrefix + item.value + adjustedAfterCursor;
-			const newLines = [...lines];
-			newLines[cursorLine] = newLine;
-
-			const isDirectory = item.label.endsWith("/");
-			const hasTrailingQuote = item.value.endsWith('"');
-			const cursorOffset = isDirectory && hasTrailingQuote ? item.value.length - 1 : item.value.length;
-
-			return {
-				lines: newLines,
-				cursorLine,
-				cursorCol: beforePrefix.length + cursorOffset,
 			};
 		}
 
@@ -491,12 +493,6 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// For natural triggers, return if it looks like a path, ends with /, starts with ~/, .
 		// Only return empty string if the text looks like it's starting a path context
 		if (pathPrefix.includes("/") || pathPrefix.startsWith(".") || pathPrefix.startsWith("~/")) {
-			return pathPrefix;
-		}
-
-		// Return empty string only after a space (not for completely empty text)
-		// Empty text should not trigger file suggestions - that's for forced Tab completion
-		if (pathPrefix === "" && text.endsWith(" ")) {
 			return pathPrefix;
 		}
 
@@ -670,6 +666,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				suggestions.push({
 					value,
 					label: name + (isDirectory ? "/" : ""),
+					kind: "file",
 				});
 			}
 
@@ -759,6 +756,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					value,
 					label: entryName + (isDirectory ? "/" : ""),
 					description: displayPath,
+					kind: "file",
 				});
 			}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,4 +1,9 @@
-import type { AutocompleteProvider, AutocompleteSuggestions } from "../autocomplete.js";
+import {
+	type AutocompleteItemKind,
+	type AutocompleteProvider,
+	type AutocompleteSuggestions,
+	extractSlashCommandPrefix,
+} from "../autocomplete.js";
 import { getKeybindings } from "../keybindings.js";
 import { decodePrintableKey, matchesKey } from "../keys.js";
 import { KillRing } from "../kill-ring.js";
@@ -242,6 +247,7 @@ export class Editor implements Component, Focusable {
 	private autocompleteList?: SelectList;
 	private autocompleteState: "regular" | "force" | null = null;
 	private autocompletePrefix: string = "";
+	private autocompleteKind: AutocompleteItemKind | null = null;
 	private autocompleteMaxVisible: number = 5;
 	private autocompleteAbort?: AbortController;
 	private autocompleteDebounceTimer?: ReturnType<typeof setTimeout>;
@@ -282,6 +288,7 @@ export class Editor implements Component, Focusable {
 	private undoStack = new UndoStack<EditorState>();
 
 	public onSubmit?: (text: string) => void;
+	public onSlashCommand?: (command: string) => void;
 	public onChange?: (text: string) => void;
 	public disableSubmit: boolean = false;
 
@@ -628,6 +635,18 @@ export class Editor implements Component, Focusable {
 			if (kb.matches(data, "tui.select.confirm")) {
 				const selected = this.autocompleteList.getSelectedItem();
 				if (selected && this.autocompleteProvider) {
+					const autocompleteKind = this.autocompleteKind;
+
+					if (autocompleteKind === "command" && this.onSlashCommand) {
+						this.pushUndoSnapshot();
+						this.lastAction = null;
+						this.removePrefixAtCursor(this.autocompletePrefix);
+						this.cancelAutocomplete();
+						if (this.onChange) this.onChange(this.getText());
+						this.onSlashCommand(`/${selected.value}`);
+						return;
+					}
+
 					this.pushUndoSnapshot();
 					this.lastAction = null;
 					const result = this.autocompleteProvider.applyCompletion(
@@ -641,9 +660,8 @@ export class Editor implements Component, Focusable {
 					this.state.cursorLine = result.cursorLine;
 					this.setCursorCol(result.cursorCol);
 
-					if (this.autocompletePrefix.startsWith("/")) {
+					if (autocompleteKind === "command") {
 						this.cancelAutocomplete();
-						// Fall through to submit
 					} else {
 						this.cancelAutocomplete();
 						if (this.onChange) this.onChange(this.getText());
@@ -1051,7 +1069,7 @@ export class Editor implements Component, Focusable {
 		// Check if we should trigger or update autocomplete
 		if (!this.autocompleteState) {
 			// Auto-trigger for "/" at the start of a line (slash commands)
-			if (char === "/" && this.isAtStartOfMessage()) {
+			if (char === "/" && this.isAtSlashCommandStart()) {
 				this.tryTriggerAutocomplete();
 			}
 			// Auto-trigger for symbol-based completion like @ or # at token boundaries
@@ -1266,6 +1284,20 @@ export class Editor implements Component, Focusable {
 		this.state.cursorCol = col;
 		this.preferredVisualCol = null;
 		this.snappedFromCursorCol = null;
+	}
+
+	/**
+	 * Remove a contiguous prefix that ends at the current cursor position from the
+	 * current line and place the cursor where the prefix started. Used to strip a
+	 * `/foo` slash-command token after the user dispatches the command via Enter.
+	 */
+	private removePrefixAtCursor(prefix: string): void {
+		const currentLine = this.state.lines[this.state.cursorLine] || "";
+		const startCol = Math.max(0, this.state.cursorCol - prefix.length);
+		const before = currentLine.slice(0, startCol);
+		const after = currentLine.slice(this.state.cursorCol);
+		this.state.lines[this.state.cursorLine] = before + after;
+		this.setCursorCol(before.length);
 	}
 
 	/**
@@ -2035,21 +2067,16 @@ export class Editor implements Component, Focusable {
 		this.setCursorCol(newCol);
 	}
 
-	// Slash menu only allowed on the first line of the editor
-	private isSlashMenuAllowed(): boolean {
-		return this.state.cursorLine === 0;
-	}
-
-	// Helper method to check if cursor is at start of message (for slash command detection)
-	private isAtStartOfMessage(): boolean {
-		if (!this.isSlashMenuAllowed()) return false;
+	// True when the just-typed `/` starts a command token.
+	private isAtSlashCommandStart(): boolean {
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
-		const beforeCursor = currentLine.slice(0, this.state.cursorCol);
-		return beforeCursor.trim() === "" || beforeCursor.trim() === "/";
+		return extractSlashCommandPrefix(currentLine.slice(0, this.state.cursorCol)) === "/";
 	}
 
 	private isInSlashCommandContext(textBeforeCursor: string): boolean {
-		return this.isSlashMenuAllowed() && textBeforeCursor.trimStart().startsWith("/");
+		const isCommandToken = extractSlashCommandPrefix(textBeforeCursor) !== null;
+		const isLineCommandArgument = textBeforeCursor.startsWith("/") && textBeforeCursor.includes(" ");
+		return isCommandToken || isLineCommandArgument;
 	}
 
 	// Autocomplete methods
@@ -2083,10 +2110,10 @@ export class Editor implements Component, Focusable {
 	}
 
 	private createAutocompleteList(
-		prefix: string,
 		items: Array<{ value: string; label: string; description?: string }>,
+		kind: AutocompleteItemKind | null,
 	): SelectList {
-		const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
+		const layout = kind === "command" ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
 		return new SelectList(items, this.autocompleteMaxVisible, this.theme.selectList, layout);
 	}
 
@@ -2249,8 +2276,10 @@ export class Editor implements Component, Focusable {
 	}
 
 	private applyAutocompleteSuggestions(suggestions: AutocompleteSuggestions, state: "regular" | "force"): void {
+		const kind = suggestions.kind ?? suggestions.items[0]?.kind ?? null;
 		this.autocompletePrefix = suggestions.prefix;
-		this.autocompleteList = this.createAutocompleteList(suggestions.prefix, suggestions.items);
+		this.autocompleteKind = kind;
+		this.autocompleteList = this.createAutocompleteList(suggestions.items, kind);
 
 		const bestMatchIndex = this.getBestAutocompleteMatchIndex(suggestions.items, suggestions.prefix);
 		if (bestMatchIndex >= 0) {
@@ -2274,6 +2303,7 @@ export class Editor implements Component, Focusable {
 		this.autocompleteState = null;
 		this.autocompleteList = undefined;
 		this.autocompletePrefix = "";
+		this.autocompleteKind = null;
 	}
 
 	private cancelAutocomplete(): void {

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -29,6 +29,14 @@ export interface EditorComponent extends Component {
 	/** Called when user submits (e.g., Enter key) */
 	onSubmit?: (text: string) => void;
 
+	/**
+	 * Called when the user picks a slash command from the autocomplete list and
+	 * confirms it (e.g., Enter). The editor has already removed the `/foo` token
+	 * from the buffer while leaving surrounding text intact. Receives the full
+	 * command including the leading `/`.
+	 */
+	onSlashCommand?: (command: string) => void;
+
 	/** Called when text changes */
 	onChange?: (text: string) => void;
 

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -3,6 +3,7 @@
 // Autocomplete support
 export {
 	type AutocompleteItem,
+	type AutocompleteItemKind,
 	type AutocompleteProvider,
 	type AutocompleteSuggestions,
 	CombinedAutocompleteProvider,

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -114,6 +114,99 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 	});
 
+	describe("mid-text slash commands", () => {
+		const buildProvider = () =>
+			new CombinedAutocompleteProvider(
+				[
+					{ name: "model", description: "Select model" },
+					{ name: "settings", description: "Open settings" },
+				],
+				"/tmp",
+			);
+
+		it("returns command suggestions when typing /mo after whitespace", async () => {
+			const provider = buildProvider();
+			const lines = ["ok let's do /mo"];
+
+			const result = await getSuggestions(provider, lines, 0, lines[0]!.length);
+
+			assert.notEqual(result, null, "Should suggest commands mid-text");
+			if (result) {
+				assert.strictEqual(result.prefix, "/mo", "Prefix should be just the slash token");
+				assert.strictEqual(result.kind, "command");
+				assert.ok(
+					result.items.some((item) => item.value === "model"),
+					"Should include 'model' suggestion",
+				);
+			}
+		});
+
+		it("does not suggest commands when slash is glued to previous text (path)", async () => {
+			const provider = buildProvider();
+			const lines = ["foo/mo"];
+
+			const result = await getSuggestions(provider, lines, 0, lines[0]!.length);
+
+			// Without a whitespace boundary, this is not a slash command; it should not return command items.
+			if (result) {
+				assert.ok(
+					!result.items.some((item) => item.value === "model"),
+					"Should not suggest 'model' for non-bounded slash",
+				);
+			}
+		});
+
+		it("does not fall through to file suggestions for a slash command token", async () => {
+			const provider = new CombinedAutocompleteProvider([], process.cwd());
+			const lines = ["hello /"];
+
+			const result = await getSuggestions(provider, lines, 0, lines[0]!.length);
+
+			assert.strictEqual(result, null);
+		});
+
+		it("closes autocomplete after typing space after a slash command token", async () => {
+			const provider = buildProvider();
+			const lines = ["hello / "];
+
+			const result = await getSuggestions(provider, lines, 0, lines[0]!.length);
+
+			assert.strictEqual(result, null);
+		});
+
+		it("applyCompletion replaces only the /prefix token mid-text", () => {
+			const provider = buildProvider();
+			const lines = ["ok let's do /mo"];
+			const result = provider.applyCompletion(
+				lines,
+				0,
+				lines[0]!.length,
+				{ value: "model", label: "model", kind: "command" },
+				"/mo",
+			);
+
+			assert.deepStrictEqual(result.lines, ["ok let's do /model "]);
+			assert.strictEqual(result.cursorLine, 0);
+			assert.strictEqual(result.cursorCol, "ok let's do /model ".length);
+		});
+
+		it("does not treat slash-prefixed file completions as commands", () => {
+			const provider = buildProvider();
+			const lines = ["/u"];
+			const result = provider.applyCompletion(
+				lines,
+				0,
+				lines[0]!.length,
+				{ value: "/usr/", label: "usr/", kind: "file" },
+				"/u",
+			);
+
+			assert.deepStrictEqual(result.lines, ["/usr/"]);
+			assert.strictEqual(result.cursorLine, 0);
+			assert.strictEqual(result.cursorCol, "/usr/".length);
+		});
+	});
+
 	describe("fd @ file suggestions", { skip: !isFdInstalled }, () => {
 		let rootDir = "";
 		let baseDir = "";

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2212,6 +2212,67 @@ describe("Editor component", () => {
 			assert.strictEqual(aborts, 1);
 		});
 
+		it("dispatches mid-text slash command via onSlashCommand and removes only the /token", async () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const provider = new CombinedAutocompleteProvider(
+				[
+					{ name: "model", description: "Select model" },
+					{ name: "settings", description: "Open settings" },
+				],
+				"/tmp",
+			);
+			editor.setAutocompleteProvider(provider);
+
+			let dispatched: string | null = null;
+			editor.onSlashCommand = (command) => {
+				dispatched = command;
+			};
+
+			// Type the surrounding prompt and the mid-text slash token.
+			for (const ch of "ok let's do /mo") {
+				editor.handleInput(ch);
+			}
+			await flushAutocomplete();
+			assert.strictEqual(editor.isShowingAutocomplete(), true);
+
+			// Confirm the highlighted suggestion (Enter).
+			editor.handleInput("\r");
+
+			assert.strictEqual(dispatched, "/model");
+			assert.strictEqual(editor.getText(), "ok let's do ");
+			assert.strictEqual(editor.isShowingAutocomplete(), false);
+		});
+
+		it("does not dispatch slash-prefixed file completions as commands", async () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const provider: AutocompleteProvider = {
+				async getSuggestions() {
+					return {
+						items: [{ value: "/usr/", label: "usr/", kind: "file" }],
+						prefix: "/u",
+						kind: "file",
+					};
+				},
+				applyCompletion,
+			};
+			editor.setAutocompleteProvider(provider);
+
+			let dispatched: string | null = null;
+			editor.onSlashCommand = (command) => {
+				dispatched = command;
+			};
+
+			editor.setText("/u");
+			editor.handleInput("\t");
+			await flushAutocomplete();
+			assert.strictEqual(editor.isShowingAutocomplete(), true);
+
+			editor.handleInput("\r");
+
+			assert.strictEqual(dispatched, null);
+			assert.strictEqual(editor.getText(), "/usr/");
+		});
+
 		it("hides autocomplete when backspacing slash command to empty", async () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 


### PR DESCRIPTION
# Summary

Enable execution of slash commands mid-text just like cursor CLI (iirc)

- slash commands can now execute mid-text via autocomplete + `<Enter>`
- slash commands that are non-destructive (e.g. /model) only remove the slash token and keep the rest of the editor
- slash commands that change/reset context (e.g. /new, /reload, /resume, /quit) clear the whole editor
- new built-in slash command metadata `clearEditor` to mark which built-in commands should clear the editor
- autocomplete suggestions are now tagged as 3 different kinds: file, command, argument
- custom editors now inherit `onSlashCommand`, so this also works when extensions replace the default editor

## Example

- `hello i am /mo` -> autocomplete starts, press `<Enter>` on `/model` -> open model selection, select the model -> editor becomes `hello i am` with model changed
- `hello i am /new` -> press `<Enter>` on `/new` autocomplete -> clear editor and create a new session
- `hello i am /new and something else` -> `/new` is not executed automatically, it is just part of the prompt

# Testing

- `npm run check`
- `./test.sh`
- added/updated TUI autocomplete coverage for mid-text slash command completion
- added/updated editor coverage for dispatching slash commands from autocomplete
- checked that slash-prefixed file completions like `/usr/` are not treated as commands
- checked that command argument completions still insert as arguments, not command dispatches

# Extra

me after this PR gets closed

<img width="350" height="260" alt="image" src="https://github.com/user-attachments/assets/eb308ee6-12c4-4ba7-b0f9-c6db0ec1b29d" />
