### PR TITLE
fix(coding-agent): redo Bun package manager node_modules handling

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -147,7 +147,9 @@ When a provider requests a retry delay longer than `retry.provider.maxRetryDelay
 }
 ```
 
-`npmCommand` is used for all npm package-manager operations, including `npm root -g`, installs, uninstalls, and dependency installs inside git packages. Use argv-style entries exactly as the process should be launched. When `npmCommand` is configured, git package dependency installs use plain `install` to avoid npm-specific flags in wrappers or alternate package managers.
+`npmCommand` is used for all npm package-manager operations, including installs, uninstalls, and dependency installs inside git packages. Use argv-style entries exactly as the process should be launched. When `npmCommand` is configured, git package dependency installs use plain `install` to avoid npm-specific flags in wrappers or alternate package managers.
+
+Normally the package manager's global modules location is queried using `root -g`. As a special case, if the first element of `npmCommand` is `"bun"`, the modules location will instead be queried with `pm bin -g`.
 
 ### Sessions
 

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -1843,8 +1843,13 @@ export class DefaultPackageManager implements PackageManager {
 		if (this.globalNpmRoot && this.globalNpmRootCommandKey === commandKey) {
 			return this.globalNpmRoot;
 		}
-		const result = this.runNpmCommandSync(["root", "-g"]);
-		this.globalNpmRoot = result.trim();
+		const isBunPackageManager = npmCommand.command === "bun";
+		if (isBunPackageManager) {
+			const binDir = this.runNpmCommandSync(["pm", "bin", "-g"]).trim();
+			this.globalNpmRoot = join(dirname(binDir), "install", "global", "node_modules");
+		} else {
+			this.globalNpmRoot = this.runNpmCommandSync(["root", "-g"]).trim();
+		}
 		this.globalNpmRootCommandKey = commandKey;
 		return this.globalNpmRoot;
 	}

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -27,7 +27,7 @@ import type { Readable } from "node:stream";
 import { globSync } from "glob";
 import ignore from "ignore";
 import { minimatch } from "minimatch";
-import { CONFIG_DIR_NAME, isBunRuntime } from "../config.js";
+import { CONFIG_DIR_NAME } from "../config.js";
 import { type GitSource, parseGitUrl } from "../utils/git.js";
 import { canonicalizePath, isLocalPath } from "../utils/paths.js";
 import { isStdoutTakenOver } from "./output-guard.js";
@@ -1843,12 +1843,8 @@ export class DefaultPackageManager implements PackageManager {
 		if (this.globalNpmRoot && this.globalNpmRootCommandKey === commandKey) {
 			return this.globalNpmRoot;
 		}
-		if (isBunRuntime) {
-			const binDir = this.runCommandSync("bun", ["pm", "bin", "-g"]).trim();
-			this.globalNpmRoot = join(dirname(binDir), "install", "global", "node_modules");
-		} else {
-			this.globalNpmRoot = this.runNpmCommandSync(["root", "-g"]).trim();
-		}
+		const result = this.runNpmCommandSync(["root", "-g"]);
+		this.globalNpmRoot = result.trim();
 		this.globalNpmRootCommandKey = commandKey;
 		return this.globalNpmRoot;
 	}


### PR DESCRIPTION
This reverts #3861 and performs its new Bun command when bun is the _package manager_, not the _runtime_.

My original change is faulty: Pi sometimes uses Bun as runtime (such as in the first-party tarball distro), but it still by default uses npm to perform package management operations (and then uses npm's node_modules _in Bun_). So it's correct to ask the package manager for its global node_modules. Rather, to make `npmCommand: ["bun"]` work, it should simply check whether bun is being used as package manager.

If someone knows a better way to distinguish bun-like package managers from npm-like package managers, I'm happy to hear them. I experimented with `npm/bun exec env` etc. but couldn't find anything that seemed very robust. This check is simplistic but should at least scope the behavior change down to just people who do `npmCommand: ["bun"]`.

Fixes #3929.