### PR TITLE
feat: add horizontal UI padding setting

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -104,6 +104,7 @@ export interface Settings {
 	doubleEscapeAction?: "fork" | "tree" | "none"; // Action for double-escape with empty editor (default: "tree")
 	treeFilterMode?: "default" | "no-tools" | "user-only" | "labeled-only" | "all"; // Default filter when opening /tree
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
+	paddingX?: number; // Horizontal padding for entire UI in characters (default: 0)
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
@@ -1038,6 +1039,16 @@ export class SettingsManager {
 	setEditorPaddingX(padding: number): void {
 		this.globalSettings.editorPaddingX = Math.max(0, Math.min(3, Math.floor(padding)));
 		this.markModified("editorPaddingX");
+		this.save();
+	}
+
+	getPaddingX(): number {
+		return this.settings.paddingX ?? 0;
+	}
+
+	setPaddingX(padding: number): void {
+		this.globalSettings.paddingX = Math.max(0, Math.min(10, Math.floor(padding)));
+		this.markModified("paddingX");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -49,6 +49,7 @@ export interface SettingsConfig {
 	doubleEscapeAction: "fork" | "tree" | "none";
 	treeFilterMode: "default" | "no-tools" | "user-only" | "labeled-only" | "all";
 	showHardwareCursor: boolean;
+	paddingX: number;
 	editorPaddingX: number;
 	autocompleteMaxVisible: number;
 	quietStartup: boolean;
@@ -76,6 +77,7 @@ export interface SettingsCallbacks {
 	onDoubleEscapeActionChange: (action: "fork" | "tree" | "none") => void;
 	onTreeFilterModeChange: (mode: "default" | "no-tools" | "user-only" | "labeled-only" | "all") => void;
 	onShowHardwareCursorChange: (enabled: boolean) => void;
+	onPaddingXChange: (padding: number) => void;
 	onEditorPaddingXChange: (padding: number) => void;
 	onAutocompleteMaxVisibleChange: (maxVisible: number) => void;
 	onQuietStartupChange: (enabled: boolean) => void;
@@ -405,9 +407,19 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
-		// Editor padding toggle (insert after show-hardware-cursor)
-		const hardwareCursorIndex = items.findIndex((item) => item.id === "show-hardware-cursor");
-		items.splice(hardwareCursorIndex + 1, 0, {
+		// UI padding toggle (insert after show-hardware-cursor)
+		const hardwareCursorIndexPadding = items.findIndex((item) => item.id === "show-hardware-cursor");
+		items.splice(hardwareCursorIndexPadding + 1, 0, {
+			id: "padding",
+			label: "UI padding",
+			description: "Horizontal padding for entire UI (0-10)",
+			currentValue: String(config.paddingX),
+			values: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+		});
+
+		// Editor padding toggle (insert after padding)
+		const paddingIndex = items.findIndex((item) => item.id === "padding");
+		items.splice(paddingIndex + 1, 0, {
 			id: "editor-padding",
 			label: "Editor padding",
 			description: "Horizontal padding for input editor (0-3)",
@@ -503,6 +515,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "show-hardware-cursor":
 						callbacks.onShowHardwareCursorChange(newValue === "true");
+						break;
+					case "padding":
+						callbacks.onPaddingXChange(parseInt(newValue, 10));
 						break;
 					case "editor-padding":
 						callbacks.onEditorPaddingXChange(parseInt(newValue, 10));

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -376,6 +376,7 @@ export class InteractiveMode {
 		this.version = VERSION;
 		this.ui = new TUI(new ProcessTerminal(), this.settingsManager.getShowHardwareCursor());
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
+		this.ui.setPaddingX(this.settingsManager.getPaddingX());
 		this.headerContainer = new Container();
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
@@ -3764,6 +3765,7 @@ export class InteractiveMode {
 					doubleEscapeAction: this.settingsManager.getDoubleEscapeAction(),
 					treeFilterMode: this.settingsManager.getTreeFilterMode(),
 					showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
+					paddingX: this.settingsManager.getPaddingX(),
 					editorPaddingX: this.settingsManager.getEditorPaddingX(),
 					autocompleteMaxVisible: this.settingsManager.getAutocompleteMaxVisible(),
 					quietStartup: this.settingsManager.getQuietStartup(),
@@ -3861,6 +3863,10 @@ export class InteractiveMode {
 					onShowHardwareCursorChange: (enabled) => {
 						this.settingsManager.setShowHardwareCursor(enabled);
 						this.ui.setShowHardwareCursor(enabled);
+					},
+					onPaddingXChange: (padding) => {
+						this.settingsManager.setPaddingX(padding);
+						this.ui.setPaddingX(padding);
 					},
 					onEditorPaddingXChange: (padding) => {
 						this.settingsManager.setEditorPaddingX(padding);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -232,6 +232,7 @@ export class TUI extends Container {
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1";
 	private clearOnShrink = process.env.PI_CLEAR_ON_SHRINK === "1"; // Clear empty rows when content shrinks (default: off)
+	private paddingX = 0; // Horizontal padding for entire UI in characters
 	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
 	private fullRedrawCount = 0;
@@ -283,6 +284,19 @@ export class TUI extends Container {
 	 */
 	setClearOnShrink(enabled: boolean): void {
 		this.clearOnShrink = enabled;
+	}
+
+	getPaddingX(): number {
+		return this.paddingX;
+	}
+
+	/**
+	 * Set horizontal padding (in characters) for the entire UI.
+	 * Content is rendered narrower and padded with spaces on both sides.
+	 */
+	setPaddingX(padding: number): void {
+		this.paddingX = Math.max(0, Math.min(10, Math.floor(padding)));
+		this.requestRender();
 	}
 
 	setFocus(component: Component | null): void {
@@ -901,8 +915,9 @@ export class TUI extends Container {
 			return targetScreenRow - currentScreenRow;
 		};
 
-		// Render all components to get new lines
-		let newLines = this.render(width);
+		// Render all components to get new lines (with reduced width for padding)
+		const effectiveWidth = width - this.paddingX * 2;
+		let newLines = effectiveWidth > 0 ? this.render(effectiveWidth) : this.render(width);
 
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {
@@ -913,6 +928,21 @@ export class TUI extends Container {
 		const cursorPos = this.extractCursorPosition(newLines, height);
 
 		newLines = this.applyLineResets(newLines);
+
+		// Apply horizontal padding to all lines
+		if (this.paddingX > 0) {
+			const pad = " ".repeat(this.paddingX);
+			for (let i = 0; i < newLines.length; i++) {
+				const line = newLines[i];
+				if (!isImageLine(line)) {
+					newLines[i] = pad + line + pad;
+				}
+			}
+			// Adjust cursor position for padding offset
+			if (cursorPos) {
+				cursorPos.col += this.paddingX;
+			}
+		}
 
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean): void => {


### PR DESCRIPTION
Add a global paddingX setting (0-10 characters) that adds horizontal padding to the entire TUI, giving content breathing room on both sides.

- Add paddingX setting to settings-manager with getter/setter
- TUI renders content at reduced width and pads lines with spaces
- Cursor position adjusted for padding offset
- Exposed in /settings as 'UI padding' option