### PR TITLE
Expose skills override to extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `pi.registerSkillsOverride()` so extensions can transform discovered skills and diagnostics before skill commands and prompt context are built.
+
 ## [0.71.1] - 2026-05-01
 
 ### Added

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -353,6 +353,21 @@ pi.on("resources_discover", async (event, _ctx) => {
 });
 ```
 
+#### registerSkillsOverride
+
+Extensions can transform loaded skills and diagnostics before Pi builds skill commands and prompt context. Overrides run during resource loading, after skill discovery. Multiple overrides are chained in extension load order.
+
+```typescript
+pi.registerSkillsOverride(({ skills, diagnostics }) => {
+  return {
+    skills: skills.filter((skill) => skill.name !== "experimental"),
+    diagnostics,
+  };
+});
+```
+
+Use this for narrow resource normalization, such as suppressing diagnostics for duplicate skill entries that point at identical content. Prefer leaving real conflicts visible.
+
 ### Session Events
 
 See [Session Format](session-format.md) for session storage internals and the SessionManager API.

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -217,6 +217,12 @@ function createExtensionAPI(
 			});
 		},
 
+		registerSkillsOverride(override): void {
+			runtime.assertActive();
+			extension.skillsOverrides ??= [];
+			extension.skillsOverrides.push(override);
+		},
+
 		registerShortcut(
 			shortcut: KeyId,
 			options: {
@@ -372,6 +378,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		commands: new Map(),
 		flags: new Map(),
 		shortcuts: new Map(),
+		skillsOverrides: [],
 	};
 }
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -43,6 +43,7 @@ import type { Static, TSchema } from "typebox";
 import type { Theme } from "../../modes/interactive/theme/theme.js";
 import type { BashResult } from "../bash-executor.js";
 import type { CompactionPreparation, CompactionResult } from "../compaction/index.js";
+import type { ResourceDiagnostic } from "../diagnostics.js";
 import type { EventBus } from "../event-bus.js";
 import type { ExecOptions, ExecResult } from "../exec.js";
 import type { ReadonlyFooterDataProvider } from "../footer-data-provider.js";
@@ -56,6 +57,7 @@ import type {
 	SessionEntry,
 	SessionManager,
 } from "../session-manager.js";
+import type { Skill } from "../skills.js";
 import type { SlashCommandInfo } from "../slash-commands.js";
 import type { SourceInfo } from "../source-info.js";
 import type { BuildSystemPromptOptions } from "../system-prompt.js";
@@ -504,6 +506,11 @@ export interface ResourcesDiscoverResult {
 	promptPaths?: string[];
 	themePaths?: string[];
 }
+
+export type SkillsOverride = (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
+	skills: Skill[];
+	diagnostics: ResourceDiagnostic[];
+};
 
 // ============================================================================
 // Session Events
@@ -1141,6 +1148,12 @@ export interface ExtensionAPI {
 	/** Register a custom command. */
 	registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">): void;
 
+	/**
+	 * Transform loaded skills and diagnostics before they are used for prompts and commands.
+	 * Runs during resource loading after skill discovery and before resource diagnostics are reported.
+	 */
+	registerSkillsOverride(override: SkillsOverride): void;
+
 	/** Register a keyboard shortcut. */
 	registerShortcut(
 		shortcut: KeyId,
@@ -1541,6 +1554,7 @@ export interface Extension {
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;
 	shortcuts: Map<KeyId, ExtensionShortcut>;
+	skillsOverrides?: SkillsOverride[];
 }
 
 /** Result of loading extensions. */

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -11,7 +11,13 @@ export type { ResourceCollision, ResourceDiagnostic } from "./diagnostics.js";
 import { canonicalizePath, isLocalPath } from "../utils/paths.js";
 import { createEventBus, type EventBus } from "./event-bus.js";
 import { createExtensionRuntime, loadExtensionFromFactory, loadExtensions } from "./extensions/loader.js";
-import type { Extension, ExtensionFactory, ExtensionRuntime, LoadExtensionsResult } from "./extensions/types.js";
+import type {
+	Extension,
+	ExtensionFactory,
+	ExtensionRuntime,
+	LoadExtensionsResult,
+	SkillsOverride,
+} from "./extensions/types.js";
 import { DefaultPackageManager, type PathMetadata } from "./package-manager.js";
 import type { PromptTemplate } from "./prompt-templates.js";
 import { loadPromptTemplates } from "./prompt-templates.js";
@@ -131,10 +137,7 @@ export interface DefaultResourceLoaderOptions {
 	systemPrompt?: string;
 	appendSystemPrompt?: string[];
 	extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
-	skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
-		skills: Skill[];
-		diagnostics: ResourceDiagnostic[];
-	};
+	skillsOverride?: SkillsOverride;
 	promptsOverride?: (base: { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] }) => {
 		prompts: PromptTemplate[];
 		diagnostics: ResourceDiagnostic[];
@@ -169,10 +172,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private systemPromptSource?: string;
 	private appendSystemPromptSource?: string[];
 	private extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
-	private skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
-		skills: Skill[];
-		diagnostics: ResourceDiagnostic[];
-	};
+	private skillsOverride?: SkillsOverride;
 	private promptsOverride?: (base: { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] }) => {
 		prompts: PromptTemplate[];
 		diagnostics: ResourceDiagnostic[];
@@ -496,7 +496,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 				includeDefaults: false,
 			});
 		}
-		const resolvedSkills = this.skillsOverride ? this.skillsOverride(skillsResult) : skillsResult;
+		const resolvedSkills = this.applySkillsOverrides(skillsResult);
 		this.skills = resolvedSkills.skills.map((skill) => ({
 			...skill,
 			sourceInfo:
@@ -505,6 +505,19 @@ export class DefaultResourceLoader implements ResourceLoader {
 				this.getDefaultSourceInfoForPath(skill.filePath),
 		}));
 		this.skillDiagnostics = resolvedSkills.diagnostics;
+	}
+
+	private applySkillsOverrides(base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }): {
+		skills: Skill[];
+		diagnostics: ResourceDiagnostic[];
+	} {
+		let current = this.skillsOverride ? this.skillsOverride(base) : base;
+		for (const extension of this.extensionsResult.extensions) {
+			for (const override of extension.skillsOverrides ?? []) {
+				current = override(current);
+			}
+		}
+		return current;
 	}
 
 	private updatePromptsFromPaths(promptPaths: string[], metadataByPath?: Map<string, PathMetadata>): void {

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -477,6 +477,37 @@ Content`,
 			expect(skills[0].name).toBe("injected");
 		});
 
+		it("should apply extension skills overrides", async () => {
+			const skillDir = join(agentDir, "skills", "base");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: base
+description: Base skill
+---
+Content`,
+			);
+
+			const loader = new DefaultResourceLoader({
+				cwd,
+				agentDir,
+				extensionFactories: [
+					(pi) => {
+						pi.registerSkillsOverride(({ skills, diagnostics }) => ({
+							skills: skills.map((skill) => ({ ...skill, description: "Overridden skill" })),
+							diagnostics,
+						}));
+					},
+				],
+			});
+			await loader.reload();
+
+			const { skills } = loader.getSkills();
+			expect(skills).toHaveLength(1);
+			expect(skills[0].description).toBe("Overridden skill");
+		});
+
 		it("should apply systemPromptOverride", async () => {
 			const loader = new DefaultResourceLoader({
 				cwd,


### PR DESCRIPTION
## Summary

- add `pi.registerSkillsOverride()` for extensions
- chain extension-provided skill overrides with the existing SDK `skillsOverride`
- document the API and cover it with a resource loader test

## Motivation

Pi already exposes `skillsOverride` through `DefaultResourceLoader` for SDK users, but regular CLI extensions cannot participate in that stage of resource loading. This makes it hard for an extension to do small, local skill normalization before skill commands and prompt context are built.

One concrete case is working inside a repository that is also listed as a skill source in `settings.json`. Pi can discover the same skill through project discovery and through the configured skill path. If the duplicate entries are identical, an extension could safely keep one copy and remove the duplicate collision diagnostic, while leaving real conflicts visible.

This PR keeps the change narrow: extensions register a synchronous override during extension load, and the existing resource loader applies those overrides immediately after skill discovery, before diagnostics are stored and before skills are used elsewhere.

## Testing

- `npm run test --workspace @mariozechner/pi-coding-agent -- resource-loader.test.ts`
- `npm run build --workspace @mariozechner/pi-coding-agent`

Note: full pre-commit `npm run check` was attempted, but this checkout currently fails on existing `packages/coding-agent/examples/extensions/sandbox` type errors around `@anthropic-ai/sandbox-runtime` / `SandboxConfig`, unrelated to this change.
