### PR TITLE
fix(coding-agent): auto-recover stale tool-call text responses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Fixed auto-recovery when models output tool call XML as text instead of making proper tool calls ([#??](https://github.com/badlogic/pi-mono/issues/??)).
 - Fixed config selector scroll indicators to show item counts instead of line counts ([#3820](https://github.com/badlogic/pi-mono/pull/3820) by [@aliou](https://github.com/aliou)).
 - Fixed exported HTML to escape embedded image data and session metadata, preventing crafted session content from injecting markup ([#3819](https://github.com/badlogic/pi-mono/pull/3819) by [@justinpbarnett](https://github.com/justinpbarnett), [#3883](https://github.com/badlogic/pi-mono/pull/3883) by [@justinpbarnett](https://github.com/justinpbarnett)).
 - Fixed Bun-based package manager startup by locating global `node_modules` relative to Bun's install layout ([#3861](https://github.com/badlogic/pi-mono/pull/3861) by [@thirtythreeforty](https://github.com/thirtythreeforty)).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -237,6 +237,9 @@ const THINKING_LEVELS_WITH_XHIGH: ThinkingLevel[] = ["off", "minimal", "low", "m
 // ============================================================================
 
 export class AgentSession {
+	private static readonly STALE_TOOL_CALL_FOLLOW_UP_TEXT =
+		"Please continue and use the proper tool calling functions instead of writing tool calls as text.";
+
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
 	readonly settingsManager: SettingsManager;
@@ -268,6 +271,9 @@ export class AgentSession {
 	private _retryAttempt = 0;
 	private _retryPromise: Promise<void> | undefined = undefined;
 	private _retryResolve: (() => void) | undefined = undefined;
+
+	// Stale tool call text recovery
+	private _staleToolCallAttempt = 0;
 
 	// Bash execution state
 	private _bashAbortController: AbortController | undefined = undefined;
@@ -496,9 +502,10 @@ export class AgentSession {
 		// When a user message starts, check if it's from either queue and remove it BEFORE emitting
 		// This ensures the UI sees the updated queue state
 		if (event.type === "message_start" && event.message.role === "user") {
-			this._overflowRecoveryAttempted = false;
 			const messageText = this._getUserMessageText(event.message);
 			if (messageText) {
+				const isStaleToolCallRecoveryFollowUp = this._isStaleToolCallRecoveryFollowUp(messageText);
+
 				// Check steering queue first
 				const steeringIndex = this._steeringMessages.indexOf(messageText);
 				if (steeringIndex !== -1) {
@@ -511,6 +518,11 @@ export class AgentSession {
 						this._followUpMessages.splice(followUpIndex, 1);
 						this._emitQueueUpdate();
 					}
+				}
+
+				if (!isStaleToolCallRecoveryFollowUp) {
+					this._overflowRecoveryAttempted = false;
+					this._staleToolCallAttempt = 0;
 				}
 			}
 		}
@@ -551,6 +563,11 @@ export class AgentSession {
 					this._overflowRecoveryAttempted = false;
 				}
 
+				// Reset stale tool call counter when the model makes proper tool calls
+				if (assistantMsg.content.some((c) => c.type === "toolCall")) {
+					this._staleToolCallAttempt = 0;
+				}
+
 				// Reset retry counter immediately on successful assistant response
 				// This prevents accumulation across multiple LLM calls within a turn
 				if (assistantMsg.stopReason !== "error" && this._retryAttempt > 0) {
@@ -573,6 +590,12 @@ export class AgentSession {
 			if (this._isRetryableError(msg)) {
 				const didRetry = await this._handleRetryableError(msg);
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
+			}
+
+			// Check for stale tool call text (model wrote tool calls as XML instead of calling them)
+			if (this._hasStaleToolCallText(msg)) {
+				this._handleStaleToolCallText(msg);
+				return;
 			}
 
 			this._resolveRetry();
@@ -2531,6 +2554,76 @@ export class AgentSession {
 	 */
 	setAutoRetryEnabled(enabled: boolean): void {
 		this.settingsManager.setRetryEnabled(enabled);
+	}
+
+	// =========================================================================
+	// Stale Tool Call Text Recovery
+	// =========================================================================
+
+	/**
+	 * Check if an assistant message contains tool-call-like XML text instead of
+	 * proper structured tool calls.
+	 * Some models (e.g., deepseek-v4-flash) occasionally output tool call blocks
+	 * as text (like `<tool_calls><invoke name="...">...</invoke></tool_calls>`)
+	 * instead of using the actual tool calling mechanism. When detected, pi
+	 * auto-continues with a hint to use proper tool calls.
+	 */
+	private _hasStaleToolCallText(message: AssistantMessage): boolean {
+		// Only check messages that stopped naturally; errors/aborts are handled
+		// elsewhere
+		if (message.stopReason !== "stop") return false;
+
+		// If there are already proper tool calls, no intervention needed
+		if (message.content.some((c) => c.type === "toolCall")) return false;
+
+		// Check text content for tool call XML patterns
+		const textContent = message.content
+			.filter((c) => c.type === "text")
+			.map((c) => (c as TextContent).text)
+			.join("");
+
+		// Pattern: <tool_calls>...</tool_calls> containing <invoke name="toolName">
+		return /<tool_calls?[^>]*>[\s\S]*?<invoke\s+name=/i.test(textContent);
+	}
+
+	/**
+	 * Handle a message that contains tool-call-like text.
+	 * Queues a follow-up message telling the model to use proper tool calls,
+	 * then schedules a continue to let the model retry.
+	 */
+	private _handleStaleToolCallText(_message: AssistantMessage): void {
+		this._staleToolCallAttempt++;
+
+		// Limit to 2 consecutive auto-retries to prevent infinite loops
+		if (this._staleToolCallAttempt > 2) {
+			this._staleToolCallAttempt = 0;
+			return;
+		}
+
+		this._resolveRetry();
+
+		// Queue a follow-up message telling the model to use proper tool calls
+		const followUpText = AgentSession.STALE_TOOL_CALL_FOLLOW_UP_TEXT;
+
+		this.agent.followUp({
+			role: "user",
+			content: [{ type: "text", text: followUpText }],
+			timestamp: Date.now(),
+		});
+
+		// Also track in UI queue so it shows as pending
+		this._followUpMessages.push(followUpText);
+		this._emitQueueUpdate();
+
+		// Schedule continue to let the model retry.
+		// Uses setTimeout to break out of the event handler chain.
+		setTimeout(() => {
+			this.agent.continue().catch(() => {});
+		}, 0);
+	}
+
+	private _isStaleToolCallRecoveryFollowUp(messageText: string): boolean {
+		return messageText === AgentSession.STALE_TOOL_CALL_FOLLOW_UP_TEXT;
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/test/suite/stale-tool-call-recovery.test.ts
+++ b/packages/coding-agent/test/suite/stale-tool-call-recovery.test.ts
@@ -1,0 +1,30 @@
+import { fauxAssistantMessage } from "@mariozechner/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./harness.js";
+
+describe("stale tool call recovery", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("stops auto-retrying after two recovery attempts instead of looping forever", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage('<tool_calls><invoke name="echo"></invoke></tool_calls>', { stopReason: "stop" }),
+			fauxAssistantMessage('<tool_calls><invoke name="echo"></invoke></tool_calls>', { stopReason: "stop" }),
+			fauxAssistantMessage('<tool_calls><invoke name="echo"></invoke></tool_calls>', { stopReason: "stop" }),
+			fauxAssistantMessage("recovered"),
+		]);
+
+		await harness.session.prompt("start");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.session.isRetrying).toBe(false);
+	});
+});

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
+const tuiSrcIndex = fileURLToPath(new URL("../tui/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
@@ -21,6 +22,7 @@ export default defineConfig({
 			{ find: /^@mariozechner\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@mariozechner\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@mariozechner\/pi-tui$/, replacement: tuiSrcIndex },
 		],
 	},
 });

--- a/packages/web-ui/example/tsconfig.json
+++ b/packages/web-ui/example/tsconfig.json
@@ -6,10 +6,10 @@
 		"moduleResolution": "bundler",
 		"paths": {
 			"*": ["./*"],
-			"@mariozechner/pi-agent-core": ["../../agent/dist/index.d.ts"],
-			"@mariozechner/pi-ai": ["../../ai/dist/index.d.ts"],
-			"@mariozechner/pi-tui": ["../../tui/dist/index.d.ts"],
-			"@mariozechner/pi-web-ui": ["../dist/index.d.ts"]
+			"@mariozechner/pi-agent-core": ["../../agent/src/index.ts"],
+			"@mariozechner/pi-ai": ["../../ai/src/index.ts"],
+			"@mariozechner/pi-tui": ["../../tui/src/index.ts"],
+			"@mariozechner/pi-web-ui": ["../src/index.ts"]
 		},
 		"strict": true,
 		"skipLibCheck": true,

--- a/packages/web-ui/tsconfig.json
+++ b/packages/web-ui/tsconfig.json
@@ -1,7 +1,17 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "paths": {
+      "*": ["./*"],
+      "@mariozechner/pi-agent-core": ["../agent/src/index.ts"],
+      "@mariozechner/pi-ai": ["../ai/src/index.ts"],
+      "@mariozechner/pi-tui": ["../tui/src/index.ts"],
+      "@mariozechner/pi-web-ui": ["./src/index.ts"]
+    }
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Fix stale tool-call XML recovery in AgentSession.

Some models emit tool calls as XML text instead of structured tool calls. For example, DeepSeek-V4-Flash emits "<DSML>...</DSML>". This change detects that case after agent_end, queues a recovery follow-up, and auto-continues the session so the user does not need to type 'continue'. It also caps consecutive recovery attempts to avoid loops and resets the counter when proper tool calls happen.
