### PR TITLE
feat(coding-agent): support auth json env

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `PI_CODING_AGENT_AUTH_JSON` for passing in-memory auth JSON without reading or writing `auth.json`.
 - Added top-level `name` support to `pi.registerProvider()` so extension-registered providers can show a friendly name in `/login` ([#3956](https://github.com/badlogic/pi-mono/issues/3956)).
 - Added `ctx.ui.getEditorComponent()` so extensions can wrap the currently configured custom editor factory ([#3935](https://github.com/badlogic/pi-mono/issues/3935)).
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -621,6 +621,7 @@ pi --thinking high "Solve this complex problem"
 | Variable | Description |
 |----------|-------------|
 | `PI_CODING_AGENT_DIR` | Override config directory (default: `~/.pi/agent`) |
+| `PI_CODING_AGENT_AUTH_JSON` | Inline `auth.json` contents. Loaded in memory, deleted during startup, and not persisted |
 | `PI_PACKAGE_DIR` | Override package directory (useful for Nix/Guix where store paths tokenize poorly) |
 | `PI_OFFLINE` | Disable startup network operations, including update checks, package update checks, and install/update telemetry |
 | `PI_SKIP_VERSION_CHECK` | Skip the Pi version update check at startup. This prevents the `pi.dev` latest-version request |

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -44,12 +44,16 @@ Use `/logout` to clear credentials. Tokens are stored in `~/.pi/agent/auth.json`
 
 ### Environment Variables or Auth File
 
-Use `/login` in interactive mode and select a provider to store an API key in `auth.json`, or set credentials via environment variable:
+Use `/login` in interactive mode and select a provider to store an API key in `auth.json`, set provider-specific credentials via environment variable, or pass full auth JSON via `PI_CODING_AGENT_AUTH_JSON`:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 pi
+
+PI_CODING_AGENT_AUTH_JSON='{"anthropic":{"type":"api_key","key":"sk-ant-..."}}' pi
 ```
+
+When `PI_CODING_AGENT_AUTH_JSON` is set, pi loads it into memory, deletes the environment variable during startup, and does not read or write `auth.json` for that process.
 
 | Provider | Environment Variable | `auth.json` key |
 |----------|----------------------|------------------|
@@ -91,7 +95,7 @@ Store credentials in `~/.pi/agent/auth.json`:
 }
 ```
 
-The file is created with `0600` permissions (user read/write only). Auth file credentials take priority over environment variables.
+The file is created with `0600` permissions (user read/write only). Auth file credentials take priority over provider-specific environment variables. `PI_CODING_AGENT_AUTH_JSON` replaces the auth file for the process and is not persisted.
 
 ### Key Resolution
 
@@ -208,6 +212,6 @@ Or set `GOOGLE_APPLICATION_CREDENTIALS` to a service account key file.
 When resolving credentials for a provider:
 
 1. CLI `--api-key` flag
-2. `auth.json` entry (API key or OAuth token)
-3. Environment variable
+2. `auth.json` entry, or in-memory `PI_CODING_AGENT_AUTH_JSON` entry (API key or OAuth token)
+3. Provider-specific environment variable
 4. Custom provider keys from `models.json`

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -260,6 +260,7 @@ pi --tools read,grep,find,ls -p "Review the code"
 | Variable | Description |
 |----------|-------------|
 | `PI_CODING_AGENT_DIR` | Override config directory; default is `~/.pi/agent` |
+| `PI_CODING_AGENT_AUTH_JSON` | Inline `auth.json` contents. Loaded in memory, deleted during startup, and not persisted |
 | `PI_PACKAGE_DIR` | Override package directory, useful for Nix/Guix store paths |
 | `PI_OFFLINE` | Disable startup network operations, including update checks, package update checks, and install/update telemetry |
 | `PI_SKIP_VERSION_CHECK` | Skip the Pi version update check at startup. This prevents the `pi.dev` latest-version request |

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -5,6 +5,7 @@
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import chalk from "chalk";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR } from "../config.js";
+import { PI_CODING_AGENT_AUTH_JSON_ENV } from "../core/auth-storage.js";
 import type { ExtensionFlag } from "../core/extensions/types.js";
 
 export type Mode = "text" | "json" | "rpc";
@@ -325,6 +326,7 @@ ${chalk.bold("Environment Variables:")}
   AWS_BEARER_TOKEN_BEDROCK         - Bedrock API key (bearer token)
   AWS_REGION                       - AWS region for Amazon Bedrock (e.g., us-east-1)
   ${ENV_AGENT_DIR.padEnd(32)} - Session storage directory (default: ~/${CONFIG_DIR_NAME}/agent)
+  ${PI_CODING_AGENT_AUTH_JSON_ENV.padEnd(32)} - Inline auth.json contents; loaded in memory and deleted at startup
   PI_PACKAGE_DIR                   - Override package directory (for Nix/Guix store paths)
   PI_OFFLINE                       - Disable startup network operations when set to 1/true/yes
   PI_TELEMETRY                     - Override install telemetry when set to 1/true/yes or 0/false/no

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -33,6 +33,8 @@ export type AuthCredential = ApiKeyCredential | OAuthCredential;
 
 export type AuthStorageData = Record<string, AuthCredential>;
 
+export const PI_CODING_AGENT_AUTH_JSON_ENV = "PI_CODING_AGENT_AUTH_JSON";
+
 export type AuthStatus = {
 	configured: boolean;
 	source?: "stored" | "runtime" | "environment" | "fallback" | "models_json_key" | "models_json_command";
@@ -200,6 +202,14 @@ export class AuthStorage {
 	}
 
 	static create(authPath?: string): AuthStorage {
+		const authJson = process.env[PI_CODING_AGENT_AUTH_JSON_ENV];
+		if (authJson !== undefined) {
+			delete process.env[PI_CODING_AGENT_AUTH_JSON_ENV];
+			const storage = new InMemoryAuthStorageBackend();
+			storage.withLock(() => ({ result: undefined, next: authJson }));
+			return new AuthStorage(storage);
+		}
+
 		return new AuthStorage(new FileAuthStorageBackend(authPath ?? join(getAgentDir(), "auth.json")));
 	}
 

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { registerOAuthProvider } from "@mariozechner/pi-ai/oauth";
 import lockfile from "proper-lockfile";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { AuthStorage } from "../src/core/auth-storage.js";
+import { AuthStorage, PI_CODING_AGENT_AUTH_JSON_ENV } from "../src/core/auth-storage.js";
 import { clearConfigValueCache } from "../src/core/resolve-config-value.js";
 
 describe("AuthStorage", () => {
@@ -19,6 +19,7 @@ describe("AuthStorage", () => {
 	});
 
 	afterEach(() => {
+		delete process.env[PI_CODING_AGENT_AUTH_JSON_ENV];
 		if (tempDir && existsSync(tempDir)) {
 			rmSync(tempDir, { recursive: true });
 		}
@@ -33,6 +34,47 @@ describe("AuthStorage", () => {
 	function toShPath(value: string): string {
 		return value.replace(/\\/g, "/").replace(/"/g, '\\"');
 	}
+
+	describe("PI_CODING_AGENT_AUTH_JSON", () => {
+		test("loads credentials from env JSON and deletes the env var", async () => {
+			process.env[PI_CODING_AGENT_AUTH_JSON_ENV] = JSON.stringify({
+				anthropic: { type: "api_key", key: "sk-ant-env-json" },
+			});
+
+			authStorage = AuthStorage.create(authJsonPath);
+
+			expect(process.env[PI_CODING_AGENT_AUTH_JSON_ENV]).toBeUndefined();
+			await expect(authStorage.getApiKey("anthropic")).resolves.toBe("sk-ant-env-json");
+			expect(existsSync(authJsonPath)).toBe(false);
+		});
+
+		test("deletes env var and does not fall back to auth file when env JSON is invalid", async () => {
+			writeAuthJson({
+				anthropic: { type: "api_key", key: "sk-ant-file" },
+			});
+			process.env[PI_CODING_AGENT_AUTH_JSON_ENV] = "{";
+
+			authStorage = AuthStorage.create(authJsonPath);
+
+			expect(process.env[PI_CODING_AGENT_AUTH_JSON_ENV]).toBeUndefined();
+			await expect(authStorage.getApiKey("anthropic")).resolves.toBeUndefined();
+			expect(authStorage.drainErrors()).toHaveLength(1);
+			expect(readFileSync(authJsonPath, "utf-8")).toBe(
+				JSON.stringify({ anthropic: { type: "api_key", key: "sk-ant-file" } }),
+			);
+		});
+
+		test("does not persist credential changes to auth.json when env JSON is set", () => {
+			process.env[PI_CODING_AGENT_AUTH_JSON_ENV] = JSON.stringify({});
+
+			authStorage = AuthStorage.create(authJsonPath);
+			authStorage.set("openai", { type: "api_key", key: "sk-openai-env-json" });
+
+			expect(process.env[PI_CODING_AGENT_AUTH_JSON_ENV]).toBeUndefined();
+			expect(authStorage.get("openai")).toEqual({ type: "api_key", key: "sk-openai-env-json" });
+			expect(existsSync(authJsonPath)).toBe(false);
+		});
+	});
 
 	describe("API key resolution", () => {
 		test("literal API key is returned directly", async () => {


### PR DESCRIPTION
## Summary

- add `PI_CODING_AGENT_AUTH_JSON` for inline auth data
- load the JSON into in-memory auth storage instead of reading/writing `auth.json`
- delete the env var immediately after capturing it, including invalid JSON paths

## Tests

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/auth-storage.test.ts`
- `npm run check`
