### PR TITLE
fix(coding-agent): correct bun global package root path calculation

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -121,7 +121,7 @@ function getGlobalPackageRoots(method: InstallMethod): string[] {
 			const bunBin = readCommandOutput("bun", ["pm", "bin", "-g"]);
 			const roots = [join(homedir(), ".bun", "install", "global", "node_modules")];
 			if (bunBin) {
-				roots.push(join(dirname(dirname(bunBin)), "install", "global", "node_modules"));
+				roots.push(join(dirname(bunBin), "install", "global", "node_modules"));
 			}
 			return roots;
 		}


### PR DESCRIPTION
Fixes #3980

The `getGlobalPackageRoots()` function used `dirname(dirname(bunBin))` which incorrectly navigated two levels up from the bun bin directory. This caused `isManagedByGlobalPackageManager()` to return `false` for bun installations, making `pi update` unable to self-update when pi was installed via bun.

Fix by using `dirname(bunBin)` to get the correct parent directory.
