### PR TITLE
fix(ai): bump default Antigravity version to 1.23.2

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bumped default Antigravity `User-Agent` version to `1.23.2`.
+
 ## [0.70.6] - 2026-04-28
 
 ### Added

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -78,7 +78,7 @@ const GEMINI_CLI_HEADERS = {
 };
 
 // Headers for Antigravity (sandbox endpoint) - requires specific User-Agent
-const DEFAULT_ANTIGRAVITY_VERSION = "1.21.9";
+const DEFAULT_ANTIGRAVITY_VERSION = "1.23.2";
 
 function getAntigravityHeaders() {
 	const version = process.env.PI_AI_ANTIGRAVITY_VERSION || DEFAULT_ANTIGRAVITY_VERSION;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bumped default Antigravity `User-Agent` version to `1.23.2` in the `antigravity-image-gen.ts` example extension.
+
 ## [0.70.6] - 2026-04-28
 
 ### New Features

--- a/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
+++ b/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
@@ -48,7 +48,7 @@ type SaveMode = (typeof SAVE_MODES)[number];
 
 const ANTIGRAVITY_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 
-const DEFAULT_ANTIGRAVITY_VERSION = "1.21.9";
+const DEFAULT_ANTIGRAVITY_VERSION = "1.23.2";
 
 const ANTIGRAVITY_HEADERS = {
 	"User-Agent": `antigravity/${process.env.PI_AI_ANTIGRAVITY_VERSION || DEFAULT_ANTIGRAVITY_VERSION} darwin/arm64`,


### PR DESCRIPTION
Bumps the default Antigravity version from `1.21.9` to `1.23.2` and documents the change in package changelogs
Resolves https://github.com/badlogic/pi-mono/issues/2815 (it came back everytime Antigravity released a new version)