### PR TITLE
feat(coding-agent): support session dir env

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `PI_CODING_AGENT_SESSION_DIR` as an environment variable equivalent to `--session-dir`.
 - Added top-level `name` support to `pi.registerProvider()` so extension-registered providers can show a friendly name in `/login` ([#3956](https://github.com/badlogic/pi-mono/issues/3956)).
 - Added `ctx.ui.getEditorComponent()` so extensions can wrap the currently configured custom editor factory ([#3935](https://github.com/badlogic/pi-mono/issues/3935)).
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -621,6 +621,7 @@ pi --thinking high "Solve this complex problem"
 | Variable | Description |
 |----------|-------------|
 | `PI_CODING_AGENT_DIR` | Override config directory (default: `~/.pi/agent`) |
+| `PI_CODING_AGENT_SESSION_DIR` | Override session storage directory (same as `--session-dir`; legacy alias: `PI_AGENT_SESSION_DIR`) |
 | `PI_PACKAGE_DIR` | Override package directory (useful for Nix/Guix where store paths tokenize poorly) |
 | `PI_OFFLINE` | Disable startup network operations, including update checks, package update checks, and install/update telemetry |
 | `PI_SKIP_VERSION_CHECK` | Skip the Pi version update check at startup. This prevents the `pi.dev` latest-version request |

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -14,7 +14,7 @@ Common options:
 - `--provider <name>`: Set the LLM provider (anthropic, openai, google, etc.)
 - `--model <pattern>`: Model pattern or ID (supports `provider/id` and optional `:<thinking>`)
 - `--no-session`: Disable session persistence
-- `--session-dir <path>`: Custom session storage directory
+- `--session-dir <path>`: Custom session storage directory (overrides `PI_CODING_AGENT_SESSION_DIR` and settings)
 
 ## Protocol Overview
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -167,7 +167,7 @@ Normally the package manager's global modules location is queried using `root -g
 { "sessionDir": ".pi/sessions" }
 ```
 
-When multiple sources specify a session directory, `--session-dir` CLI flag takes precedence over `sessionDir` in settings.json.
+When multiple sources specify a session directory, precedence is `--session-dir`, then `PI_CODING_AGENT_SESSION_DIR` (or legacy alias `PI_AGENT_SESSION_DIR`), then `sessionDir` in settings.json, then the default session directory. All sources expand `~`.
 
 ### Model Cycling
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -260,6 +260,7 @@ pi --tools read,grep,find,ls -p "Review the code"
 | Variable | Description |
 |----------|-------------|
 | `PI_CODING_AGENT_DIR` | Override config directory; default is `~/.pi/agent` |
+| `PI_CODING_AGENT_SESSION_DIR` | Override session storage directory (same as `--session-dir`; legacy alias: `PI_AGENT_SESSION_DIR`) |
 | `PI_PACKAGE_DIR` | Override package directory, useful for Nix/Guix store paths |
 | `PI_OFFLINE` | Disable startup network operations, including update checks, package update checks, and install/update telemetry |
 | `PI_SKIP_VERSION_CHECK` | Skip the Pi version update check at startup. This prevents the `pi.dev` latest-version request |

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -4,7 +4,7 @@
 
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import chalk from "chalk";
-import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR } from "../config.js";
+import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, ENV_CODING_AGENT_SESSION_DIR } from "../config.js";
 import type { ExtensionFlag } from "../core/extensions/types.js";
 
 export type Mode = "text" | "json" | "rpc";
@@ -324,7 +324,8 @@ ${chalk.bold("Environment Variables:")}
   AWS_SECRET_ACCESS_KEY            - AWS secret key for Amazon Bedrock
   AWS_BEARER_TOKEN_BEDROCK         - Bedrock API key (bearer token)
   AWS_REGION                       - AWS region for Amazon Bedrock (e.g., us-east-1)
-  ${ENV_AGENT_DIR.padEnd(32)} - Session storage directory (default: ~/${CONFIG_DIR_NAME}/agent)
+  ${ENV_AGENT_DIR.padEnd(32)} - Config directory (default: ~/${CONFIG_DIR_NAME}/agent)
+  ${ENV_CODING_AGENT_SESSION_DIR.padEnd(32)} - Session storage directory (same as --session-dir)
   PI_PACKAGE_DIR                   - Override package directory (for Nix/Guix store paths)
   PI_OFFLINE                       - Disable startup network operations when set to 1/true/yes
   PI_TELEMETRY                     - Override install telemetry when set to 1/true/yes or 0/false/no

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -327,6 +327,8 @@ export const VERSION: string = pkg.version || "0.0.0";
 
 // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
 export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
+export const ENV_CODING_AGENT_SESSION_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_SESSION_DIR`;
+export const ENV_AGENT_SESSION_DIR = `${APP_NAME.toUpperCase()}_AGENT_SESSION_DIR`;
 
 const DEFAULT_SHARE_VIEWER_URL = "https://pi.dev/session/";
 
@@ -334,6 +336,24 @@ const DEFAULT_SHARE_VIEWER_URL = "https://pi.dev/session/";
 export function getShareViewerUrl(gistId: string): string {
 	const baseUrl = process.env.PI_SHARE_VIEWER_URL || DEFAULT_SHARE_VIEWER_URL;
 	return `${baseUrl}#${gistId}`;
+}
+
+export function expandHomePath(path: string): string {
+	if (path === "~") return homedir();
+	if (path.startsWith("~/")) return join(homedir(), path.slice(2));
+	return path;
+}
+
+export function getEnvSessionDir(): string | undefined {
+	const envDir = process.env[ENV_CODING_AGENT_SESSION_DIR] || process.env[ENV_AGENT_SESSION_DIR];
+	return envDir ? expandHomePath(envDir) : undefined;
+}
+
+export function resolveConfiguredSessionDir(
+	cliSessionDir: string | undefined,
+	settingsSessionDir: string | undefined,
+): string | undefined {
+	return cliSessionDir !== undefined ? expandHomePath(cliSessionDir) : (getEnvSessionDir() ?? settingsSessionDir);
 }
 
 // =============================================================================
@@ -344,10 +364,7 @@ export function getShareViewerUrl(gistId: string): string {
 export function getAgentDir(): string {
 	const envDir = process.env[ENV_AGENT_DIR];
 	if (envDir) {
-		// Expand tilde to home directory
-		if (envDir === "~") return homedir();
-		if (envDir.startsWith("~/")) return homedir() + envDir.slice(1);
-		return envDir;
+		return expandHomePath(envDir);
 	}
 	return join(homedir(), CONFIG_DIR_NAME, "agent");
 }

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1,9 +1,8 @@
 import type { Transport } from "@mariozechner/pi-ai";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { homedir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
-import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
+import { CONFIG_DIR_NAME, expandHomePath, getAgentDir } from "../config.js";
 
 export interface CompactionSettings {
 	enabled?: boolean; // default: true
@@ -578,13 +577,7 @@ export class SettingsManager {
 		if (!sessionDir) {
 			return sessionDir;
 		}
-		if (sessionDir === "~") {
-			return homedir();
-		}
-		if (sessionDir.startsWith("~/")) {
-			return join(homedir(), sessionDir.slice(2));
-		}
-		return sessionDir;
+		return expandHomePath(sessionDir);
 	}
 
 	getDefaultProvider(): string | undefined {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -15,7 +15,7 @@ import { processFileArguments } from "./cli/file-processor.js";
 import { buildInitialMessage } from "./cli/initial-message.js";
 import { listModels } from "./cli/list-models.js";
 import { selectSession } from "./cli/session-picker.js";
-import { getAgentDir, VERSION } from "./config.js";
+import { getAgentDir, resolveConfiguredSessionDir, VERSION } from "./config.js";
 import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.js";
 import {
 	type AgentSessionRuntimeDiagnostic,
@@ -493,7 +493,7 @@ export async function main(args: string[], options?: MainOptions) {
 	// settings, resources, provider registrations, and models must be resolved only after
 	// the target session cwd is known. The startup-cwd settings manager is used only for
 	// sessionDir lookup during session selection.
-	const sessionDir = parsed.sessionDir ?? startupSettingsManager.getSessionDir();
+	const sessionDir = resolveConfiguredSessionDir(parsed.sessionDir, startupSettingsManager.getSessionDir());
 	let sessionManager = await createSessionManager(parsed, cwd, sessionDir, startupSettingsManager);
 	const missingSessionCwdIssue = getMissingSessionCwdIssue(sessionManager, cwd);
 	if (missingSessionCwdIssue) {

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -1,7 +1,20 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
-import { detectInstallMethod, getSelfUpdateCommand, getUpdateInstruction } from "../src/config.js";
+import {
+	detectInstallMethod,
+	ENV_AGENT_SESSION_DIR,
+	ENV_CODING_AGENT_SESSION_DIR,
+	expandHomePath,
+	getEnvSessionDir,
+	getSelfUpdateCommand,
+	getUpdateInstruction,
+	resolveConfiguredSessionDir,
+} from "../src/config.js";
 
 const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
+const originalSessionDirEnv = process.env[ENV_CODING_AGENT_SESSION_DIR];
+const originalLegacySessionDirEnv = process.env[ENV_AGENT_SESSION_DIR];
 
 function setExecPath(value: string): void {
 	Object.defineProperty(process, "execPath", {
@@ -13,6 +26,16 @@ function setExecPath(value: string): void {
 afterEach(() => {
 	if (execPathDescriptor) {
 		Object.defineProperty(process, "execPath", execPathDescriptor);
+	}
+	if (originalSessionDirEnv === undefined) {
+		delete process.env[ENV_CODING_AGENT_SESSION_DIR];
+	} else {
+		process.env[ENV_CODING_AGENT_SESSION_DIR] = originalSessionDirEnv;
+	}
+	if (originalLegacySessionDirEnv === undefined) {
+		delete process.env[ENV_AGENT_SESSION_DIR];
+	} else {
+		process.env[ENV_AGENT_SESSION_DIR] = originalLegacySessionDirEnv;
 	}
 });
 
@@ -36,5 +59,43 @@ describe("detectInstallMethod", () => {
 		expect(getUpdateInstruction("@mariozechner/pi-coding-agent")).toBe(
 			"Update @mariozechner/pi-coding-agent using the package manager, wrapper, or source checkout that provides this installation.",
 		);
+	});
+});
+
+describe("session directory config", () => {
+	test("expands tilde paths", () => {
+		expect(expandHomePath("~")).toBe(homedir());
+		expect(expandHomePath("~/sessions")).toBe(join(homedir(), "sessions"));
+		expect(expandHomePath("./sessions")).toBe("./sessions");
+	});
+
+	test("reads session directory from environment", () => {
+		process.env[ENV_CODING_AGENT_SESSION_DIR] = "~/pi-sessions";
+
+		expect(getEnvSessionDir()).toBe(join(homedir(), "pi-sessions"));
+	});
+
+	test("supports legacy session directory environment alias", () => {
+		delete process.env[ENV_CODING_AGENT_SESSION_DIR];
+		process.env[ENV_AGENT_SESSION_DIR] = "/tmp/pi-agent-sessions";
+
+		expect(getEnvSessionDir()).toBe("/tmp/pi-agent-sessions");
+	});
+
+	test("prefers primary environment variable over legacy alias", () => {
+		process.env[ENV_CODING_AGENT_SESSION_DIR] = "/tmp/pi-coding-agent-sessions";
+		process.env[ENV_AGENT_SESSION_DIR] = "/tmp/pi-agent-sessions";
+
+		expect(getEnvSessionDir()).toBe("/tmp/pi-coding-agent-sessions");
+	});
+
+	test("resolves session directory precedence", () => {
+		process.env[ENV_CODING_AGENT_SESSION_DIR] = "/env/sessions";
+
+		expect(resolveConfiguredSessionDir("~/cli-sessions", "/settings/sessions")).toBe(join(homedir(), "cli-sessions"));
+		expect(resolveConfiguredSessionDir(undefined, "/settings/sessions")).toBe("/env/sessions");
+		delete process.env[ENV_CODING_AGENT_SESSION_DIR];
+		expect(resolveConfiguredSessionDir(undefined, "/settings/sessions")).toBe("/settings/sessions");
+		expect(resolveConfiguredSessionDir(undefined, undefined)).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

- add `PI_CODING_AGENT_SESSION_DIR` as an env equivalent to `--session-dir`
- keep precedence as `--session-dir` > env > settings > default
- document the env var and add config tests

## Tests

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/config.test.ts`
- `npm run check`
