### PR TITLE
feat(modelconfig): add syntax for api key by command uncached

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Added
 
 - Added Cloudflare Workers AI as a built-in provider with `CLOUDFLARE_API_KEY`/`CLOUDFLARE_ACCOUNT_ID` setup, default model resolution, `/login` support, and provider documentation ([#3851](https://github.com/badlogic/pi-mono/pull/3851) by [@mchenco](https://github.com/mchenco)).
+- Added `!!` (double-bang) syntax for API key commands that should never be cached, useful for short-lived tokens like cloud provider access tokens. Use `"apiKey": "!!gcloud auth print-access-token"` to execute the command fresh on every request.
 
 ### Changed
 

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -143,12 +143,17 @@ Set `api` at provider level (default for all models) or model level (override pe
 
 ### Value Resolution
 
-The `apiKey` and `headers` fields support three formats:
+The `apiKey` and `headers` fields support these formats:
 
-- **Shell command:** `"!command"` executes and uses stdout
+- **Shell command (cached):** `"!command"` executes and caches stdout for process lifetime
   ```json
   "apiKey": "!security find-generic-password -ws 'anthropic'"
   "apiKey": "!op read 'op://vault/item/credential'"
+  ```
+- **Shell command (never cached):** `"!!command"` executes on every request (for short-lived tokens)
+  ```json
+  "apiKey": "!!gcloud auth print-access-token"
+  "apiKey": "!!aws sts get-session-token --query 'Credentials.SessionToken' --output text"
   ```
 - **Environment variable:** Uses the value of the named variable
   ```json
@@ -159,7 +164,11 @@ The `apiKey` and `headers` fields support three formats:
   "apiKey": "sk-..."
   ```
 
-For `models.json`, shell commands are resolved at request time. pi intentionally does not apply built-in TTL, stale reuse, or recovery logic for arbitrary commands. Different commands need different caching and failure strategies, and pi cannot infer the right one.
+Use `!!` (double-bang) for credentials that expire quickly (e.g., cloud provider tokens with short TTLs). The command runs fresh on every API request.
+
+Use `!` (single-bang) for credentials that are stable for the session (e.g., keychain lookups, 1Password reads). The result is cached for the process lifetime.
+
+For `models.json`, both `!` and `!!` commands are resolved at request time. pi intentionally does not apply built-in TTL, stale reuse, or recovery logic for arbitrary commands. Different commands need different caching and failure strategies, and pi cannot infer the right one.
 
 If your command is slow, expensive, rate-limited, or should keep using a previous value on transient failures, wrap it in your own script or command that implements the caching or TTL behavior you want.
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -716,6 +716,7 @@ export class ModelRegistry {
 			return authStatus;
 		}
 
+		// Both "!" (cached) and "!!" (uncached) are command-based
 		if (providerApiKey.startsWith("!")) {
 			return { configured: true, source: "models_json_command" };
 		}

--- a/packages/coding-agent/src/core/resolve-config-value.ts
+++ b/packages/coding-agent/src/core/resolve-config-value.ts
@@ -11,10 +11,15 @@ const commandResultCache = new Map<string, string | undefined>();
 
 /**
  * Resolve a config value (API key, header value, etc.) to an actual value.
+ * - If starts with "!!", executes the rest as a shell command and uses stdout (never cached)
  * - If starts with "!", executes the rest as a shell command and uses stdout (cached)
  * - Otherwise checks environment variable first, then treats as literal (not cached)
  */
 export function resolveConfigValue(config: string): string | undefined {
+	if (config.startsWith("!!")) {
+		// Double-bang: never cache, always execute fresh (for short-lived tokens)
+		return executeCommandUncached(config.slice(1));
+	}
 	if (config.startsWith("!")) {
 		return executeCommand(config);
 	}
@@ -86,9 +91,15 @@ function executeCommand(commandConfig: string): string | undefined {
 }
 
 /**
- * Resolve all header values using the same resolution logic as API keys.
+ * Resolve a config value without caching (always executes commands fresh).
+ * - If starts with "!!" or "!", executes the rest as a shell command
+ * - Otherwise checks environment variable first, then treats as literal
  */
 export function resolveConfigValueUncached(config: string): string | undefined {
+	if (config.startsWith("!!")) {
+		// Double-bang: strip both and execute (same as single-bang in uncached context)
+		return executeCommandUncached(config.slice(1));
+	}
 	if (config.startsWith("!")) {
 		return executeCommandUncached(config);
 	}
@@ -100,6 +111,10 @@ export function resolveConfigValueOrThrow(config: string, description: string): 
 	const resolvedValue = resolveConfigValueUncached(config);
 	if (resolvedValue !== undefined) {
 		return resolvedValue;
+	}
+
+	if (config.startsWith("!!")) {
+		throw new Error(`Failed to resolve ${description} from shell command: ${config.slice(2)}`);
 	}
 
 	if (config.startsWith("!")) {

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -295,6 +295,74 @@ describe("AuthStorage", () => {
 					}
 				}
 			});
+
+			test("apiKey with !! prefix is never cached (executes every time)", async () => {
+				const counterFile = join(tempDir, "counter");
+				writeFileSync(counterFile, "0");
+
+				const counterPath = toShPath(counterFile);
+				const command = `!!sh -c 'count=$(cat "${counterPath}"); echo $((count + 1)) > "${counterPath}"; echo "key-value"'`;
+				writeAuthJson({
+					anthropic: { type: "api_key", key: command },
+				});
+
+				authStorage = AuthStorage.create(authJsonPath);
+
+				// Call multiple times - command should run each time
+				await authStorage.getApiKey("anthropic");
+				await authStorage.getApiKey("anthropic");
+				await authStorage.getApiKey("anthropic");
+
+				// Command should have run three times (not cached)
+				const count = parseInt(readFileSync(counterFile, "utf-8").trim(), 10);
+				expect(count).toBe(3);
+			});
+
+			test("apiKey with !! prefix is not cached across AuthStorage instances", async () => {
+				const counterFile = join(tempDir, "counter");
+				writeFileSync(counterFile, "0");
+
+				const counterPath = toShPath(counterFile);
+				const command = `!!sh -c 'count=$(cat "${counterPath}"); echo $((count + 1)) > "${counterPath}"; echo "key-value"'`;
+				writeAuthJson({
+					anthropic: { type: "api_key", key: command },
+				});
+
+				// Create multiple AuthStorage instances
+				const storage1 = AuthStorage.create(authJsonPath);
+				await storage1.getApiKey("anthropic");
+
+				const storage2 = AuthStorage.create(authJsonPath);
+				await storage2.getApiKey("anthropic");
+
+				// Command should have run twice (once per call, not cached)
+				const count = parseInt(readFileSync(counterFile, "utf-8").trim(), 10);
+				expect(count).toBe(2);
+			});
+
+			test("apiKey with !! prefix retries on failure (not cached)", async () => {
+				const counterFile = join(tempDir, "counter");
+				writeFileSync(counterFile, "0");
+
+				const counterPath = toShPath(counterFile);
+				const command = `!!sh -c 'count=$(cat "${counterPath}"); echo $((count + 1)) > "${counterPath}"; exit 1'`;
+				writeAuthJson({
+					anthropic: { type: "api_key", key: command },
+				});
+
+				authStorage = AuthStorage.create(authJsonPath);
+
+				// Call multiple times - all should return undefined but command runs each time
+				const key1 = await authStorage.getApiKey("anthropic");
+				const key2 = await authStorage.getApiKey("anthropic");
+
+				expect(key1).toBeUndefined();
+				expect(key2).toBeUndefined();
+
+				// Command should have run twice (failures not cached with !!)
+				const count = parseInt(readFileSync(counterFile, "utf-8").trim(), 10);
+				expect(count).toBe(2);
+			});
 		});
 	});
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1081,6 +1081,17 @@ describe("ModelRegistry", () => {
 			expect(apiKey).toBe("test-api-key-from-command");
 		});
 
+		test("apiKey with !! prefix executes command and uses stdout (never cached)", async () => {
+			writeRawModelsJson({
+				"custom-provider": providerWithApiKey("!!echo test-api-key-from-command"),
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const apiKey = await registry.getApiKeyForProvider("custom-provider");
+
+			expect(apiKey).toBe("test-api-key-from-command");
+		});
+
 		test("apiKey with ! prefix trims whitespace from command output", async () => {
 			writeRawModelsJson({
 				"custom-provider": providerWithApiKey("!echo '  spaced-key  '"),
@@ -1314,6 +1325,25 @@ describe("ModelRegistry", () => {
 					configured: true,
 					source: "models_json_command",
 				});
+				expect(readFileSync(counterFile, "utf-8")).toBe("0");
+			});
+
+			test("provider auth status reports !! command apiKey values as models_json_command", () => {
+				const counterFile = join(tempDir, "status-counter");
+				writeFileSync(counterFile, "0");
+				const counterPath = toShPath(counterFile);
+				const command = `!!sh -c 'echo 1 > "${counterPath}"; echo key-value'`;
+				writeRawModelsJson({
+					"custom-provider": providerWithApiKey(command),
+				});
+
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+				expect(registry.getProviderAuthStatus("custom-provider")).toEqual({
+					configured: true,
+					source: "models_json_command",
+				});
+				// Command should not be executed for status check
 				expect(readFileSync(counterFile, "utf-8")).toBe("0");
 			});
 


### PR DESCRIPTION
# Changes

Introduces syntax to execute arbitrary commands for getting API keys while the apiKey will not be cached. This is to support using short-lived credentials for long PI sessions.

## Note:
- commit hooks were skipped as there seems to be a lot of issues with the code base outside of my changes

Fixes #3872