### PR TITLE
fix(coding-agent): remove detached: true on Windows to fix pwsh.exe shellPath support

### DIFF
--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -83,7 +83,7 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 				}
 				const child = spawn(shell, [...args, command], {
 					cwd,
-					detached: true,
+					detached: process.platform !== "win32",
 					env: env ?? getShellEnv(),
 					stdio: ["ignore", "pipe", "pipe"],
 				});


### PR DESCRIPTION
## Summary

Fixes #4012 

On Windows, `spawn(..., { detached: true })` prevents `pwsh.exe` (PowerShell) from producing any stdout/stderr through pipe streams. This is because `detached` creates a new process group which breaks pwsh's console host communication.

`bash.exe` and other cygwin/msys2 shells are unaffected by `detached: true`, but they don't need it either — on Windows, `killProcessTree()` already uses `taskkill /F /T /PID` which kills the process tree by PID regardless of whether the process was spawned detached.

The `detached` flag only matters on Unix, where `kill(-pid, SIGKILL)` requires a process group that is only created via `detached: true`.

## Change

```diff
 packages/coding-agent/src/core/tools/bash.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
- detached: true,
+ detached: process.platform !== "win32",
```

## Verification

- ✅ `bash.exe` (Git Bash) — `whoami` works, timeout/abort still works via `taskkill /T`
- ✅ `pwsh.exe` (PowerShell 7) — `whoami`, `Get-ChildItem`, pipelines all produce correct output