### PR TITLE
fix(ai): add reasoningEffortMap to DeepSeek V4 models across all providers

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1096,6 +1096,12 @@ async function generateModels() {
 			candidate.compat = {
 				...candidate.compat,
 				requiresReasoningContentOnAssistantMessages: true,
+				reasoningEffortMap: deepseekCompat.reasoningEffortMap,
+				// Set deepseek thinking format for all providers except OpenRouter
+				// (OpenRouter normalizes reasoning via its own reason: { effort } format)
+				...(candidate.provider !== "openrouter" && {
+					thinkingFormat: deepseekCompat.thinkingFormat,
+				}),
 			};
 		}
 	}

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -7519,7 +7519,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "opencode-go",
 			baseUrl: "https://opencode.ai/zen/go/v1",
-			compat: {"requiresReasoningContentOnAssistantMessages":true},
+			compat: {"requiresReasoningContentOnAssistantMessages":true,"thinkingFormat":"deepseek","reasoningEffortMap":{"minimal":"high","low":"high","medium":"high","high":"high","xhigh":"max"}},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -7537,7 +7537,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "opencode-go",
 			baseUrl: "https://opencode.ai/zen/go/v1",
-			compat: {"requiresReasoningContentOnAssistantMessages":true},
+			compat: {"requiresReasoningContentOnAssistantMessages":true,"thinkingFormat":"deepseek","reasoningEffortMap":{"minimal":"high","low":"high","medium":"high","high":"high","xhigh":"max"}},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -8492,7 +8492,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "openrouter",
 			baseUrl: "https://openrouter.ai/api/v1",
-			compat: {"requiresReasoningContentOnAssistantMessages":true},
+			compat: {"requiresReasoningContentOnAssistantMessages":true,"reasoningEffortMap":{"minimal":"high","low":"high","medium":"high","high":"high","xhigh":"max"}},
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -8510,7 +8510,7 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "openrouter",
 			baseUrl: "https://openrouter.ai/api/v1",
-			compat: {"requiresReasoningContentOnAssistantMessages":true},
+			compat: {"requiresReasoningContentOnAssistantMessages":true,"reasoningEffortMap":{"minimal":"high","low":"high","medium":"high","high":"high","xhigh":"max"}},
 			reasoning: true,
 			input: ["text"],
 			cost: {


### PR DESCRIPTION
## Problem

When using DeepSeek V4 models through **opencode-go** or **openrouter** providers, the `reasoningEffortMap` and `thinkingFormat` compat settings are missing. Only the built-in `deepseek` provider had correct settings (auto-detected by `detectCompat`).

### Impact
1. **`xhigh` thinking level sends wrong value**: Users get `"xhigh"` instead of `"max"` (DeepSeek's maximum reasoning effort)
2. **Missing `thinkingFormat` for opencode-go**: The `thinking: { type: "enabled" }` parameter is not sent, which DeepSeek requires for thinking mode alongside `reasoning_effort`

### Root Cause
The `generate-models.ts` script at line 1095 only sets `requiresReasoningContentOnAssistantMessages: true` for all DeepSeek V4 models, but does not spread the full `deepseekCompat` object (which also includes `thinkingFormat` and `reasoningEffortMap`).

For the `deepseek` provider, these fields are auto-detected by `detectCompat()` (via `isDeepSeek = provider === "deepseek"`). But other providers like `opencode-go` and `openrouter` are not recognized as DeepSeek, so they default to empty maps and generic thinking formats.

## Fix
- Spread `deepseekCompat.reasoningEffortMap` onto ALL DeepSeek V4 models
- Also set `thinkFormat: "deepseek"` for non-OpenRouter providers (OpenRouter normalizes reasoning via its own format)

### Before
```
// opencode-go deepseek-v4-flash
compat: {"requiresReasoningContentOnAssistantMessages":true}

// openrouter deepseek-v4-flash  
compat: {"requiresReasoningContentOnAssistantMessages":true}
```

### After
```
// opencode-go deepseek-v4-flash
compat: {"requiresReasoningContentOnAssistantMessages":true,"thinkingFormat":"deepseek","reasoningEffortMap":{"minimal":"high","low":"high","medium":"high","high":"high","xhigh":"max"}}

// openrouter deepseek-v4-flash (no thinkingFormat - keeps auto-detected "openrouter")
compat: {"requiresReasoningContentOnAssistantMessages":true,"reasoningEffortMap":{"minimal":"high","low":"high","medium":"high","high":"high","xhigh":"max"}}
```

## Testing
- Verified all 6 DeepSeek V4 compat entries across deepseek, opencode-go, and openrouter providers
- DeepSeek V4 Flash confirmed to return `reasoning_content` from API calls