### PR TITLE
feat(coding-agent): compress skill blocks during compaction

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -18,6 +18,7 @@ import { buildSessionContext, type CompactionEntry, type SessionEntry } from "..
 import {
 	computeFileLists,
 	createFileOps,
+	extractAndCompressSkillBlocks,
 	extractFileOpsFromMessage,
 	type FileOperations,
 	formatFileOperations,
@@ -453,6 +454,10 @@ export function findCutPoint(
 
 const SUMMARIZATION_PROMPT = `The messages above are a conversation to summarize. Create a structured context checkpoint summary that another LLM will use to continue the work.
 
+## Skills Invoked
+[List of skill names invoked in this conversation, if any]
+[Note: Full skill content was compressed — reload with /skill:<name> if needed]
+
 Use this EXACT format:
 
 ## Goal
@@ -502,6 +507,10 @@ Use this EXACT format:
 ## Constraints & Preferences
 - [Preserve existing, add new ones discovered]
 
+## Skills Invoked
+[Skills invoked in the new messages, if any]
+[Note: Reload with /skill:<name> if needed]
+
 ## Progress
 ### Done
 - [x] [Include previously done items AND newly completed items]
@@ -545,13 +554,25 @@ export async function generateSummary(
 		basePrompt = `${basePrompt}\n\nAdditional focus: ${customInstructions}`;
 	}
 
+	// Compress skill blocks before serialization to save tokens
+	// Skill blocks (<skill name="...">) can be 500-2500 tokens each
+	// We extract their names and replace full content with a compressed marker
+	const { compressedMessages, skillNames } = extractAndCompressSkillBlocks(currentMessages);
+
 	// Serialize conversation to text so model doesn't try to continue it
 	// Convert to LLM messages first (handles custom types like bashExecution, custom, etc.)
-	const llmMessages = convertToLlm(currentMessages);
-	const conversationText = serializeConversation(llmMessages);
+	const llmMessages = convertToLlm(compressedMessages);
+	const conversationText = serializeConversation(llmMessages, { compressSkillBlocks: false }); // Already compressed
 
 	// Build the prompt with conversation wrapped in tags
 	let promptText = `<conversation>\n${conversationText}\n</conversation>\n\n`;
+
+	// Include skill names in the prompt if any skills were invoked
+	if (skillNames.length > 0) {
+		const skillList = skillNames.map((n) => `/skill:${n}`).join(", ");
+		promptText += `<skills-invoked>\n${skillList}\n</skills-invoked>\n\n`;
+	}
+
 	if (previousSummary) {
 		promptText += `<previous-summary>\n${previousSummary}\n</previous-summary>\n\n`;
 	}
@@ -795,9 +816,18 @@ async function generateTurnPrefixSummary(
 	signal?: AbortSignal,
 ): Promise<string> {
 	const maxTokens = Math.floor(0.5 * reserveTokens); // Smaller budget for turn prefix
-	const llmMessages = convertToLlm(messages);
-	const conversationText = serializeConversation(llmMessages);
-	const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${TURN_PREFIX_SUMMARIZATION_PROMPT}`;
+
+	// Compress skill blocks before serialization
+	const { compressedMessages, skillNames } = extractAndCompressSkillBlocks(messages);
+	const llmMessages = convertToLlm(compressedMessages);
+	const conversationText = serializeConversation(llmMessages, { compressSkillBlocks: false }); // Already compressed
+
+	let promptText = `<conversation>\n${conversationText}\n</conversation>\n\n`;
+	if (skillNames.length > 0) {
+		const skillList = skillNames.map((n) => `/skill:${n}`).join(", ");
+		promptText += `<skills-invoked>\n${skillList}\n</skills-invoked>\n\n`;
+	}
+	promptText += TURN_PREFIX_SUMMARIZATION_PROMPT;
 	const summarizationMessages = [
 		{
 			role: "user" as const,

--- a/packages/coding-agent/src/core/compaction/utils.ts
+++ b/packages/coding-agent/src/core/compaction/utils.ts
@@ -82,6 +82,104 @@ export function formatFileOperations(readFiles: string[], modifiedFiles: string[
 }
 
 // ============================================================================
+// Skill Block Detection & Compression
+// ============================================================================
+
+/**
+ * Check if a message contains a <skill> XML block.
+ * These are injected by _expandSkillCommand() in agent-session.ts.
+ */
+export function isSkillBlock(message: AgentMessage): boolean {
+	if (message.role !== "user") return false;
+	const content = (message as { content: string | Array<{ type: string; text?: string }> }).content;
+	if (typeof content === "string") {
+		return content.includes("<skill name=");
+	}
+	if (Array.isArray(content)) {
+		return content.some(
+			(block) => block.type === "text" && block.text && block.text.includes("<skill name="),
+		);
+	}
+	return false;
+}
+
+/**
+ * Extract skill names from a <skill> block.
+ */
+function extractSkillNames(text: string): string[] {
+	const names: string[] = [];
+	const matches = text.matchAll(/<skill name="([^"]+)"/g);
+	for (const match of matches) {
+		names.push(match[1]);
+	}
+	return names;
+}
+
+/**
+ * Compress a skill block to just its metadata, replacing the full content with a marker.
+ * Input:  <skill name="xxx" location="...">...</skill>
+ * Output: <skill name="xxx" location="...">[skill content compressed — use /skill:xxx to reload]</skill>
+ */
+export function compressSkillBlock(message: AgentMessage): {
+	compressed: AgentMessage;
+	skillNames: string[];
+} {
+	const content = (message as { content: string | Array<{ type: string; text?: string }> }).content;
+	const text =
+		typeof content === "string"
+			? content
+			: content.find((b) => b.type === "text")?.text || "";
+
+	const skillNames = extractSkillNames(text);
+
+	// Replace full skill block content with a compressed marker
+	const compressedText = text.replace(
+		/<skill name="([^"]+)" location="([^"]+)">[\s\S]*?<\/skill>/g,
+		'<skill name="$1" location="$2">[skill content compressed — use /skill:$1 to reload]</skill>',
+	);
+
+	const compressedContent =
+		typeof content === "string"
+			? compressedText
+			: [{ type: "text" as const, text: compressedText }];
+
+	const compressed: AgentMessage = {
+		...message,
+		content: compressedContent as AgentMessage["content"],
+	};
+
+	return { compressed, skillNames };
+}
+
+/**
+ * Extract and compress skill blocks from messages, returning the compressed messages
+ * and a list of all skill names found.
+ */
+export function extractAndCompressSkillBlocks(
+	messages: AgentMessage[],
+): {
+	compressedMessages: AgentMessage[];
+	skillNames: string[];
+} {
+	const skillNames = new Set<string>();
+
+	const compressedMessages = messages.map((msg) => {
+		if (!isSkillBlock(msg)) return msg;
+
+		const { compressed, skillNames: names } = compressSkillBlock(msg);
+		for (const name of names) {
+			skillNames.add(name);
+		}
+		return compressed;
+	});
+
+	return {
+		compressedMessages,
+		skillNames: Array.from(skillNames),
+	};
+}
+
+// ============================================================================
 // Message Serialization
 // ============================================================================
 
@@ -103,21 +201,33 @@ function truncateForSummary(text: string, maxChars: number): string {
  * This prevents the model from treating it as a conversation to continue.
  * Call convertToLlm() first to handle custom message types.
  *
+ * Skill blocks (<skill name="...">) are serialized in a compact form
+ * to save tokens — they appear as [Skill: name] rather than full content.
+ *
  * Tool results are truncated to keep the summarization request within
  * reasonable token budgets. Full content is not needed for summarization.
  */
-export function serializeConversation(messages: Message[]): string {
+export function serializeConversation(messages: Message[], options?: { compressSkillBlocks?: boolean }): string {
 	const parts: string[] = [];
+	const compressSkill = options?.compressSkillBlocks ?? true;
 
 	for (const msg of messages) {
 		if (msg.role === "user") {
-			const content =
+			let content =
 				typeof msg.content === "string"
 					? msg.content
 					: msg.content
 							.filter((c): c is { type: "text"; text: string } => c.type === "text")
 							.map((c) => c.text)
 							.join("");
+
+			// Compress skill blocks to save tokens
+			if (compressSkill && content.includes("<skill name=")) {
+				const skillNames = extractSkillNames(content);
+				const skillList = skillNames.map((n) => `/skill:${n}`).join(", ");
+				content = `[Skills loaded: ${skillList}]`;
+			}
+
 			if (content) parts.push(`[User]: ${content}`);
 		} else if (msg.role === "assistant") {
 			const textParts: string[] = [];


### PR DESCRIPTION
## Summary

Compress `<skill>` XML blocks during compaction to save tokens and preserve critical skill rules.

## Problem

When users invoke skills via `/skill:xxx`, the full SKILL.md content (~500-2500 tokens) is injected into the conversation. During compaction, these skill blocks were treated as regular messages and summarized by the LLM, often losing critical rules like TDD gates and hard constraints.

## Solution

1. **Detect skill blocks** via `isSkillBlock()` function
2. **Compress to metadata** via `compressSkillBlock()` (replaces full content with `/skill:xxx` reload marker)
3. **Record skill names** in `<skills-invoked>` tag for the summary prompt
4. **Update prompts** to include `## Skills Invoked` section

## Impact

| Metric | Before | After |
|--------|--------|-------|
| 5 skill blocks | ~4,000 tokens | ~300 tokens |
| Skill rule preservation | Depends on LLM summary | Explicit, can reload via `/skill:xxx` |
| Non-skill conversations | No change | No change |

## Files Changed

- `packages/coding-agent/src/core/compaction/utils.ts` - +114 lines (skill block utilities)
- `packages/coding-agent/src/core/compaction/compaction.ts` - +40 lines (prompt updates, compression integration)

## Testing

Unit tests needed for:
- `isSkillBlock()` correctly identifies `<skill>` blocks
- `compressSkillBlock()` produces correct metadata format
- `extractAndCompressSkillBlocks()` handles multiple skills