### PR TITLE
Fix handoff context after compaction

### DIFF
--- a/packages/coding-agent/examples/extensions/handoff.ts
+++ b/packages/coding-agent/examples/extensions/handoff.ts
@@ -14,7 +14,12 @@
 
 import { complete, type Message } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, SessionEntry } from "@mariozechner/pi-coding-agent";
-import { BorderedLoader, convertToLlm, serializeConversation } from "@mariozechner/pi-coding-agent";
+import {
+	BorderedLoader,
+	buildSessionContext,
+	convertToLlm,
+	serializeConversation,
+} from "@mariozechner/pi-coding-agent";
 
 const SYSTEM_PROMPT = `You are a context transfer assistant. Given a conversation history and the user's goal for a new thread, generate a focused prompt that:
 
@@ -38,6 +43,22 @@ Files involved:
 ## Task
 [Clear description of what to do next based on user's goal]`;
 
+type HandoffSessionManager = {
+	getEntries(): SessionEntry[];
+	getLeafId(): string | null;
+};
+
+export function buildHandoffConversation(sessionManager: HandoffSessionManager): {
+	messageCount: number;
+	text: string;
+} {
+	const messages = buildSessionContext(sessionManager.getEntries(), sessionManager.getLeafId()).messages;
+	return {
+		messageCount: messages.length,
+		text: serializeConversation(convertToLlm(messages)),
+	};
+}
+
 export default function (pi: ExtensionAPI) {
 	pi.registerCommand("handoff", {
 		description: "Transfer context to a new focused session",
@@ -58,20 +79,15 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
-			// Gather conversation context from current branch
-			const branch = ctx.sessionManager.getBranch();
-			const messages = branch
-				.filter((entry): entry is SessionEntry & { type: "message" } => entry.type === "message")
-				.map((entry) => entry.message);
+			// Gather canonical compacted conversation context from the current session.
+			const conversation = buildHandoffConversation(ctx.sessionManager);
 
-			if (messages.length === 0) {
+			if (conversation.messageCount === 0) {
 				ctx.ui.notify("No conversation to hand off", "error");
 				return;
 			}
 
-			// Convert to LLM format and serialize
-			const llmMessages = convertToLlm(messages);
-			const conversationText = serializeConversation(llmMessages);
+			const conversationText = conversation.text;
 			const currentSessionFile = ctx.sessionManager.getSessionFile();
 
 			// Generate the handoff prompt with loader UI

--- a/packages/coding-agent/test/handoff-extension.test.ts
+++ b/packages/coding-agent/test/handoff-extension.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CompactionEntry, SessionEntry, SessionMessageEntry } from "../src/core/session-manager.js";
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+	const [{ convertToLlm }, { serializeConversation }, { buildSessionContext }] = await Promise.all([
+		import("../src/core/messages.js"),
+		import("../src/core/compaction/utils.js"),
+		import("../src/core/session-manager.js"),
+	]);
+
+	return {
+		BorderedLoader: class BorderedLoader {},
+		buildSessionContext,
+		convertToLlm,
+		serializeConversation,
+	};
+});
+
+import { buildHandoffConversation } from "../examples/extensions/handoff.js";
+
+function msg(id: string, parentId: string | null, role: "user" | "assistant", text: string): SessionMessageEntry {
+	const base = { type: "message" as const, id, parentId, timestamp: "2025-01-01T00:00:00Z" };
+	if (role === "user") {
+		return { ...base, message: { role, content: text, timestamp: 1 } };
+	}
+	return {
+		...base,
+		message: {
+			role,
+			content: [{ type: "text", text }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 1,
+		},
+	};
+}
+
+function compaction(id: string, parentId: string | null, summary: string, firstKeptEntryId: string): CompactionEntry {
+	return {
+		type: "compaction",
+		id,
+		parentId,
+		timestamp: "2025-01-01T00:00:00Z",
+		summary,
+		firstKeptEntryId,
+		tokensBefore: 1000,
+	};
+}
+
+describe("handoff extension conversation context", () => {
+	it("serializes compacted context instead of all raw branch messages", () => {
+		const entries: SessionEntry[] = [
+			msg("1", null, "user", "OLD RAW USER MESSAGE"),
+			msg("2", "1", "assistant", "OLD RAW ASSISTANT MESSAGE"),
+			msg("3", "2", "user", "KEPT USER MESSAGE"),
+			msg("4", "3", "assistant", "KEPT ASSISTANT MESSAGE"),
+			compaction("5", "4", "COMPACTED SESSION SUMMARY", "3"),
+			msg("6", "5", "user", "RECENT USER MESSAGE"),
+			msg("7", "6", "assistant", "RECENT ASSISTANT MESSAGE"),
+		];
+
+		const conversation = buildHandoffConversation({
+			getEntries: () => entries,
+			getLeafId: () => "7",
+		});
+
+		expect(conversation.messageCount).toBe(5);
+		expect(conversation.text).toContain("COMPACTED SESSION SUMMARY");
+		expect(conversation.text).toContain("KEPT USER MESSAGE");
+		expect(conversation.text).toContain("KEPT ASSISTANT MESSAGE");
+		expect(conversation.text).toContain("RECENT USER MESSAGE");
+		expect(conversation.text).toContain("RECENT ASSISTANT MESSAGE");
+		expect(conversation.text).not.toContain("OLD RAW USER MESSAGE");
+		expect(conversation.text).not.toContain("OLD RAW ASSISTANT MESSAGE");
+	});
+});

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -4,6 +4,8 @@ import { defineConfig } from "vitest/config";
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
+const codingAgentSrcIndex = fileURLToPath(new URL("./src/index.ts", import.meta.url));
+const tuiSrcIndex = fileURLToPath(new URL("../tui/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
@@ -21,6 +23,8 @@ export default defineConfig({
 			{ find: /^@mariozechner\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@mariozechner\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@mariozechner\/pi-coding-agent$/, replacement: codingAgentSrcIndex },
+			{ find: /^@mariozechner\/pi-tui$/, replacement: tuiSrcIndex },
 		],
 	},
 });


### PR DESCRIPTION
## Summary
- Update the `/handoff` extension example to build its prompt context from canonical session context instead of raw branch message entries.
- Keep the existing `convertToLlm()` + `serializeConversation()` serialization path for the generated handoff prompt.

## Fix
- Use exported `buildSessionContext(getEntries(), getLeafId()).messages` so compacted sessions include the compaction summary plus kept/recent messages and do not re-expand old pre-compaction raw messages.
- Add a regression test for compacted handoff serialization.

## Testing
- `cd packages/coding-agent && npm test -- handoff-extension.test.ts session-manager/build-context.test.ts`
- `npx tsgo --noEmit`
- `npm run build`
- Pre-commit hook: `npm run check`