### PR TITLE
fix: show correct path for ~/.agents/skills in config selector

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -2222,10 +2222,24 @@ export class DefaultPackageManager implements PackageManager {
 		);
 		addResources(
 			"skills",
-			[...collectAutoSkillEntries(userDirs.skills, "pi"), ...collectAutoSkillEntries(userAgentsSkillsDir, "agents")],
+			collectAutoSkillEntries(userDirs.skills, "pi"),
 			userMetadata,
 			userOverrides.skills,
 			globalBaseDir,
+		);
+
+		const userAgentsMetadata: PathMetadata = {
+			source: "auto",
+			scope: "user",
+			origin: "top-level",
+			baseDir: join(getHomeDir(), ".agents"),
+		};
+		addResources(
+			"skills",
+			collectAutoSkillEntries(userAgentsSkillsDir, "agents"),
+			userAgentsMetadata,
+			userOverrides.skills,
+			join(getHomeDir(), ".agents"),
 		);
 		addResources(
 			"prompts",

--- a/packages/coding-agent/src/modes/interactive/components/config-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector.ts
@@ -61,7 +61,8 @@ function getGroupLabel(metadata: PathMetadata): string {
 	}
 	// Top-level resources
 	if (metadata.source === "auto") {
-		return metadata.scope === "user" ? "User (~/.pi/agent/)" : "Project (.pi/)";
+		const label = metadata.baseDir ?? (metadata.scope === "user" ? "~/.pi/agent" : ".pi");
+		return metadata.scope === "user" ? `User (${label}/)` : `Project (${label}/)`;
 	}
 	return metadata.scope === "user" ? "User settings" : "Project settings";
 }


### PR DESCRIPTION
## Problem

Skills from `~/.agents/skills` are displayed under `User (~/.pi/agent/)` in `pi config`, even though they live in a different directory. The `getGroupLabel()` function hardcodes the path string.

## Root Cause

In `package-manager.ts` line 2225, both `~/.pi/agent/skills` and `~/.agents/skills` are added with the same `userMetadata` (which has `baseDir: ~/.pi/agent`). The `getGroupLabel()` function in `config-selector.ts` then hardcodes `"User (~/.pi/agent/)"` for all user-scope auto-discovered resources.

## Fix

1. **`package-manager.ts`**: Split the `addResources` call for user skills so that `~/.agents/skills` gets its own `PathMetadata` with `baseDir` pointing to `~/.agents`.

2. **`config-selector.ts`**: Use `metadata.baseDir` in the label when available, falling back to the hardcoded defaults only when `baseDir` is undefined.

After this fix, `pi config` shows:
- `User (~/.pi/agent/)` for skills from `~/.pi/agent/skills`
- `User (~/.agents/)` for skills from `~/.agents/skills`

Fixes #3978