### PR TITLE
Add Gloo AI as a First-Class Provider for Pi-Mono

### DIFF
--- a/.claude/skills/dev-logs/SKILL.md
+++ b/.claude/skills/dev-logs/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: dev-logs
+description: Tail and search pi-mono dev logs for troubleshooting — filter by provider, service, level, or freeform pattern.
+argument-hint: '[gloo] [--level ERROR] [--lines 50] [--follow]'
+---
+
+# Dev Logs
+
+Inspect local pi-mono logs while debugging the `pi` TUI or Gloo provider.
+
+## Arguments
+
+<arguments> #$ARGUMENTS </arguments>
+
+- First positional arg — grep pattern, e.g. `gloo`, `token`, `stream error`
+- `--level <LEVEL>` — filter to `DEBUG`, `INFO`, `WARN`, or `ERROR`
+- `--lines <N>` — number of recent lines to show; default `50`
+- `--follow` — run a blocking `tail -f`
+- No arguments — show the last 50 lines of the most recent log
+
+## Log locations
+
+Check these in order and use the first existing relevant log:
+
+```bash
+$HOME/.local/share/pi/log/dev.log
+$HOME/.local/share/pi/log/*.log
+$HOME/.local/share/opencode/log/dev.log      # only when comparing with opencode behavior
+/tmp/ai-api-dev.log                          # local backend, if started by /gloo-local-dev
+```
+
+If no pi log directory exists, tell the user to start the local TUI first:
+
+```bash
+npm run build
+node packages/coding-agent/dist/cli.js
+```
+
+## Analysis checklist
+
+When filtering for `gloo`, look for:
+
+- OAuth provider login/prompt errors
+- `GLOO_CLIENT_ID` / `GLOO_CLIENT_SECRET` missing configuration
+- token grant failures against `/oauth2/token`
+- request failures to `/ai/v2/chat/completions`
+- streaming parser errors, especially DeepSeek `reasoning_content`
+- model/tool errors for blocklisted models
+
+Summarize:
+
+1. log file used
+2. number of lines scanned
+3. error/warning count
+4. likely root cause
+5. concrete next command (`/gloo-verify`, `/gloo-env local`, restart TUI, check `ai-api` logs, etc.)

--- a/.claude/skills/gloo-env/SKILL.md
+++ b/.claude/skills/gloo-env/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: gloo-env
+description: Toggle Gloo AI provider between prod (platform.ai.gloo.com) and local (localhost:8000) in .env.local
+argument-hint: '[prod|local]'
+---
+
+# Gloo Environment Toggle
+
+Switch pi-mono's Gloo AI provider base URL between production and local `ai-api`.
+
+## Arguments
+
+<arguments> #$ARGUMENTS </arguments>
+
+- `prod` — set `GLOO_BASE_URL=https://platform.ai.gloo.com`
+- `local` — set `GLOO_BASE_URL=http://localhost:8000`
+- No argument — report the current setting only
+
+## Execution
+
+1. Read `.env.local` in the repo root.
+2. Determine current environment:
+   - `platform.ai.gloo.com` → prod
+   - `localhost` / `127.0.0.1` / missing → local
+3. If no argument was provided, stop after reporting current state.
+4. Update or add `GLOO_BASE_URL`:
+   - `prod`: `GLOO_BASE_URL=https://platform.ai.gloo.com`
+   - `local`: `GLOO_BASE_URL=http://localhost:8000`
+5. Confirm the value by reading `.env.local` again.
+
+## Notes
+
+- Prod performs OAuth2 `client_credentials` against `${GLOO_BASE_URL}/oauth2/token`; `GLOO_CLIENT_ID` and `GLOO_CLIENT_SECRET` must be valid Gloo platform credentials.
+- Local `ai-api` has no OAuth2 endpoint; when `ENVIRONMENT=local`, it accepts any non-empty Bearer token. The pi-mono Gloo helper detects localhost and uses `GLOO_CLIENT_ID` as the bearer.
+- Restart the local `pi` TUI/dev process after switching environments.

--- a/.claude/skills/gloo-local-dev/SKILL.md
+++ b/.claude/skills/gloo-local-dev/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: gloo-local-dev
+description: Orchestrate local Gloo AI development — verify ai-api is running, configure pi-mono, and inspect logs.
+argument-hint: '[--skip-api] [--skip-pi] [--no-logs]'
+---
+
+# Gloo Local Dev Orchestrator
+
+Bring up the local Gloo AI stack: `ai-api` on `localhost:8000` and pi-mono configured to point at it.
+
+## Arguments
+
+<arguments> #$ARGUMENTS </arguments>
+
+- `--skip-api` — skip backend checks
+- `--skip-pi` — skip `.env.local` updates in pi-mono
+- `--no-logs` — skip log inspection
+
+## Phase 1 — Locate ai-api
+
+Read `AI_API_DIR` from `.env.local`:
+
+```bash
+grep '^AI_API_DIR=' .env.local | cut -d= -f2-
+```
+
+If missing, stop and ask the user to add it, e.g.:
+
+```bash
+echo 'AI_API_DIR=/Users/patrick/workspaces/clients/servant-glooai/repos/ai-api' >> .env.local
+```
+
+Verify the repo:
+
+```bash
+ls "$AI_API_DIR/app/main.py"
+```
+
+## Phase 2 — Check backend prerequisites
+
+Skip if `--skip-api`.
+
+```bash
+python3.11 --version
+poetry --version
+ls "$AI_API_DIR/.env"
+docker ps --filter "name=ai-api-postgres" --format "{{.Names}} {{.Status}}"
+docker ps --filter "name=ai-api-redis" --format "{{.Names}} {{.Status}}"
+```
+
+Start Docker services if needed:
+
+```bash
+cd "$AI_API_DIR" && docker compose up -d postgres redis-stack
+```
+
+Run migrations before starting the server:
+
+```bash
+cd "$AI_API_DIR" && poetry run alembic upgrade head
+```
+
+## Phase 3 — Ensure ai-api is running
+
+```bash
+curl -sf -o /dev/null -w "%{http_code}" http://localhost:8000/docs
+```
+
+If not `200`, start it in the background and log to `/tmp/ai-api-dev.log`:
+
+```bash
+cd "$AI_API_DIR" && poetry run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 > /tmp/ai-api-dev.log 2>&1
+```
+
+Wait a few seconds and verify `/docs` again. If it fails, read the last 30 lines of `/tmp/ai-api-dev.log` and report the startup error.
+
+## Phase 4 — Configure pi-mono
+
+Skip if `--skip-pi`.
+
+Update `.env.local` at the pi-mono repo root:
+
+```bash
+GLOO_BASE_URL=http://localhost:8000
+```
+
+Verify `GLOO_CLIENT_ID` and `GLOO_CLIENT_SECRET` are present. Local `ai-api` accepts any non-empty Bearer token when `ENVIRONMENT=local`, and the pi-mono helper skips OAuth2 for localhost.
+
+## Phase 5 — Verify and inspect logs
+
+Run:
+
+```bash
+set -a && source .env.local && set +a
+cd packages/ai && npm run verify:gloo
+```
+
+If `--no-logs` is not set, inspect:
+
+- `/tmp/ai-api-dev.log` — backend startup/request errors
+- `$HOME/.local/share/pi/log/dev.log` or newest `$HOME/.local/share/pi/log/*.log` — TUI/provider errors
+
+## Ready message
+
+Report:
+
+```text
+Local Gloo AI stack is ready:
+  ai-api: http://localhost:8000
+  pi-mono: GLOO_BASE_URL=http://localhost:8000
+
+Run the local TUI:
+  npm run build
+  node packages/coding-agent/dist/cli.js
+```

--- a/.claude/skills/gloo-verify/SKILL.md
+++ b/.claude/skills/gloo-verify/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: gloo-verify
+description: End-to-end smoke verification of pi-mono's Gloo AI provider — creds, static catalog, OAuth2, live streaming, and tool-blocklist checks.
+argument-hint: '[--local]'
+---
+
+# Gloo AI Provider Verifier
+
+Run the Gloo smoke verifier after touching provider code, rebasing, or switching environments.
+
+## Arguments
+
+<arguments> #$ARGUMENTS </arguments>
+
+- `--local` — verify against `http://localhost:8000`; requires local `ai-api` running.
+- No arguments — verify against `https://platform.ai.gloo.com`.
+
+## Execution
+
+From the repo root:
+
+```bash
+set -a && source .env.local && set +a
+cd packages/ai
+npm run verify:gloo
+```
+
+For local mode, first ensure `.env.local` has `GLOO_BASE_URL=http://localhost:8000` (use `/gloo-env local`) and `ai-api` is running, then run the same verifier.
+
+## What it checks
+
+- Provider registration (`gloo` + `gloo-openai-completions`)
+- 22-model Gloo catalog and decommissioned-model exclusions
+- Toolcall blocklist for models the platform rejects with tools
+- Presence of `GLOO_CLIENT_ID` and `GLOO_CLIENT_SECRET`
+- OAuth2 token grant in prod; local auth shortcut for localhost
+- Live streaming for representative Anthropic, OpenAI, DeepSeek, and blocklisted Llama models
+
+## Interpreting failures
+
+| Failure | Likely cause | Next step |
+|---|---|---|
+| Missing creds | `.env.local` absent/not sourced | Source `.env.local` and retry |
+| Token grant 401/403 | Rotated or revoked Gloo credential | Check Gloo Studio API credentials |
+| Local token 404 | Trying OAuth against local `ai-api` | Set `GLOO_BASE_URL=http://localhost:8000` |
+| Catalog mismatch | Model list drift | Update `models.gloo.ts` or verifier expectations |
+| DeepSeek R1 internal error | Known platform regression as of 2026-04-29 | Keep verifier on `gloo-deepseek-v3.2` until recovered |
+| Blocklisted model rejects tools | Wrapper failed to strip tools | Inspect `packages/ai/src/providers/gloo.ts` |
+
+A clean run ends with `11/11 passed`.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Gloo AI OAuth2 client_credentials.
+#
+# Get yours at https://studio.ai.gloo.com/api-credentials, or run
+# ./install.sh which will open the page in your browser and walk you
+# through the auth flow.
+#
+# This file is checked in as a template. The real values live in
+# .env.local (gitignored) for repo-local dev, or in the canonical
+# per-user credentials file at ${XDG_CONFIG_HOME:-~/.config}/gloopi/credentials
+# that the gloopi shim sources at launch.
+
+GLOO_CLIENT_ID=
+GLOO_CLIENT_SECRET=
+
+# Default to production. Override to http://localhost:8000 only when
+# running ai-api locally (paired with the gloo-local-dev skill).
+GLOO_BASE_URL=https://platform.ai.gloo.com

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ packages/*/dist-firefox/
 *.cpuprofile
 
 # Environment
-.env
+.env*
+!.env.example
 
 # Editor files
 .vscode/

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -46,6 +46,10 @@
 			"types": "./dist/providers/openai-responses.d.ts",
 			"import": "./dist/providers/openai-responses.js"
 		},
+		"./gloo": {
+			"types": "./dist/providers/gloo.d.ts",
+			"import": "./dist/providers/gloo.js"
+		},
 		"./oauth": {
 			"types": "./dist/oauth.d.ts",
 			"import": "./dist/oauth.js"
@@ -69,6 +73,7 @@
 		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
 		"dev:tsc": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
 		"test": "vitest --run",
+		"verify:gloo": "npx tsx scripts/verify-gloo.ts",
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {

--- a/packages/ai/scripts/verify-gloo.ts
+++ b/packages/ai/scripts/verify-gloo.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env tsx
+/**
+ * verify-gloo — fast end-to-end smoke test for the Gloo AI provider.
+ *
+ * Wraps the live integration into a single CLI so contributors and CI
+ * agents can prove "Gloo end-to-end is healthy" in ~15 seconds without
+ * spinning up the full pi-coding-agent / pi-mom stack:
+ *
+ *   1. Branch + node version sanity (informational; no failures here).
+ *   2. Credential presence — GLOO_CLIENT_ID + GLOO_CLIENT_SECRET (masked).
+ *   3. Static catalog assertions — model count, toolcall:false flags,
+ *      decommissioned-model absence, registry lookup.
+ *   4. Live OAuth2 client_credentials grant against $GLOO_BASE_URL.
+ *   5. Representative streaming smokes:
+ *        - Sonnet 4.6 (Anthropic, text)
+ *        - GPT-4.1 (OpenAI, text)
+ *        - DeepSeek V3.2 (open-source, text)
+ *      DeepSeek R1 is intentionally skipped — see
+ *      .context/logs/2026-04-29-gloo-deepseek-r1-platform-regression.md.
+ *   6. Toolcall-blocklist enforcement — stream against Llama-4-Maverick
+ *      with tools attached; the wrapper must strip them before sending
+ *      so the platform doesn't HTTP 400 us out.
+ *
+ * Flags:
+ *   --local        require GLOO_BASE_URL to point at localhost; fail loudly
+ *                  if pointing at prod.
+ *   --no-stream    skip the streaming smoke tests (catalog + OAuth only).
+ *
+ * Exit codes:
+ *   0 = all checks passed
+ *   1 = at least one check failed
+ *   2 = environment misconfiguration (handled before any live calls)
+ */
+
+import { GLOO_TOOLCALL_BLOCKLIST } from "../src/providers/gloo.js";
+import { getModel, getModels, getProviders } from "../src/models.js";
+import "../src/providers/register-builtins.js";
+import { streamSimple } from "../src/stream.js";
+import type { Context } from "../src/types.js";
+import { clearGlooTokenCache, getGlooAccessToken } from "../src/utils/oauth/gloo.js";
+
+const ANSI = {
+	reset: "\x1b[0m",
+	bold: "\x1b[1m",
+	dim: "\x1b[2m",
+	red: "\x1b[31m",
+	green: "\x1b[32m",
+	yellow: "\x1b[33m",
+	blue: "\x1b[34m",
+	cyan: "\x1b[36m",
+};
+const isTty = process.stdout.isTTY;
+const c = (color: keyof typeof ANSI, s: string) => (isTty ? `${ANSI[color]}${s}${ANSI.reset}` : s);
+
+interface CheckResult {
+	name: string;
+	ok: boolean;
+	detail?: string;
+	durationMs: number;
+}
+
+const results: CheckResult[] = [];
+
+async function check(name: string, fn: () => Promise<string | void> | string | void): Promise<boolean> {
+	const start = Date.now();
+	try {
+		const detail = await fn();
+		const ok = true;
+		const r: CheckResult = { name, ok, durationMs: Date.now() - start };
+		if (detail) r.detail = detail;
+		results.push(r);
+		console.log(`  ${c("green", "✓")} ${name}${detail ? c("dim", ` — ${detail}`) : ""} ${c("dim", `(${r.durationMs}ms)`)}`);
+		return true;
+	} catch (error) {
+		const r: CheckResult = {
+			name,
+			ok: false,
+			detail: error instanceof Error ? error.message : String(error),
+			durationMs: Date.now() - start,
+		};
+		results.push(r);
+		console.log(
+			`  ${c("red", "✗")} ${name} ${c("dim", `(${r.durationMs}ms)`)}\n      ${c("red", r.detail ?? "(unknown error)")}`,
+		);
+		return false;
+	}
+}
+
+function mask(value: string | undefined, visible = 4): string {
+	if (!value) return c("dim", "(missing)");
+	if (value.length <= visible) return value;
+	return `${value.slice(0, visible)}${c("dim", "…" + value.slice(-2))}`;
+}
+
+function shortPrompt(): Context {
+	return {
+		systemPrompt: "Reply with exactly one short sentence and nothing else.",
+		messages: [
+			{
+				role: "user",
+				content: [{ type: "text", text: "Say hi from Gloo to pi-mono." }],
+				timestamp: Date.now(),
+			},
+		],
+	};
+}
+
+async function smokeModel(modelId: string): Promise<string> {
+	// Models are typed via getModel's overload, but we accept arbitrary ids
+	// here for verification flexibility.
+	const model = getModel("gloo", modelId as never);
+	if (!model) throw new Error(`model not in registry: ${modelId}`);
+	const result = await streamSimple(model, shortPrompt(), { maxTokens: 64 }).result();
+	if (result.stopReason !== "stop") {
+		throw new Error(`stopReason=${result.stopReason} errorMessage=${result.errorMessage ?? "(none)"}`);
+	}
+	const text = result.content
+		.filter((block) => block.type === "text")
+		.map((block) => (block as { text: string }).text)
+		.join("")
+		.trim();
+	return `${result.usage.input}→${result.usage.output} tokens · "${text.slice(0, 40)}${text.length > 40 ? "…" : ""}"`;
+}
+
+async function main(): Promise<number> {
+	const args = new Set(process.argv.slice(2));
+	const wantLocal = args.has("--local");
+	const skipStream = args.has("--no-stream");
+
+	const baseUrl = process.env.GLOO_BASE_URL ?? "https://platform.ai.gloo.com";
+	const isLocal = baseUrl.includes("localhost") || baseUrl.includes("127.0.0.1");
+
+	console.log(c("bold", "verify-gloo") + c("dim", " · pi-mono · " + new Date().toISOString()));
+	console.log(c("dim", "  GLOO_BASE_URL=") + baseUrl + c("dim", isLocal ? " (local)" : " (prod)"));
+	console.log(c("dim", "  GLOO_CLIENT_ID=") + mask(process.env.GLOO_CLIENT_ID, 8));
+	console.log(c("dim", "  GLOO_CLIENT_SECRET=") + mask(process.env.GLOO_CLIENT_SECRET, 4));
+	console.log("");
+
+	if (wantLocal && !isLocal) {
+		console.log(c("red", "✗ --local was passed but GLOO_BASE_URL is not localhost. Aborting."));
+		return 2;
+	}
+	if (!wantLocal && isLocal) {
+		console.log(
+			c(
+				"red",
+				`✗ GLOO_BASE_URL is ${baseUrl} but --local was not passed. ` +
+					"Either start local ai-api and re-run with --local, or unset GLOO_BASE_URL to default to prod.",
+			),
+		);
+		return 2;
+	}
+
+	console.log(c("bold", "Static catalog"));
+	await check("provider 'gloo' is registered", () => {
+		const providers = getProviders();
+		if (!providers.includes("gloo")) throw new Error("not in getProviders()");
+	});
+	await check("catalog has 22 models", () => {
+		const n = getModels("gloo").length;
+		if (n !== 22) throw new Error(`got ${n}`);
+		return `${n} models`;
+	});
+	await check("toolcall blocklist has 3 entries", () => {
+		if (GLOO_TOOLCALL_BLOCKLIST.size !== 3) throw new Error(`got ${GLOO_TOOLCALL_BLOCKLIST.size}`);
+		return Array.from(GLOO_TOOLCALL_BLOCKLIST).join(", ");
+	});
+	await check("decommissioned 'gloo-google-gemini-3-pro-preview' absent", () => {
+		const m = getModel("gloo", "gloo-google-gemini-3-pro-preview" as never);
+		if (m) throw new Error("still in registry");
+	});
+
+	console.log("\n" + c("bold", "Credentials"));
+	const hasCreds = !!process.env.GLOO_CLIENT_ID && !!process.env.GLOO_CLIENT_SECRET;
+	await check("GLOO_CLIENT_ID + GLOO_CLIENT_SECRET set", () => {
+		if (!process.env.GLOO_CLIENT_ID) throw new Error("GLOO_CLIENT_ID missing");
+		if (!process.env.GLOO_CLIENT_SECRET) throw new Error("GLOO_CLIENT_SECRET missing");
+	});
+
+	if (!hasCreds) {
+		console.log("\n" + c("yellow", "Skipping live tier — set GLOO_CLIENT_ID + GLOO_CLIENT_SECRET to run."));
+		return summarize();
+	}
+
+	console.log("\n" + c("bold", "OAuth"));
+	clearGlooTokenCache();
+	await check("OAuth2 client_credentials grant succeeds", async () => {
+		const token = await getGlooAccessToken();
+		if (!token) throw new Error("empty token");
+		return `len=${token.length} prefix=${token.slice(0, 12)}…`;
+	});
+	await check("token is cached after first grant", async () => {
+		const t1 = await getGlooAccessToken();
+		const t2 = await getGlooAccessToken();
+		if (t1 !== t2) throw new Error("cache miss");
+		return "shared instance";
+	});
+
+	if (skipStream) {
+		console.log("\n" + c("yellow", "Skipping streaming smoke tests (--no-stream)."));
+		return summarize();
+	}
+
+	console.log("\n" + c("bold", "Streaming smokes"));
+	await check("gloo-anthropic-claude-sonnet-4.6", () => smokeModel("gloo-anthropic-claude-sonnet-4.6"));
+	await check("gloo-openai-gpt-4.1", () => smokeModel("gloo-openai-gpt-4.1"));
+	await check(
+		"gloo-deepseek-v3.2 (R1 skipped — platform regression 2026-04-29)",
+		() => smokeModel("gloo-deepseek-v3.2"),
+	);
+
+	console.log("\n" + c("bold", "Toolcall blocklist enforcement"));
+	await check("gloo-meta-llama-4-maverick streams when tools present (wrapper strips them)", async () => {
+		const model = getModel("gloo", "gloo-meta-llama-4-maverick");
+		const ctx: Context = {
+			...shortPrompt(),
+			tools: [
+				{
+					name: "noop",
+					description: "Returns nothing.",
+					parameters: { type: "object", properties: {} },
+				},
+			],
+		};
+		const result = await streamSimple(model, ctx, { maxTokens: 64 }).result();
+		if (result.stopReason !== "stop") {
+			throw new Error(`stopReason=${result.stopReason} errorMessage=${result.errorMessage ?? "(none)"}`);
+		}
+		return `${result.usage.input}→${result.usage.output} tokens`;
+	});
+
+	return summarize();
+}
+
+function summarize(): number {
+	const passed = results.filter((r) => r.ok).length;
+	const failed = results.filter((r) => !r.ok).length;
+	const total = results.length;
+	const totalMs = results.reduce((sum, r) => sum + r.durationMs, 0);
+
+	console.log("");
+	console.log(c("bold", "Summary"));
+	console.log(`  ${passed}/${total} passed${failed ? c("red", ` · ${failed} failed`) : ""} ${c("dim", `· ${totalMs}ms`)}`);
+
+	if (failed > 0) {
+		console.log("\n" + c("red", "Failures:"));
+		for (const r of results) {
+			if (r.ok) continue;
+			console.log(`  ${c("red", "✗")} ${r.name}\n      ${r.detail ?? "(no detail)"}`);
+		}
+		return 1;
+	}
+	return 0;
+}
+
+main()
+	.then((code) => process.exit(code))
+	.catch((error) => {
+		console.error(c("red", "fatal: ") + (error instanceof Error ? error.message : String(error)));
+		process.exit(2);
+	});

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -98,6 +98,16 @@ function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
 		return ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"];
 	}
 
+	// Gloo AI uses OAuth2 client_credentials. The actual bearer is minted at
+	// request time by providers/gloo.ts via getGlooAccessToken; this entry
+	// just lets findEnvKeys() report whether the provider is configured.
+	// getEnvApiKey("gloo") deliberately returns the sentinel "<authenticated>"
+	// (handled below) so downstream code that gates on "is the key non-empty"
+	// keeps working — but no caller should treat it as a usable bearer.
+	if (provider === "gloo") {
+		return ["GLOO_CLIENT_ID", "GLOO_CLIENT_SECRET"];
+	}
+
 	const envMap: Record<string, string> = {
 		openai: "OPENAI_API_KEY",
 		"azure-openai-responses": "AZURE_OPENAI_API_KEY",
@@ -139,6 +149,14 @@ export function findEnvKeys(provider: string): string[] | undefined {
 	if (!envVars) return undefined;
 
 	const found = envVars.filter((envVar) => !!process.env[envVar] || !!getProcEnv(envVar));
+
+	// Gloo AI requires *both* env vars to be set (client_id + client_secret).
+	// A half-configured state is worse than unconfigured — it would make the
+	// provider show as available, then fail at first request.
+	if (provider === "gloo" && found.length !== envVars.length) {
+		return undefined;
+	}
+
 	return found.length > 0 ? found : undefined;
 }
 
@@ -150,6 +168,15 @@ export function findEnvKeys(provider: string): string[] | undefined {
 export function getEnvApiKey(provider: KnownProvider): string | undefined;
 export function getEnvApiKey(provider: string): string | undefined;
 export function getEnvApiKey(provider: string): string | undefined {
+	// Gloo AI: bearer is minted at request time by providers/gloo.ts via
+	// OAuth2 client_credentials. Do NOT return the raw client_id here — it
+	// would be sent as `Bearer <client_id>` and rejected. Sentinel matches
+	// the google-vertex/amazon-bedrock pattern for auth-by-other-means.
+	if (provider === "gloo") {
+		const envKeys = findEnvKeys("gloo");
+		return envKeys && envKeys.length === 2 ? "<authenticated>" : undefined;
+	}
+
 	const envKeys = findEnvKeys(provider);
 	if (envKeys?.[0]) {
 		return process.env[envKeys[0]] || getProcEnv(envKeys[0]);

--- a/packages/ai/src/models.gloo.ts
+++ b/packages/ai/src/models.gloo.ts
@@ -1,0 +1,244 @@
+/**
+ * Gloo AI model catalog.
+ *
+ * Lives outside `models.generated.ts` so upstream regenerations
+ * (`npm run generate-models`) don't wipe out the Gloo entries on rebase.
+ * `models.ts` merges this map into the live registry alongside MODELS.
+ *
+ * Catalog is the same set of 23 models seeded by the glooai/opencode fork
+ * (verified 2026-04-27 against `platform.ai.gloo.com/ai/v2/models`).
+ *
+ * Notes:
+ * - `baseUrl` resolves at module load from `GLOO_BASE_URL` so tests and
+ *   `gloo-local-dev` can swap to localhost without editing this file.
+ * - `cost` is zero across the board because Gloo customers are billed via
+ *   their platform contract, not per-token. Pi-ai's calculateCost therefore
+ *   returns zero — that's correct, not a placeholder.
+ * - Pi-ai's `Model` type doesn't have a `toolcall` flag, so the
+ *   "platform rejects tools for this model" list lives next to the wrapper
+ *   in `providers/gloo.ts` (`GLOO_TOOLCALL_BLOCKLIST`).
+ */
+
+import type { Model } from "./types.js";
+
+function glooBaseUrl(): string {
+	return `${(process.env.GLOO_BASE_URL ?? "https://platform.ai.gloo.com").replace(/\/$/, "")}/ai/v2`;
+}
+
+interface GlooModelDef {
+	id: string;
+	name: string;
+	contextWindow: number;
+	maxTokens: number;
+	reasoning: boolean;
+	image: boolean;
+}
+
+const GLOO_MODEL_DEFS: GlooModelDef[] = [
+	// Anthropic
+	{
+		id: "gloo-anthropic-claude-haiku-4.5",
+		name: "Claude Haiku 4.5",
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+		reasoning: false,
+		image: true,
+	},
+	{
+		id: "gloo-anthropic-claude-sonnet-4",
+		name: "Claude Sonnet 4",
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		reasoning: true,
+		image: true,
+	},
+	{
+		id: "gloo-anthropic-claude-sonnet-4.5",
+		name: "Claude Sonnet 4.5",
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		reasoning: true,
+		image: true,
+	},
+	{
+		id: "gloo-anthropic-claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		reasoning: true,
+		image: true,
+	},
+	{
+		id: "gloo-anthropic-claude-opus-4.5",
+		name: "Claude Opus 4.5",
+		contextWindow: 200_000,
+		maxTokens: 32_768,
+		reasoning: true,
+		image: true,
+	},
+	{
+		id: "gloo-anthropic-claude-opus-4.6",
+		name: "Claude Opus 4.6",
+		contextWindow: 200_000,
+		maxTokens: 32_768,
+		reasoning: true,
+		image: true,
+	},
+	// Google
+	{
+		id: "gloo-google-gemini-2.5-flash-lite",
+		name: "Gemini 2.5 Flash Lite",
+		contextWindow: 1_000_000,
+		maxTokens: 8_192,
+		reasoning: false,
+		image: true,
+	},
+	{
+		id: "gloo-google-gemini-2.5-flash",
+		name: "Gemini 2.5 Flash",
+		contextWindow: 1_000_000,
+		maxTokens: 8_192,
+		reasoning: true,
+		image: true,
+	},
+	{
+		id: "gloo-google-gemini-2.5-pro",
+		name: "Gemini 2.5 Pro",
+		contextWindow: 1_000_000,
+		maxTokens: 16_384,
+		reasoning: true,
+		image: true,
+	},
+	// OpenAI
+	{
+		id: "gloo-openai-gpt-5-nano",
+		name: "GPT-5 Nano",
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+		reasoning: false,
+		image: true,
+	},
+	{
+		id: "gloo-openai-gpt-5-mini",
+		name: "GPT-5 Mini",
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+		reasoning: true,
+		image: true,
+	},
+	{
+		id: "gloo-openai-gpt-4.1-mini",
+		name: "GPT-4.1 Mini",
+		contextWindow: 1_000_000,
+		maxTokens: 32_768,
+		reasoning: false,
+		image: true,
+	},
+	{
+		id: "gloo-openai-gpt-4.1",
+		name: "GPT-4.1",
+		contextWindow: 1_000_000,
+		maxTokens: 32_768,
+		reasoning: false,
+		image: true,
+	},
+	{
+		id: "gloo-openai-gpt-5.2",
+		name: "GPT-5.2",
+		contextWindow: 128_000,
+		maxTokens: 32_768,
+		reasoning: true,
+		image: true,
+	},
+	{
+		id: "gloo-openai-gpt-5.4",
+		name: "GPT-5.4",
+		contextWindow: 128_000,
+		maxTokens: 32_768,
+		reasoning: true,
+		image: true,
+	},
+	{
+		id: "gloo-openai-gpt-5.2-pro",
+		name: "GPT-5.2 Pro",
+		contextWindow: 128_000,
+		maxTokens: 32_768,
+		reasoning: true,
+		image: true,
+	},
+	// Open Source — toolcall blocklist enforced in providers/gloo.ts
+	{
+		id: "gloo-meta-llama-3.1-8b-instruct",
+		name: "Llama 3.1 8B Instruct",
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		reasoning: false,
+		image: false,
+	},
+	{
+		id: "gloo-meta-llama-4-maverick",
+		name: "Meta Llama 4 Maverick",
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+		reasoning: true,
+		image: true,
+	},
+	{
+		id: "gloo-deepseek-chat-v3.1",
+		name: "DeepSeek Chat V3.1",
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		reasoning: false,
+		image: false,
+	},
+	{
+		id: "gloo-deepseek-v3.2",
+		name: "DeepSeek V3.2",
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		reasoning: true,
+		image: false,
+	},
+	{
+		id: "gloo-deepseek-r1",
+		name: "DeepSeek R1",
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		reasoning: true,
+		image: false,
+	},
+	{
+		id: "gloo-openai-gpt-oss-120b",
+		name: "GPT OSS 120B",
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+		reasoning: true,
+		image: false,
+	},
+];
+
+function buildGlooModel(def: GlooModelDef): Model<"gloo-openai-completions"> {
+	return {
+		id: def.id,
+		name: def.name,
+		api: "gloo-openai-completions",
+		provider: "gloo",
+		baseUrl: glooBaseUrl(),
+		reasoning: def.reasoning,
+		input: def.image ? ["text", "image"] : ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: def.contextWindow,
+		maxTokens: def.maxTokens,
+	};
+}
+
+const glooEntries: Record<string, Model<"gloo-openai-completions">> = {};
+for (const def of GLOO_MODEL_DEFS) {
+	glooEntries[def.id] = buildGlooModel(def);
+}
+
+export const MODELS_GLOO = {
+	gloo: glooEntries,
+} as const;
+
+export type GlooModelId = (typeof GLOO_MODEL_DEFS)[number]["id"];

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,9 +1,13 @@
 import { MODELS } from "./models.generated.js";
+import { MODELS_GLOO } from "./models.gloo.js";
 import type { Api, KnownProvider, Model, Usage } from "./types.js";
 
 const modelRegistry: Map<string, Map<string, Model<Api>>> = new Map();
 
-// Initialize registry from MODELS on module load
+// Initialize registry from MODELS on module load. MODELS_GLOO merges in
+// after the upstream-generated MODELS so the Gloo entries survive an
+// upstream regeneration (`npm run generate-models`) — the regen rewrites
+// models.generated.ts but never touches models.gloo.ts.
 for (const [provider, models] of Object.entries(MODELS)) {
 	const providerModels = new Map<string, Model<Api>>();
 	for (const [id, model] of Object.entries(models)) {
@@ -11,17 +15,28 @@ for (const [provider, models] of Object.entries(MODELS)) {
 	}
 	modelRegistry.set(provider, providerModels);
 }
+for (const [provider, models] of Object.entries(MODELS_GLOO)) {
+	const providerModels = modelRegistry.get(provider) ?? new Map<string, Model<Api>>();
+	for (const [id, model] of Object.entries(models)) {
+		providerModels.set(id, model as Model<Api>);
+	}
+	modelRegistry.set(provider, providerModels);
+}
+
+// Merged type-level catalog so getModel("gloo", "gloo-...") gets autocomplete
+// from the MODELS_GLOO file just like the auto-generated MODELS entries.
+type AllModels = typeof MODELS & typeof MODELS_GLOO;
 
 type ModelApi<
-	TProvider extends KnownProvider,
-	TModelId extends keyof (typeof MODELS)[TProvider],
-> = (typeof MODELS)[TProvider][TModelId] extends { api: infer TApi } ? (TApi extends Api ? TApi : never) : never;
+	TProvider extends keyof AllModels,
+	TModelId extends keyof AllModels[TProvider],
+> = AllModels[TProvider][TModelId] extends { api: infer TApi } ? (TApi extends Api ? TApi : never) : never;
 
-export function getModel<TProvider extends KnownProvider, TModelId extends keyof (typeof MODELS)[TProvider]>(
+export function getModel<TProvider extends keyof AllModels, TModelId extends keyof AllModels[TProvider]>(
 	provider: TProvider,
 	modelId: TModelId,
 ): Model<ModelApi<TProvider, TModelId>> {
-	const providerModels = modelRegistry.get(provider);
+	const providerModels = modelRegistry.get(provider as string);
 	return providerModels?.get(modelId as string) as Model<ModelApi<TProvider, TModelId>>;
 }
 
@@ -29,11 +44,11 @@ export function getProviders(): KnownProvider[] {
 	return Array.from(modelRegistry.keys()) as KnownProvider[];
 }
 
-export function getModels<TProvider extends KnownProvider>(
+export function getModels<TProvider extends keyof AllModels>(
 	provider: TProvider,
-): Model<ModelApi<TProvider, keyof (typeof MODELS)[TProvider]>>[] {
-	const models = modelRegistry.get(provider);
-	return models ? (Array.from(models.values()) as Model<ModelApi<TProvider, keyof (typeof MODELS)[TProvider]>>[]) : [];
+): Model<ModelApi<TProvider, keyof AllModels[TProvider]>>[] {
+	const models = modelRegistry.get(provider as string);
+	return models ? (Array.from(models.values()) as Model<ModelApi<TProvider, keyof AllModels[TProvider]>>[]) : [];
 }
 
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {

--- a/packages/ai/src/providers/gloo.ts
+++ b/packages/ai/src/providers/gloo.ts
@@ -1,0 +1,179 @@
+/**
+ * Gloo AI provider — OAuth2 client_credentials wrapper around the
+ * OpenAI-compatible chat-completions endpoint at `${GLOO_BASE_URL}/ai/v2`.
+ *
+ * Why a wrapper instead of just a "openai-completions" provider with the
+ * Gloo baseUrl: Gloo bearer tokens are short-lived (1h default) and must
+ * be minted via OAuth2 client_credentials at request time. Pi-ai's
+ * provider registry resolves apiKeys synchronously from `getEnvApiKey()`
+ * before the stream call, so a token-fetching step can't live there.
+ *
+ * This module registers a separate `"gloo-openai-completions"` `Api` tag
+ * so Gloo models route through this wrapper, which:
+ *
+ *   1. Uses `options.apiKey` when auth-storage supplies a persisted OAuth bearer,
+ *      otherwise resolves a fresh bearer via `getGlooAccessToken()` (cached + coalesced).
+ *   2. Strips `context.tools` for models the platform rejects when tools
+ *      are present (HTTP 400 "model does not support function calling"):
+ *      deepseek-r1, llama-4-maverick, llama-3.1-8b-instruct.
+ *   3. Casts the model to `Model<"openai-completions">` and delegates to
+ *      `streamOpenAICompletions` / `streamSimpleOpenAICompletions`.
+ *
+ * `GLOO_BASE_URL` (default `https://platform.ai.gloo.com`) is resolved
+ * from the model's `baseUrl` — set per-model in `models.gloo.ts` so the
+ * same model catalog can target prod, staging, or a local `ai-api`.
+ */
+
+import type {
+	Api,
+	AssistantMessage,
+	AssistantMessageEvent,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	StreamFunction,
+} from "../types.js";
+import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { getGlooAccessToken } from "../utils/oauth/gloo.js";
+import {
+	type OpenAICompletionsOptions,
+	streamOpenAICompletions,
+	streamSimpleOpenAICompletions,
+} from "./openai-completions.js";
+
+export type GlooOptions = OpenAICompletionsOptions;
+
+/**
+ * Models the Gloo platform rejects with HTTP 400
+ * "model does not support function calling" — strip tools before delegating.
+ *
+ * Verified 2026-04-27 against platform.ai.gloo.com via the opencode fork's
+ * gloo-models.test.ts; mirrored here so pi-coding-agent / pi-mom don't
+ * silently fail when an agent loop tries to send tools to one of these.
+ */
+export const GLOO_TOOLCALL_BLOCKLIST: ReadonlySet<string> = new Set([
+	"gloo-deepseek-r1",
+	"gloo-meta-llama-4-maverick",
+	"gloo-meta-llama-3.1-8b-instruct",
+]);
+
+function modelRejectsTools(modelId: string): boolean {
+	return GLOO_TOOLCALL_BLOCKLIST.has(modelId);
+}
+
+function castToOpenAIModel(model: Model<"gloo-openai-completions">): Model<"openai-completions"> {
+	// Same shape, swap the api tag so streamOpenAICompletions doesn't error
+	// on the model.api guard inside api-registry.ts.
+	return { ...model, api: "openai-completions" } as unknown as Model<"openai-completions">;
+}
+
+function stripToolsIfBlocked(model: Model<"gloo-openai-completions">, context: Context): Context {
+	if (!modelRejectsTools(model.id) || !context.tools || context.tools.length === 0) {
+		return context;
+	}
+	return { ...context, tools: undefined };
+}
+
+function forwardStream(target: AssistantMessageEventStream, source: AsyncIterable<AssistantMessageEvent>): void {
+	(async () => {
+		for await (const event of source) {
+			target.push(event);
+		}
+		target.end();
+	})();
+}
+
+function buildErrorMessage<TApi extends Api>(model: Model<TApi>, error: unknown): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "error",
+		errorMessage: error instanceof Error ? error.message : String(error),
+		timestamp: Date.now(),
+	};
+}
+
+export const streamGloo: StreamFunction<"gloo-openai-completions", GlooOptions> = (
+	model: Model<"gloo-openai-completions">,
+	context: Context,
+	options?: GlooOptions,
+): AssistantMessageEventStream => {
+	const outer = new AssistantMessageEventStream();
+
+	(async () => {
+		try {
+			const baseUrl = stripChatCompletionsSuffix(model.baseUrl);
+			const token =
+				options?.apiKey ??
+				(await getGlooAccessToken({
+					baseUrl,
+					signal: options?.signal,
+				}));
+			const inner = streamOpenAICompletions(castToOpenAIModel(model), stripToolsIfBlocked(model, context), {
+				...options,
+				apiKey: token,
+			});
+			forwardStream(outer, inner);
+		} catch (error) {
+			const message = buildErrorMessage(model, error);
+			outer.push({ type: "error", reason: "error", error: message });
+			outer.end(message);
+		}
+	})();
+
+	return outer;
+};
+
+export const streamSimpleGloo: StreamFunction<"gloo-openai-completions", SimpleStreamOptions> = (
+	model: Model<"gloo-openai-completions">,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream => {
+	const outer = new AssistantMessageEventStream();
+
+	(async () => {
+		try {
+			const baseUrl = stripChatCompletionsSuffix(model.baseUrl);
+			const token =
+				options?.apiKey ??
+				(await getGlooAccessToken({
+					baseUrl,
+					signal: options?.signal,
+				}));
+			const inner = streamSimpleOpenAICompletions(castToOpenAIModel(model), stripToolsIfBlocked(model, context), {
+				...options,
+				apiKey: token,
+			});
+			forwardStream(outer, inner);
+		} catch (error) {
+			const message = buildErrorMessage(model, error);
+			outer.push({ type: "error", reason: "error", error: message });
+			outer.end(message);
+		}
+	})();
+
+	return outer;
+};
+
+/**
+ * Model `baseUrl` is the OpenAI-compatible inference endpoint
+ * (`${GLOO_BASE_URL}/ai/v2`). The OAuth2 token endpoint lives at
+ * `${GLOO_BASE_URL}/oauth2/token` — the helper takes the bare base URL,
+ * so we strip the `/ai/v2` suffix here before passing it through.
+ *
+ * Exported for testability.
+ */
+export function stripChatCompletionsSuffix(modelBaseUrl: string): string {
+	return modelBaseUrl.replace(/\/ai\/v2\/?$/, "");
+}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1026,6 +1026,12 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
 	const isCloudflareWorkersAI = provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
 
+	// Gloo AI hosts DeepSeek models behind its own OpenAI-compatible endpoint
+	// (provider="gloo", baseUrl=platform.ai.gloo.com). Treat those as DeepSeek
+	// for streaming-format purposes so reasoning_content deltas and the
+	// deepseek thinkingFormat are activated.
+	const isGlooDeepSeek = provider === "gloo" && model.id.startsWith("gloo-deepseek-");
+
 	const isNonStandard =
 		provider === "cerebras" ||
 		baseUrl.includes("cerebras.ai") ||
@@ -1033,6 +1039,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		baseUrl.includes("api.x.ai") ||
 		baseUrl.includes("chutes.ai") ||
 		baseUrl.includes("deepseek.com") ||
+		isGlooDeepSeek ||
 		isZai ||
 		provider === "opencode" ||
 		baseUrl.includes("opencode.ai") ||
@@ -1042,7 +1049,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
 	const isGroq = provider === "groq" || baseUrl.includes("groq.com");
-	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
+	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com") || isGlooDeepSeek;
 	const cacheControlFormat = provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
 	const reasoningEffortMap = isDeepSeek

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -13,6 +13,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import type { BedrockOptions } from "./amazon-bedrock.js";
 import type { AnthropicOptions } from "./anthropic.js";
 import type { AzureOpenAIResponsesOptions } from "./azure-openai-responses.js";
+import type { GlooOptions } from "./gloo.js";
 import type { GoogleOptions } from "./google.js";
 import type { GoogleGeminiCliOptions } from "./google-gemini-cli.js";
 import type { GoogleVertexOptions } from "./google-vertex.js";
@@ -79,6 +80,11 @@ interface OpenAIResponsesProviderModule {
 	streamSimpleOpenAIResponses: StreamFunction<"openai-responses", SimpleStreamOptions>;
 }
 
+interface GlooProviderModule {
+	streamGloo: StreamFunction<"gloo-openai-completions", GlooOptions>;
+	streamSimpleGloo: StreamFunction<"gloo-openai-completions", SimpleStreamOptions>;
+}
+
 interface BedrockProviderModule {
 	streamBedrock: (
 		model: Model<"bedrock-converse-stream">,
@@ -120,6 +126,9 @@ let openAICompletionsProviderModulePromise:
 	| undefined;
 let openAIResponsesProviderModulePromise:
 	| Promise<LazyProviderModule<"openai-responses", OpenAIResponsesOptions, SimpleStreamOptions>>
+	| undefined;
+let glooProviderModulePromise:
+	| Promise<LazyProviderModule<"gloo-openai-completions", GlooOptions, SimpleStreamOptions>>
 	| undefined;
 let bedrockProviderModuleOverride:
 	| LazyProviderModule<"bedrock-converse-stream", BedrockOptions, SimpleStreamOptions>
@@ -326,6 +335,19 @@ function loadOpenAIResponsesProviderModule(): Promise<
 	return openAIResponsesProviderModulePromise;
 }
 
+function loadGlooProviderModule(): Promise<
+	LazyProviderModule<"gloo-openai-completions", GlooOptions, SimpleStreamOptions>
+> {
+	glooProviderModulePromise ||= import("./gloo.js").then((module) => {
+		const provider = module as GlooProviderModule;
+		return {
+			stream: provider.streamGloo,
+			streamSimple: provider.streamSimpleGloo,
+		};
+	});
+	return glooProviderModulePromise;
+}
+
 function loadBedrockProviderModule(): Promise<
 	LazyProviderModule<"bedrock-converse-stream", BedrockOptions, SimpleStreamOptions>
 > {
@@ -360,6 +382,8 @@ export const streamOpenAICompletions = createLazyStream(loadOpenAICompletionsPro
 export const streamSimpleOpenAICompletions = createLazySimpleStream(loadOpenAICompletionsProviderModule);
 export const streamOpenAIResponses = createLazyStream(loadOpenAIResponsesProviderModule);
 export const streamSimpleOpenAIResponses = createLazySimpleStream(loadOpenAIResponsesProviderModule);
+export const streamGloo = createLazyStream(loadGlooProviderModule);
+export const streamSimpleGloo = createLazySimpleStream(loadGlooProviderModule);
 const streamBedrockLazy = createLazyStream(loadBedrockProviderModule);
 const streamSimpleBedrockLazy = createLazySimpleStream(loadBedrockProviderModule);
 
@@ -422,6 +446,12 @@ export function registerBuiltInApiProviders(): void {
 		api: "bedrock-converse-stream",
 		stream: streamBedrockLazy,
 		streamSimple: streamSimpleBedrockLazy,
+	});
+
+	registerApiProvider({
+		api: "gloo-openai-completions",
+		stream: streamGloo,
+		streamSimple: streamSimpleGloo,
 	});
 }
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -12,7 +12,11 @@ export type KnownApi =
 	| "bedrock-converse-stream"
 	| "google-generative-ai"
 	| "google-gemini-cli"
-	| "google-vertex";
+	| "google-vertex"
+	// Gloo AI — OpenAI-compatible wire format with OAuth2 client_credentials
+	// auth resolved at request time. Routed through a thin wrapper around
+	// the openai-completions stream that injects a fresh bearer token.
+	| "gloo-openai-completions";
 
 export type Api = KnownApi | (string & {});
 
@@ -42,7 +46,8 @@ export type KnownProvider =
 	| "opencode"
 	| "opencode-go"
 	| "kimi-coding"
-	| "cloudflare-workers-ai";
+	| "cloudflare-workers-ai"
+	| "gloo";
 export type Provider = KnownProvider | string;
 
 export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh";

--- a/packages/ai/src/utils/oauth/gloo.ts
+++ b/packages/ai/src/utils/oauth/gloo.ts
@@ -1,0 +1,427 @@
+/**
+ * Gloo AI OAuth2 client_credentials provider.
+ *
+ * Unlike Anthropic / GitHub Copilot / Google Gemini CLI / Antigravity /
+ * OpenAI Codex — which all use browser-launched PKCE flows — Gloo's
+ * `/oauth2/token` endpoint uses the **client_credentials** grant. There's
+ * no browser dance: the user gets a static `(client_id, client_secret)`
+ * pair from `https://studio.ai.gloo.com/api-credentials`, and the bearer
+ * is minted on demand by the API.
+ *
+ * Despite that, the integration into pi-mono's OAuth registry stays
+ * uniform: this module exposes a `glooOAuthProvider` that implements
+ * `OAuthProviderInterface` so it shows up alongside the others in
+ * `/login` ("Gloo AI · unconfigured"), drives credential collection via
+ * the same `OAuthLoginCallbacks.onPrompt` path the manual-code flows
+ * already use, and persists `OAuthCredentials` in the same store. The
+ * difference is that `refresh` here holds the long-lived `client_secret`
+ * (used to mint new bearers) and `access` holds the short-lived bearer.
+ *
+ * Two consumption paths are supported:
+ *   1. Interactive — user runs `/login`, picks "Gloo AI", pastes
+ *      client_id + client_secret, and the registry persists creds.
+ *      pi-coding-agent's auth-storage layer feeds `getApiKey(creds)`
+ *      (the bearer) into model requests as `options.apiKey`.
+ *   2. Headless / CI — `GLOO_CLIENT_ID` + `GLOO_CLIENT_SECRET` are set
+ *      in the environment. `getGlooAccessToken()` mints from env and
+ *      caches; the gloo provider wrapper falls back to this when
+ *      `options.apiKey` is absent.
+ *
+ * Both paths share the percent-encoded Basic auth helper so credentials
+ * with reserved characters (`:`, `+`, `=`, `&`) round-trip cleanly.
+ */
+
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface GlooTokenCache {
+	accessToken: string;
+	expiresAt: number;
+}
+
+export interface GlooTokenOptions {
+	/** Defaults to `process.env.GLOO_CLIENT_ID`. */
+	clientId?: string;
+	/** Defaults to `process.env.GLOO_CLIENT_SECRET`. */
+	clientSecret?: string;
+	/** Defaults to `process.env.GLOO_BASE_URL ?? "https://platform.ai.gloo.com"`. */
+	baseUrl?: string;
+	/** OAuth scope. Defaults to `"api/access"`. */
+	scope?: string;
+	/** Optional AbortSignal for the underlying token fetch. */
+	signal?: AbortSignal;
+}
+
+/**
+ * Persisted credential shape for the Gloo provider.
+ *
+ * `OAuthCredentials` is intentionally permissive — additional fields
+ * are passed through. We document the contract here so future readers
+ * (including a possible upstream PR reviewer) know what to expect.
+ *
+ * - `refresh` — the user-supplied `client_secret`. Long-lived; used to
+ *   mint new bearers via the OAuth2 client_credentials grant.
+ * - `access` — the most recently minted bearer JWT.
+ * - `expires` — bearer expiry (Unix ms), with the same 60s safety
+ *   margin used elsewhere.
+ * - `clientId` — the user-supplied `client_id`. Needed alongside the
+ *   `client_secret` to mint a fresh bearer.
+ * - `baseUrl` — the Gloo platform base URL the client was issued for
+ *   (typically `https://platform.ai.gloo.com`). Stored on creds so a
+ *   user who logged in once against staging doesn't accidentally use
+ *   those creds against prod.
+ * - `label` — optional display label for the single stored credential
+ *   (e.g. `personal`, `servant-internal`). Re-running `/login` replaces
+ *   the previous single-slot credential.
+ */
+export interface GlooOAuthCredentials extends OAuthCredentials {
+	clientId: string;
+	baseUrl: string;
+	label?: string;
+}
+
+// ============================================================================
+// Constants and shared helpers
+// ============================================================================
+
+const DEFAULT_BASE_URL = "https://platform.ai.gloo.com";
+const DEFAULT_SCOPE = "api/access";
+const DEFAULT_TOKEN_TTL_SEC = 3600;
+const EXPIRY_SAFETY_MARGIN_SEC = 60;
+const STUDIO_CREDENTIALS_URL = "https://studio.ai.gloo.com/api-credentials";
+
+function isLocalUrl(url: string): boolean {
+	return url.includes("localhost") || url.includes("127.0.0.1");
+}
+
+function normalizeBaseUrl(url: string): string {
+	return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+function buildBasicAuthHeader(clientId: string, clientSecret: string): string {
+	// Match the verify-gloo and install-flow encoding contract: percent-encode
+	// each field individually, join with `:`, then base64. btoa is available
+	// everywhere; Buffer is preferred in Node/Bun to avoid surrogate issues.
+	const encoded = `${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`;
+	if (typeof Buffer !== "undefined") {
+		return `Basic ${Buffer.from(encoded).toString("base64")}`;
+	}
+	return `Basic ${btoa(encoded)}`;
+}
+
+interface TokenResponse {
+	access_token: string;
+	expires_in?: number;
+	token_type?: string;
+}
+
+interface FetchTokenOpts {
+	baseUrl: string;
+	clientId: string;
+	clientSecret: string;
+	scope: string;
+	signal?: AbortSignal;
+}
+
+/**
+ * Low-level token-grant helper. Returns the cache-shaped tuple used by
+ * both the in-memory cache below and the persisted `OAuthCredentials`
+ * lifecycle.
+ *
+ * Local-mode (`baseUrl` pointing at localhost/127.0.0.1) skips the
+ * `/oauth2/token` exchange entirely — local `ai-api` running with
+ * `ENVIRONMENT=local` accepts any Bearer; we use the `client_id` as
+ * the bearer to keep the rest of the pipeline uniform.
+ */
+async function fetchGlooToken(opts: FetchTokenOpts): Promise<GlooTokenCache> {
+	const { baseUrl, clientId, clientSecret, scope, signal } = opts;
+
+	if (isLocalUrl(baseUrl)) {
+		return {
+			accessToken: clientId,
+			expiresAt: Date.now() + DEFAULT_TOKEN_TTL_SEC * 1000,
+		};
+	}
+
+	const tokenUrl = `${baseUrl}/oauth2/token`;
+	const response = await fetch(tokenUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			Authorization: buildBasicAuthHeader(clientId, clientSecret),
+		},
+		body: new URLSearchParams({
+			grant_type: "client_credentials",
+			scope,
+		}),
+		signal,
+	});
+
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		const idPrefix = `${clientId.slice(0, 8)}…`;
+		throw new Error(
+			`Gloo AI token request failed (${response.status} ${response.statusText}) for client ${idPrefix}: ${text.slice(0, 300)}`,
+		);
+	}
+
+	const data = (await response.json()) as TokenResponse;
+	if (!data.access_token) {
+		throw new Error("Gloo AI token response missing access_token");
+	}
+
+	const expiresInSec = data.expires_in ?? DEFAULT_TOKEN_TTL_SEC;
+	return {
+		accessToken: data.access_token,
+		expiresAt: Date.now() + (expiresInSec - EXPIRY_SAFETY_MARGIN_SEC) * 1000,
+	};
+}
+
+// ============================================================================
+// Headless / env-driven path — used by the gloo provider wrapper as a
+// fallback when `options.apiKey` is not supplied by the auth-storage layer.
+// ============================================================================
+
+// Cache scoped per-(baseUrl, clientId) so multiple Gloo tenants in the
+// same process don't stomp each other's tokens.
+const tokenCache = new Map<string, GlooTokenCache>();
+const pendingRequests = new Map<string, Promise<string>>();
+
+function cacheKey(baseUrl: string, clientId: string): string {
+	return `${baseUrl}::${clientId}`;
+}
+
+/**
+ * Resolve a valid Gloo bearer token from environment variables (or
+ * explicit `options`), refreshing if expired and coalescing concurrent
+ * requests for the same `(baseUrl, clientId)` pair.
+ *
+ * This is the headless code path. The interactive `/login` flow persists
+ * creds and feeds the bearer in via `options.apiKey` directly; this
+ * helper is the fallback for CI / scripted use where env vars are set.
+ *
+ * Throws if credentials are missing or the platform rejects them.
+ */
+export async function getGlooAccessToken(options: GlooTokenOptions = {}): Promise<string> {
+	const clientId = options.clientId ?? process.env.GLOO_CLIENT_ID;
+	const clientSecret = options.clientSecret ?? process.env.GLOO_CLIENT_SECRET;
+	const baseUrl = normalizeBaseUrl(options.baseUrl ?? process.env.GLOO_BASE_URL ?? DEFAULT_BASE_URL);
+	const scope = options.scope ?? DEFAULT_SCOPE;
+
+	if (!clientId) {
+		throw new Error(
+			"Gloo AI is not configured: GLOO_CLIENT_ID is missing. Run /login → Gloo AI to set up credentials.",
+		);
+	}
+	if (!clientSecret && !isLocalUrl(baseUrl)) {
+		throw new Error(
+			"Gloo AI is not configured: GLOO_CLIENT_SECRET is missing. Run /login → Gloo AI to set up credentials.",
+		);
+	}
+
+	const key = cacheKey(baseUrl, clientId);
+	const cached = tokenCache.get(key);
+	if (cached && Date.now() < cached.expiresAt) {
+		return cached.accessToken;
+	}
+
+	const inFlight = pendingRequests.get(key);
+	if (inFlight) {
+		return inFlight;
+	}
+
+	const promise = fetchGlooToken({
+		baseUrl,
+		clientId,
+		clientSecret: clientSecret ?? clientId, // local-mode tolerates either
+		scope,
+		signal: options.signal,
+	})
+		.then((entry) => {
+			tokenCache.set(key, entry);
+			return entry.accessToken;
+		})
+		.finally(() => {
+			pendingRequests.delete(key);
+		});
+
+	pendingRequests.set(key, promise);
+	return promise;
+}
+
+/**
+ * Clear cached Gloo tokens. Useful for tests or after rotating credentials.
+ *
+ * Pass `(baseUrl, clientId)` to clear a single tenant; omit both to clear
+ * everything.
+ */
+export function clearGlooTokenCache(baseUrl?: string, clientId?: string): void {
+	if (!baseUrl || !clientId) {
+		tokenCache.clear();
+		pendingRequests.clear();
+		return;
+	}
+	const key = cacheKey(normalizeBaseUrl(baseUrl), clientId);
+	tokenCache.delete(key);
+	pendingRequests.delete(key);
+}
+
+/**
+ * Inspect the current Gloo token cache. Test/debug helper — do not rely
+ * on this from production code.
+ */
+export function getGlooTokenCache(baseUrl: string, clientId: string): GlooTokenCache | undefined {
+	return tokenCache.get(cacheKey(normalizeBaseUrl(baseUrl), clientId));
+}
+
+// ============================================================================
+// Interactive /login path — implements OAuthProviderInterface
+// ============================================================================
+
+/**
+ * Walk the user through pasting `(client_id, client_secret)`, validate the
+ * pair with a live token grant, and return a fully-populated
+ * `OAuthCredentials` ready for the registry to persist.
+ *
+ * Mirrors the shape of the other login* helpers in this directory so it
+ * can be exported as a sibling — `loginAnthropic`, `loginGitHubCopilot`,
+ * etc. The TUI's `OAuthLoginCallbacks` already drives one-line prompts
+ * (Anthropic uses it for the manual code redirect), so two consecutive
+ * prompts work without any UI changes.
+ */
+export async function loginGloo(callbacks: OAuthLoginCallbacks): Promise<GlooOAuthCredentials> {
+	const baseUrl = normalizeBaseUrl(process.env.GLOO_BASE_URL ?? DEFAULT_BASE_URL);
+
+	callbacks.onAuth({
+		url: STUDIO_CREDENTIALS_URL,
+		instructions:
+			"Sign in to Gloo Studio, create or copy a client credential, and paste the values below. " +
+			"The client_secret is shown only at creation time — copy it before closing the dialog.",
+	});
+
+	const clientId = (await callbacks.onPrompt({ message: "Paste your Gloo client_id:" })).trim();
+	if (!clientId) {
+		throw new Error("Gloo client_id is required");
+	}
+
+	const clientSecret = (await callbacks.onPrompt({ message: "Paste your Gloo client_secret:" })).trim();
+	if (!clientSecret) {
+		throw new Error("Gloo client_secret is required");
+	}
+
+	const label = (
+		await callbacks.onPrompt({
+			message: "Optional label for this Gloo credential (e.g. personal, servant-internal):",
+		})
+	).trim();
+
+	callbacks.onProgress?.(`Validating credentials against ${baseUrl}…`);
+
+	let tokenEntry: GlooTokenCache;
+	try {
+		tokenEntry = await fetchGlooToken({
+			baseUrl,
+			clientId,
+			clientSecret,
+			scope: DEFAULT_SCOPE,
+			signal: callbacks.signal,
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Gloo credentials were rejected by ${baseUrl}. ` +
+				`Double-check the values from ${STUDIO_CREDENTIALS_URL} and try again.\n` +
+				`  Underlying error: ${message}`,
+		);
+	}
+
+	callbacks.onProgress?.("Gloo credentials validated.");
+
+	// Seed the in-memory cache too so the headless path can reuse the
+	// freshly minted bearer if it's invoked in the same process before
+	// expiry (e.g. tests that exercise both paths).
+	tokenCache.set(cacheKey(baseUrl, clientId), tokenEntry);
+
+	return {
+		clientId,
+		baseUrl,
+		...(label ? { label } : {}),
+		refresh: clientSecret,
+		access: tokenEntry.accessToken,
+		expires: tokenEntry.expiresAt,
+	};
+}
+
+/**
+ * Re-mint the bearer using the persisted `client_id` + `client_secret`.
+ *
+ * Called by the registry whenever `Date.now() >= credentials.expires`.
+ * Returns updated credentials (same `client_id` / `client_secret`,
+ * fresh `access` and `expires`).
+ */
+export async function refreshGlooToken(credentials: OAuthCredentials): Promise<GlooOAuthCredentials> {
+	const clientId = readString(credentials, "clientId");
+	const baseUrl = normalizeBaseUrl(readString(credentials, "baseUrl") || DEFAULT_BASE_URL);
+	const clientSecret = credentials.refresh;
+	if (!clientId) {
+		throw new Error("Gloo credentials are corrupted: missing clientId. Re-run /login → Gloo AI.");
+	}
+	if (!clientSecret) {
+		throw new Error("Gloo credentials are corrupted: missing refresh (client_secret). Re-run /login → Gloo AI.");
+	}
+
+	const entry = await fetchGlooToken({
+		baseUrl,
+		clientId,
+		clientSecret,
+		scope: DEFAULT_SCOPE,
+	});
+
+	tokenCache.set(cacheKey(baseUrl, clientId), entry);
+
+	const label = readString(credentials, "label");
+
+	return {
+		clientId,
+		baseUrl,
+		...(label ? { label } : {}),
+		refresh: clientSecret,
+		access: entry.accessToken,
+		expires: entry.expiresAt,
+	};
+}
+
+function readString(credentials: OAuthCredentials, key: string): string {
+	const value = credentials[key];
+	return typeof value === "string" ? value : "";
+}
+
+/**
+ * Pi-mono OAuth provider entry for Gloo AI.
+ *
+ * Registered in `BUILT_IN_OAUTH_PROVIDERS` so it shows up automatically
+ * in `/login` ("Gloo AI · unconfigured") next to the other providers,
+ * with no changes required to the TUI picker.
+ */
+export const glooOAuthProvider: OAuthProviderInterface = {
+	id: "gloo",
+	name: "Gloo AI",
+	// No callback server — Gloo's OAuth2 client_credentials grant doesn't
+	// involve a redirect URI, so manual-code-input UX doesn't apply here.
+	usesCallbackServer: false,
+
+	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+		return loginGloo(callbacks);
+	},
+
+	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+		return refreshGlooToken(credentials);
+	},
+
+	getApiKey(credentials: OAuthCredentials): string {
+		return credentials.access;
+	},
+};

--- a/packages/ai/src/utils/oauth/gloo.ts
+++ b/packages/ai/src/utils/oauth/gloo.ts
@@ -307,7 +307,7 @@ export async function loginGloo(callbacks: OAuthLoginCallbacks): Promise<GlooOAu
 		throw new Error("Gloo client_id is required");
 	}
 
-	const clientSecret = (await callbacks.onPrompt({ message: "Paste your Gloo client_secret:" })).trim();
+	const clientSecret = (await callbacks.onPrompt({ message: "Paste your Gloo client_secret:", secret: true })).trim();
 	if (!clientSecret) {
 		throw new Error("Gloo client_secret is required");
 	}

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -19,6 +19,16 @@ export {
 	normalizeDomain,
 	refreshGitHubCopilotToken,
 } from "./github-copilot.js";
+export type { GlooOAuthCredentials, GlooTokenCache, GlooTokenOptions } from "./gloo.js";
+// Gloo AI (OAuth2 client_credentials — non-interactive, no PKCE)
+export {
+	clearGlooTokenCache,
+	getGlooAccessToken,
+	getGlooTokenCache,
+	glooOAuthProvider,
+	loginGloo,
+	refreshGlooToken,
+} from "./gloo.js";
 // Google Antigravity
 export { antigravityOAuthProvider, loginAntigravity, refreshAntigravityToken } from "./google-antigravity.js";
 // Google Gemini CLI
@@ -34,6 +44,7 @@ export * from "./types.js";
 
 import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
+import { glooOAuthProvider } from "./gloo.js";
 import { antigravityOAuthProvider } from "./google-antigravity.js";
 import { geminiCliOAuthProvider } from "./google-gemini-cli.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
@@ -45,6 +56,7 @@ const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	geminiCliOAuthProvider,
 	antigravityOAuthProvider,
 	openaiCodexOAuthProvider,
+	glooOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -16,6 +16,8 @@ export type OAuthPrompt = {
 	message: string;
 	placeholder?: string;
 	allowEmpty?: boolean;
+	/** Mask user input while typing/pasting sensitive values such as client secrets. */
+	secret?: boolean;
 };
 
 export type OAuthAuthInfo = {

--- a/packages/ai/test/gloo-models.test.ts
+++ b/packages/ai/test/gloo-models.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Gloo AI provider integration tests.
+ *
+ * Two layers:
+ *   1. Catalog/static — runs everywhere. Asserts the 23-model catalog is
+ *      registered, has the expected shape, and that the toolcall blocklist
+ *      contains the three known-bad models.
+ *   2. Live — runs only when GLOO_CLIENT_ID + GLOO_CLIENT_SECRET are set in
+ *      the environment. Mints a real OAuth bearer, streams against three
+ *      representative models (Sonnet 4.6, GPT-4.1, DeepSeek R1), and
+ *      confirms the platform's tool-rejection contract for DeepSeek R1.
+ *
+ * The live tier is gated, never required, and times out at 30s per case so
+ * it can run as part of the regular `npm test` without flaking CI.
+ */
+
+import { describe, expect, it } from "vitest";
+import { findEnvKeys, getEnvApiKey } from "../src/env-api-keys.js";
+import { getModel, getModels, getProviders } from "../src/models.js";
+import { GLOO_TOOLCALL_BLOCKLIST, stripChatCompletionsSuffix } from "../src/providers/gloo.js";
+import { streamSimple } from "../src/stream.js";
+import type { Context } from "../src/types.js";
+
+const HAS_GLOO_CREDS = !!(process.env.GLOO_CLIENT_ID && process.env.GLOO_CLIENT_SECRET);
+
+describe("Gloo AI catalog (static)", () => {
+	it("registers gloo as a provider", () => {
+		expect(getProviders()).toContain("gloo");
+	});
+
+	it("seeds 22 models in the catalog", () => {
+		// 6 Anthropic + 3 Google + 7 OpenAI + 6 open-source = 22.
+		// (gloo-google-gemini-3-pro-preview was dropped 2026-04-27 from upstream.)
+		const models = getModels("gloo");
+		expect(models.length).toBe(22);
+	});
+
+	it("every gloo model is tagged with api='gloo-openai-completions' and provider='gloo'", () => {
+		for (const model of getModels("gloo")) {
+			expect(model.api).toBe("gloo-openai-completions");
+			expect(model.provider).toBe("gloo");
+			expect(model.baseUrl).toMatch(/\/ai\/v2$/);
+		}
+	});
+
+	it("getModel('gloo', 'gloo-anthropic-claude-sonnet-4.6') resolves", () => {
+		const m = getModel("gloo", "gloo-anthropic-claude-sonnet-4.6");
+		expect(m).toBeTruthy();
+		expect(m.id).toBe("gloo-anthropic-claude-sonnet-4.6");
+		expect(m.contextWindow).toBe(200_000);
+		expect(m.reasoning).toBe(true);
+		expect(m.input).toContain("image");
+	});
+
+	it("toolcall blocklist contains the three known-bad models", () => {
+		expect(GLOO_TOOLCALL_BLOCKLIST.has("gloo-deepseek-r1")).toBe(true);
+		expect(GLOO_TOOLCALL_BLOCKLIST.has("gloo-meta-llama-4-maverick")).toBe(true);
+		expect(GLOO_TOOLCALL_BLOCKLIST.has("gloo-meta-llama-3.1-8b-instruct")).toBe(true);
+		// And nothing else — keeps the list tight.
+		expect(GLOO_TOOLCALL_BLOCKLIST.size).toBe(3);
+	});
+
+	it("decommissioned models are absent from the catalog", () => {
+		// gloo-google-gemini-3-pro-preview was removed on 2026-04-27 because
+		// /ai/v2/models started returning "model not supported".
+		const m = getModel("gloo", "gloo-google-gemini-3-pro-preview" as never);
+		expect(m).toBeUndefined();
+	});
+
+	it("stripChatCompletionsSuffix peels '/ai/v2' off the model baseUrl", () => {
+		expect(stripChatCompletionsSuffix("https://platform.ai.gloo.com/ai/v2")).toBe("https://platform.ai.gloo.com");
+		expect(stripChatCompletionsSuffix("https://platform.ai.gloo.com/ai/v2/")).toBe("https://platform.ai.gloo.com");
+		expect(stripChatCompletionsSuffix("http://localhost:8000/ai/v2")).toBe("http://localhost:8000");
+	});
+
+	it("env-api-keys reports gloo configured iff both env vars are set", () => {
+		const original = { id: process.env.GLOO_CLIENT_ID, secret: process.env.GLOO_CLIENT_SECRET };
+		try {
+			process.env.GLOO_CLIENT_ID = "test-id";
+			process.env.GLOO_CLIENT_SECRET = "test-secret";
+			expect(findEnvKeys("gloo")).toEqual(["GLOO_CLIENT_ID", "GLOO_CLIENT_SECRET"]);
+			expect(getEnvApiKey("gloo")).toBe("<authenticated>");
+
+			delete process.env.GLOO_CLIENT_SECRET;
+			expect(findEnvKeys("gloo")).toBeUndefined();
+			expect(getEnvApiKey("gloo")).toBeUndefined();
+		} finally {
+			if (original.id !== undefined) process.env.GLOO_CLIENT_ID = original.id;
+			else delete process.env.GLOO_CLIENT_ID;
+			if (original.secret !== undefined) process.env.GLOO_CLIENT_SECRET = original.secret;
+			else delete process.env.GLOO_CLIENT_SECRET;
+		}
+	});
+});
+
+describe.skipIf(!HAS_GLOO_CREDS)("Gloo AI live smoke (requires GLOO_CLIENT_ID + GLOO_CLIENT_SECRET)", () => {
+	function shortPrompt(): Context {
+		return {
+			systemPrompt: "Reply with exactly one short sentence and nothing else.",
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "text", text: "Say hi from Gloo to pi-mono." }],
+					timestamp: Date.now(),
+				},
+			],
+		};
+	}
+
+	it("streams gloo-anthropic-claude-sonnet-4.6 to a finished response", { timeout: 30000, retry: 1 }, async () => {
+		const model = getModel("gloo", "gloo-anthropic-claude-sonnet-4.6");
+		const result = await streamSimple(model, shortPrompt(), { maxTokens: 64 }).result();
+		expect(result.stopReason, result.errorMessage).toBe("stop");
+		expect(result.errorMessage).toBeFalsy();
+		const text = result.content
+			.filter((block) => block.type === "text")
+			.map((block) => (block as { text: string }).text)
+			.join("");
+		expect(text.length).toBeGreaterThan(0);
+	});
+
+	it("streams gloo-openai-gpt-4.1 to a finished response", { timeout: 30000, retry: 1 }, async () => {
+		const model = getModel("gloo", "gloo-openai-gpt-4.1");
+		const result = await streamSimple(model, shortPrompt(), { maxTokens: 64 }).result();
+		expect(result.stopReason, result.errorMessage).toBe("stop");
+		expect(result.errorMessage).toBeFalsy();
+	});
+
+	it(
+		"streams gloo-deepseek-v3.2 (open-source representative) to a finished response",
+		{ timeout: 30000, retry: 1 },
+		async () => {
+			// We pick V3.2 (not R1) as the open-source live smoke because as of
+			// 2026-04-29 the Gloo platform returns
+			//   { code: 3001, type: "internal_error", message: "Streaming error occurred", fault: "internal" }
+			// for `gloo-deepseek-r1` while V3.2 and Chat V3.1 both stream cleanly.
+			// Trace logged via x-sentry-trace-id; see
+			// .context/logs/2026-04-29-gloo-deepseek-r1-platform-regression.md.
+			const model = getModel("gloo", "gloo-deepseek-v3.2");
+			const result = await streamSimple(model, shortPrompt(), { maxTokens: 128 }).result();
+			expect(result.stopReason, result.errorMessage).toBe("stop");
+			expect(result.errorMessage).toBeFalsy();
+		},
+	);
+
+	it(
+		"strips tools for blocklisted models — vanilla request to gloo-meta-llama-4-maverick succeeds with tools client-side-removed",
+		{ timeout: 30000, retry: 1 },
+		async () => {
+			const model = getModel("gloo", "gloo-meta-llama-4-maverick");
+			const ctx: Context = {
+				...shortPrompt(),
+				tools: [
+					{
+						name: "noop",
+						description: "Returns nothing.",
+						parameters: { type: "object", properties: {} },
+					},
+				],
+			};
+			const result = await streamSimple(model, ctx, { maxTokens: 128 }).result();
+			// Wrapper drops tools client-side, so the platform never sees them
+			// and the request succeeds instead of hitting HTTP 400
+			// "model does not support function calling".
+			expect(result.stopReason, result.errorMessage).toBe("stop");
+			expect(result.errorMessage).toBeFalsy();
+		},
+	);
+});

--- a/packages/ai/test/gloo-oauth.test.ts
+++ b/packages/ai/test/gloo-oauth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearGlooTokenCache, loginGloo, refreshGlooToken } from "../src/utils/oauth/gloo.js";
+import type { OAuthPrompt } from "../src/utils/oauth/types.js";
 
 function jsonResponse(body: unknown, status: number = 200): Response {
 	return new Response(JSON.stringify(body), {
@@ -55,16 +56,21 @@ describe.sequential("Gloo OAuth", () => {
 		vi.stubGlobal("fetch", fetchMock);
 
 		const prompts = ["client-id", "client-secret", "servant-internal"];
+		const promptMetadata: OAuthPrompt[] = [];
 		const authUrls: string[] = [];
 		const progress: string[] = [];
 
 		const credentials = await loginGloo({
 			onAuth: (info) => authUrls.push(info.url),
-			onPrompt: async () => prompts.shift() ?? "",
+			onPrompt: async (prompt) => {
+				promptMetadata.push(prompt);
+				return prompts.shift() ?? "";
+			},
 			onProgress: (message) => progress.push(message),
 		});
 
 		expect(authUrls).toEqual(["https://studio.ai.gloo.com/api-credentials"]);
+		expect(promptMetadata.map((prompt) => prompt.secret ?? false)).toEqual([false, true, false]);
 		expect(progress.at(-1)).toBe("Gloo credentials validated.");
 		expect(credentials).toMatchObject({
 			clientId: "client-id",

--- a/packages/ai/test/gloo-oauth.test.ts
+++ b/packages/ai/test/gloo-oauth.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearGlooTokenCache, loginGloo, refreshGlooToken } from "../src/utils/oauth/gloo.js";
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+}
+
+function getUrl(input: unknown): string {
+	if (typeof input === "string") {
+		return input;
+	}
+	if (input instanceof URL) {
+		return input.toString();
+	}
+	if (input instanceof Request) {
+		return input.url;
+	}
+	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+function getFormBody(init?: RequestInit): URLSearchParams {
+	if (!(init?.body instanceof URLSearchParams)) {
+		throw new Error(`Expected URLSearchParams request body, got ${typeof init?.body}`);
+	}
+	return init.body;
+}
+
+describe.sequential("Gloo OAuth", () => {
+	afterEach(() => {
+		clearGlooTokenCache();
+		vi.unstubAllGlobals();
+	});
+
+	it("prompts for client credentials and optional label, validates them, and returns persisted credentials", async () => {
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			expect(getUrl(input)).toBe("https://platform.ai.gloo.com/oauth2/token");
+			expect(init?.method).toBe("POST");
+			expect(init?.headers).toMatchObject({
+				"Content-Type": "application/x-www-form-urlencoded",
+			});
+			expect(String((init?.headers as Record<string, string>).Authorization)).toMatch(/^Basic /);
+			const body = getFormBody(init);
+			expect(body.get("grant_type")).toBe("client_credentials");
+			expect(body.get("scope")).toBe("api/access");
+			return jsonResponse({
+				access_token: "access-token",
+				expires_in: 3600,
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const prompts = ["client-id", "client-secret", "servant-internal"];
+		const authUrls: string[] = [];
+		const progress: string[] = [];
+
+		const credentials = await loginGloo({
+			onAuth: (info) => authUrls.push(info.url),
+			onPrompt: async () => prompts.shift() ?? "",
+			onProgress: (message) => progress.push(message),
+		});
+
+		expect(authUrls).toEqual(["https://studio.ai.gloo.com/api-credentials"]);
+		expect(progress.at(-1)).toBe("Gloo credentials validated.");
+		expect(credentials).toMatchObject({
+			clientId: "client-id",
+			baseUrl: "https://platform.ai.gloo.com",
+			label: "servant-internal",
+			refresh: "client-secret",
+			access: "access-token",
+		});
+		expect(credentials.expires).toBeGreaterThan(Date.now());
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("refreshes persisted credentials without dropping the label", async () => {
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			expect(getUrl(input)).toBe("https://platform.ai.gloo.com/oauth2/token");
+			expect(init?.method).toBe("POST");
+			const body = getFormBody(init);
+			expect(body.get("grant_type")).toBe("client_credentials");
+			expect(body.get("scope")).toBe("api/access");
+			return jsonResponse({
+				access_token: "new-access-token",
+				expires_in: 1800,
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await refreshGlooToken({
+			clientId: "client-id",
+			baseUrl: "https://platform.ai.gloo.com",
+			label: "servant-internal",
+			refresh: "client-secret",
+			access: "old-access-token",
+			expires: Date.now() - 1,
+		});
+
+		expect(credentials).toMatchObject({
+			clientId: "client-id",
+			baseUrl: "https://platform.ai.gloo.com",
+			label: "servant-internal",
+			refresh: "client-secret",
+			access: "new-access-token",
+		});
+		expect(credentials.expires).toBeGreaterThan(Date.now());
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -38,6 +38,9 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"opencode-go": "kimi-k2.6",
 	"kimi-coding": "kimi-for-coding",
 	"cloudflare-workers-ai": "@cf/moonshotai/kimi-k2.6",
+	// Gloo AI defaults to Sonnet 4.6 — Anthropic-quality reasoning, fast,
+	// and on the Bedrock-direct tier so latency is competitive.
+	gloo: "gloo-anthropic-claude-sonnet-4.6",
 };
 
 export interface ScopedModel {

--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -50,18 +50,10 @@ export class LoginDialogComponent extends Container implements Focusable {
 		this.contentContainer = new Container();
 		this.addChild(this.contentContainer);
 
-		// Input (always present, used when needed)
-		this.input = new Input();
-		this.input.onSubmit = () => {
-			if (this.inputResolver) {
-				this.inputResolver(this.input.getValue());
-				this.inputResolver = undefined;
-				this.inputRejecter = undefined;
-			}
-		};
-		this.input.onEscape = () => {
-			this.cancel();
-		};
+		// Current prompt input. Each prompt gets a fresh Input instance so
+		// previously submitted fields remain visually stable and don't mirror
+		// the active field's value.
+		this.input = this.createInput();
 
 		// Bottom border
 		this.addChild(new DynamicBorder());
@@ -79,6 +71,28 @@ export class LoginDialogComponent extends Container implements Focusable {
 			this.inputRejecter = undefined;
 		}
 		this.onComplete(false, "Login cancelled");
+	}
+
+	private createInput(masked: boolean = false): Input {
+		const input = new Input();
+		input.masked = masked;
+		input.focused = this._focused;
+		input.onSubmit = () => {
+			if (this.inputResolver) {
+				this.inputResolver(input.getValue());
+				this.inputResolver = undefined;
+				this.inputRejecter = undefined;
+			}
+		};
+		input.onEscape = () => {
+			this.cancel();
+		};
+		return input;
+	}
+
+	private replaceInput(masked: boolean = false): void {
+		this.input.focused = false;
+		this.input = this.createInput(masked);
 	}
 
 	/**
@@ -109,6 +123,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	 * Show input for manual code/URL entry (for callback server providers)
 	 */
 	showManualInput(prompt: string): Promise<string> {
+		this.replaceInput(false);
 		this.contentContainer.addChild(new Spacer(1));
 		this.contentContainer.addChild(new Text(theme.fg("dim", prompt), 1, 0));
 		this.contentContainer.addChild(this.input);
@@ -125,7 +140,8 @@ export class LoginDialogComponent extends Container implements Focusable {
 	 * Called by onPrompt callback - show prompt and wait for input
 	 * Note: Does NOT clear content, appends to existing (preserves URL from showAuth)
 	 */
-	showPrompt(message: string, placeholder?: string): Promise<string> {
+	showPrompt(message: string, placeholder?: string, secret: boolean = false): Promise<string> {
+		this.replaceInput(secret);
 		this.contentContainer.addChild(new Spacer(1));
 		this.contentContainer.addChild(new Text(theme.fg("text", message), 1, 0));
 		if (placeholder) {
@@ -140,7 +156,6 @@ export class LoginDialogComponent extends Container implements Focusable {
 			),
 		);
 
-		this.input.setValue("");
 		this.tui.requestRender();
 
 		return new Promise((resolve, reject) => {

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -17,6 +17,12 @@ export type AuthSelectorProvider = {
 	authType: "oauth" | "api_key";
 };
 
+function getCredentialDisplayLabel(credential: unknown): string | undefined {
+	if (typeof credential !== "object" || credential === null || !("label" in credential)) return undefined;
+	const label = credential.label;
+	return typeof label === "string" && label.trim() ? label.trim() : undefined;
+}
+
 /**
  * Component that renders an auth provider selector
  */
@@ -150,7 +156,10 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 
 	private formatStatusIndicator(provider: AuthSelectorProvider): string {
 		const credential = this.authStorage.get(provider.id);
-		if (credential?.type === provider.authType) return theme.fg("success", " ✓ configured");
+		if (credential?.type === provider.authType) {
+			const label = getCredentialDisplayLabel(credential);
+			return theme.fg("success", label ? ` ✓ ${label} configured` : " ✓ configured");
+		}
 		if (credential) {
 			const label = credential.type === "oauth" ? "subscription configured" : "API key configured";
 			return theme.fg("muted", " • ") + theme.fg("warning", label);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4706,8 +4706,8 @@ export class InteractiveMode {
 					// For Anthropic: onPrompt is called immediately after
 				},
 
-				onPrompt: async (prompt: { message: string; placeholder?: string }) => {
-					return dialog.showPrompt(prompt.message, prompt.placeholder);
+				onPrompt: async (prompt: { message: string; placeholder?: string; secret?: boolean }) => {
+					return dialog.showPrompt(prompt.message, prompt.placeholder, prompt.secret);
 				},
 
 				onProgress: (message: string) => {

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -62,6 +62,32 @@ describe("OAuthSelectorComponent", () => {
 		expect(output).toContain("subscription configured");
 	});
 
+	it("shows a stored OAuth credential label when present", () => {
+		const authStorage = AuthStorage.inMemory({
+			gloo: {
+				type: "oauth",
+				access: "access-token",
+				refresh: "client-secret",
+				expires: Date.now() + 60_000,
+				clientId: "client-id",
+				baseUrl: "https://platform.ai.gloo.com",
+				label: "servant-internal",
+			},
+		});
+		const selector = new OAuthSelectorComponent(
+			"login",
+			authStorage,
+			[{ id: "gloo", name: "Gloo AI", authType: "oauth" }],
+			() => {},
+			() => {},
+		);
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+
+		expect(output).toContain("Gloo AI");
+		expect(output).toContain("servant-internal configured");
+	});
+
 	it("shows environment API key auth as configured", () => {
 		process.env.OPENAI_API_KEY = "test-openai-key";
 		const authStorage = AuthStorage.inMemory();

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -20,6 +20,7 @@ export class Input implements Component, Focusable {
 	private cursor: number = 0; // Cursor position in the value
 	public onSubmit?: (value: string) => void;
 	public onEscape?: () => void;
+	public masked: boolean = false;
 
 	/** Focusable interface - set by TUI when focus changes */
 	focused: boolean = false;
@@ -442,16 +443,17 @@ export class Input implements Component, Focusable {
 
 		let visibleText = "";
 		let cursorDisplay = this.cursor;
-		const totalWidth = visibleWidth(this.value);
+		const displayValue = this.masked ? "•".repeat([...segmenter.segment(this.value)].length) : this.value;
+		const totalWidth = visibleWidth(displayValue);
 
 		if (totalWidth < availableWidth) {
 			// Everything fits (leave room for cursor at end)
-			visibleText = this.value;
+			visibleText = displayValue;
 		} else {
 			// Need horizontal scrolling
 			// Reserve one column for cursor if it's at the end
 			const scrollWidth = this.cursor === this.value.length ? availableWidth - 1 : availableWidth;
-			const cursorCol = visibleWidth(this.value.slice(0, this.cursor));
+			const cursorCol = visibleWidth(displayValue.slice(0, this.cursor));
 
 			if (scrollWidth > 0) {
 				const halfWidth = Math.floor(scrollWidth / 2);
@@ -468,8 +470,8 @@ export class Input implements Component, Focusable {
 					startCol = Math.max(0, cursorCol - halfWidth);
 				}
 
-				visibleText = sliceByColumn(this.value, startCol, scrollWidth, true);
-				const beforeCursor = sliceByColumn(this.value, startCol, Math.max(0, cursorCol - startCol), true);
+				visibleText = sliceByColumn(displayValue, startCol, scrollWidth, true);
+				const beforeCursor = sliceByColumn(displayValue, startCol, Math.max(0, cursorCol - startCol), true);
 				cursorDisplay = beforeCursor.length;
 			} else {
 				visibleText = "";

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -35,6 +35,25 @@ describe("Input component", () => {
 	});
 
 	describe("render", () => {
+		it("masks rendered value without changing submitted value", () => {
+			const input = new Input();
+			let submitted: string | undefined;
+			input.masked = true;
+			input.focused = true;
+			input.onSubmit = (value) => {
+				submitted = value;
+			};
+
+			input.setValue("super-secret");
+			const [line] = input.render(80);
+			input.handleInput("\r");
+
+			assert.ok(line);
+			assert.strictEqual(line.match(/•/g)?.length, "super-secret".length);
+			assert.doesNotMatch(line, /super-secret/);
+			assert.strictEqual(submitted, "super-secret");
+		});
+
 		it("does not overflow with wide CJK and fullwidth text", () => {
 			const width = 93;
 			const cases = [


### PR DESCRIPTION
## Summary

This PR adds Gloo AI as a first-class provider in Pi so Pi can run coding-agent sessions through the Gloo AI inference platform.

It includes:

- a Gloo AI provider backed by OAuth2 `client_credentials`
- a 22-model Gloo catalog kept outside the generated upstream model list
- OpenAI-compatible streaming support via the existing completions provider
- DeepSeek compatibility handling for Gloo-hosted DeepSeek models
- client-side tool stripping for Gloo models that currently reject tool calls
- `/login` integration so users can paste Gloo `client_id` / `client_secret` credentials and persist them in Pi auth storage
- secret masking for the Gloo `client_secret` prompt in the TUI
- a `verify:gloo` smoke-test script and targeted tests
- Gloo-oriented Claude Code skills for local/prod env toggling, verification, local dev, and log inspection

## Why

Gloo AI exposes an OpenAI-compatible chat-completions API at `https://platform.ai.gloo.com/ai/v2`, but access is granted through short-lived OAuth2 bearer tokens minted from Gloo Studio client credentials. Pi's existing provider model assumes a synchronous API key, so this PR adds a thin Gloo-specific wrapper that mints or refreshes the bearer before delegating to the existing OpenAI-compatible streaming implementation.

This lets Pi users select Gloo-hosted models directly and use Pi as a coding agent against Gloo AI.

## Implementation Notes

- Adds a new API tag: `gloo-openai-completions`.
- Adds `models.gloo.ts` instead of editing generated model output, so `generate-models` can still run safely.
- `providers/gloo.ts` prefers an `options.apiKey` bearer from auth storage, then falls back to env-driven token minting via `GLOO_CLIENT_ID` / `GLOO_CLIENT_SECRET`.
- Gloo `/login` uses the existing OAuth provider registry, but the flow is client-credentials based rather than PKCE/browser-callback based.
- The Gloo `client_secret` prompt is marked secret and masked in the TUI input component.
- Tool calls are stripped for models currently known to reject function calling: DeepSeek R1, Llama 4 Maverick, and Llama 3.1 8B Instruct.
- Gloo-hosted DeepSeek models use the same reasoning-content compatibility path as native DeepSeek.

## Verification

Validated in the `glooai/pi-mono` fork before opening this upstream PR:

- [x] `npm run build`
- [x] `npm run check`
- [x] `cd packages/ai && npm run verify:gloo` — 11/11 live checks passed
- [x] `cd packages/ai && npx vitest --run test/gloo-models.test.ts` — 12/12 live checks passed with Gloo credentials
- [x] `cd packages/ai && npx vitest --run test/gloo-oauth.test.ts test/gloo-models.test.ts`
- [x] `cd packages/coding-agent && npx vitest --run test/oauth-selector.test.ts`
- [x] `cd packages/tui && node --test --import tsx test/input.test.ts`
- [x] Manual `/login → Gloo AI` smoke test: client ID remains visible, client secret is masked, fields do not mirror, credentials validate successfully

## Notes

- `gloo-deepseek-r1` currently returns a platform-side SSE `internal_error`, so live smoke coverage uses `gloo-deepseek-v3.2` as the DeepSeek representative until the platform regression is resolved.
- Full `packages/ai npm test` includes unrelated OpenAI Codex live tests that may fail when the configured ChatGPT account does not support `gpt-5.2-codex`; targeted Gloo and TUI tests pass.
