### PR TITLE
fix(coding-agent): handle duplicate session entries

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -673,6 +673,7 @@ export class SessionManager {
 	private cwd: string;
 	private persist: boolean;
 	private flushed: boolean = false;
+	private persistedEntryCount: number = 0;
 	private fileEntries: FileEntry[] = [];
 	private byId: Map<string, SessionEntry> = new Map();
 	private labelsById: Map<string, string> = new Map();
@@ -720,6 +721,7 @@ export class SessionManager {
 
 			this._buildIndex();
 			this.flushed = true;
+			this.persistedEntryCount = this.fileEntries.length;
 		} else {
 			const explicitPath = this.sessionFile;
 			this.newSession();
@@ -743,6 +745,7 @@ export class SessionManager {
 		this.labelsById.clear();
 		this.leafId = null;
 		this.flushed = false;
+		this.persistedEntryCount = 0;
 
 		if (this.persist) {
 			const fileTimestamp = timestamp.replace(/[:.]/g, "-");
@@ -776,6 +779,8 @@ export class SessionManager {
 		if (!this.persist || !this.sessionFile) return;
 		const content = `${this.fileEntries.map((e) => JSON.stringify(e)).join("\n")}\n`;
 		writeFileSync(this.sessionFile, content);
+		this.flushed = true;
+		this.persistedEntryCount = this.fileEntries.length;
 	}
 
 	isPersisted(): boolean {
@@ -802,20 +807,20 @@ export class SessionManager {
 		if (!this.persist || !this.sessionFile) return;
 
 		const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
-		if (!hasAssistant) {
-			// Mark as not flushed so when assistant arrives, all entries get written
-			this.flushed = false;
+		if (!hasAssistant && !this.flushed) {
+			// Defer brand-new sessions until the first assistant response.
 			return;
 		}
 
 		if (!this.flushed) {
-			for (const e of this.fileEntries) {
+			for (const e of this.fileEntries.slice(this.persistedEntryCount)) {
 				appendFileSync(this.sessionFile, `${JSON.stringify(e)}\n`);
 			}
 			this.flushed = true;
 		} else {
 			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
 		}
+		this.persistedEntryCount = this.fileEntries.length;
 	}
 
 	private _appendEntry(entry: SessionEntry): void {
@@ -1074,18 +1079,23 @@ export class SessionManager {
 	 */
 	getTree(): SessionTreeNode[] {
 		const entries = this.getEntries();
+		const uniqueEntries: SessionEntry[] = [];
 		const nodeMap = new Map<string, SessionTreeNode>();
 		const roots: SessionTreeNode[] = [];
 
-		// Create nodes with resolved labels
+		// Create nodes with resolved labels. Duplicate ids can appear in files
+		// written by older persistence paths; keep the first entry so one corrupt
+		// id cannot make tree rendering revisit the same node repeatedly.
 		for (const entry of entries) {
+			if (nodeMap.has(entry.id)) continue;
+			uniqueEntries.push(entry);
 			const label = this.labelsById.get(entry.id);
 			const labelTimestamp = this.labelTimestampsById.get(entry.id);
 			nodeMap.set(entry.id, { entry, children: [], label, labelTimestamp });
 		}
 
 		// Build tree
-		for (const entry of entries) {
+		for (const entry of uniqueEntries) {
 			const node = nodeMap.get(entry.id)!;
 			if (entry.parentId === null || entry.parentId === entry.id) {
 				roots.push(node);
@@ -1226,15 +1236,13 @@ export class SessionManager {
 
 			// Only write the file now if it contains an assistant message.
 			// Otherwise defer to _persist(), which creates the file on the
-			// first assistant response, matching the newSession() contract
-			// and avoiding the duplicate-header bug when _persist()'s
-			// no-assistant guard later resets flushed to false.
+			// first assistant response, matching the newSession() contract.
 			const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
 			if (hasAssistant) {
 				this._rewriteFile();
-				this.flushed = true;
 			} else {
 				this.flushed = false;
+				this.persistedEntryCount = 0;
 			}
 
 			return newSessionFile;

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -580,6 +580,54 @@ describe("createBranchedSession", () => {
 		}
 	});
 
+	it("does not duplicate migrated pre-assistant entries when the first assistant is appended", () => {
+		const tempDir = join(tmpdir(), `session-migrated-before-assistant-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+		const file = join(tempDir, "legacy-session.jsonl");
+
+		try {
+			writeFileSync(
+				file,
+				`${[
+					JSON.stringify({
+						type: "session",
+						id: "legacy-session",
+						timestamp: new Date().toISOString(),
+						cwd: tempDir,
+					}),
+					JSON.stringify({
+						type: "message",
+						timestamp: new Date().toISOString(),
+						message: userMsg("legacy user message"),
+					}),
+				].join("\n")}\n`,
+			);
+
+			const migrated = SessionManager.open(file, tempDir);
+			const migratedRecords = parseSessionFile(file);
+			const migratedEntryIds = migratedRecords
+				.filter((record) => record.type !== "session")
+				.map((record) => record.id)
+				.filter((id): id is string => typeof id === "string");
+			expect(migratedEntryIds).toHaveLength(1);
+
+			migrated.appendModelChange("anthropic", "claude-sonnet-4");
+			migrated.appendMessage(userMsg("new user message"));
+			migrated.appendMessage(assistantMsg("new assistant message"));
+
+			const records = parseSessionFile(file);
+			expect(records.filter((record) => record.type === "session")).toHaveLength(1);
+
+			const entryIds = records
+				.filter((record) => record.type !== "session")
+				.map((record) => record.id)
+				.filter((id): id is string => typeof id === "string");
+			expect(new Set(entryIds).size).toBe(entryIds.length);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("writes file immediately when forking from a point with assistant messages", () => {
 		const tempDir = join(tmpdir(), `session-fork-with-assistant-${Date.now()}`);
 		mkdirSync(tempDir, { recursive: true });

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -1,9 +1,27 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { describe, expect, it } from "vitest";
 import { type CustomEntry, SessionManager } from "../../src/core/session-manager.js";
 import { assistantMsg, userMsg } from "../utilities.js";
+
+function writeSessionSnapshot(session: SessionManager): string {
+	const sessionFile = session.getSessionFile();
+	const header = session.getHeader();
+	if (!sessionFile || !header) throw new Error("expected persisted session with header");
+
+	const content = [header, ...session.getEntries()].map((entry) => JSON.stringify(entry)).join("\n");
+	writeFileSync(sessionFile, `${content}\n`, "utf8");
+	return sessionFile;
+}
+
+function parseSessionFile(file: string): any[] {
+	return readFileSync(file, "utf-8")
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
+}
 
 describe("SessionManager append and tree traversal", () => {
 	describe("append operations", () => {
@@ -273,6 +291,35 @@ describe("SessionManager append and tree traversal", () => {
 			const node3 = node2.children.find((c) => c.entry.id === id3)!;
 			expect(node3.children).toHaveLength(1); // id4
 		});
+
+		it("returns each entry id once when a session file contains duplicate entries", () => {
+			const tempDir = join(tmpdir(), `session-tree-duplicate-ids-${Date.now()}`);
+			mkdirSync(tempDir, { recursive: true });
+
+			try {
+				const session = SessionManager.create(tempDir, tempDir);
+				const rootId = session.appendMessage(userMsg("root"));
+				const childId = session.appendMessage(assistantMsg("child"));
+				const leafId = session.appendMessage(userMsg("leaf"));
+				const file = writeSessionSnapshot(session);
+
+				const [header, root, child, leaf] = parseSessionFile(file);
+				const duplicatedRecords = [header, root, child, root, child, leaf];
+				writeFileSync(file, `${duplicatedRecords.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+
+				const reopened = SessionManager.open(file, tempDir);
+				const tree = reopened.getTree();
+
+				expect(tree).toHaveLength(1);
+				expect(tree[0].entry.id).toBe(rootId);
+				expect(tree[0].children).toHaveLength(1);
+				expect(tree[0].children[0].entry.id).toBe(childId);
+				expect(tree[0].children[0].children).toHaveLength(1);
+				expect(tree[0].children[0].children[0].entry.id).toBe(leafId);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
 	});
 
 	describe("branch", () => {
@@ -498,6 +545,34 @@ describe("createBranchedSession", () => {
 			const entryIds = records
 				.filter((r) => r.type !== "session")
 				.map((r) => r.id)
+				.filter((id): id is string => typeof id === "string");
+			expect(new Set(entryIds).size).toBe(entryIds.length);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not duplicate materialized entries when continuing a pre-assistant session", () => {
+		const tempDir = join(tmpdir(), `session-materialized-before-assistant-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+
+		try {
+			const session = SessionManager.create(tempDir, tempDir);
+			session.appendSessionInfo("materialized child");
+			session.appendCustomEntry("managed-child", { slot: 1 });
+			const file = writeSessionSnapshot(session);
+
+			const reopened = SessionManager.open(file, tempDir);
+			reopened.appendModelChange("anthropic", "claude-sonnet-4");
+			reopened.appendMessage(userMsg("hello"));
+			reopened.appendMessage(assistantMsg("hi"));
+
+			const records = parseSessionFile(file);
+			expect(records.filter((record) => record.type === "session")).toHaveLength(1);
+
+			const entryIds = records
+				.filter((record) => record.type !== "session")
+				.map((record) => record.id)
 				.filter((id): id is string => typeof id === "string");
 			expect(new Set(entryIds).size).toBe(entryIds.length);
 		} finally {


### PR DESCRIPTION
## summary
- track how many session records are already persisted when reopening a pre-assistant session, so later writes append only new entries
- skip duplicate entry ids while building the session tree, preventing repeated node chains from being rendered
- add regressions for duplicate persisted ids, materialized pre-assistant sessions, and migrated legacy no-assistant sessions

## concrete repro
A core-only repro does not require extensions:

1. Start with a valid legacy/no-version session JSONL containing a user message and no assistant message.
2. Open it with `SessionManager.open()`. This migrates the file to v3 and rewrites it, so the file exists on disk with an entry id but still no assistant message.
3. Append a pre-assistant entry such as `model_change`.
4. Append the first assistant message.

Before this PR, `_persist()` has `flushed === false` and appends all in-memory entries to the existing file. That duplicates the migrated entry id. This reproduces the duplicate non-header entry ids that make `/tree` traverse repeated node chains.

The regression test is `does not duplicate migrated pre-assistant entries when the first assistant is appended`.

## testing
- npx biome check packages/coding-agent/src/core/session-manager.ts packages/coding-agent/test/session-manager/tree-traversal.test.ts
- npm --prefix packages/coding-agent run build
- npm --prefix packages/coding-agent test -- test/session-manager/tree-traversal.test.ts test/tree-selector.test.ts test/session-manager/labels.test.ts test/session-manager/file-operations.test.ts
- npm run check (pre-commit hook)

Supersedes #3911. Related issue: #3930.