### PR TITLE
feat(coding-agent): add --profile and PI_PROFILE for isolated state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `--profile` and `PI_PROFILE` support for isolated Pi config, auth, sessions, models, and extensions.
+
 ## [0.70.6] - 2026-04-28
 
 ### New Features

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -43,6 +43,7 @@ export interface Args {
 	listModels?: string | true;
 	offline?: boolean;
 	verbose?: boolean;
+	profile?: string;
 	messages: string[];
 	fileArgs: string[];
 	/** Unknown flags (potentially extension flags) - map of flag name to value */
@@ -71,6 +72,8 @@ export function parseArgs(args: string[]): Args {
 			result.help = true;
 		} else if (arg === "--version" || arg === "-v") {
 			result.version = true;
+		} else if (arg === "--profile" && i + 1 < args.length) {
+			result.profile = args[++i];
 		} else if (arg === "--mode" && i + 1 < args.length) {
 			const mode = args[++i];
 			if (mode === "text" || mode === "json" || mode === "rpc") {
@@ -242,6 +245,7 @@ ${chalk.bold("Options:")}
   --list-models [search]         List available models (with optional fuzzy search)
   --verbose                      Force verbose startup (overrides quietStartup setting)
   --offline                      Disable startup network operations (same as PI_OFFLINE=1)
+  --profile <name>               Use a named profile for isolated config, auth, sessions, and state
   --help, -h                     Show this help
   --version, -v                  Show version number
 
@@ -324,6 +328,7 @@ ${chalk.bold("Environment Variables:")}
   AWS_BEARER_TOKEN_BEDROCK         - Bedrock API key (bearer token)
   AWS_REGION                       - AWS region for Amazon Bedrock (e.g., us-east-1)
   ${ENV_AGENT_DIR.padEnd(32)} - Session storage directory (default: ~/${CONFIG_DIR_NAME}/agent)
+  PI_PROFILE                     - Profile name (alternative to --profile)
   PI_PACKAGE_DIR                   - Override package directory (for Nix/Guix store paths)
   PI_OFFLINE                       - Disable startup network operations when set to 1/true/yes
   PI_TELEMETRY                     - Override install telemetry when set to 1/true/yes or 0/false/no

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -349,6 +349,10 @@ export function getAgentDir(): string {
 		if (envDir.startsWith("~/")) return homedir() + envDir.slice(1);
 		return envDir;
 	}
+	const profile = process.env.PI_PROFILE;
+	if (profile) {
+		return join(homedir(), CONFIG_DIR_NAME, "profiles", profile, "agent");
+	}
 	return join(homedir(), CONFIG_DIR_NAME, "agent");
 }
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -15,7 +15,7 @@ import { processFileArguments } from "./cli/file-processor.js";
 import { buildInitialMessage } from "./cli/initial-message.js";
 import { listModels } from "./cli/list-models.js";
 import { selectSession } from "./cli/session-picker.js";
-import { getAgentDir, VERSION } from "./config.js";
+import { ENV_AGENT_DIR, getAgentDir, VERSION } from "./config.js";
 import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.js";
 import {
 	type AgentSessionRuntimeDiagnostic,
@@ -422,6 +422,13 @@ export interface MainOptions {
 
 export async function main(args: string[], options?: MainOptions) {
 	resetTimings();
+	const parsed = parseArgs(args);
+	if (parsed.profile) {
+		process.env.PI_PROFILE = parsed.profile;
+	}
+	if (!process.env[ENV_AGENT_DIR]) {
+		process.env[ENV_AGENT_DIR] = getAgentDir();
+	}
 	const offlineMode = args.includes("--offline") || isTruthyEnvFlag(process.env.PI_OFFLINE);
 	if (offlineMode) {
 		process.env.PI_OFFLINE = "1";
@@ -436,7 +443,6 @@ export async function main(args: string[], options?: MainOptions) {
 		return;
 	}
 
-	const parsed = parseArgs(args);
 	if (parsed.diagnostics.length > 0) {
 		for (const d of parsed.diagnostics) {
 			const color = d.type === "error" ? chalk.red : chalk.yellow;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -11,6 +11,10 @@ import type { Terminal } from "./terminal.js";
 import { getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
 import { extractSegments, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.js";
 
+function getAgentLogDir(): string {
+	return process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".pi", "agent");
+}
+
 /**
  * Component interface - all components must implement this
  */
@@ -944,7 +948,7 @@ export class TUI extends Container {
 		const debugRedraw = process.env.PI_DEBUG_REDRAW === "1";
 		const logRedraw = (reason: string): void => {
 			if (!debugRedraw) return;
-			const logPath = path.join(os.homedir(), ".pi", "agent", "pi-debug.log");
+			const logPath = path.join(getAgentLogDir(), "pi-debug.log");
 			const msg = `[${new Date().toISOString()}] fullRender: ${reason} (prev=${this.previousLines.length}, new=${newLines.length}, height=${height})\n`;
 			fs.appendFileSync(logPath, msg);
 		};
@@ -1104,7 +1108,7 @@ export class TUI extends Container {
 			const isImage = isImageLine(line);
 			if (!isImage && visibleWidth(line) > width) {
 				// Log all lines to crash file for debugging
-				const crashLogPath = path.join(os.homedir(), ".pi", "agent", "pi-crash.log");
+				const crashLogPath = path.join(getAgentLogDir(), "pi-crash.log");
 				const crashData = [
 					`Crash at ${new Date().toISOString()}`,
 					`Terminal width: ${width}`,


### PR DESCRIPTION
## Add `--profile` and `PI_PROFILE` for isolated state

### What
Adds a `--profile` CLI flag and `PI_PROFILE` env var as a DX layer built on top of the existing `PI_CODING_AGENT_DIR` mechanism. When used, Pi resolves state to `~/.pi/profiles/<name>/agent`. When not used, behavior is completely unchanged.

### Why
- **Zero path knowledge**: users shouldn't manually construct `~/.pi/profiles/.../agent` paths.
- **Fast context switching**: switch between work, personal, or local-LLM setups without juggling shell env vars.
- **Cross-platform by default**: no hardcoded home paths.
- **Intent over location**: `--profile` sets `PI_PROFILE` internally, so extensions that want to know the active context can read a semantic identifier; extensions that don't care keep using `getAgentDir()` unchanged.

### How
```bash
pi --profile work
PI_PROFILE=work pi
```

**Priority chain in `getAgentDir()`:**
1. `PI_CODING_AGENT_DIR` — used as-is (absolute override)
2. `PI_PROFILE` — derived to `~/.pi/profiles/<name>/agent`
3. Default — `~/.pi/agent`

### What changed
- **`getAgentDir()`** (`config.ts`): added `PI_PROFILE` fallback. All existing code that already called `getAgentDir()` now supports profiles automatically.
- **`main()`** (`main.ts`): parses `--profile` early and normalizes `PI_CODING_AGENT_DIR` before any command logic (install/config/session), so all commands see the correct directory.
- **`parseArgs()`** (`args.ts`): added `--profile` parsing, help text, and `PI_PROFILE` env var documentation.
- **`TUI`** (`tui.ts`): debug/crash logs (`pi-debug.log`, `pi-crash.log`) now respect `PI_CODING_AGENT_DIR` instead of hardcoding `~/.pi/agent`.

### Design notes — what we intentionally did not do

**Profile name sanitization**
We did not add path-traversal guards (rejecting `../`, slashes, control characters, etc.). `PI_CODING_AGENT_DIR` already allows arbitrary paths without validation — it is user-controlled input on the user's own system. Adding sanitization here would create an inconsistency and expand the scope without adding real safety.

**Conflict error when `--profile` and `PI_CODING_AGENT_DIR` are both used**
We did not fail or warn when both are provided. `PI_CODING_AGENT_DIR` already wins by priority in `getAgentDir()`. This is the existing and expected behavior — the explicit override always takes precedence. Adding a warning would create noise for a legitimate use case (e.g., `PI_CODING_AGENT_DIR` in `.bashrc` + `--profile` for ad-hoc override).

**Scope boundaries**
- `packages/pods` and `packages/mom` have their own config paths and are outside the coding-agent state boundary. They were intentionally not touched.
- No new dependencies or exports were added.
- `PI_PROFILE` was kept as a lightweight env var rather than a full object model or config file structure.
- Extensions and components that hardcode `~/.pi/agent/` instead of using the exported `getAgentDir()` are already broken for any non-default `PI_CODING_AGENT_DIR`. Fixing them is out of scope — they should use `getAgentDir()` from `@mariozechner/pi-coding-agent`.

### Checklist
- [x] Changes are minimal and focused
- [x] `getAgentDir()` remains the single source of truth for path resolution
- [x] TUI logs no longer leak across profiles
- [x] All commands (install, config, interactive, print) see the normalized directory
- [x] `CHANGELOG.md` updated under `[Unreleased]`

---

**Testing note**: `npm run check` fails on this repo due to pre-existing missing `typebox` and `@types/uuid` dependencies in `node_modules`. The changed files themselves produce no LSP diagnostics.
