### PR TITLE
fix(tui): render cursor inactive on terminal blur

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/config-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector.ts
@@ -196,6 +196,10 @@ class ResourceList implements Component, Focusable {
 		this.searchInput.focused = value;
 	}
 
+	setTerminalFocused(focused: boolean): void {
+		this.searchInput.setTerminalFocused(focused);
+	}
+
 	constructor(groups: ResourceGroup[], settingsManager: SettingsManager, cwd: string, agentDir: string) {
 		this.groups = groups;
 		this.settingsManager = settingsManager;

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -305,6 +305,10 @@ class SessionList implements Component, Focusable {
 		this.searchInput.focused = value;
 	}
 
+	setTerminalFocused(focused: boolean): void {
+		this.searchInput.setTerminalFocused(focused);
+	}
+
 	constructor(
 		sessions: SessionInfo[],
 		showCwd: boolean,

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -1088,6 +1088,10 @@ class LabelInput implements Component, Focusable {
 		this.input.focused = value;
 	}
 
+	setTerminalFocused(focused: boolean): void {
+		this.input.setTerminalFocused(focused);
+	}
+
 	constructor(entryId: string, currentLabel: string | undefined) {
 		this.entryId = entryId;
 		this.input = new Input();

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -223,6 +223,7 @@ export class Editor implements Component, Focusable {
 
 	/** Focusable interface - set by TUI when focus changes */
 	focused: boolean = false;
+	terminalFocused: boolean = true;
 
 	protected tui: TUI;
 	private theme: EditorTheme;
@@ -406,6 +407,10 @@ export class Editor implements Component, Focusable {
 		// No cached state to invalidate currently
 	}
 
+	setTerminalFocused(focused: boolean): void {
+		this.terminalFocused = focused;
+	}
+
 	render(width: number): string[] {
 		const maxPadding = Math.max(0, Math.floor((width - 1) / 2));
 		const paddingX = Math.min(this.paddingX, maxPadding);
@@ -485,12 +490,12 @@ export class Editor implements Component, Focusable {
 					const afterGraphemes = [...this.segment(after)];
 					const firstGrapheme = afterGraphemes[0]?.segment || "";
 					const restAfter = after.slice(firstGrapheme.length);
-					const cursor = `\x1b[7m${firstGrapheme}\x1b[0m`;
+					const cursor = this.terminalFocused ? `\x1b[7m${firstGrapheme}\x1b[0m` : firstGrapheme;
 					displayText = before + marker + cursor + restAfter;
 					// lineVisibleWidth stays the same - we're replacing, not adding
 				} else {
 					// Cursor is at the end - add highlighted space
-					const cursor = "\x1b[7m \x1b[0m";
+					const cursor = this.terminalFocused ? "\x1b[7m \x1b[0m" : " ";
 					displayText = before + marker + cursor;
 					lineVisibleWidth = lineVisibleWidth + 1;
 					// If cursor overflows content width into the padding, flag it

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -23,6 +23,7 @@ export class Input implements Component, Focusable {
 
 	/** Focusable interface - set by TUI when focus changes */
 	focused: boolean = false;
+	terminalFocused: boolean = true;
 
 	// Bracketed paste mode buffering
 	private pasteBuffer: string = "";
@@ -431,6 +432,10 @@ export class Input implements Component, Focusable {
 		// No cached state to invalidate currently
 	}
 
+	setTerminalFocused(focused: boolean): void {
+		this.terminalFocused = focused;
+	}
+
 	render(width: number): string[] {
 		// Calculate visible window
 		const prompt = "> ";
@@ -490,7 +495,7 @@ export class Input implements Component, Focusable {
 		const marker = this.focused ? CURSOR_MARKER : "";
 
 		// Use inverse video to show cursor
-		const cursorChar = `\x1b[7m${atCursor}\x1b[27m`; // ESC[7m = reverse video, ESC[27m = normal
+		const cursorChar = this.terminalFocused ? `\x1b[7m${atCursor}\x1b[27m` : atCursor;
 		const textWithCursor = beforeCursor + marker + cursorChar + afterCursor;
 
 		// Calculate visual width

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -78,6 +78,11 @@ export class SettingsList implements Component {
 		this.submenuComponent?.invalidate?.();
 	}
 
+	setTerminalFocused(focused: boolean): void {
+		this.searchInput?.setTerminalFocused(focused);
+		this.submenuComponent?.setTerminalFocused?.(focused);
+	}
+
 	render(width: number): string[] {
 		// If submenu is active, render it instead
 		if (this.submenuComponent) {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -102,6 +102,8 @@ export class ProcessTerminal implements Terminal {
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		process.stdout.write("\x1b[?2004h");
+		// Enable focus reporting - terminal sends \x1b[I on focus and \x1b[O on blur.
+		process.stdout.write("\x1b[?1004h");
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.resizeHandler);
@@ -275,6 +277,8 @@ export class ProcessTerminal implements Terminal {
 
 		// Disable bracketed paste mode
 		process.stdout.write("\x1b[?2004l");
+		// Disable focus reporting
+		process.stdout.write("\x1b[?1004l");
 
 		// Disable Kitty keyboard protocol if not already done by drainInput()
 		if (this._kittyProtocolActive) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -38,6 +38,11 @@ export interface Component {
 	 * Called when theme changes or when component needs to re-render from scratch.
 	 */
 	invalidate(): void;
+
+	/**
+	 * Optional notification when the terminal window gains or loses focus.
+	 */
+	setTerminalFocused?(focused: boolean): void;
 }
 
 type InputListenerResult = { consume?: boolean; data?: string } | undefined;
@@ -177,8 +182,10 @@ export interface OverlayHandle {
  */
 export class Container implements Component {
 	children: Component[] = [];
+	private childTerminalFocused = true;
 
 	addChild(component: Component): void {
+		component.setTerminalFocused?.(this.childTerminalFocused);
 		this.children.push(component);
 	}
 
@@ -196,6 +203,13 @@ export class Container implements Component {
 	invalidate(): void {
 		for (const child of this.children) {
 			child.invalidate?.();
+		}
+	}
+
+	setTerminalFocused(focused: boolean): void {
+		this.childTerminalFocused = focused;
+		for (const child of this.children) {
+			child.setTerminalFocused?.(focused);
 		}
 	}
 
@@ -236,6 +250,7 @@ export class TUI extends Container {
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
 	private fullRedrawCount = 0;
 	private stopped = false;
+	private terminalFocused = true;
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
@@ -285,6 +300,26 @@ export class TUI extends Container {
 		this.clearOnShrink = enabled;
 	}
 
+	private handleTerminalFocusReport(focused: boolean): void {
+		if (this.terminalFocused === focused) return;
+		this.terminalFocused = focused;
+		this.setTerminalFocusedForAll(focused);
+		this.requestRender();
+	}
+
+	private setTerminalFocusedForAll(focused: boolean): void {
+		for (const child of this.children) {
+			this.setTerminalFocusedForComponent(child, focused);
+		}
+		for (const overlay of this.overlayStack) {
+			this.setTerminalFocusedForComponent(overlay.component, focused);
+		}
+	}
+
+	private setTerminalFocusedForComponent(component: Component, focused: boolean): void {
+		component.setTerminalFocused?.(focused);
+	}
+
 	setFocus(component: Component | null): void {
 		// Clear focused flag on old component
 		if (isFocusable(this.focusedComponent)) {
@@ -296,6 +331,7 @@ export class TUI extends Container {
 		// Set focused flag on new component
 		if (isFocusable(component)) {
 			component.focused = true;
+			this.setTerminalFocusedForComponent(component, this.terminalFocused);
 		}
 	}
 
@@ -417,6 +453,8 @@ export class TUI extends Container {
 
 	start(): void {
 		this.stopped = false;
+		this.terminalFocused = true;
+		this.setTerminalFocusedForAll(true);
 		this.terminal.start(
 			(data) => this.handleInput(data),
 			() => this.requestRender(),
@@ -449,6 +487,8 @@ export class TUI extends Container {
 
 	stop(): void {
 		this.stopped = true;
+		this.terminalFocused = true;
+		this.setTerminalFocusedForAll(true);
 		if (this.renderTimer) {
 			clearTimeout(this.renderTimer);
 			this.renderTimer = undefined;
@@ -519,6 +559,11 @@ export class TUI extends Container {
 	}
 
 	private handleInput(data: string): void {
+		if (data === "\x1b[I" || data === "\x1b[O") {
+			this.handleTerminalFocusReport(data === "\x1b[I");
+			return;
+		}
+
 		if (this.inputListeners.size > 0) {
 			let current = data;
 			for (const listener of this.inputListeners) {
@@ -1234,7 +1279,7 @@ export class TUI extends Container {
 		}
 
 		this.hardwareCursorRow = targetRow;
-		if (this.showHardwareCursor) {
+		if (this.showHardwareCursor || !this.terminalFocused) {
 			this.terminal.showCursor();
 		} else {
 			this.terminal.hideCursor();

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
-import { type Component, TUI } from "../src/tui.js";
+import { Input } from "../src/components/input.js";
+import { type Component, Container, TUI } from "../src/tui.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
 
 class TestComponent implements Component {
@@ -62,6 +63,55 @@ function getCellItalic(terminal: VirtualTerminal, row: number, col: number): num
 	assert.ok(cell, `Missing cell at row ${row} col ${col}`);
 	return cell.isItalic();
 }
+
+describe("TUI terminal focus handling", () => {
+	it("consumes terminal focus reports and updates cursor rendering", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const input = new Input();
+		input.setValue("abc");
+		tui.addChild(input);
+		tui.setFocus(input);
+
+		tui.start();
+		await terminal.waitForRender();
+
+		assert.ok(input.render(10)[0]?.includes("\x1b[7m"), "focused terminal should render inverse cursor");
+
+		terminal.sendInput("\x1b[O");
+		await terminal.waitForRender();
+
+		assert.ok(!input.render(10)[0]?.includes("\x1b[7m"), "blurred terminal should not render inverse cursor");
+
+		terminal.sendInput("\x1b[I");
+		await terminal.waitForRender();
+
+		assert.ok(input.render(10)[0]?.includes("\x1b[7m"), "refocused terminal should render inverse cursor");
+
+		tui.stop();
+	});
+
+	it("propagates current terminal focus to children added after blur", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const container = new Container();
+		tui.addChild(container);
+
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[O");
+		await terminal.waitForRender();
+
+		const input = new Input();
+		input.setValue("abc");
+		container.addChild(input);
+
+		assert.ok(!input.render(10)[0]?.includes("\x1b[7m"), "late child should inherit blurred terminal state");
+
+		tui.stop();
+	});
+});
 
 describe("TUI resize handling", () => {
 	it("triggers full re-render when terminal height changes", async () => {


### PR DESCRIPTION
Fixes #3896

  ## Summary

  - Enable terminal focus reporting in the TUI.
  - Track focus/blur reports and re-render when terminal focus changes.
  - Render text cursors without inverse video while the terminal window is blurred.
  - Propagate terminal focus state through nested components so inputs added after blur inherit the current state.

  ## Testing

  - `npm run check`
  - Manual: ran pi in interactive mode and verified the prompt cursor switches to inactive when the terminal loses focus, then returns to active when focused again.