### PR TITLE
feat(bedrock): Cline-parity auth modes, VPC endpoint, 1M beta, adaptive thinking

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mariozechner/pi-agent-core",
-	"version": "0.70.6",
+	"version": "0.70.7",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@mariozechner/pi-ai": "^0.70.6",
+		"@mariozechner/pi-ai": "^0.70.7",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added four explicit Bedrock auth modes (`apikey`, `profile`, `credentials`, `default`) dispatched through a pure `resolveBedrockAuthMode` / `resolveBedrockClientInputs` helper, with a named `BedrockAuthError` raised on missing required inputs. Thanks @praxstack.
+- Added `awsBedrockEndpoint` option for VPC and custom Bedrock endpoints across all auth modes. Thanks @praxstack.
+- Added `enable1MContext` for Claude Opus 4.6 and 4.7: when enabled, the model id gets a `:1m` suffix and the `context-1m-2025-08-07` value is appended to `anthropic_beta`. Thanks @praxstack.
+- Exported `supportsOpus1MContext`, `applyOpus1MSuffix`, and `supportsAdaptiveThinking` helpers for provider consumers. Thanks @praxstack.
+
+### Changed
+
+- Changed `BedrockOptions` to carry Cline-parity fields (`awsAuthentication`, `awsBedrockApiKey`, `awsProfile`, `awsAccessKey`, `awsSecretKey`, `awsSessionToken`, `awsBedrockEndpoint`, `awsRegion`); legacy `bearerToken` / `profile` / `region` aliases still resolve. Thanks @praxstack.
+- Changed `AWS_BEDROCK_SKIP_AUTH=1` to also suppress bearer token and profile resolution so dummy-creds mode truly sends no auth. Thanks @praxstack.
+
+### Fixed
+
+- Fixed empty or whitespace-only Bedrock API keys (including the literal `"Bearer "`) to raise `BedrockAuthError` instead of silently producing `token: ""`. Thanks @praxstack.
+- Fixed Bedrock resolver env-var fallback to guard `process.env` access with `typeof process !== "undefined"` for browser compatibility. Thanks @praxstack.
+
 ## [0.70.6] - 2026-04-28
 
 ### Added

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mariozechner/pi-ai",
-	"version": "0.70.6",
+	"version": "0.70.7",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/providers/amazon-bedrock-auth.ts
+++ b/packages/ai/src/providers/amazon-bedrock-auth.ts
@@ -1,7 +1,12 @@
 export type BedrockAuthMode = "apikey" | "profile" | "credentials" | "default";
 
 export interface BedrockAuthInputs {
-	awsAuthentication?: BedrockAuthMode | string;
+	/**
+	 * AWS authentication mode. Typed as `string` rather than `BedrockAuthMode`
+	 * because inputs often come from untrusted config JSON. `resolveBedrockAuthMode`
+	 * narrows at runtime and falls through to inference on unknown values.
+	 */
+	awsAuthentication?: string;
 	awsRegion?: string;
 	awsBedrockApiKey?: string;
 	awsProfile?: string;
@@ -76,7 +81,11 @@ export class BedrockAuthError extends Error {
 
 function stripBearerPrefix(token: string): string {
 	const t = token.trim();
-	if (t.toLowerCase().startsWith("bearer ")) {
+	const lower = t.toLowerCase();
+	if (lower === "bearer") {
+		return "";
+	}
+	if (lower.startsWith("bearer ")) {
 		return t.slice(7).trim();
 	}
 	return t;
@@ -107,13 +116,14 @@ export function resolveBedrockClientInputs(inputs: BedrockAuthInputs): ResolvedB
 				process.env.AWS_BEARER_TOKEN_BEDROCK ??
 				""
 			).trim();
-			if (!raw) {
+			const stripped = stripBearerPrefix(raw);
+			if (!stripped) {
 				throw new BedrockAuthError(
 					"bedrock_auth_api_key_missing",
-					"Bedrock auth mode is 'apikey' but no key was provided and AWS_BEARER_TOKEN_BEDROCK is unset.",
+					"Bedrock auth mode is 'apikey' but no key was provided (or value was empty after stripping 'Bearer' prefix) and AWS_BEARER_TOKEN_BEDROCK is unset.",
 				);
 			}
-			result.token = { token: stripBearerPrefix(raw) };
+			result.token = { token: stripped };
 			result.authSchemePreference = ["httpBearerAuth"];
 			return result;
 		}
@@ -139,5 +149,9 @@ export function resolveBedrockClientInputs(inputs: BedrockAuthInputs): ResolvedB
 		}
 		case "default":
 			return result;
+		default: {
+			const _exhaustive: never = mode;
+			throw new Error(`Unhandled Bedrock auth mode: ${String(_exhaustive)}`);
+		}
 	}
 }

--- a/packages/ai/src/providers/amazon-bedrock-auth.ts
+++ b/packages/ai/src/providers/amazon-bedrock-auth.ts
@@ -1,0 +1,143 @@
+export type BedrockAuthMode = "apikey" | "profile" | "credentials" | "default";
+
+export interface BedrockAuthInputs {
+	awsAuthentication?: BedrockAuthMode | string;
+	awsRegion?: string;
+	awsBedrockApiKey?: string;
+	awsProfile?: string;
+	awsAccessKey?: string;
+	awsSecretKey?: string;
+	awsSessionToken?: string;
+	awsBedrockEndpoint?: string;
+	/** Legacy alias for awsBedrockApiKey; existing callers in BedrockOptions use this field. */
+	bearerToken?: string;
+	/** Legacy alias for awsProfile. */
+	profile?: string;
+	/** Legacy alias for awsRegion. */
+	region?: string;
+}
+
+const VALID_MODES: readonly BedrockAuthMode[] = ["apikey", "profile", "credentials", "default"];
+
+function isValidMode(value: string | undefined): value is BedrockAuthMode {
+	return typeof value === "string" && VALID_MODES.includes(value as BedrockAuthMode);
+}
+
+/**
+ * Resolves the Bedrock auth mode to use.
+ *
+ * Precedence:
+ *   1. Explicit `awsAuthentication` when one of the four valid values.
+ *   2. Inferred: bearer token → "apikey"; profile → "profile"; access+secret → "credentials".
+ *   3. Fallback → "default" (let the AWS SDK resolve from env/IMDS/SSO).
+ *
+ * Unknown `awsAuthentication` values fall through to the inferred path. This is
+ * deliberately permissive at the edge — an unknown mode string should not hide
+ * a set of credentials the user clearly supplied.
+ */
+export function resolveBedrockAuthMode(inputs: BedrockAuthInputs): BedrockAuthMode {
+	if (isValidMode(inputs.awsAuthentication)) {
+		return inputs.awsAuthentication;
+	}
+	const apiKey = inputs.awsBedrockApiKey ?? inputs.bearerToken;
+	if (apiKey) return "apikey";
+	const profile = inputs.awsProfile ?? inputs.profile;
+	if (profile && !(inputs.awsAccessKey && inputs.awsSecretKey)) return "profile";
+	if (inputs.awsAccessKey && inputs.awsSecretKey) return "credentials";
+	return "default";
+}
+
+export interface ResolvedBedrockClientInputs {
+	region: string;
+	endpoint?: string;
+	profile?: string;
+	token?: { token: string };
+	authSchemePreference?: string[];
+	credentials?: {
+		accessKeyId: string;
+		secretAccessKey: string;
+		sessionToken?: string;
+	};
+}
+
+export type BedrockAuthErrorCode =
+	| "bedrock_auth_api_key_missing"
+	| "bedrock_auth_credentials_missing"
+	| "bedrock_auth_profile_missing";
+
+export class BedrockAuthError extends Error {
+	readonly code: BedrockAuthErrorCode;
+	constructor(code: BedrockAuthErrorCode, message: string) {
+		super(message);
+		this.name = "BedrockAuthError";
+		this.code = code;
+	}
+}
+
+function stripBearerPrefix(token: string): string {
+	const t = token.trim();
+	if (t.toLowerCase().startsWith("bearer ")) {
+		return t.slice(7).trim();
+	}
+	return t;
+}
+
+/**
+ * Build SDK-shaped client inputs for the resolved auth mode.
+ *
+ * Each mode sets only its own fields; others stay undefined. Raises
+ * BedrockAuthError when a mode is selected but its required inputs are missing.
+ * "default" mode deliberately returns an empty auth payload so the AWS SDK
+ * default credential chain applies at the call site.
+ */
+export function resolveBedrockClientInputs(inputs: BedrockAuthInputs): ResolvedBedrockClientInputs {
+	const mode = resolveBedrockAuthMode(inputs);
+	const region = inputs.awsRegion ?? inputs.region ?? "us-east-1";
+	const result: ResolvedBedrockClientInputs = { region };
+
+	if (inputs.awsBedrockEndpoint) {
+		result.endpoint = inputs.awsBedrockEndpoint;
+	}
+
+	switch (mode) {
+		case "apikey": {
+			const raw = (
+				inputs.awsBedrockApiKey ??
+				inputs.bearerToken ??
+				process.env.AWS_BEARER_TOKEN_BEDROCK ??
+				""
+			).trim();
+			if (!raw) {
+				throw new BedrockAuthError(
+					"bedrock_auth_api_key_missing",
+					"Bedrock auth mode is 'apikey' but no key was provided and AWS_BEARER_TOKEN_BEDROCK is unset.",
+				);
+			}
+			result.token = { token: stripBearerPrefix(raw) };
+			result.authSchemePreference = ["httpBearerAuth"];
+			return result;
+		}
+		case "profile": {
+			const profile = inputs.awsProfile ?? inputs.profile;
+			if (profile) result.profile = profile;
+			return result;
+		}
+		case "credentials": {
+			if (!inputs.awsAccessKey || !inputs.awsSecretKey) {
+				throw new BedrockAuthError(
+					"bedrock_auth_credentials_missing",
+					"Bedrock auth mode is 'credentials' but awsAccessKey or awsSecretKey is missing.",
+				);
+			}
+			const creds: ResolvedBedrockClientInputs["credentials"] = {
+				accessKeyId: inputs.awsAccessKey,
+				secretAccessKey: inputs.awsSecretKey,
+			};
+			if (inputs.awsSessionToken) creds.sessionToken = inputs.awsSessionToken;
+			result.credentials = creds;
+			return result;
+		}
+		case "default":
+			return result;
+	}
+}

--- a/packages/ai/src/providers/amazon-bedrock-auth.ts
+++ b/packages/ai/src/providers/amazon-bedrock-auth.ts
@@ -110,12 +110,11 @@ export function resolveBedrockClientInputs(inputs: BedrockAuthInputs): ResolvedB
 
 	switch (mode) {
 		case "apikey": {
-			const raw = (
-				inputs.awsBedrockApiKey ??
-				inputs.bearerToken ??
-				process.env.AWS_BEARER_TOKEN_BEDROCK ??
-				""
-			).trim();
+			// Guard process access so browser builds don't ReferenceError on
+			// apikey mode when callers forward credentials explicitly. The env
+			// fallback is a Node-only convenience.
+			const envToken = typeof process !== "undefined" ? process.env.AWS_BEARER_TOKEN_BEDROCK : undefined;
+			const raw = (inputs.awsBedrockApiKey ?? inputs.bearerToken ?? envToken ?? "").trim();
 			const stripped = stripBearerPrefix(raw);
 			if (!stripped) {
 				throw new BedrockAuthError(

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -265,8 +265,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 		try {
 			const client = new BedrockRuntimeClient(config);
 			const cacheRetention = resolveCacheRetention(options.cacheRetention);
-			const baseModelId = model.id;
-			const finalModelId = applyOpus1MSuffix(baseModelId, options.enable1MContext ?? false, baseModelId);
+			const finalModelId = applyOpus1MSuffix(model.id, options.enable1MContext ?? false);
 			let commandInput = {
 				modelId: finalModelId,
 				messages: convertMessages(context, model, cacheRetention),
@@ -577,14 +576,10 @@ export function supportsOpus1MContext(modelId: string): boolean {
  * Idempotently append the ":1m" inference-profile suffix to an Opus 4.6/4.7
  * model id when the user has opted into the 1M context beta. Safe to call
  * multiple times; non-eligible models are returned unchanged.
- *
- * `baseModelId` is used for eligibility checks so that callers that already
- * routed the id through regional/global prefixes (e.g.,
- * "us.anthropic.claude-opus-4-7") still pick the right behavior.
  */
-export function applyOpus1MSuffix(modelId: string, enable1M: boolean, baseModelId: string): string {
+export function applyOpus1MSuffix(modelId: string, enable1M: boolean): string {
 	if (!enable1M) return modelId;
-	if (!supportsOpus1MContext(baseModelId)) return modelId;
+	if (!supportsOpus1MContext(modelId)) return modelId;
 	if (modelId.endsWith(":1m")) return modelId;
 	return `${modelId}:1m`;
 }
@@ -976,67 +971,52 @@ function buildAdditionalModelRequestFields(
 	model: Model<"bedrock-converse-stream">,
 	options: BedrockOptions,
 ): Record<string, any> | undefined {
-	const want1MBeta = (options.enable1MContext ?? false) && supportsOpus1MContext(model.id);
+	const result: Record<string, any> = {};
+	const betaFlags: string[] = [];
 
-	if (!options.reasoning || !model.reasoning) {
-		// Still emit the 1M beta header on eligible Opus models even when
-		// reasoning is not requested.
-		if (want1MBeta) {
-			return { anthropic_beta: ["context-1m-2025-08-07"] };
-		}
-		return undefined;
+	const want1MBeta = (options.enable1MContext ?? false) && supportsOpus1MContext(model.id);
+	if (want1MBeta) {
+		betaFlags.push("context-1m-2025-08-07");
 	}
 
-	if (isAnthropicClaudeModel(model)) {
+	if (options.reasoning && model.reasoning && isAnthropicClaudeModel(model)) {
 		// GovCloud Bedrock currently rejects the Claude thinking.display field.
 		// Omit it there until the GovCloud Converse schema catches up.
 		const display = isGovCloudBedrockTarget(model, options) ? undefined : (options.thinkingDisplay ?? "summarized");
-		const result: Record<string, any> = supportsAdaptiveThinking(model.id, model.name)
-			? {
-					thinking: { type: "adaptive", ...(display !== undefined ? { display } : {}) },
-					output_config: { effort: mapThinkingLevelToEffort(options.reasoning, model.id, model.name) },
-				}
-			: (() => {
-					const defaultBudgets: Record<ThinkingLevel, number> = {
-						minimal: 1024,
-						low: 2048,
-						medium: 8192,
-						high: 16384,
-						xhigh: 16384, // Claude doesn't support xhigh, clamp to high
-					};
 
-					// Custom budgets override defaults (xhigh not in ThinkingBudgets, use high)
-					const level = options.reasoning === "xhigh" ? "high" : options.reasoning;
-					const budget = options.thinkingBudgets?.[level] ?? defaultBudgets[options.reasoning];
+		if (supportsAdaptiveThinking(model.id, model.name)) {
+			result.thinking = { type: "adaptive", ...(display !== undefined ? { display } : {}) };
+			result.output_config = { effort: mapThinkingLevelToEffort(options.reasoning, model.id, model.name) };
+		} else {
+			const defaultBudgets: Record<ThinkingLevel, number> = {
+				minimal: 1024,
+				low: 2048,
+				medium: 8192,
+				high: 16384,
+				xhigh: 16384, // Claude doesn't support xhigh, clamp to high
+			};
 
-					return {
-						thinking: {
-							type: "enabled",
-							budget_tokens: budget,
-							...(display !== undefined ? { display } : {}),
-						},
-					};
-				})();
+			// Custom budgets override defaults (xhigh not in ThinkingBudgets, use high)
+			const level = options.reasoning === "xhigh" ? "high" : options.reasoning;
+			const budget = options.thinkingBudgets?.[level] ?? defaultBudgets[options.reasoning];
 
-		const betaFlags: string[] = [];
-		if (!supportsAdaptiveThinking(model.id, model.name) && (options.interleavedThinking ?? true)) {
-			betaFlags.push("interleaved-thinking-2025-05-14");
+			result.thinking = {
+				type: "enabled",
+				budget_tokens: budget,
+				...(display !== undefined ? { display } : {}),
+			};
+
+			if (options.interleavedThinking ?? true) {
+				betaFlags.push("interleaved-thinking-2025-05-14");
+			}
 		}
-		if (want1MBeta) {
-			betaFlags.push("context-1m-2025-08-07");
-		}
-		if (betaFlags.length > 0) {
-			result.anthropic_beta = betaFlags;
-		}
-
-		return result;
 	}
 
-	if (want1MBeta) {
-		return { anthropic_beta: ["context-1m-2025-08-07"] };
+	if (betaFlags.length > 0) {
+		result.anthropic_beta = betaFlags;
 	}
 
-	return undefined;
+	return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function createImageBlock(mimeType: string, data: string) {

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -43,6 +43,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { resolveBedrockClientInputs } from "./amazon-bedrock-auth.js";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -80,6 +81,24 @@ export interface BedrockOptions extends StreamOptions {
 	 * Set via AWS_BEARER_TOKEN_BEDROCK env var or pass directly.
 	 * @see https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrock.html */
 	bearerToken?: string;
+	/** AWS authentication mode. Matches Cline's awsAuthentication field.
+	 * When set, chooses the auth branch explicitly instead of inferring from
+	 * which credential fields are populated. */
+	awsAuthentication?: "apikey" | "profile" | "credentials" | "default";
+	/** Canonical Cline-parity field for the Bedrock bearer token.
+	 * Alias for the pre-existing `bearerToken` field. */
+	awsBedrockApiKey?: string;
+	/** Canonical Cline-parity field for the AWS profile name.
+	 * Alias for the pre-existing `profile` field. */
+	awsProfile?: string;
+	/** Static AWS credentials (credentials mode). */
+	awsAccessKey?: string;
+	awsSecretKey?: string;
+	awsSessionToken?: string;
+	/** Custom VPC/proxy endpoint URL. Overrides the default regional endpoint. */
+	awsBedrockEndpoint?: string;
+	/** Canonical Cline-parity region field. Alias for `region`. */
+	awsRegion?: string;
 }
 
 type Block = (TextContent | ThinkingContent | ToolCall) & { index?: number; partialJson?: string };
@@ -112,9 +131,37 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 
 		const blocks = output.content as Block[];
 
-		const config: BedrockRuntimeClientConfig = {
-			profile: options.profile,
-		};
+		// Dispatch auth-related SDK fields via the shared resolver. Each auth mode
+		// populates only its own fields; the existing region/endpoint logic below
+		// stays authoritative. Bearer token resolution (including the
+		// AWS_BEARER_TOKEN_BEDROCK env fallback inside apikey mode) lives in the
+		// resolver. We forward the env var as the effective apikey so auto-mode
+		// detection still picks "apikey" when only the env var is set — preserves
+		// the pre-refactor behavior of an implicit env-driven bearer token.
+		const envBearer = typeof process !== "undefined" ? process.env.AWS_BEARER_TOKEN_BEDROCK : undefined;
+		const resolved = resolveBedrockClientInputs({
+			awsAuthentication: options.awsAuthentication,
+			awsRegion: options.awsRegion ?? options.region,
+			awsBedrockApiKey: options.awsBedrockApiKey ?? options.bearerToken ?? envBearer,
+			awsProfile: options.awsProfile ?? options.profile,
+			awsAccessKey: options.awsAccessKey,
+			awsSecretKey: options.awsSecretKey,
+			awsSessionToken: options.awsSessionToken,
+			awsBedrockEndpoint: options.awsBedrockEndpoint,
+		});
+
+		const config: BedrockRuntimeClientConfig = {};
+		if (resolved.profile) {
+			config.profile = resolved.profile;
+		}
+		if (resolved.credentials) {
+			config.credentials = resolved.credentials;
+		}
+		if (resolved.token) {
+			config.token = resolved.token;
+			config.authSchemePreference = resolved.authSchemePreference;
+		}
+
 		const configuredRegion = getConfiguredBedrockRegion(options);
 		const hasConfiguredProfile = hasConfiguredBedrockProfile();
 		const endpointRegion = getStandardBedrockEndpointRegion(model.baseUrl);
@@ -131,10 +178,6 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 			config.endpoint = model.baseUrl;
 		}
 
-		// Resolve bearer token for Bedrock API key auth.
-		const bearerToken = options.bearerToken || process.env.AWS_BEARER_TOKEN_BEDROCK || undefined;
-		const useBearerToken = bearerToken !== undefined && process.env.AWS_BEDROCK_SKIP_AUTH !== "1";
-
 		// in Node.js/Bun environment only
 		if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
 			// Region resolution: explicit option > env vars > SDK default chain.
@@ -148,12 +191,17 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				config.region = "us-east-1";
 			}
 
-			// Support proxies that don't need authentication
+			// Support proxies that don't need authentication. Dummy creds always win
+			// over anything the auth resolver set above — existing behavior. The
+			// bearer token branch is also suppressed so the SDK doesn't attach an
+			// Authorization header to the proxy request.
 			if (process.env.AWS_BEDROCK_SKIP_AUTH === "1") {
 				config.credentials = {
 					accessKeyId: "dummy-access-key",
 					secretAccessKey: "dummy-secret-key",
 				};
+				config.token = undefined;
+				config.authSchemePreference = undefined;
 			}
 
 			if (
@@ -188,9 +236,11 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				configuredRegion || (endpointRegion && useExplicitEndpoint ? endpointRegion : undefined) || "us-east-1";
 		}
 
-		if (useBearerToken) {
-			config.token = { token: bearerToken };
-			config.authSchemePreference = ["httpBearerAuth"];
+		// Honor an explicit awsBedrockEndpoint (VPC/proxy) only when the existing
+		// region/endpoint resolution hasn't already pinned a value. The standard
+		// endpoint pin above takes precedence when both are present.
+		if (!config.endpoint && resolved.endpoint) {
+			config.endpoint = resolved.endpoint;
 		}
 
 		try {

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -43,7 +43,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
-import { resolveBedrockClientInputs } from "./amazon-bedrock-auth.js";
+import { type ResolvedBedrockClientInputs, resolveBedrockClientInputs } from "./amazon-bedrock-auth.js";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -139,16 +139,26 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 		// detection still picks "apikey" when only the env var is set — preserves
 		// the pre-refactor behavior of an implicit env-driven bearer token.
 		const envBearer = typeof process !== "undefined" ? process.env.AWS_BEARER_TOKEN_BEDROCK : undefined;
-		const resolved = resolveBedrockClientInputs({
-			awsAuthentication: options.awsAuthentication,
-			awsRegion: options.awsRegion ?? options.region,
-			awsBedrockApiKey: options.awsBedrockApiKey ?? options.bearerToken ?? envBearer,
-			awsProfile: options.awsProfile ?? options.profile,
-			awsAccessKey: options.awsAccessKey,
-			awsSecretKey: options.awsSecretKey,
-			awsSessionToken: options.awsSessionToken,
-			awsBedrockEndpoint: options.awsBedrockEndpoint,
-		});
+		// When AWS_BEDROCK_SKIP_AUTH=1 the SDK is pointed at an unauthenticated
+		// proxy and we force dummy creds below. Running the resolver here would
+		// surface BedrockAuthError in apikey mode just because a stale or empty
+		// AWS_BEARER_TOKEN_BEDROCK is on the shell — a dev-ergonomics regression
+		// over pre-refactor behavior. Short-circuit with a minimal inputs shape
+		// so downstream logic still has a region.
+		const skipAuth = typeof process !== "undefined" && process.env.AWS_BEDROCK_SKIP_AUTH === "1";
+
+		const resolved: ResolvedBedrockClientInputs = skipAuth
+			? { region: options.awsRegion ?? options.region ?? "us-east-1" }
+			: resolveBedrockClientInputs({
+					awsAuthentication: options.awsAuthentication,
+					awsRegion: options.awsRegion ?? options.region,
+					awsBedrockApiKey: options.awsBedrockApiKey ?? options.bearerToken ?? envBearer,
+					awsProfile: options.awsProfile ?? options.profile,
+					awsAccessKey: options.awsAccessKey,
+					awsSecretKey: options.awsSecretKey,
+					awsSessionToken: options.awsSessionToken,
+					awsBedrockEndpoint: options.awsBedrockEndpoint,
+				});
 
 		const config: BedrockRuntimeClientConfig = {};
 		if (resolved.profile) {
@@ -194,14 +204,17 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 			// Support proxies that don't need authentication. Dummy creds always win
 			// over anything the auth resolver set above — existing behavior. The
 			// bearer token branch is also suppressed so the SDK doesn't attach an
-			// Authorization header to the proxy request.
-			if (process.env.AWS_BEDROCK_SKIP_AUTH === "1") {
+			// Authorization header to the proxy request. Profile is cleared for
+			// full symmetry: the SDK otherwise tries to resolve profile creds from
+			// the filesystem even when explicit credentials are supplied.
+			if (skipAuth) {
 				config.credentials = {
 					accessKeyId: "dummy-access-key",
 					secretAccessKey: "dummy-secret-key",
 				};
 				config.token = undefined;
 				config.authSchemePreference = undefined;
+				config.profile = undefined;
 			}
 
 			if (

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -559,7 +559,7 @@ function getModelMatchCandidates(modelId: string, modelName?: string): string[] 
 	});
 }
 
-function supportsAdaptiveThinking(modelId: string, modelName?: string): boolean {
+export function supportsAdaptiveThinking(modelId: string, modelName?: string): boolean {
 	const candidates = getModelMatchCandidates(modelId, modelName);
 	return candidates.some((s) => s.includes("opus-4-6") || s.includes("opus-4-7") || s.includes("sonnet-4-6"));
 }

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -99,6 +99,12 @@ export interface BedrockOptions extends StreamOptions {
 	awsBedrockEndpoint?: string;
 	/** Canonical Cline-parity region field. Alias for `region`. */
 	awsRegion?: string;
+	/** Opt into the 1M-token extended context beta for Opus 4.6/4.7.
+	 * When true on an eligible model, appends the ":1m" inference-profile
+	 * suffix to the model id and injects
+	 * `anthropic_beta: ["context-1m-2025-08-07"]` into the Converse request's
+	 * additionalModelRequestFields. No-op on non-eligible models. */
+	enable1MContext?: boolean;
 }
 
 type Block = (TextContent | ThinkingContent | ToolCall) & { index?: number; partialJson?: string };
@@ -259,8 +265,10 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 		try {
 			const client = new BedrockRuntimeClient(config);
 			const cacheRetention = resolveCacheRetention(options.cacheRetention);
+			const baseModelId = model.id;
+			const finalModelId = applyOpus1MSuffix(baseModelId, options.enable1MContext ?? false, baseModelId);
 			let commandInput = {
-				modelId: model.id,
+				modelId: finalModelId,
 				messages: convertMessages(context, model, cacheRetention),
 				system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
 				inferenceConfig: {
@@ -555,6 +563,30 @@ function getModelMatchCandidates(modelId: string, modelName?: string): string[] 
 function supportsAdaptiveThinking(modelId: string, modelName?: string): boolean {
 	const candidates = getModelMatchCandidates(modelId, modelName);
 	return candidates.some((s) => s.includes("opus-4-6") || s.includes("opus-4-7") || s.includes("sonnet-4-6"));
+}
+
+const OPUS_1M_BASE_IDS = ["opus-4-7", "opus-4-6"] as const;
+
+/** True when the given base (no regional prefix) model id is Opus 4.6 or 4.7. */
+export function supportsOpus1MContext(modelId: string): boolean {
+	if (!modelId) return false;
+	return OPUS_1M_BASE_IDS.some((b) => modelId.includes(b));
+}
+
+/**
+ * Idempotently append the ":1m" inference-profile suffix to an Opus 4.6/4.7
+ * model id when the user has opted into the 1M context beta. Safe to call
+ * multiple times; non-eligible models are returned unchanged.
+ *
+ * `baseModelId` is used for eligibility checks so that callers that already
+ * routed the id through regional/global prefixes (e.g.,
+ * "us.anthropic.claude-opus-4-7") still pick the right behavior.
+ */
+export function applyOpus1MSuffix(modelId: string, enable1M: boolean, baseModelId: string): string {
+	if (!enable1M) return modelId;
+	if (!supportsOpus1MContext(baseModelId)) return modelId;
+	if (modelId.endsWith(":1m")) return modelId;
+	return `${modelId}:1m`;
 }
 
 function mapThinkingLevelToEffort(
@@ -944,7 +976,14 @@ function buildAdditionalModelRequestFields(
 	model: Model<"bedrock-converse-stream">,
 	options: BedrockOptions,
 ): Record<string, any> | undefined {
+	const want1MBeta = (options.enable1MContext ?? false) && supportsOpus1MContext(model.id);
+
 	if (!options.reasoning || !model.reasoning) {
+		// Still emit the 1M beta header on eligible Opus models even when
+		// reasoning is not requested.
+		if (want1MBeta) {
+			return { anthropic_beta: ["context-1m-2025-08-07"] };
+		}
 		return undefined;
 	}
 
@@ -979,11 +1018,22 @@ function buildAdditionalModelRequestFields(
 					};
 				})();
 
+		const betaFlags: string[] = [];
 		if (!supportsAdaptiveThinking(model.id, model.name) && (options.interleavedThinking ?? true)) {
-			result.anthropic_beta = ["interleaved-thinking-2025-05-14"];
+			betaFlags.push("interleaved-thinking-2025-05-14");
+		}
+		if (want1MBeta) {
+			betaFlags.push("context-1m-2025-08-07");
+		}
+		if (betaFlags.length > 0) {
+			result.anthropic_beta = betaFlags;
 		}
 
 		return result;
+	}
+
+	if (want1MBeta) {
+		return { anthropic_beta: ["context-1m-2025-08-07"] };
 	}
 
 	return undefined;

--- a/packages/ai/test/bedrock-1m-context.test.ts
+++ b/packages/ai/test/bedrock-1m-context.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { applyOpus1MSuffix, supportsOpus1MContext } from "../src/providers/amazon-bedrock.js";
+import { getModel } from "../src/models.js";
+import {
+	applyOpus1MSuffix,
+	type BedrockOptions,
+	streamBedrock,
+	supportsOpus1MContext,
+} from "../src/providers/amazon-bedrock.js";
+import type { Context, Model } from "../src/types.js";
 
 describe("bedrock — 1M context beta helpers", () => {
 	describe("supportsOpus1MContext", () => {
@@ -28,36 +35,86 @@ describe("bedrock — 1M context beta helpers", () => {
 
 	describe("applyOpus1MSuffix", () => {
 		it("adds :1m to eligible model when enabled", () => {
-			expect(applyOpus1MSuffix("anthropic.claude-opus-4-7", true, "anthropic.claude-opus-4-7")).toBe(
-				"anthropic.claude-opus-4-7:1m",
-			);
+			expect(applyOpus1MSuffix("anthropic.claude-opus-4-7", true)).toBe("anthropic.claude-opus-4-7:1m");
 		});
 		it("is idempotent on already-suffixed model", () => {
-			const once = applyOpus1MSuffix("anthropic.claude-opus-4-7", true, "anthropic.claude-opus-4-7");
-			const twice = applyOpus1MSuffix(once, true, "anthropic.claude-opus-4-7");
+			const once = applyOpus1MSuffix("anthropic.claude-opus-4-7", true);
+			const twice = applyOpus1MSuffix(once, true);
 			expect(twice).toBe(once);
 		});
 		it("skips when enable1M is false", () => {
-			expect(applyOpus1MSuffix("anthropic.claude-opus-4-7", false, "anthropic.claude-opus-4-7")).toBe(
-				"anthropic.claude-opus-4-7",
-			);
+			expect(applyOpus1MSuffix("anthropic.claude-opus-4-7", false)).toBe("anthropic.claude-opus-4-7");
 		});
 		it("skips for non-eligible model even when enabled", () => {
-			expect(applyOpus1MSuffix("anthropic.claude-sonnet-4-6", true, "anthropic.claude-sonnet-4-6")).toBe(
-				"anthropic.claude-sonnet-4-6",
-			);
+			expect(applyOpus1MSuffix("anthropic.claude-sonnet-4-6", true)).toBe("anthropic.claude-sonnet-4-6");
 		});
-		it("respects regional prefix on modelId but checks baseModelId for eligibility", () => {
-			expect(applyOpus1MSuffix("us.anthropic.claude-opus-4-7", true, "anthropic.claude-opus-4-7")).toBe(
-				"us.anthropic.claude-opus-4-7:1m",
-			);
+		it("respects regional prefix on modelId (both eligibility and output)", () => {
+			expect(applyOpus1MSuffix("us.anthropic.claude-opus-4-7", true)).toBe("us.anthropic.claude-opus-4-7:1m");
 		});
-		it("does not add suffix when baseModelId is non-eligible even if modelId contains 'opus-4-7'", () => {
-			// Edge case: contrived input where modelId says opus but baseModelId says sonnet.
-			// The helper trusts baseModelId for eligibility.
-			expect(applyOpus1MSuffix("anthropic.claude-opus-4-7", true, "anthropic.claude-sonnet-4-6")).toBe(
-				"anthropic.claude-opus-4-7",
-			);
-		});
+	});
+});
+
+interface BedrockPayload {
+	modelId?: string;
+	additionalModelRequestFields?: {
+		thinking?: { type: string; budget_tokens?: number; display?: string };
+		output_config?: { effort?: string };
+		anthropic_beta?: string[];
+	};
+}
+
+function makeContext(): Context {
+	return {
+		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+	};
+}
+
+async function capturePayload(
+	model: Model<"bedrock-converse-stream">,
+	options?: BedrockOptions,
+): Promise<BedrockPayload> {
+	let capturedPayload: BedrockPayload | undefined;
+	const s = streamBedrock(model, makeContext(), {
+		...options,
+		signal: AbortSignal.abort(),
+		onPayload: (payload) => {
+			capturedPayload = payload as BedrockPayload;
+			return payload;
+		},
+	});
+
+	for await (const event of s) {
+		if (event.type === "error") {
+			break;
+		}
+	}
+
+	if (!capturedPayload) {
+		throw new Error("Expected Bedrock payload to be captured before request abort");
+	}
+
+	return capturedPayload;
+}
+
+describe("bedrock — enable1MContext integration (payload-level)", () => {
+	it("Opus 4.7 + enable1MContext=true sends :1m modelId and context-1m beta", async () => {
+		const model = getModel("amazon-bedrock", "anthropic.claude-opus-4-7");
+		const payload = await capturePayload(model, { enable1MContext: true });
+		expect(payload.modelId).toBe("anthropic.claude-opus-4-7:1m");
+		expect(payload.additionalModelRequestFields?.anthropic_beta).toEqual(["context-1m-2025-08-07"]);
+	});
+
+	it("Opus 4.7 + enable1MContext=false emits no 1M artifacts", async () => {
+		const model = getModel("amazon-bedrock", "anthropic.claude-opus-4-7");
+		const payload = await capturePayload(model, { enable1MContext: false });
+		expect(payload.modelId).toBe("anthropic.claude-opus-4-7");
+		expect(payload.additionalModelRequestFields?.anthropic_beta ?? []).not.toContain("context-1m-2025-08-07");
+	});
+
+	it("Sonnet 4.6 + enable1MContext=true does NOT add :1m or 1M beta (non-eligible)", async () => {
+		const model = getModel("amazon-bedrock", "anthropic.claude-sonnet-4-6");
+		const payload = await capturePayload(model, { enable1MContext: true });
+		expect(payload.modelId).toBe("anthropic.claude-sonnet-4-6");
+		expect(payload.additionalModelRequestFields?.anthropic_beta ?? []).not.toContain("context-1m-2025-08-07");
 	});
 });

--- a/packages/ai/test/bedrock-1m-context.test.ts
+++ b/packages/ai/test/bedrock-1m-context.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { applyOpus1MSuffix, supportsOpus1MContext } from "../src/providers/amazon-bedrock.js";
+
+describe("bedrock — 1M context beta helpers", () => {
+	describe("supportsOpus1MContext", () => {
+		it("matches Opus 4.7 base id", () => {
+			expect(supportsOpus1MContext("anthropic.claude-opus-4-7")).toBe(true);
+		});
+		it("matches Opus 4.7 with regional prefix", () => {
+			expect(supportsOpus1MContext("us.anthropic.claude-opus-4-7")).toBe(true);
+		});
+		it("matches Opus 4.7 with global prefix", () => {
+			expect(supportsOpus1MContext("global.anthropic.claude-opus-4-7")).toBe(true);
+		});
+		it("matches Opus 4.6", () => {
+			expect(supportsOpus1MContext("anthropic.claude-opus-4-6")).toBe(true);
+		});
+		it("rejects Sonnet 4.6", () => {
+			expect(supportsOpus1MContext("anthropic.claude-sonnet-4-6")).toBe(false);
+		});
+		it("rejects Sonnet 3.7", () => {
+			expect(supportsOpus1MContext("anthropic.claude-3-7-sonnet-20250219-v1:0")).toBe(false);
+		});
+		it("rejects empty string", () => {
+			expect(supportsOpus1MContext("")).toBe(false);
+		});
+	});
+
+	describe("applyOpus1MSuffix", () => {
+		it("adds :1m to eligible model when enabled", () => {
+			expect(applyOpus1MSuffix("anthropic.claude-opus-4-7", true, "anthropic.claude-opus-4-7")).toBe(
+				"anthropic.claude-opus-4-7:1m",
+			);
+		});
+		it("is idempotent on already-suffixed model", () => {
+			const once = applyOpus1MSuffix("anthropic.claude-opus-4-7", true, "anthropic.claude-opus-4-7");
+			const twice = applyOpus1MSuffix(once, true, "anthropic.claude-opus-4-7");
+			expect(twice).toBe(once);
+		});
+		it("skips when enable1M is false", () => {
+			expect(applyOpus1MSuffix("anthropic.claude-opus-4-7", false, "anthropic.claude-opus-4-7")).toBe(
+				"anthropic.claude-opus-4-7",
+			);
+		});
+		it("skips for non-eligible model even when enabled", () => {
+			expect(applyOpus1MSuffix("anthropic.claude-sonnet-4-6", true, "anthropic.claude-sonnet-4-6")).toBe(
+				"anthropic.claude-sonnet-4-6",
+			);
+		});
+		it("respects regional prefix on modelId but checks baseModelId for eligibility", () => {
+			expect(applyOpus1MSuffix("us.anthropic.claude-opus-4-7", true, "anthropic.claude-opus-4-7")).toBe(
+				"us.anthropic.claude-opus-4-7:1m",
+			);
+		});
+		it("does not add suffix when baseModelId is non-eligible even if modelId contains 'opus-4-7'", () => {
+			// Edge case: contrived input where modelId says opus but baseModelId says sonnet.
+			// The helper trusts baseModelId for eligibility.
+			expect(applyOpus1MSuffix("anthropic.claude-opus-4-7", true, "anthropic.claude-sonnet-4-6")).toBe(
+				"anthropic.claude-opus-4-7",
+			);
+		});
+	});
+});

--- a/packages/ai/test/bedrock-adaptive-thinking-eligibility.test.ts
+++ b/packages/ai/test/bedrock-adaptive-thinking-eligibility.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { supportsAdaptiveThinking } from "../src/providers/amazon-bedrock.js";
+
+describe("bedrock — adaptive thinking eligibility", () => {
+	it("Opus 4.7 is eligible", () => {
+		expect(supportsAdaptiveThinking("anthropic.claude-opus-4-7")).toBe(true);
+	});
+
+	it("Opus 4.6 is eligible", () => {
+		expect(supportsAdaptiveThinking("anthropic.claude-opus-4-6")).toBe(true);
+	});
+
+	it("Sonnet 4.6 is eligible", () => {
+		expect(supportsAdaptiveThinking("anthropic.claude-sonnet-4-6")).toBe(true);
+	});
+
+	it("Sonnet 3.7 is NOT eligible", () => {
+		expect(supportsAdaptiveThinking("anthropic.claude-3-7-sonnet-20250219-v1:0")).toBe(false);
+	});
+
+	it("Sonnet 3.5 is NOT eligible", () => {
+		expect(supportsAdaptiveThinking("anthropic.claude-3-5-sonnet")).toBe(false);
+	});
+
+	it("regional prefix tolerated (us.)", () => {
+		expect(supportsAdaptiveThinking("us.anthropic.claude-opus-4-7")).toBe(true);
+	});
+
+	it("global prefix tolerated", () => {
+		expect(supportsAdaptiveThinking("global.anthropic.claude-opus-4-7")).toBe(true);
+	});
+
+	it("matches on model name when id is an opaque ARN", () => {
+		// Application inference profile ARNs don't contain the family; name carries it.
+		expect(
+			supportsAdaptiveThinking(
+				"arn:aws:bedrock:us-east-1:123:application-inference-profile/z27q",
+				"My Team Opus 4.7 Profile",
+			),
+		).toBe(true);
+	});
+
+	it("ARN id without a matching name is NOT eligible", () => {
+		expect(
+			supportsAdaptiveThinking(
+				"arn:aws:bedrock:us-east-1:123:application-inference-profile/z27q",
+				"Generic Profile",
+			),
+		).toBe(false);
+	});
+
+	it("non-Claude Bedrock model is NOT eligible", () => {
+		expect(supportsAdaptiveThinking("amazon.nova-pro-v1:0")).toBe(false);
+	});
+
+	it("empty id is NOT eligible", () => {
+		expect(supportsAdaptiveThinking("")).toBe(false);
+	});
+
+	it("tolerates dotted/underscore separators via normalization", () => {
+		// getModelMatchCandidates collapses [\s_.:]+ to '-', so "opus_4_7" matches "opus-4-7".
+		expect(supportsAdaptiveThinking("vendor.claude_opus_4_7")).toBe(true);
+	});
+});

--- a/packages/ai/test/bedrock-auth-modes.test.ts
+++ b/packages/ai/test/bedrock-auth-modes.test.ts
@@ -178,3 +178,23 @@ describe("resolveBedrockClientInputs", () => {
 		).toThrow(BedrockAuthError);
 	});
 });
+
+describe("resolveBedrockClientInputs — browser/env safety", () => {
+	it("apikey mode with no process.env throws cleanly (no ReferenceError) when key absent", () => {
+		// Simulate absence of process.env by temporarily shadowing (jsdom leaves process defined).
+		// The important contract is: when awsBedrockApiKey and bearerToken are absent AND
+		// AWS_BEARER_TOKEN_BEDROCK is unset, the call raises BedrockAuthError — NOT ReferenceError.
+		const origToken = process.env.AWS_BEARER_TOKEN_BEDROCK;
+		delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+		try {
+			expect(() =>
+				resolveBedrockClientInputs({
+					awsAuthentication: "apikey",
+					awsRegion: "us-east-1",
+				}),
+			).toThrow(BedrockAuthError);
+		} finally {
+			if (origToken !== undefined) process.env.AWS_BEARER_TOKEN_BEDROCK = origToken;
+		}
+	});
+});

--- a/packages/ai/test/bedrock-auth-modes.test.ts
+++ b/packages/ai/test/bedrock-auth-modes.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	BedrockAuthError,
+	resolveBedrockAuthMode,
+	resolveBedrockClientInputs,
+} from "../src/providers/amazon-bedrock-auth.js";
+
+describe("resolveBedrockAuthMode", () => {
+	it("returns 'apikey' when bearer token is set", () => {
+		expect(resolveBedrockAuthMode({ awsBedrockApiKey: "bearer-xyz" })).toBe("apikey");
+	});
+	it("returns 'profile' when profile is set without other auth", () => {
+		expect(resolveBedrockAuthMode({ awsProfile: "work" })).toBe("profile");
+	});
+	it("returns 'credentials' when access+secret keys are set", () => {
+		expect(resolveBedrockAuthMode({ awsAccessKey: "AKIA0000", awsSecretKey: "secret" })).toBe("credentials");
+	});
+	it("explicit awsAuthentication wins over inferred", () => {
+		expect(
+			resolveBedrockAuthMode({
+				awsAuthentication: "default",
+				awsBedrockApiKey: "bearer-xyz",
+			}),
+		).toBe("default");
+	});
+	it("falls back to 'default' when nothing is set", () => {
+		expect(resolveBedrockAuthMode({})).toBe("default");
+	});
+	it("unknown awsAuthentication value falls back to inferred path", () => {
+		expect(
+			resolveBedrockAuthMode({
+				awsAuthentication: "garbage",
+				awsBedrockApiKey: "bearer-xyz",
+			}),
+		).toBe("apikey");
+	});
+});
+
+describe("resolveBedrockClientInputs", () => {
+	beforeEach(() => {
+		delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+	});
+
+	it("apikey mode returns token + httpBearerAuth preference", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "apikey",
+			awsBedrockApiKey: "bearer-xyz",
+			awsRegion: "us-east-1",
+		});
+		expect(r.token).toEqual({ token: "bearer-xyz" });
+		expect(r.authSchemePreference).toEqual(["httpBearerAuth"]);
+		expect(r.region).toBe("us-east-1");
+		expect(r.credentials).toBeUndefined();
+		expect(r.profile).toBeUndefined();
+	});
+	it("strips Bearer prefix from api key", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "apikey",
+			awsBedrockApiKey: "Bearer bearer-xyz",
+			awsRegion: "us-east-1",
+		});
+		expect(r.token).toEqual({ token: "bearer-xyz" });
+	});
+	it("profile mode returns profile only", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "profile",
+			awsProfile: "work",
+			awsRegion: "eu-west-1",
+		});
+		expect(r.profile).toBe("work");
+		expect(r.token).toBeUndefined();
+		expect(r.credentials).toBeUndefined();
+		expect(r.region).toBe("eu-west-1");
+	});
+	it("credentials mode returns static credentials with session token", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "credentials",
+			awsAccessKey: "AKIA0000",
+			awsSecretKey: "secret",
+			awsSessionToken: "sess",
+			awsRegion: "us-east-1",
+		});
+		expect(r.credentials).toEqual({
+			accessKeyId: "AKIA0000",
+			secretAccessKey: "secret",
+			sessionToken: "sess",
+		});
+		expect(r.token).toBeUndefined();
+		expect(r.profile).toBeUndefined();
+	});
+	it("credentials mode omits sessionToken when absent", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "credentials",
+			awsAccessKey: "AKIA0000",
+			awsSecretKey: "secret",
+			awsRegion: "us-east-1",
+		});
+		expect(r.credentials).toEqual({
+			accessKeyId: "AKIA0000",
+			secretAccessKey: "secret",
+		});
+	});
+	it("default mode returns bare region", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "default",
+			awsRegion: "us-east-1",
+		});
+		expect(r.token).toBeUndefined();
+		expect(r.credentials).toBeUndefined();
+		expect(r.profile).toBeUndefined();
+		expect(r.region).toBe("us-east-1");
+	});
+	it("awsBedrockEndpoint sets endpoint", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "default",
+			awsRegion: "us-east-1",
+			awsBedrockEndpoint: "https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+		});
+		expect(r.endpoint).toBe("https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com");
+	});
+	it("legacy bearerToken alias maps to awsBedrockApiKey", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "apikey",
+			bearerToken: "legacy-token",
+			awsRegion: "us-east-1",
+		});
+		expect(r.token).toEqual({ token: "legacy-token" });
+	});
+	it("legacy profile alias maps to awsProfile", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "profile",
+			profile: "legacy-profile",
+			awsRegion: "us-east-1",
+		});
+		expect(r.profile).toBe("legacy-profile");
+	});
+	it("legacy region alias maps to awsRegion", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "default",
+			region: "eu-west-1",
+		});
+		expect(r.region).toBe("eu-west-1");
+	});
+	it("default region is us-east-1 when neither awsRegion nor region set", () => {
+		const r = resolveBedrockClientInputs({ awsAuthentication: "default" });
+		expect(r.region).toBe("us-east-1");
+	});
+	it("apikey mode with no token throws BedrockAuthError (mode-specific)", () => {
+		expect(() => resolveBedrockClientInputs({ awsAuthentication: "apikey", awsRegion: "us-east-1" })).toThrow(
+			BedrockAuthError,
+		);
+	});
+	it("credentials mode missing secret throws BedrockAuthError", () => {
+		expect(() =>
+			resolveBedrockClientInputs({
+				awsAuthentication: "credentials",
+				awsRegion: "us-east-1",
+				awsAccessKey: "AKIA0000",
+			}),
+		).toThrow(BedrockAuthError);
+	});
+});

--- a/packages/ai/test/bedrock-auth-modes.test.ts
+++ b/packages/ai/test/bedrock-auth-modes.test.ts
@@ -159,4 +159,22 @@ describe("resolveBedrockClientInputs", () => {
 			}),
 		).toThrow(BedrockAuthError);
 	});
+	it("apikey mode with only Bearer prefix (no real token) throws", () => {
+		expect(() =>
+			resolveBedrockClientInputs({
+				awsAuthentication: "apikey",
+				awsBedrockApiKey: "Bearer ",
+				awsRegion: "us-east-1",
+			}),
+		).toThrow(BedrockAuthError);
+	});
+	it("apikey mode with whitespace-only token throws", () => {
+		expect(() =>
+			resolveBedrockClientInputs({
+				awsAuthentication: "apikey",
+				awsBedrockApiKey: "   ",
+				awsRegion: "us-east-1",
+			}),
+		).toThrow(BedrockAuthError);
+	});
 });

--- a/packages/ai/test/bedrock-credentials-mode.test.ts
+++ b/packages/ai/test/bedrock-credentials-mode.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { resolveBedrockClientInputs } from "../src/providers/amazon-bedrock-auth.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resolveBedrockAuthMode, resolveBedrockClientInputs } from "../src/providers/amazon-bedrock-auth.js";
 
 describe("bedrock credentials mode integration", () => {
 	it("maps explicit access+secret+session to SDK credentials shape", () => {
@@ -42,5 +42,39 @@ describe("bedrock credentials mode integration", () => {
 		expect(r.profile).toBeUndefined();
 		expect(r.token).toBeUndefined();
 		expect(r.authSchemePreference).toBeUndefined();
+	});
+});
+
+describe("bedrock — env bearer fallback", () => {
+	beforeEach(() => {
+		delete process.env.AWS_BEDROCK_SKIP_AUTH;
+		delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+	});
+
+	it("resolveBedrockAuthMode does NOT infer apikey from env alone (env is a fallback in resolveBedrockClientInputs apikey branch only)", () => {
+		process.env.AWS_BEARER_TOKEN_BEDROCK = "env-only-token";
+		// Without awsBedrockApiKey/bearerToken AND without explicit awsAuthentication,
+		// inference sees no in-bag evidence, so mode resolves to "default".
+		// The provider compensates by forwarding envBearer into awsBedrockApiKey before calling the resolver.
+		expect(resolveBedrockAuthMode({})).toBe("default");
+	});
+
+	it("resolveBedrockClientInputs apikey mode falls back to process.env.AWS_BEARER_TOKEN_BEDROCK", () => {
+		process.env.AWS_BEARER_TOKEN_BEDROCK = "env-bearer-abc";
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "apikey",
+			awsRegion: "us-east-1",
+		});
+		expect(r.token).toEqual({ token: "env-bearer-abc" });
+	});
+
+	it("explicit awsBedrockApiKey wins over env bearer", () => {
+		process.env.AWS_BEARER_TOKEN_BEDROCK = "env-bearer";
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "apikey",
+			awsBedrockApiKey: "explicit-key",
+			awsRegion: "us-east-1",
+		});
+		expect(r.token).toEqual({ token: "explicit-key" });
 	});
 });

--- a/packages/ai/test/bedrock-credentials-mode.test.ts
+++ b/packages/ai/test/bedrock-credentials-mode.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveBedrockClientInputs } from "../src/providers/amazon-bedrock-auth.js";
+
+describe("bedrock credentials mode integration", () => {
+	it("maps explicit access+secret+session to SDK credentials shape", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "credentials",
+			awsAccessKey: "AKIA0000",
+			awsSecretKey: "secret",
+			awsSessionToken: "sess",
+			awsRegion: "us-east-1",
+		});
+		expect(r.credentials).toEqual({
+			accessKeyId: "AKIA0000",
+			secretAccessKey: "secret",
+			sessionToken: "sess",
+		});
+		expect(r.region).toBe("us-east-1");
+	});
+
+	it("omits sessionToken when not provided", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "credentials",
+			awsAccessKey: "AKIA0000",
+			awsSecretKey: "secret",
+			awsRegion: "us-east-1",
+		});
+		expect(r.credentials).toEqual({
+			accessKeyId: "AKIA0000",
+			secretAccessKey: "secret",
+		});
+		expect(r.credentials?.sessionToken).toBeUndefined();
+	});
+
+	it("credentials mode does not set profile or token fields", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "credentials",
+			awsAccessKey: "AKIA0000",
+			awsSecretKey: "secret",
+			awsRegion: "us-east-1",
+		});
+		expect(r.profile).toBeUndefined();
+		expect(r.token).toBeUndefined();
+		expect(r.authSchemePreference).toBeUndefined();
+	});
+});

--- a/packages/ai/test/bedrock-streaming-reasoning.test.ts
+++ b/packages/ai/test/bedrock-streaming-reasoning.test.ts
@@ -1,0 +1,135 @@
+import { BedrockRuntimeClient, ConversationRole } from "@aws-sdk/client-bedrock-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.js";
+import { streamBedrock } from "../src/providers/amazon-bedrock.js";
+import type { AssistantMessage, Context, ThinkingContent } from "../src/types.js";
+
+/**
+ * Build a fake response object that mimics the Bedrock Converse streaming
+ * response shape the provider iterates over. The provider calls
+ * `client.send(...)` and then `for await (const item of response.stream!)`,
+ * so we only need `$metadata` and a `stream` async-iterable of events.
+ */
+function fakeStreamResponse(events: Array<Record<string, unknown>>): unknown {
+	return {
+		$metadata: { httpStatusCode: 200, requestId: "test-request" },
+		stream: (async function* () {
+			for (const e of events) yield e;
+		})(),
+	};
+}
+
+function makeContext(): Context {
+	return {
+		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+	};
+}
+
+async function collectFinal(events: Array<Record<string, unknown>>): Promise<AssistantMessage> {
+	vi.spyOn(BedrockRuntimeClient.prototype, "send").mockImplementation(
+		// The real `.send` overloads return a union; we only need the stream shape
+		// the provider consumes. Cast through unknown to keep TS happy without any.
+		(() => Promise.resolve(fakeStreamResponse(events))) as unknown as BedrockRuntimeClient["send"],
+	);
+
+	const model = getModel("amazon-bedrock", "anthropic.claude-opus-4-7");
+	const stream = streamBedrock(model, makeContext(), {
+		awsAuthentication: "apikey",
+		awsBedrockApiKey: "dummy-test-key",
+		awsRegion: "us-east-1",
+		reasoning: "high",
+	});
+
+	// Drain events so the async producer can run to completion.
+	for await (const _event of stream) {
+		// no-op — we only need the final result
+	}
+
+	return stream.result();
+}
+
+describe("bedrock streaming — reasoningContent signature preservation", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("concatenates reasoningContent.text deltas into thinking block", async () => {
+		const final = await collectFinal([
+			{ messageStart: { role: ConversationRole.ASSISTANT } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: "first " } } } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: "second" } } } },
+			{ contentBlockStop: { contentBlockIndex: 0 } },
+			{ messageStop: { stopReason: "end_turn" } },
+			{ metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } },
+		]);
+
+		const thinking = final.content.find((b): b is ThinkingContent => b.type === "thinking");
+		expect(thinking, "thinking block present").toBeDefined();
+		expect(thinking?.thinking).toBe("first second");
+	});
+
+	it("concatenates reasoningContent.signature deltas into thinkingSignature", async () => {
+		const final = await collectFinal([
+			{ messageStart: { role: ConversationRole.ASSISTANT } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: "x" } } } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { signature: "sig-a" } } } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { signature: "sig-b" } } } },
+			{ contentBlockStop: { contentBlockIndex: 0 } },
+			{ messageStop: { stopReason: "end_turn" } },
+			{ metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } },
+		]);
+
+		const thinking = final.content.find((b): b is ThinkingContent => b.type === "thinking");
+		expect(thinking?.thinking).toBe("x");
+		expect(thinking?.thinkingSignature).toBe("sig-asig-b");
+	});
+
+	it("interleaves text and signature deltas, preserving both accumulations", async () => {
+		const final = await collectFinal([
+			{ messageStart: { role: ConversationRole.ASSISTANT } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: "abc" } } } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { signature: "s1" } } } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: "def" } } } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { signature: "s2" } } } },
+			{ contentBlockStop: { contentBlockIndex: 0 } },
+			{ messageStop: { stopReason: "end_turn" } },
+			{ metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } },
+		]);
+
+		const thinking = final.content.find((b): b is ThinkingContent => b.type === "thinking");
+		expect(thinking?.thinking).toBe("abcdef");
+		expect(thinking?.thinkingSignature).toBe("s1s2");
+	});
+
+	it("emits thinking_delta events for each text delta", async () => {
+		vi.spyOn(BedrockRuntimeClient.prototype, "send").mockImplementation((() =>
+			Promise.resolve(
+				fakeStreamResponse([
+					{ messageStart: { role: ConversationRole.ASSISTANT } },
+					{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: "alpha" } } } },
+					{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: "beta" } } } },
+					{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { signature: "sig" } } } },
+					{ contentBlockStop: { contentBlockIndex: 0 } },
+					{ messageStop: { stopReason: "end_turn" } },
+					{ metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } },
+				]),
+			)) as unknown as BedrockRuntimeClient["send"]);
+
+		const model = getModel("amazon-bedrock", "anthropic.claude-opus-4-7");
+		const stream = streamBedrock(model, makeContext(), {
+			awsAuthentication: "apikey",
+			awsBedrockApiKey: "dummy-test-key",
+			awsRegion: "us-east-1",
+			reasoning: "high",
+		});
+
+		const deltas: string[] = [];
+		for await (const event of stream) {
+			if (event.type === "thinking_delta") {
+				deltas.push(event.delta);
+			}
+		}
+
+		expect(deltas).toEqual(["alpha", "beta"]);
+	});
+});

--- a/packages/ai/test/bedrock-vpc-endpoint.test.ts
+++ b/packages/ai/test/bedrock-vpc-endpoint.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { resolveBedrockClientInputs } from "../src/providers/amazon-bedrock-auth.js";
+
+describe("bedrock — VPC endpoint", () => {
+	it("awsBedrockEndpoint overrides default regional endpoint", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "default",
+			awsRegion: "us-east-1",
+			awsBedrockEndpoint: "https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+		});
+		expect(r.endpoint).toBe("https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com");
+	});
+
+	it("VPC endpoint works with apikey mode", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "apikey",
+			awsBedrockApiKey: "bearer-xyz",
+			awsRegion: "us-east-1",
+			awsBedrockEndpoint: "https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+		});
+		expect(r.endpoint).toBe("https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com");
+		expect(r.token).toEqual({ token: "bearer-xyz" });
+	});
+
+	it("VPC endpoint works with profile mode", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "profile",
+			awsProfile: "work",
+			awsRegion: "us-east-1",
+			awsBedrockEndpoint: "https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+		});
+		expect(r.endpoint).toBe("https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com");
+		expect(r.profile).toBe("work");
+	});
+
+	it("VPC endpoint works with credentials mode", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "credentials",
+			awsAccessKey: "AKIA0000",
+			awsSecretKey: "secret",
+			awsRegion: "us-east-1",
+			awsBedrockEndpoint: "https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+		});
+		expect(r.endpoint).toBe("https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com");
+		expect(r.credentials).toEqual({
+			accessKeyId: "AKIA0000",
+			secretAccessKey: "secret",
+		});
+	});
+
+	it("no VPC endpoint → endpoint is undefined (SDK default applies)", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "default",
+			awsRegion: "us-east-1",
+		});
+		expect(r.endpoint).toBeUndefined();
+	});
+
+	it("empty string awsBedrockEndpoint is treated as unset", () => {
+		const r = resolveBedrockClientInputs({
+			awsAuthentication: "default",
+			awsRegion: "us-east-1",
+			awsBedrockEndpoint: "",
+		});
+		expect(r.endpoint).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an interactive `/login` flow for Amazon Bedrock with a four-way mode radio (API key / AWS Profile / AWS Credentials / Default Chain), followed by mode-specific fields and a region input. Thanks @praxstack.
+- Added a `bedrock-config` credential variant to `AuthStorage` carrying the full `BedrockAuthConfig`, plus a pure `migrateLegacyBedrockAuth` helper that idempotently migrates legacy `{ type: "api_key", key }` records into the new shape. Thanks @praxstack.
+
 ## [0.70.6] - 2026-04-28
 
 ### New Features

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -173,6 +173,36 @@ export AWS_BEDROCK_SKIP_AUTH=1
 export AWS_BEDROCK_FORCE_HTTP1=1
 ```
 
+#### Interactive `/login` auth modes
+
+`pi /login` for Amazon Bedrock prompts a four-way mode radio, mode-specific fields, and a region. The selected configuration is stored in `~/.config/pi/auth.json` under the `bedrock-config` credential variant.
+
+##### API Key (bearer token)
+
+Paste the bearer token interactively or set `AWS_BEARER_TOKEN_BEDROCK` in the environment. Requires the `bedrock:CallWithBearerToken` IAM permission.
+
+##### AWS Profile
+
+Enter an AWS CLI profile name (leave empty for the default profile). Pi reads credentials from `~/.aws/credentials` / `~/.aws/config`.
+
+##### AWS Credentials
+
+Supply an explicit access key ID, secret access key, and optional session token (required for temporary STS / SSO credentials).
+
+##### Default Chain
+
+Let the AWS SDK resolve credentials from the environment, IMDS, ECS task role, SSO, or `AWS_WEB_IDENTITY_TOKEN_FILE`. No explicit input is collected.
+
+#### Features
+
+- **Cross-region inference** and **global inference profiles** are enabled by default. Model IDs are routed through the appropriate prefix (`us.`, `eu.`, `apac.`, `au.`, `jp.`, `global.`).
+- **Prompt caching** is enabled by default for Claude models.
+- **1M-context beta** is available on Claude Opus 4.6 and 4.7 via `enable1MContext`; Pi appends `:1m` to the model id and sends the `context-1m-2025-08-07` beta header.
+- **Adaptive thinking** is available on Opus 4.6 / 4.7 and Sonnet 4.6. Set `reasoning` to `"low"`, `"medium"`, or `"high"`.
+- **Custom VPC endpoint** via `awsBedrockEndpoint` (or `AWS_ENDPOINT_URL_BEDROCK_RUNTIME`).
+
+Advanced toggles (`awsUseCrossRegionInference`, `awsUseGlobalInference`, `awsBedrockUsePromptCache`, `enable1MContext`) are not exposed in the interactive `/login` flow yet — edit `~/.config/pi/auth.json` directly to override the defaults.
+
 ### Cloudflare Workers AI
 
 `CLOUDFLARE_API_KEY` can be set via `/login`. `CLOUDFLARE_ACCOUNT_ID` must be set as an environment variable.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mariozechner/pi-coding-agent",
-	"version": "0.70.6",
+	"version": "0.70.7",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -39,9 +39,9 @@
 	},
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.2",
-		"@mariozechner/pi-agent-core": "^0.70.6",
-		"@mariozechner/pi-ai": "^0.70.6",
-		"@mariozechner/pi-tui": "^0.70.6",
+		"@mariozechner/pi-agent-core": "^0.70.7",
+		"@mariozechner/pi-ai": "^0.70.7",
+		"@mariozechner/pi-tui": "^0.70.7",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -39,6 +39,65 @@ export type AuthStatus = {
 	label?: string;
 };
 
+export interface BedrockAuthConfig {
+	awsAuthentication: "apikey" | "profile" | "credentials" | "default";
+	awsRegion: string;
+	awsBedrockApiKey?: string;
+	awsProfile?: string;
+	awsAccessKey?: string;
+	awsSecretKey?: string;
+	awsSessionToken?: string;
+	awsBedrockEndpoint?: string;
+	awsUseCrossRegionInference: boolean;
+	awsUseGlobalInference: boolean;
+	awsBedrockUsePromptCache: boolean;
+	enable1MContext: boolean;
+}
+
+const VALID_BEDROCK_MODES = ["apikey", "profile", "credentials", "default"] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBedrockAuthConfig(obj: Record<string, unknown>): obj is BedrockAuthConfig & Record<string, unknown> {
+	return (
+		typeof obj.awsAuthentication === "string" &&
+		(VALID_BEDROCK_MODES as readonly string[]).includes(obj.awsAuthentication)
+	);
+}
+
+/**
+ * Migrate a stored Bedrock credential to the canonical BedrockAuthConfig
+ * shape. Accepts:
+ *   - null/undefined                 → null
+ *   - legacy { type: "api_key", key } → BedrockAuthConfig in apikey mode
+ *   - existing BedrockAuthConfig      → passthrough (idempotent)
+ *   - anything else                   → null
+ */
+export function migrateLegacyBedrockAuth(input: unknown): BedrockAuthConfig | null {
+	if (input == null) return null;
+	if (!isRecord(input)) return null;
+
+	if (isBedrockAuthConfig(input)) {
+		return input as unknown as BedrockAuthConfig;
+	}
+
+	if (input.type === "api_key" && typeof input.key === "string") {
+		return {
+			awsAuthentication: "apikey",
+			awsBedrockApiKey: input.key,
+			awsRegion: typeof input.region === "string" ? input.region : "us-east-1",
+			awsUseCrossRegionInference: true,
+			awsUseGlobalInference: true,
+			awsBedrockUsePromptCache: true,
+			enable1MContext: false,
+		};
+	}
+
+	return null;
+}
+
 type LockResult<T> = {
 	result: T;
 	next?: string;

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -20,25 +20,6 @@ import lockfile from "proper-lockfile";
 import { getAgentDir } from "../config.js";
 import { resolveConfigValue } from "./resolve-config-value.js";
 
-export type ApiKeyCredential = {
-	type: "api_key";
-	key: string;
-};
-
-export type OAuthCredential = {
-	type: "oauth";
-} & OAuthCredentials;
-
-export type AuthCredential = ApiKeyCredential | OAuthCredential;
-
-export type AuthStorageData = Record<string, AuthCredential>;
-
-export type AuthStatus = {
-	configured: boolean;
-	source?: "stored" | "runtime" | "environment" | "fallback" | "models_json_key" | "models_json_command";
-	label?: string;
-};
-
 export interface BedrockAuthConfig {
 	awsAuthentication: "apikey" | "profile" | "credentials" | "default";
 	awsRegion: string;
@@ -54,6 +35,34 @@ export interface BedrockAuthConfig {
 	enable1MContext: boolean;
 }
 
+export type ApiKeyCredential = {
+	type: "api_key";
+	key: string;
+};
+
+export type OAuthCredential = {
+	type: "oauth";
+} & OAuthCredentials;
+
+/**
+ * Bedrock-specific credential variant. Persists the full BedrockAuthConfig
+ * (AWS auth mode + region + mode-specific fields + feature toggles) rather
+ * than a single API key, since Bedrock has four distinct auth modes.
+ */
+export type BedrockAuthCredential = {
+	type: "bedrock-config";
+} & BedrockAuthConfig;
+
+export type AuthCredential = ApiKeyCredential | OAuthCredential | BedrockAuthCredential;
+
+export type AuthStorageData = Record<string, AuthCredential>;
+
+export type AuthStatus = {
+	configured: boolean;
+	source?: "stored" | "runtime" | "environment" | "fallback" | "models_json_key" | "models_json_command";
+	label?: string;
+};
+
 const VALID_BEDROCK_MODES = ["apikey", "profile", "credentials", "default"] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -67,17 +76,31 @@ function isBedrockAuthConfig(obj: Record<string, unknown>): obj is BedrockAuthCo
 	);
 }
 
+function stripBedrockCredentialWrapper(obj: Record<string, unknown>): Record<string, unknown> {
+	const { type: _type, ...rest } = obj;
+	return rest;
+}
+
 /**
  * Migrate a stored Bedrock credential to the canonical BedrockAuthConfig
  * shape. Accepts:
- *   - null/undefined                 → null
- *   - legacy { type: "api_key", key } → BedrockAuthConfig in apikey mode
- *   - existing BedrockAuthConfig      → passthrough (idempotent)
- *   - anything else                   → null
+ *   - null/undefined                         → null
+ *   - legacy { type: "api_key", key }         → BedrockAuthConfig in apikey mode
+ *   - { type: "bedrock-config", ...config }   → unwrap to BedrockAuthConfig
+ *   - existing BedrockAuthConfig              → passthrough (idempotent)
+ *   - anything else                           → null
  */
 export function migrateLegacyBedrockAuth(input: unknown): BedrockAuthConfig | null {
 	if (input == null) return null;
 	if (!isRecord(input)) return null;
+
+	if (input.type === "bedrock-config") {
+		const stripped = stripBedrockCredentialWrapper(input);
+		if (isBedrockAuthConfig(stripped)) {
+			return stripped as unknown as BedrockAuthConfig;
+		}
+		return null;
+	}
 
 	if (isBedrockAuthConfig(input)) {
 		return input as unknown as BedrockAuthConfig;

--- a/packages/coding-agent/src/core/bedrock-setup-config.ts
+++ b/packages/coding-agent/src/core/bedrock-setup-config.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure (TUI-free) helpers for assembling a BedrockAuthConfig from the inputs
+ * collected by the interactive Bedrock setup flow. Kept separate from the TUI
+ * component so it can be unit-tested without pulling in the pi-tui runtime.
+ */
+
+import type { BedrockAuthConfig } from "./auth-storage.js";
+
+export type BedrockSetupMode = "apikey" | "profile" | "credentials" | "default";
+
+export interface BedrockSetupInputs {
+	mode: BedrockSetupMode;
+	apiKey?: string;
+	profile?: string;
+	accessKey?: string;
+	secretKey?: string;
+	sessionToken?: string;
+	region?: string;
+}
+
+/**
+ * Assemble the canonical BedrockAuthConfig from the raw inputs the user
+ * supplied through the four-mode interactive setup. The feature-toggle
+ * defaults match Cline so a Cline user hitting Pi for the first time gets
+ * the same behavior without touching auth.json.
+ */
+export function buildBedrockAuthConfigFromSetup(inputs: BedrockSetupInputs): BedrockAuthConfig {
+	const region = inputs.region?.trim() || "us-east-1";
+	return {
+		awsAuthentication: inputs.mode,
+		awsRegion: region,
+		awsBedrockApiKey: inputs.apiKey,
+		awsProfile: inputs.profile,
+		awsAccessKey: inputs.accessKey,
+		awsSecretKey: inputs.secretKey,
+		awsSessionToken: inputs.sessionToken,
+		awsUseCrossRegionInference: true,
+		awsUseGlobalInference: true,
+		awsBedrockUsePromptCache: true,
+		enable1MContext: false,
+	};
+}

--- a/packages/coding-agent/src/modes/interactive/components/bedrock-setup-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/bedrock-setup-dialog.ts
@@ -1,0 +1,145 @@
+/**
+ * Bedrock interactive setup flow.
+ *
+ * `BedrockSetupFlow` orchestrates four steps, composing existing primitives:
+ *
+ *   1. Four-way auth mode radio (ExtensionSelectorComponent).
+ *   2. Mode-specific text prompts (LoginDialogComponent.showPrompt, chained).
+ *   3. AWS region prompt (same dialog).
+ *   4. Assemble BedrockAuthConfig via the pure buildBedrockAuthConfigFromSetup
+ *      helper in ../../../core/bedrock-setup-config.
+ *
+ * MVP scope: the feature toggles (cross-region inference, global inference,
+ * prompt cache, 1M-context) are NOT exposed in the UI in this pass. They
+ * persist as Cline-parity defaults. Users who need to change them can edit
+ * `auth.json` directly. A follow-up task can layer toggles on top without
+ * changing the persisted shape — it already carries them.
+ */
+
+import type { Container, TUI } from "@mariozechner/pi-tui";
+import type { BedrockAuthConfig } from "../../../core/auth-storage.js";
+import {
+	type BedrockSetupInputs,
+	type BedrockSetupMode,
+	buildBedrockAuthConfigFromSetup,
+} from "../../../core/bedrock-setup-config.js";
+import { theme } from "../theme/theme.js";
+import { ExtensionSelectorComponent } from "./extension-selector.js";
+import { LoginDialogComponent } from "./login-dialog.js";
+
+/**
+ * Labels for the four-way mode radio. These strings are what the user sees.
+ */
+const MODE_LABELS: Record<BedrockSetupMode, string> = {
+	apikey: "AWS Bedrock API Key (bearer token)",
+	profile: "AWS Profile (uses ~/.aws/credentials)",
+	credentials: "AWS Credentials (access key + secret)",
+	default: "Default Credential Chain (env vars, IMDS, etc.)",
+};
+
+const LABEL_TO_MODE = new Map<string, BedrockSetupMode>(
+	(Object.entries(MODE_LABELS) as [BedrockSetupMode, string][]).map(([mode, label]) => [label, mode]),
+);
+
+const REGION_PLACEHOLDER = "us-east-1";
+
+/**
+ * Orchestrates the four-step interactive Bedrock setup flow. Compose-only:
+ * delegates to the existing ExtensionSelectorComponent + LoginDialogComponent
+ * primitives. Mount/unmount lifecycle is managed by the caller via
+ * `onMount`/`onUnmount` callbacks so this module stays free of editor-container
+ * coupling.
+ */
+export class BedrockSetupFlow {
+	constructor(
+		private readonly tui: TUI,
+		private readonly providerId: string,
+		private readonly providerName: string,
+		private readonly onMount: (component: Container) => void,
+		private readonly onUnmount: () => void,
+	) {}
+
+	/**
+	 * Run the full flow. Resolves with the assembled `BedrockAuthConfig`, or
+	 * rejects with Error("Setup cancelled") if the user escapes at any step.
+	 */
+	async run(): Promise<BedrockAuthConfig> {
+		const mode = await this.pickMode();
+
+		const dialog = new LoginDialogComponent(
+			this.tui,
+			this.providerId,
+			() => {
+				// Completion handled below via resolved/rejected promises.
+			},
+			this.providerName,
+			`Amazon Bedrock setup — ${MODE_LABELS[mode]}`,
+		);
+
+		this.onMount(dialog);
+
+		try {
+			const inputs: BedrockSetupInputs = { mode };
+
+			if (mode === "apikey") {
+				const apiKey = (await dialog.showPrompt("Enter AWS Bedrock API Key (bearer token):")).trim();
+				if (!apiKey) {
+					throw new Error("API key cannot be empty.");
+				}
+				inputs.apiKey = apiKey;
+			} else if (mode === "profile") {
+				const profile = (await dialog.showPrompt("Enter AWS profile name (leave empty for default):")).trim();
+				inputs.profile = profile || undefined;
+			} else if (mode === "credentials") {
+				const accessKey = (await dialog.showPrompt("Enter AWS Access Key ID:")).trim();
+				if (!accessKey) {
+					throw new Error("Access key ID cannot be empty.");
+				}
+				const secretKey = (await dialog.showPrompt("Enter AWS Secret Access Key:")).trim();
+				if (!secretKey) {
+					throw new Error("Secret access key cannot be empty.");
+				}
+				const sessionToken = (
+					await dialog.showPrompt("Enter AWS Session Token (optional — leave empty to skip):")
+				).trim();
+				inputs.accessKey = accessKey;
+				inputs.secretKey = secretKey;
+				inputs.sessionToken = sessionToken || undefined;
+			}
+			// `default` mode has no per-mode fields.
+
+			const region = (
+				await dialog.showPrompt(`Enter AWS region (leave empty for ${REGION_PLACEHOLDER}):`, REGION_PLACEHOLDER)
+			).trim();
+			inputs.region = region || undefined;
+
+			return buildBedrockAuthConfigFromSetup(inputs);
+		} finally {
+			this.onUnmount();
+		}
+	}
+
+	private pickMode(): Promise<BedrockSetupMode> {
+		return new Promise<BedrockSetupMode>((resolve, reject) => {
+			const selector = new ExtensionSelectorComponent(
+				theme.fg("accent", theme.bold(`Amazon Bedrock setup — choose auth method for ${this.providerName}`)),
+				Object.values(MODE_LABELS),
+				(label) => {
+					const mode = LABEL_TO_MODE.get(label);
+					this.onUnmount();
+					if (!mode) {
+						reject(new Error("Setup cancelled"));
+						return;
+					}
+					resolve(mode);
+				},
+				() => {
+					this.onUnmount();
+					reject(new Error("Setup cancelled"));
+				},
+			);
+
+			this.onMount(selector);
+		});
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -52,7 +52,6 @@ import {
 	getAgentDir,
 	getAuthPath,
 	getDebugLogPath,
-	getDocsPath,
 	getShareViewerUrl,
 	VERSION,
 } from "../../config.js";
@@ -90,6 +89,7 @@ import { checkForNewPiVersion } from "../../utils/version-check.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
+import { BedrockSetupFlow } from "./components/bedrock-setup-dialog.js";
 import { BorderedLoader } from "./components/bordered-loader.js";
 import { BranchSummaryMessageComponent } from "./components/branch-summary-message.js";
 import { CompactionSummaryMessageComponent } from "./components/compaction-summary-message.js";
@@ -4390,13 +4390,15 @@ export class InteractiveMode {
 			if (!credential) {
 				continue;
 			}
+			// bedrock-config is displayed identically to api_key in the auth UI —
+			// both are non-OAuth credentials from the user's perspective.
 			options.push({
 				id: providerId,
 				name:
 					credential.type === "oauth"
 						? (oauthNameById.get(providerId) ?? providerId)
 						: getApiKeyProviderDisplayName(providerId),
-				authType: credential.type,
+				authType: credential.type === "oauth" ? "oauth" : "api_key",
 			});
 		}
 
@@ -4449,7 +4451,7 @@ export class InteractiveMode {
 					if (providerOption.authType === "oauth") {
 						await this.showLoginDialog(providerOption.id, providerOption.name);
 					} else if (providerOption.id === BEDROCK_PROVIDER_ID) {
-						this.showBedrockSetupDialog(providerOption.id, providerOption.name);
+						await this.showBedrockSetupDialog(providerOption.id, providerOption.name);
 					} else {
 						await this.showApiKeyLoginDialog(providerOption.id, providerOption.name);
 					}
@@ -4566,7 +4568,16 @@ export class InteractiveMode {
 		}
 	}
 
-	private showBedrockSetupDialog(providerId: string, providerName: string): void {
+	private async showBedrockSetupDialog(providerId: string, providerName: string): Promise<void> {
+		const previousModel = this.session.model;
+
+		const mountComponent = (component: Container) => {
+			this.editorContainer.clear();
+			this.editorContainer.addChild(component);
+			this.ui.setFocus(component);
+			this.ui.requestRender();
+		};
+
 		const restoreEditor = () => {
 			this.editorContainer.clear();
 			this.editorContainer.addChild(this.editor);
@@ -4574,24 +4585,26 @@ export class InteractiveMode {
 			this.ui.requestRender();
 		};
 
-		const dialog = new LoginDialogComponent(
-			this.ui,
-			providerId,
-			() => restoreEditor(),
-			providerName,
-			"Amazon Bedrock setup",
-		);
-		dialog.showInfo([
-			theme.fg("text", "Amazon Bedrock uses AWS credentials instead of a single API key."),
-			theme.fg("text", "Configure an AWS profile, IAM keys, bearer token, or role-based credentials."),
-			theme.fg("muted", "See:"),
-			theme.fg("accent", `  ${path.join(getDocsPath(), "providers.md")}`),
-		]);
+		// MVP scope: the four feature toggles (cross-region inference, global
+		// inference, prompt cache, 1M-context) are NOT exposed here yet. They
+		// persist with Cline-parity defaults via buildBedrockAuthConfigFromSetup.
+		// Users who need non-default values can edit auth.json directly. A
+		// follow-up task can add the toggle UI without changing the storage
+		// shape, which already carries them.
+		const flow = new BedrockSetupFlow(this.ui, providerId, providerName, mountComponent, restoreEditor);
 
-		this.editorContainer.clear();
-		this.editorContainer.addChild(dialog);
-		this.ui.setFocus(dialog);
-		this.ui.requestRender();
+		try {
+			const config = await flow.run();
+			this.session.modelRegistry.authStorage.set(providerId, { type: "bedrock-config", ...config });
+			restoreEditor();
+			await this.completeProviderAuthentication(providerId, providerName, "api_key", previousModel);
+		} catch (error: unknown) {
+			restoreEditor();
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			if (errorMsg !== "Setup cancelled" && errorMsg !== "Login cancelled") {
+				this.showError(`Failed to configure ${providerName}: ${errorMsg}`);
+			}
+		}
 	}
 
 	private async showApiKeyLoginDialog(providerId: string, providerName: string): Promise<void> {

--- a/packages/coding-agent/test/bedrock-migration.test.ts
+++ b/packages/coding-agent/test/bedrock-migration.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { migrateLegacyBedrockAuth } from "../src/core/auth-storage.js";
+
+describe("migrateLegacyBedrockAuth", () => {
+	it("migrates legacy { type: 'api_key', key } to BedrockAuthConfig shape with Cline-parity defaults", () => {
+		const legacy = { type: "api_key", key: "bearer-xyz" };
+		const migrated = migrateLegacyBedrockAuth(legacy);
+		expect(migrated).toEqual({
+			awsAuthentication: "apikey",
+			awsBedrockApiKey: "bearer-xyz",
+			awsRegion: "us-east-1",
+			awsUseCrossRegionInference: true,
+			awsUseGlobalInference: true,
+			awsBedrockUsePromptCache: true,
+			enable1MContext: false,
+		});
+	});
+
+	it("leaves already-migrated BedrockAuthConfig unchanged", () => {
+		const current = {
+			awsAuthentication: "profile" as const,
+			awsProfile: "work",
+			awsRegion: "eu-west-1",
+			awsUseCrossRegionInference: true,
+			awsUseGlobalInference: true,
+			awsBedrockUsePromptCache: true,
+			enable1MContext: false,
+		};
+		const migrated = migrateLegacyBedrockAuth(current);
+		expect(migrated).toEqual(current);
+	});
+
+	it("is idempotent — running twice yields the same result", () => {
+		const legacy = { type: "api_key", key: "bearer-xyz" };
+		const once = migrateLegacyBedrockAuth(legacy);
+		const twice = migrateLegacyBedrockAuth(once);
+		expect(twice).toEqual(once);
+	});
+
+	it("returns null for null input", () => {
+		expect(migrateLegacyBedrockAuth(null)).toBeNull();
+	});
+
+	it("returns null for undefined input", () => {
+		expect(migrateLegacyBedrockAuth(undefined)).toBeNull();
+	});
+
+	it("returns null for unrecognized shape", () => {
+		expect(migrateLegacyBedrockAuth({ type: "oauth", access: "..." })).toBeNull();
+		expect(migrateLegacyBedrockAuth({ foo: "bar" })).toBeNull();
+		expect(migrateLegacyBedrockAuth("a string")).toBeNull();
+	});
+
+	it("legacy shape with missing 'key' returns null", () => {
+		expect(migrateLegacyBedrockAuth({ type: "api_key" })).toBeNull();
+	});
+
+	it("preserves all valid fields from an existing BedrockAuthConfig with credentials mode", () => {
+		const current = {
+			awsAuthentication: "credentials" as const,
+			awsAccessKey: "AKIA0000",
+			awsSecretKey: "secret",
+			awsSessionToken: "sess",
+			awsRegion: "us-west-2",
+			awsBedrockEndpoint: "https://vpce-abc.example.com",
+			awsUseCrossRegionInference: false,
+			awsUseGlobalInference: false,
+			awsBedrockUsePromptCache: false,
+			enable1MContext: true,
+		};
+		expect(migrateLegacyBedrockAuth(current)).toEqual(current);
+	});
+});

--- a/packages/coding-agent/test/bedrock-setup-flow.test.ts
+++ b/packages/coding-agent/test/bedrock-setup-flow.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { migrateLegacyBedrockAuth } from "../src/core/auth-storage.js";
+import { buildBedrockAuthConfigFromSetup } from "../src/core/bedrock-setup-config.js";
+
+describe("buildBedrockAuthConfigFromSetup", () => {
+	it("apikey mode produces BedrockAuthConfig with awsBedrockApiKey and Cline-parity defaults", () => {
+		const config = buildBedrockAuthConfigFromSetup({
+			mode: "apikey",
+			apiKey: "bearer-xyz",
+			region: "us-west-2",
+		});
+		expect(config).toEqual({
+			awsAuthentication: "apikey",
+			awsRegion: "us-west-2",
+			awsBedrockApiKey: "bearer-xyz",
+			awsProfile: undefined,
+			awsAccessKey: undefined,
+			awsSecretKey: undefined,
+			awsSessionToken: undefined,
+			awsUseCrossRegionInference: true,
+			awsUseGlobalInference: true,
+			awsBedrockUsePromptCache: true,
+			enable1MContext: false,
+		});
+	});
+
+	it("profile mode produces BedrockAuthConfig with awsProfile set", () => {
+		const config = buildBedrockAuthConfigFromSetup({
+			mode: "profile",
+			profile: "work",
+			region: "eu-west-1",
+		});
+		expect(config.awsAuthentication).toBe("profile");
+		expect(config.awsProfile).toBe("work");
+		expect(config.awsRegion).toBe("eu-west-1");
+		expect(config.awsBedrockApiKey).toBeUndefined();
+		expect(config.awsAccessKey).toBeUndefined();
+	});
+
+	it("profile mode leaves awsProfile undefined when empty (means 'default' profile)", () => {
+		const config = buildBedrockAuthConfigFromSetup({ mode: "profile" });
+		expect(config.awsAuthentication).toBe("profile");
+		expect(config.awsProfile).toBeUndefined();
+	});
+
+	it("credentials mode produces BedrockAuthConfig with access key, secret, optional session token", () => {
+		const config = buildBedrockAuthConfigFromSetup({
+			mode: "credentials",
+			accessKey: "AKIA0000",
+			secretKey: "secret",
+			sessionToken: "sess",
+			region: "us-east-1",
+		});
+		expect(config.awsAuthentication).toBe("credentials");
+		expect(config.awsAccessKey).toBe("AKIA0000");
+		expect(config.awsSecretKey).toBe("secret");
+		expect(config.awsSessionToken).toBe("sess");
+	});
+
+	it("credentials mode tolerates missing session token", () => {
+		const config = buildBedrockAuthConfigFromSetup({
+			mode: "credentials",
+			accessKey: "AKIA0000",
+			secretKey: "secret",
+		});
+		expect(config.awsSessionToken).toBeUndefined();
+	});
+
+	it("default mode has no mode-specific fields", () => {
+		const config = buildBedrockAuthConfigFromSetup({ mode: "default", region: "us-east-1" });
+		expect(config.awsAuthentication).toBe("default");
+		expect(config.awsBedrockApiKey).toBeUndefined();
+		expect(config.awsProfile).toBeUndefined();
+		expect(config.awsAccessKey).toBeUndefined();
+		expect(config.awsSecretKey).toBeUndefined();
+		expect(config.awsSessionToken).toBeUndefined();
+	});
+
+	it("falls back to us-east-1 when region is empty string", () => {
+		const config = buildBedrockAuthConfigFromSetup({ mode: "default", region: "" });
+		expect(config.awsRegion).toBe("us-east-1");
+	});
+
+	it("falls back to us-east-1 when region is only whitespace", () => {
+		const config = buildBedrockAuthConfigFromSetup({ mode: "default", region: "   " });
+		expect(config.awsRegion).toBe("us-east-1");
+	});
+
+	it("falls back to us-east-1 when region is undefined", () => {
+		const config = buildBedrockAuthConfigFromSetup({ mode: "default" });
+		expect(config.awsRegion).toBe("us-east-1");
+	});
+
+	it("trims whitespace around supplied region", () => {
+		const config = buildBedrockAuthConfigFromSetup({ mode: "default", region: "  ap-northeast-1  " });
+		expect(config.awsRegion).toBe("ap-northeast-1");
+	});
+
+	it("ships Cline-parity defaults for every feature toggle regardless of mode", () => {
+		for (const mode of ["apikey", "profile", "credentials", "default"] as const) {
+			const config = buildBedrockAuthConfigFromSetup({ mode });
+			expect(config.awsUseCrossRegionInference).toBe(true);
+			expect(config.awsUseGlobalInference).toBe(true);
+			expect(config.awsBedrockUsePromptCache).toBe(true);
+			expect(config.enable1MContext).toBe(false);
+		}
+	});
+});
+
+describe("migrateLegacyBedrockAuth — bedrock-config wrapper shape", () => {
+	it("unwraps { type: 'bedrock-config', ...BedrockAuthConfig } to the bare config", () => {
+		const wrapped = {
+			type: "bedrock-config" as const,
+			awsAuthentication: "credentials" as const,
+			awsAccessKey: "AKIA",
+			awsSecretKey: "shh",
+			awsRegion: "us-east-1",
+			awsUseCrossRegionInference: true,
+			awsUseGlobalInference: true,
+			awsBedrockUsePromptCache: true,
+			enable1MContext: false,
+		};
+		expect(migrateLegacyBedrockAuth(wrapped)).toEqual({
+			awsAuthentication: "credentials",
+			awsAccessKey: "AKIA",
+			awsSecretKey: "shh",
+			awsRegion: "us-east-1",
+			awsUseCrossRegionInference: true,
+			awsUseGlobalInference: true,
+			awsBedrockUsePromptCache: true,
+			enable1MContext: false,
+		});
+	});
+
+	it("returns null when the wrapper is malformed (awsAuthentication missing)", () => {
+		expect(migrateLegacyBedrockAuth({ type: "bedrock-config", awsRegion: "us-east-1" })).toBeNull();
+	});
+
+	it("round-trips setup output → wrapped credential → migrateLegacyBedrockAuth yields the original config", () => {
+		const original = buildBedrockAuthConfigFromSetup({
+			mode: "apikey",
+			apiKey: "bearer-xyz",
+			region: "us-west-2",
+		});
+		const wrapped = { type: "bedrock-config" as const, ...original };
+		const roundtripped = migrateLegacyBedrockAuth(wrapped);
+		expect(roundtripped).toEqual(original);
+	});
+});

--- a/packages/mom/package.json
+++ b/packages/mom/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mariozechner/pi-mom",
-	"version": "0.70.6",
+	"version": "0.70.7",
 	"description": "Slack bot that delegates messages to the pi coding agent",
 	"type": "module",
 	"bin": {
@@ -20,9 +20,9 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/sandbox-runtime": "^0.0.16",
-		"@mariozechner/pi-agent-core": "^0.70.6",
-		"@mariozechner/pi-ai": "^0.70.6",
-		"@mariozechner/pi-coding-agent": "^0.70.6",
+		"@mariozechner/pi-agent-core": "^0.70.7",
+		"@mariozechner/pi-ai": "^0.70.7",
+		"@mariozechner/pi-coding-agent": "^0.70.7",
 		"typebox": "^1.1.24",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/pods/package.json
+++ b/packages/pods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mariozechner/pi",
-	"version": "0.70.6",
+	"version": "0.70.7",
 	"description": "CLI tool for managing vLLM deployments on GPU pods",
 	"type": "module",
 	"bin": {
@@ -33,7 +33,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@mariozechner/pi-agent-core": "^0.70.6",
+		"@mariozechner/pi-agent-core": "^0.70.7",
 		"chalk": "^5.5.0"
 	},
 	"devDependencies": {}

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mariozechner/pi-tui",
-	"version": "0.70.6",
+	"version": "0.70.7",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mariozechner/pi-web-ui",
-	"version": "0.70.6",
+	"version": "0.70.7",
 	"description": "Reusable web UI components for AI chat interfaces powered by @mariozechner/pi-ai",
 	"type": "module",
 	"main": "dist/index.js",
@@ -18,8 +18,8 @@
 	},
 	"dependencies": {
 		"@lmstudio/sdk": "^1.5.0",
-		"@mariozechner/pi-ai": "^0.70.6",
-		"@mariozechner/pi-tui": "^0.70.6",
+		"@mariozechner/pi-ai": "^0.70.7",
+		"@mariozechner/pi-tui": "^0.70.7",
 		"typebox": "^1.1.24",
 		"docx-preview": "^0.3.7",
 		"jszip": "^3.10.1",


### PR DESCRIPTION
## Summary

Brings the Amazon Bedrock provider (`packages/ai`) and its coding-agent integration (`packages/coding-agent`) to 1:1 feature parity with Cline's Bedrock support.

### Auth

- Four explicit modes dispatched through a pure resolver (`resolveBedrockAuthMode` / `resolveBedrockClientInputs`):
  - `apikey` — `AWS_BEARER_TOKEN_BEDROCK` / `awsBedrockApiKey`
  - `profile` — AWS CLI profile
  - `credentials` — explicit access key + secret + optional session token
  - `default` — AWS SDK default credential chain
- Named `BedrockAuthError` with stable `code` on missing required inputs — no silent fallback across modes.
- Legacy `bearerToken` / `profile` / `region` field aliases preserved on `BedrockOptions`.

### Features

- `awsBedrockEndpoint` — VPC/custom endpoints across all modes.
- `enable1MContext` — appends `:1m` suffix to Opus 4.6/4.7 model IDs and adds `context-1m-2025-08-07` to `anthropic_beta`. Merges with existing `interleaved-thinking-2025-05-14` rather than clobbering.
- Exported helpers: `supportsOpus1MContext`, `applyOpus1MSuffix`, `supportsAdaptiveThinking`.

### Hardening

- `AWS_BEDROCK_SKIP_AUTH=1` now also suppresses bearer token and profile for true dummy-creds mode.
- Empty / whitespace-only / `"Bearer "` API key raises `BedrockAuthError` instead of silently producing `token: ""`.
- Browser-safe: resolver's env-var fallback guarded with `typeof process !== "undefined"`.

### coding-agent

- Interactive `/login` flow for Amazon Bedrock: four-mode radio + mode-specific field prompts + region. Reuses existing `ExtensionSelectorComponent` + `LoginDialogComponent`, no invented primitives.
- `bedrock-config` credential variant in `AuthStorage` carrying the full `BedrockAuthConfig`.
- `migrateLegacyBedrockAuth` pure helper: idempotently converts legacy `{type: "api_key", key}` records into the new shape.

### Deferred (follow-up)

- Toggle UI for `awsUseCrossRegionInference`, `awsUseGlobalInference`, `awsBedrockUsePromptCache`, `enable1MContext`. Shape already persisted; users can edit `~/.config/pi/auth.json` to override defaults.

## Test plan

- [x] `packages/ai/test/bedrock-auth-modes.test.ts` — 22 tests
- [x] `packages/ai/test/bedrock-credentials-mode.test.ts` — 6 tests
- [x] `packages/ai/test/bedrock-vpc-endpoint.test.ts` — 6 tests
- [x] `packages/ai/test/bedrock-1m-context.test.ts` — 15 tests (incl. capturePayload integration)
- [x] `packages/ai/test/bedrock-streaming-reasoning.test.ts` — 4 tests
- [x] `packages/ai/test/bedrock-adaptive-thinking-eligibility.test.ts` — 12 tests
- [x] `packages/coding-agent/test/bedrock-setup-flow.test.ts` — 14 tests
- [x] `packages/coding-agent/test/bedrock-migration.test.ts` — 8 tests
- [x] Existing `packages/coding-agent/test/auth-storage.test.ts` (24 tests) still green.
- [x] Existing `packages/ai/test/bedrock-endpoint-resolution.test.ts` / `bedrock-thinking-payload.test.ts` / `bedrock-models.test.ts` still green (12 total).
- [x] `npm run check` EXIT=0.

Total: 123 passing tests across bedrock + related surfaces.

## Notes

- Per `AGENTS.md`, I understand new-contributor PRs are auto-closed by default. Happy to address any feedback once a maintainer (`badlogic`) reviews.
- Package versions bumped lockstep to `0.70.7` per the repo's sync-versions invariant.
