### PR TITLE
fix: regenerate package-lock.json so sandbox example dep installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,35 @@
 				"node": ">=20.0.0"
 			}
 		},
+		"node_modules/@anthropic-ai/sandbox-runtime": {
+			"version": "0.0.26",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.26.tgz",
+			"integrity": "sha512-DYV5LSsVMnzq0lbfaYMSpxZPUMAx4+hy343dRss+pVCLIfF62qOhxpYfZ5TmOk1GTDQm5f9wPprMNSStmnsV4w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@pondwader/socks5-server": "^1.0.10",
+				"@types/lodash-es": "^4.17.12",
+				"commander": "^12.1.0",
+				"lodash-es": "^4.17.21",
+				"shell-quote": "^1.8.3",
+				"zod": "^3.24.1"
+			},
+			"bin": {
+				"srt": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@anthropic-ai/sandbox-runtime/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
 		"node_modules/@anthropic-ai/sdk": {
 			"version": "0.91.1",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
@@ -2452,6 +2481,12 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/@pondwader/socks5-server": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@pondwader/socks5-server/-/socks5-server-1.0.10.tgz",
+			"integrity": "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==",
+			"license": "MIT"
+		},
 		"node_modules/@preact/signals-core": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
@@ -3838,6 +3873,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/lodash": {
+			"version": "4.17.24",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+			"integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+			"license": "MIT"
+		},
+		"node_modules/@types/lodash-es": {
+			"version": "4.17.12",
+			"resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+			"integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/lodash": "*"
+			}
+		},
 		"node_modules/@types/mime-types": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
@@ -4540,12 +4590,12 @@
 			"license": "MIT"
 		},
 		"node_modules/commander": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">= 12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/concurrently": {
@@ -5753,6 +5803,15 @@
 				"katex": "cli.js"
 			}
 		},
+		"node_modules/katex/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/koffi": {
 			"version": "2.16.1",
 			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
@@ -6052,6 +6111,12 @@
 			"dependencies": {
 				"@types/trusted-types": "^2.0.2"
 			}
+		},
+		"node_modules/lodash-es": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+			"license": "MIT"
 		},
 		"node_modules/long": {
 			"version": "5.3.2",
@@ -8268,57 +8333,6 @@
 			"version": "1.1.0",
 			"dependencies": {
 				"@anthropic-ai/sandbox-runtime": "^0.0.26"
-			}
-		},
-		"packages/coding-agent/examples/extensions/sandbox/node_modules/@anthropic-ai/sandbox-runtime": {
-			"version": "0.0.26",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@pondwader/socks5-server": "^1.0.10",
-				"@types/lodash-es": "^4.17.12",
-				"commander": "^12.1.0",
-				"lodash-es": "^4.17.21",
-				"shell-quote": "^1.8.3",
-				"zod": "^3.24.1"
-			},
-			"bin": {
-				"srt": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"packages/coding-agent/examples/extensions/sandbox/node_modules/@pondwader/socks5-server": {
-			"version": "1.0.10",
-			"license": "MIT"
-		},
-		"packages/coding-agent/examples/extensions/sandbox/node_modules/@types/lodash": {
-			"version": "4.17.23",
-			"license": "MIT"
-		},
-		"packages/coding-agent/examples/extensions/sandbox/node_modules/@types/lodash-es": {
-			"version": "4.17.12",
-			"license": "MIT",
-			"dependencies": {
-				"@types/lodash": "*"
-			}
-		},
-		"packages/coding-agent/examples/extensions/sandbox/node_modules/commander": {
-			"version": "12.1.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/coding-agent/examples/extensions/sandbox/node_modules/lodash-es": {
-			"version": "4.18.1",
-			"license": "MIT"
-		},
-		"packages/coding-agent/examples/extensions/sandbox/node_modules/zod": {
-			"version": "3.25.76",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"packages/coding-agent/examples/extensions/with-deps": {


### PR DESCRIPTION
## Summary

`packages/coding-agent/examples/extensions/sandbox` is in the workspaces array of root `package.json`, but the committed `package-lock.json` only recorded `@anthropic-ai/sandbox-runtime@0.0.26` at the nested workspace path. Running bare `npm install` on a clean checkout does **not** actually install the package, so root-level `tsgo --noEmit` fails with 19 errors against `packages/coding-agent/examples/extensions/sandbox/index.ts` — \"Cannot find module '@anthropic-ai/sandbox-runtime'\" plus a chain of \"`network`/`filesystem` does not exist on `SandboxConfig`\" errors that all stem from the unresolvable type import.

This means `npm run check` (and therefore the husky pre-commit hook) fails on a clean upstream checkout, blocking contributor PRs that touch any other file.

## Repro on `main`

```bash
git checkout main
rm -rf node_modules packages/*/node_modules packages/coding-agent/examples/extensions/*/node_modules
npm install
npx tsgo --noEmit  # 19 errors in examples/extensions/sandbox/index.ts
```

## Fix

Regenerated the lockfile:

```bash
rm -rf node_modules package-lock.json
npm install
```

After regen, `@anthropic-ai/sandbox-runtime` hoists to root `node_modules` and the type resolves cleanly. Side effect: `commander` hoists to 12.1.0 (sandbox-runtime requires `^12`); `katex` keeps a private 8.3.0 copy nested. Diff is small.

## Verified

- `npm install` on a fresh checkout now installs `@anthropic-ai/sandbox-runtime`
- `npx tsgo --noEmit` clean
- `npm run build && npm run check` pass
- Husky pre-commit hook passes (was failing before)

## Why filing now

Hit while preparing a separate fix for openclaw/openclaw#74664 (`openai-completions` ignoring `compat.supportsTools=false`) — pre-commit blocked the AI-package change with errors in an unrelated example. This PR unblocks contributor flows.