### PR TITLE
fix(coding-agent): report edit access failures correctly

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `edit` and edit-preview access errors to report permission failures instead of incorrectly reporting write-protected files as missing ([#3894](https://github.com/badlogic/pi-mono/issues/3894)).
+
 ## [0.70.6] - 2026-04-28
 
 ### New Features

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed `edit` and edit-preview access errors to report permission failures instead of incorrectly reporting write-protected files as missing ([#3894](https://github.com/badlogic/pi-mono/issues/3894)).
-
 ## [0.70.6] - 2026-04-28
 
 ### New Features

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -413,17 +413,8 @@ export async function computeEditsDiff(
 		try {
 			await access(absolutePath, constants.R_OK);
 		} catch (error: unknown) {
-			if (error instanceof Error && "code" in error) {
-				switch (error.code) {
-					case "ENOENT":
-					case "ENOTDIR":
-						return { error: `File not found: ${path}` };
-					case "EACCES":
-					case "EPERM":
-						return { error: `Permission denied: ${path}` };
-				}
-			}
-			return { error: `Failed to access file: ${path}` };
+			const errorMessage = error instanceof Error && "code" in error ? `Error code: ${error.code}` : String(error);
+			return { error: `Could not write file: ${path}. ${errorMessage}.` };
 		}
 
 		// Read the file

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -412,8 +412,18 @@ export async function computeEditsDiff(
 		// Check if file exists and is readable
 		try {
 			await access(absolutePath, constants.R_OK);
-		} catch {
-			return { error: `File not found: ${path}` };
+		} catch (error: unknown) {
+			if (error instanceof Error && "code" in error) {
+				switch (error.code) {
+					case "ENOENT":
+					case "ENOTDIR":
+						return { error: `File not found: ${path}` };
+					case "EACCES":
+					case "EPERM":
+						return { error: `Permission denied: ${path}` };
+				}
+			}
+			return { error: `Failed to access file: ${path}` };
 		}
 
 		// Read the file

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -341,11 +341,23 @@ export function createEditToolDefinition(
 								// Check if file exists.
 								try {
 									await ops.access(absolutePath);
-								} catch {
+								} catch (error: unknown) {
 									if (signal) {
 										signal.removeEventListener("abort", onAbort);
 									}
-									reject(new Error(`File not found: ${path}`));
+									if (error instanceof Error && "code" in error) {
+										switch (error.code) {
+											case "ENOENT":
+											case "ENOTDIR":
+												reject(new Error(`File not found: ${path}`));
+												return;
+											case "EACCES":
+											case "EPERM":
+												reject(new Error(`Permission denied: ${path}`));
+												return;
+										}
+									}
+									reject(new Error(`Failed to access file: ${path}`));
 									return;
 								}
 

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -342,22 +342,12 @@ export function createEditToolDefinition(
 								try {
 									await ops.access(absolutePath);
 								} catch (error: unknown) {
+									const errorMessage =
+										error instanceof Error && "code" in error ? `Error code: ${error.code}` : String(error);
 									if (signal) {
 										signal.removeEventListener("abort", onAbort);
 									}
-									if (error instanceof Error && "code" in error) {
-										switch (error.code) {
-											case "ENOENT":
-											case "ENOTDIR":
-												reject(new Error(`File not found: ${path}`));
-												return;
-											case "EACCES":
-											case "EPERM":
-												reject(new Error(`Permission denied: ${path}`));
-												return;
-										}
-									}
-									reject(new Error(`Failed to access file: ${path}`));
+									reject(new Error(`Could not write file: ${path}. ${errorMessage}.`));
 									return;
 								}
 

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1,9 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { executeBashWithOperations } from "../src/core/bash-executor.js";
 import { createBashTool, createLocalBashOperations } from "../src/core/tools/bash.js";
+import { computeEditsDiff } from "../src/core/tools/edit-diff.js";
 import {
 	createEditTool,
 	createFindTool,
@@ -253,6 +254,17 @@ describe("Coding Agent Tools", () => {
 			).rejects.toThrow(/Could not find the exact text/);
 		});
 
+		it("should report file not found when the edit target does not exist", async () => {
+			const missingFile = join(testDir, "missing.txt");
+
+			await expect(
+				editTool.execute("test-call-6b", {
+					path: missingFile,
+					edits: [{ oldText: "hello", newText: "world" }],
+				}),
+			).rejects.toThrow(`File not found: ${missingFile}`);
+		});
+
 		it("should fail if text appears multiple times", async () => {
 			const testFile = join(testDir, "edit-test.txt");
 			const originalContent = "foo foo foo";
@@ -365,6 +377,86 @@ describe("Coding Agent Tools", () => {
 			).rejects.toThrow(/Could not find/);
 
 			expect(readFileSync(testFile, "utf-8")).toBe(originalContent);
+		});
+
+		it("should report permission denied for read-only files", async () => {
+			const testFile = join(testDir, "edit-readonly.txt");
+			writeFileSync(testFile, "hello\n");
+			chmodSync(testFile, 0o444);
+
+			await expect(
+				editTool.execute("test-call-14", {
+					path: testFile,
+					edits: [{ oldText: "hello", newText: "world" }],
+				}),
+			).rejects.toThrow(`Permission denied: ${testFile}`);
+		});
+
+		it("should report permission denied when edit access fails with EPERM", async () => {
+			const permissionDeniedTool = createEditTool(testDir, {
+				operations: {
+					access: async () => {
+						const error = new Error("operation not permitted");
+						Object.assign(error, { code: "EPERM" });
+						throw error;
+					},
+					readFile: async () => Buffer.from("hello\n", "utf-8"),
+					writeFile: async () => {},
+				},
+			});
+
+			await expect(
+				permissionDeniedTool.execute("test-call-15", {
+					path: "denied.txt",
+					edits: [{ oldText: "hello", newText: "world" }],
+				}),
+			).rejects.toThrow("Permission denied: denied.txt");
+		});
+
+		it("should report a generic access failure for unknown edit access errors", async () => {
+			const genericFailureTool = createEditTool(testDir, {
+				operations: {
+					access: async () => {
+						throw new Error("disk offline");
+					},
+					readFile: async () => Buffer.from("hello\n", "utf-8"),
+					writeFile: async () => {},
+				},
+			});
+
+			await expect(
+				genericFailureTool.execute("test-call-16", {
+					path: "broken.txt",
+					edits: [{ oldText: "hello", newText: "world" }],
+				}),
+			).rejects.toThrow("Failed to access file: broken.txt");
+		});
+
+		it("should report file not found in diff preview for missing files", async () => {
+			const missingFile = join(testDir, "missing-preview.txt");
+			const result = await computeEditsDiff(missingFile, [{ oldText: "hello", newText: "world" }], testDir);
+
+			expect(result).toEqual({ error: `File not found: ${missingFile}` });
+		});
+
+		it("should report file not found in diff preview when path component is not a directory", async () => {
+			const parentFile = join(testDir, "not-a-directory.txt");
+			writeFileSync(parentFile, "hello\n");
+			const invalidPath = join(parentFile, "child.txt");
+
+			const result = await computeEditsDiff(invalidPath, [{ oldText: "hello", newText: "world" }], testDir);
+
+			expect(result).toEqual({ error: `File not found: ${invalidPath}` });
+		});
+
+		it("should report permission denied in diff preview for unreadable files", async () => {
+			const unreadableFile = join(testDir, "unreadable-preview.txt");
+			writeFileSync(unreadableFile, "hello\n");
+			chmodSync(unreadableFile, 0o222);
+
+			const result = await computeEditsDiff(unreadableFile, [{ oldText: "hello", newText: "world" }], testDir);
+
+			expect(result).toEqual({ error: `Permission denied: ${unreadableFile}` });
 		});
 	});
 

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -254,7 +254,7 @@ describe("Coding Agent Tools", () => {
 			).rejects.toThrow(/Could not find the exact text/);
 		});
 
-		it("should report file not found when the edit target does not exist", async () => {
+		it("should include ENOENT when the edit target does not exist", async () => {
 			const missingFile = join(testDir, "missing.txt");
 
 			await expect(
@@ -262,7 +262,7 @@ describe("Coding Agent Tools", () => {
 					path: missingFile,
 					edits: [{ oldText: "hello", newText: "world" }],
 				}),
-			).rejects.toThrow(`File not found: ${missingFile}`);
+			).rejects.toThrow(`Could not write file: ${missingFile}. Error code: ENOENT.`);
 		});
 
 		it("should fail if text appears multiple times", async () => {
@@ -379,7 +379,7 @@ describe("Coding Agent Tools", () => {
 			expect(readFileSync(testFile, "utf-8")).toBe(originalContent);
 		});
 
-		it("should report permission denied for read-only files", async () => {
+		it("should include EACCES for read-only files", async () => {
 			const testFile = join(testDir, "edit-readonly.txt");
 			writeFileSync(testFile, "hello\n");
 			chmodSync(testFile, 0o444);
@@ -389,10 +389,10 @@ describe("Coding Agent Tools", () => {
 					path: testFile,
 					edits: [{ oldText: "hello", newText: "world" }],
 				}),
-			).rejects.toThrow(`Permission denied: ${testFile}`);
+			).rejects.toThrow(`Could not write file: ${testFile}. Error code: EACCES.`);
 		});
 
-		it("should report permission denied when edit access fails with EPERM", async () => {
+		it("should include EPERM when edit access fails with EPERM", async () => {
 			const permissionDeniedTool = createEditTool(testDir, {
 				operations: {
 					access: async () => {
@@ -410,10 +410,10 @@ describe("Coding Agent Tools", () => {
 					path: "denied.txt",
 					edits: [{ oldText: "hello", newText: "world" }],
 				}),
-			).rejects.toThrow("Permission denied: denied.txt");
+			).rejects.toThrow("Could not write file: denied.txt. Error code: EPERM.");
 		});
 
-		it("should report a generic access failure for unknown edit access errors", async () => {
+		it("should include the original error message for unknown edit access errors", async () => {
 			const genericFailureTool = createEditTool(testDir, {
 				operations: {
 					access: async () => {
@@ -429,34 +429,34 @@ describe("Coding Agent Tools", () => {
 					path: "broken.txt",
 					edits: [{ oldText: "hello", newText: "world" }],
 				}),
-			).rejects.toThrow("Failed to access file: broken.txt");
+			).rejects.toThrow("Could not write file: broken.txt. Error: disk offline.");
 		});
 
-		it("should report file not found in diff preview for missing files", async () => {
+		it("should include ENOENT in diff preview for missing files", async () => {
 			const missingFile = join(testDir, "missing-preview.txt");
 			const result = await computeEditsDiff(missingFile, [{ oldText: "hello", newText: "world" }], testDir);
 
-			expect(result).toEqual({ error: `File not found: ${missingFile}` });
+			expect(result).toEqual({ error: `Could not write file: ${missingFile}. Error code: ENOENT.` });
 		});
 
-		it("should report file not found in diff preview when path component is not a directory", async () => {
+		it("should include ENOTDIR in diff preview when path component is not a directory", async () => {
 			const parentFile = join(testDir, "not-a-directory.txt");
 			writeFileSync(parentFile, "hello\n");
 			const invalidPath = join(parentFile, "child.txt");
 
 			const result = await computeEditsDiff(invalidPath, [{ oldText: "hello", newText: "world" }], testDir);
 
-			expect(result).toEqual({ error: `File not found: ${invalidPath}` });
+			expect(result).toEqual({ error: `Could not write file: ${invalidPath}. Error code: ENOTDIR.` });
 		});
 
-		it("should report permission denied in diff preview for unreadable files", async () => {
+		it("should include EACCES in diff preview for unreadable files", async () => {
 			const unreadableFile = join(testDir, "unreadable-preview.txt");
 			writeFileSync(unreadableFile, "hello\n");
 			chmodSync(unreadableFile, 0o222);
 
 			const result = await computeEditsDiff(unreadableFile, [{ oldText: "hello", newText: "world" }], testDir);
 
-			expect(result).toEqual({ error: `Permission denied: ${unreadableFile}` });
+			expect(result).toEqual({ error: `Could not write file: ${unreadableFile}. Error code: EACCES.` });
 		});
 	});
 

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -392,27 +392,6 @@ describe("Coding Agent Tools", () => {
 			).rejects.toThrow(`Could not write file: ${testFile}. Error code: EACCES.`);
 		});
 
-		it("should include EPERM when edit access fails with EPERM", async () => {
-			const permissionDeniedTool = createEditTool(testDir, {
-				operations: {
-					access: async () => {
-						const error = new Error("operation not permitted");
-						Object.assign(error, { code: "EPERM" });
-						throw error;
-					},
-					readFile: async () => Buffer.from("hello\n", "utf-8"),
-					writeFile: async () => {},
-				},
-			});
-
-			await expect(
-				permissionDeniedTool.execute("test-call-15", {
-					path: "denied.txt",
-					edits: [{ oldText: "hello", newText: "world" }],
-				}),
-			).rejects.toThrow("Could not write file: denied.txt. Error code: EPERM.");
-		});
-
 		it("should include the original error message for unknown edit access errors", async () => {
 			const genericFailureTool = createEditTool(testDir, {
 				operations: {
@@ -437,16 +416,6 @@ describe("Coding Agent Tools", () => {
 			const result = await computeEditsDiff(missingFile, [{ oldText: "hello", newText: "world" }], testDir);
 
 			expect(result).toEqual({ error: `Could not write file: ${missingFile}. Error code: ENOENT.` });
-		});
-
-		it("should include ENOTDIR in diff preview when path component is not a directory", async () => {
-			const parentFile = join(testDir, "not-a-directory.txt");
-			writeFileSync(parentFile, "hello\n");
-			const invalidPath = join(parentFile, "child.txt");
-
-			const result = await computeEditsDiff(invalidPath, [{ oldText: "hello", newText: "world" }], testDir);
-
-			expect(result).toEqual({ error: `Could not write file: ${invalidPath}. Error code: ENOTDIR.` });
 		});
 
 		it("should include EACCES in diff preview for unreadable files", async () => {


### PR DESCRIPTION
**Description**

- Reject (`edit`) / return (`edit-diff`) errors based on their `code` instead of returning `File not found: ${path}`
- Added tests that should cover those scenarios
- closes #3894