### PR TITLE
fix: handle shift+enter in legacy terminals

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -154,7 +154,7 @@ The editor can be temporarily replaced by other UI, like built-in `/settings` or
 |---------|-----|
 | File reference | Type `@` to fuzzy-search project files |
 | Path completion | Tab to complete paths |
-| Multi-line | Shift+Enter (or Ctrl+Enter on Windows Terminal) |
+| Multi-line | Shift+Enter (or Ctrl+Enter on Windows Terminal; see docs/terminal-setup.md) |
 | Images | Ctrl+V to paste (Alt+V on Windows), or drag onto terminal |
 | Bash commands | `!command` runs and sends output to LLM, `!!command` runs without sending |
 

--- a/packages/coding-agent/docs/terminal-setup.md
+++ b/packages/coding-agent/docs/terminal-setup.md
@@ -43,6 +43,20 @@ config.enable_kitty_keyboard = true
 return config
 ```
 
+Without `enable_kitty_keyboard = true`, Shift+Enter can be indistinguishable from plain Enter.
+
+## macOS Terminal.app
+
+Terminal.app does not enable Kitty keyboard reporting by default. If Shift+Enter still submits the message, add a key mapping in **Settings → Profiles → Keyboard** that sends `\e[13;2u` for **Shift+Return**.
+
+Pi recognizes that sequence out of the box. If you prefer not to customize Terminal.app, bind `ctrl+j` to `newLine` in `~/.pi/agent/keybindings.json`:
+
+```json
+{
+  "newLine": ["shift+enter", "ctrl+j"]
+}
+```
+
 ## VS Code (Integrated Terminal)
 
 `keybindings.json` locations:

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -21,7 +21,7 @@ The editor can be replaced temporarily by built-in UI such as `/settings` or by 
 |---------|-----|
 | File reference | Type `@` to fuzzy-search project files |
 | Path completion | Press Tab to complete paths |
-| Multi-line input | Shift+Enter, or Ctrl+Enter on Windows Terminal |
+| Multi-line input | Shift+Enter, or Ctrl+Enter on Windows Terminal; see [Terminal setup](terminal-setup.md) |
 | Images | Paste with Ctrl+V, Alt+V on Windows, or drag into the terminal |
 | Shell command | `!command` runs and sends output to the model |
 | Hidden shell command | `!!command` runs without sending output to the model |

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -719,6 +719,19 @@ function isWindowsTerminalSession(): boolean {
 }
 
 /**
+ * Some terminals reuse SS3 M (\x1bOM) for Shift+Enter without Kitty support.
+ * Detect the ones we know about so Enter can stay Enter everywhere else.
+ */
+function isLegacyShiftEnterTerminal(): boolean {
+	return (
+		Boolean(process.env.KONSOLE_VERSION) ||
+		process.env.TERM_PROGRAM === "Apple_Terminal" ||
+		process.env.TERM_PROGRAM === "WezTerm" ||
+		Boolean(process.env.WEZTERM_PANE)
+	);
+}
+
+/**
  * Raw 0x08 (BS) is ambiguous in legacy terminals.
  *
  * - Windows Terminal uses it for Ctrl+Backspace.
@@ -889,6 +902,10 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 				if (matchesModifyOtherKeys(data, CODEPOINTS.enter, MODIFIERS.shift)) {
 					return true;
 				}
+				// Legacy SS3 M mappings used by some terminals for Shift+Enter.
+				if (data === "\x1bOM" && isLegacyShiftEnterTerminal()) {
+					return true;
+				}
 				// When Kitty protocol is active, legacy sequences are custom terminal mappings
 				// \x1b\r = Kitty's "map shift+enter send_text all \e\r"
 				// \n = Ghostty's "keybind = shift+enter=text:\n"
@@ -920,7 +937,7 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 				return (
 					data === "\r" ||
 					(!_kittyProtocolActive && data === "\n") ||
-					data === "\x1bOM" || // SS3 M (numpad enter in some terminals)
+					(data === "\x1bOM" && !isLegacyShiftEnterTerminal()) || // SS3 M (numpad enter in some terminals)
 					matchesKittySequence(data, CODEPOINTS.enter, 0) ||
 					matchesKittySequence(data, CODEPOINTS.kpEnter, 0)
 				);
@@ -1266,6 +1283,7 @@ export function parseKey(data: string): string | undefined {
 	if (_kittyProtocolActive) {
 		if (data === "\x1b\r" || data === "\n") return "shift+enter";
 	}
+	if (data === "\x1bOM" && isLegacyShiftEnterTerminal()) return "shift+enter";
 
 	const legacySequenceKeyId = LEGACY_SEQUENCE_KEY_IDS[data];
 	if (legacySequenceKeyId) return legacySequenceKeyId;
@@ -1280,7 +1298,13 @@ export function parseKey(data: string): string | undefined {
 	if (data === "\x1b\x1d") return "ctrl+alt+]";
 	if (data === "\x1b\x1f") return "ctrl+alt+-";
 	if (data === "\t") return "tab";
-	if (data === "\r" || (!_kittyProtocolActive && data === "\n") || data === "\x1bOM") return "enter";
+	if (
+		data === "\r" ||
+		(!_kittyProtocolActive && data === "\n") ||
+		(data === "\x1bOM" && !isLegacyShiftEnterTerminal())
+	) {
+		return "enter";
+	}
 	if (data === "\x00") return "ctrl+space";
 	if (data === " ") return "space";
 	if (data === "\x7f") return "backspace";

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { stripVTControlCharacters } from "node:util";
 import { type AutocompleteProvider, CombinedAutocompleteProvider } from "../src/autocomplete.js";
 import { Editor, wordWrapLine } from "../src/components/editor.js";
+import { isKittyProtocolActive, setKittyProtocolActive } from "../src/keys.js";
 import { TUI } from "../src/tui.js";
 import { visibleWidth } from "../src/utils.js";
 import { defaultEditorTheme } from "./test-themes.js";
@@ -11,6 +12,31 @@ import { VirtualTerminal } from "./virtual-terminal.js";
 /** Create a TUI with a virtual terminal for testing */
 function createTestTUI(cols = 80, rows = 24): TUI {
 	return new TUI(new VirtualTerminal(cols, rows));
+}
+
+function withEnvVars(vars: Record<string, string | undefined>, fn: () => void): void {
+	const previous = new Map<string, string | undefined>();
+
+	for (const [name, value] of Object.entries(vars)) {
+		previous.set(name, process.env[name]);
+		if (value === undefined) {
+			delete process.env[name];
+		} else {
+			process.env[name] = value;
+		}
+	}
+
+	try {
+		fn();
+	} finally {
+		for (const [name, value] of previous) {
+			if (value === undefined) {
+				delete process.env[name];
+			} else {
+				process.env[name] = value;
+			}
+		}
+	}
 }
 
 /** Standard applyCompletion that replaces prefix with item.value */
@@ -363,6 +389,28 @@ describe("Editor component", () => {
 			editor.handleInput("\r");
 			// Only the last backslash is removed, newline inserted
 			assert.strictEqual(editor.getText(), "\\\\\n");
+		});
+	});
+
+	describe("Shift+Enter handling", () => {
+		it("inserts a newline for SS3 M in known terminals", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			let submitted = false;
+			editor.onSubmit = () => {
+				submitted = true;
+			};
+
+			const previousKitty = isKittyProtocolActive();
+			try {
+				withEnvVars({ KONSOLE_VERSION: undefined, TERM_PROGRAM: "WezTerm", WEZTERM_PANE: "4" }, () => {
+					setKittyProtocolActive(false);
+					editor.handleInput("\x1bOM");
+					assert.strictEqual(editor.getText(), "\n");
+					assert.strictEqual(submitted, false);
+				});
+			} finally {
+				setKittyProtocolActive(previousKitty);
+			}
 		});
 	});
 

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -327,6 +327,36 @@ describe("matchesKey", () => {
 			setKittyProtocolActive(false);
 		});
 
+		it("should treat SS3 M as shift+enter in known terminals", () => {
+			withEnvVars({ KONSOLE_VERSION: undefined, TERM_PROGRAM: undefined, WEZTERM_PANE: undefined }, () => {
+				setKittyProtocolActive(false);
+				assert.strictEqual(matchesKey("\x1bOM", "shift+enter"), false);
+				assert.strictEqual(matchesKey("\x1bOM", "enter"), true);
+				assert.strictEqual(parseKey("\x1bOM"), "enter");
+			});
+
+			withEnvVars({ KONSOLE_VERSION: "24.08.0", TERM_PROGRAM: undefined, WEZTERM_PANE: undefined }, () => {
+				setKittyProtocolActive(false);
+				assert.strictEqual(matchesKey("\x1bOM", "shift+enter"), true);
+				assert.strictEqual(matchesKey("\x1bOM", "enter"), false);
+				assert.strictEqual(parseKey("\x1bOM"), "shift+enter");
+			});
+
+			withEnvVars({ TERM_PROGRAM: "Apple_Terminal", KONSOLE_VERSION: undefined, WEZTERM_PANE: undefined }, () => {
+				setKittyProtocolActive(false);
+				assert.strictEqual(matchesKey("\x1bOM", "shift+enter"), true);
+				assert.strictEqual(matchesKey("\x1bOM", "enter"), false);
+				assert.strictEqual(parseKey("\x1bOM"), "shift+enter");
+			});
+
+			withEnvVars({ TERM_PROGRAM: "WezTerm", KONSOLE_VERSION: undefined, WEZTERM_PANE: undefined }, () => {
+				setKittyProtocolActive(false);
+				assert.strictEqual(matchesKey("\x1bOM", "shift+enter"), true);
+				assert.strictEqual(matchesKey("\x1bOM", "enter"), false);
+				assert.strictEqual(parseKey("\x1bOM"), "shift+enter");
+			});
+		});
+
 		it("should parse ctrl+space", () => {
 			setKittyProtocolActive(false);
 			assert.strictEqual(matchesKey("\x00", "ctrl+space"), true);


### PR DESCRIPTION
## Summary\n- Treat legacy SS3 M as Shift+Enter in known terminals so newline inserts instead of submit.\n- Add editor/keys regression tests and terminal setup docs.\n\n## Testing\n- npm test --workspace @mariozechner/pi-tui\n- npx biome check packages/tui/src/keys.ts packages/tui/test/keys.test.ts packages/tui/test/editor.test.ts packages/coding-agent/docs/terminal-setup.md packages/coding-agent/README.md packages/coding-agent/docs/usage.md\n\nCloses #3884