### PR TITLE
fix(coding-agent): clear editor after normal submit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ plans/
 .pi/hf-sessions/
 .pi/hf-sessions-backup/
 collect.sh
+.claude/worktrees/

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2617,6 +2617,7 @@ export class InteractiveMode {
 				this.onInputCallback(text);
 			}
 			this.editor.addToHistory?.(text);
+			this.editor.setText("");
 		};
 	}
 


### PR DESCRIPTION
## Problem

After submitting a prompt in the interactive TUI from an idle state (not streaming, not compacting, not in bash mode), the editor retains the submitted text instead of clearing. Reproduces consistently: type anything, hit Enter, observe that the text stays in the editor while the agent processes.

## Root cause

The editor submit handler in `InteractiveMode` (`packages/coding-agent/src/modes/interactive/interactive-mode.ts`) has four sibling branches that all call `this.editor.setText("")` explicitly:

- bash-mode submission
- compaction-queued submission (line ~2593)
- streaming steer submission (line ~2605)
- follow-up submission (line ~3325)

The fifth — the normal idle submission — does not. It used to rely on the `user` branch of the `message_start` event handler calling `editor.setText("")` as a side effect. That call was removed in 3964984f ("fix(coding-agent): keep editor text on queued steering"), which was the correct fix for the queued-steering case but also silently removed the clear for the normal path.

## Fix

Add the missing `this.editor.setText("")` to the normal submission path, matching the other four branches. The queued-steering fix from 3964984f remains intact because it operates on a different call site (the `message_start` event handler for delivery of queued messages, not the editor's local submit handler).

## Verification

- `npm run check` passes (biome + tsgo).
- Manually reproducible before the fix; cleared correctly after.

## Notes

No tests added — the handler is a closure inside the TUI class with no existing unit-test coverage of the other four sibling clears, so adding one just for this branch would be inconsistent. Happy to add a regression test if a test harness for InteractiveMode submit handling is desired.