### PR TITLE
fix(tui): support Vietnamese/IME input with combining marks

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -131,7 +131,11 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 			if (wrapOppIndex >= 0 && currentWidth - wrapOppWidth + gWidth <= maxWidth) {
 				// Backtrack to last wrap opportunity (the remaining content
 				// plus the current grapheme still fits within maxWidth).
-				chunks.push({ text: line.slice(chunkStart, wrapOppIndex), startIndex: chunkStart, endIndex: wrapOppIndex });
+				chunks.push({
+					text: line.slice(chunkStart, wrapOppIndex),
+					startIndex: chunkStart,
+					endIndex: wrapOppIndex,
+				});
 				chunkStart = wrapOppIndex;
 				currentWidth -= wrapOppWidth;
 			} else if (chunkStart < charIndex) {
@@ -140,7 +144,11 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 				// boundary wouldn't help because the remaining content plus
 				// the current grapheme (e.g. a wide character) still exceeds
 				// maxWidth.
-				chunks.push({ text: line.slice(chunkStart, charIndex), startIndex: chunkStart, endIndex: charIndex });
+				chunks.push({
+					text: line.slice(chunkStart, charIndex),
+					startIndex: chunkStart,
+					endIndex: charIndex,
+				});
 				chunkStart = charIndex;
 				currentWidth = 0;
 			}
@@ -156,7 +164,11 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 			const subChunks = wordWrapLine(grapheme, maxWidth);
 			for (let j = 0; j < subChunks.length - 1; j++) {
 				const sc = subChunks[j]!;
-				chunks.push({ text: sc.text, startIndex: charIndex + sc.startIndex, endIndex: charIndex + sc.endIndex });
+				chunks.push({
+					text: sc.text,
+					startIndex: charIndex + sc.startIndex,
+					endIndex: charIndex + sc.endIndex,
+				});
 			}
 			const last = subChunks[subChunks.length - 1]!;
 			chunkStart = charIndex + last.startIndex;
@@ -179,7 +191,11 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 	}
 
 	// Push final chunk.
-	chunks.push({ text: line.slice(chunkStart), startIndex: chunkStart, endIndex: line.length });
+	chunks.push({
+		text: line.slice(chunkStart),
+		startIndex: chunkStart,
+		endIndex: line.length,
+	});
 
 	return chunks;
 }
@@ -969,7 +985,7 @@ export class Editor implements Component, Focusable {
 	 * - Expand tabs to 4 spaces
 	 */
 	private normalizeText(text: string): string {
-		return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\t/g, "    ");
+		return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\t/g, "    ").normalize("NFC");
 	}
 
 	/**
@@ -1022,6 +1038,7 @@ export class Editor implements Component, Focusable {
 
 	// All the editor methods from before...
 	private insertCharacter(char: string, skipUndoCoalescing?: boolean): void {
+		char = char.normalize("NFC");
 		this.historyIndex = -1; // Exit history browsing mode
 
 		// Undo coalescing (fish-style):
@@ -1273,7 +1290,11 @@ export class Editor implements Component, Focusable {
 	 * Shared by moveCursor() and pageScroll().
 	 */
 	private moveToVisualLine(
-		visualLines: Array<{ logicalLine: number; startCol: number; length: number }>,
+		visualLines: Array<{
+			logicalLine: number;
+			startCol: number;
+			length: number;
+		}>,
 		currentVisualLine: number,
 		targetVisualLine: number,
 	): void {
@@ -1428,7 +1449,10 @@ export class Editor implements Component, Focusable {
 
 			// Calculate text to be deleted and save to kill ring (backward deletion = prepend)
 			const deletedText = currentLine.slice(0, this.state.cursorCol);
-			this.killRing.push(deletedText, { prepend: true, accumulate: this.lastAction === "kill" });
+			this.killRing.push(deletedText, {
+				prepend: true,
+				accumulate: this.lastAction === "kill",
+			});
 			this.lastAction = "kill";
 
 			// Delete from start of line up to cursor
@@ -1438,7 +1462,10 @@ export class Editor implements Component, Focusable {
 			this.pushUndoSnapshot();
 
 			// At start of line - merge with previous line, treating newline as deleted text
-			this.killRing.push("\n", { prepend: true, accumulate: this.lastAction === "kill" });
+			this.killRing.push("\n", {
+				prepend: true,
+				accumulate: this.lastAction === "kill",
+			});
 			this.lastAction = "kill";
 
 			const previousLine = this.state.lines[this.state.cursorLine - 1] || "";
@@ -1463,7 +1490,10 @@ export class Editor implements Component, Focusable {
 
 			// Calculate text to be deleted and save to kill ring (forward deletion = append)
 			const deletedText = currentLine.slice(this.state.cursorCol);
-			this.killRing.push(deletedText, { prepend: false, accumulate: this.lastAction === "kill" });
+			this.killRing.push(deletedText, {
+				prepend: false,
+				accumulate: this.lastAction === "kill",
+			});
 			this.lastAction = "kill";
 
 			// Delete from cursor to end of line
@@ -1472,7 +1502,10 @@ export class Editor implements Component, Focusable {
 			this.pushUndoSnapshot();
 
 			// At end of line - merge with next line, treating newline as deleted text
-			this.killRing.push("\n", { prepend: false, accumulate: this.lastAction === "kill" });
+			this.killRing.push("\n", {
+				prepend: false,
+				accumulate: this.lastAction === "kill",
+			});
 			this.lastAction = "kill";
 
 			const nextLine = this.state.lines[this.state.cursorLine + 1] || "";
@@ -1496,7 +1529,10 @@ export class Editor implements Component, Focusable {
 				this.pushUndoSnapshot();
 
 				// Treat newline as deleted text (backward deletion = prepend)
-				this.killRing.push("\n", { prepend: true, accumulate: this.lastAction === "kill" });
+				this.killRing.push("\n", {
+					prepend: true,
+					accumulate: this.lastAction === "kill",
+				});
 				this.lastAction = "kill";
 
 				const previousLine = this.state.lines[this.state.cursorLine - 1] || "";
@@ -1541,7 +1577,10 @@ export class Editor implements Component, Focusable {
 				this.pushUndoSnapshot();
 
 				// Treat newline as deleted text (forward deletion = append)
-				this.killRing.push("\n", { prepend: false, accumulate: this.lastAction === "kill" });
+				this.killRing.push("\n", {
+					prepend: false,
+					accumulate: this.lastAction === "kill",
+				});
 				this.lastAction = "kill";
 
 				const nextLine = this.state.lines[this.state.cursorLine + 1] || "";
@@ -1630,7 +1669,11 @@ export class Editor implements Component, Focusable {
 	 * - length: length of this visual line segment
 	 */
 	private buildVisualLineMap(width: number): Array<{ logicalLine: number; startCol: number; length: number }> {
-		const visualLines: Array<{ logicalLine: number; startCol: number; length: number }> = [];
+		const visualLines: Array<{
+			logicalLine: number;
+			startCol: number;
+			length: number;
+		}> = [];
 
 		for (let i = 0; i < this.state.lines.length; i++) {
 			const line = this.state.lines[i] || "";
@@ -1660,7 +1703,11 @@ export class Editor implements Component, Focusable {
 	 * Find the visual line index that contains the given logical position.
 	 */
 	private findVisualLineAt(
-		visualLines: Array<{ logicalLine: number; startCol: number; length: number }>,
+		visualLines: Array<{
+			logicalLine: number;
+			startCol: number;
+			length: number;
+		}>,
 		line: number,
 		col: number,
 	): number {
@@ -1682,7 +1729,11 @@ export class Editor implements Component, Focusable {
 	 * Find the visual line index for the current cursor position.
 	 */
 	private findCurrentVisualLine(
-		visualLines: Array<{ logicalLine: number; startCol: number; length: number }>,
+		visualLines: Array<{
+			logicalLine: number;
+			startCol: number;
+			length: number;
+		}>,
 	): number {
 		return this.findVisualLineAt(visualLines, this.state.cursorLine, this.state.cursorCol);
 	}
@@ -2287,6 +2338,9 @@ export class Editor implements Component, Focusable {
 
 	private updateAutocomplete(): void {
 		if (!this.autocompleteState || !this.autocompleteProvider) return;
-		this.requestAutocomplete({ force: this.autocompleteState === "force", explicitTab: false });
+		this.requestAutocomplete({
+			force: this.autocompleteState === "force",
+			explicitTab: false,
+		});
 	}
 }

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -210,6 +210,7 @@ export class Input implements Component, Focusable {
 	}
 
 	private insertCharacter(char: string): void {
+		char = char.normalize("NFC");
 		// Undo coalescing: consecutive word chars coalesce into one undo unit
 		if (isWhitespaceChar(char) || this.lastAction !== "type-word") {
 			this.pushUndo();
@@ -249,7 +250,10 @@ export class Input implements Component, Focusable {
 		if (this.cursor === 0) return;
 		this.pushUndo();
 		const deletedText = this.value.slice(0, this.cursor);
-		this.killRing.push(deletedText, { prepend: true, accumulate: this.lastAction === "kill" });
+		this.killRing.push(deletedText, {
+			prepend: true,
+			accumulate: this.lastAction === "kill",
+		});
 		this.lastAction = "kill";
 		this.value = this.value.slice(this.cursor);
 		this.cursor = 0;
@@ -259,7 +263,10 @@ export class Input implements Component, Focusable {
 		if (this.cursor >= this.value.length) return;
 		this.pushUndo();
 		const deletedText = this.value.slice(this.cursor);
-		this.killRing.push(deletedText, { prepend: false, accumulate: this.lastAction === "kill" });
+		this.killRing.push(deletedText, {
+			prepend: false,
+			accumulate: this.lastAction === "kill",
+		});
 		this.lastAction = "kill";
 		this.value = this.value.slice(0, this.cursor);
 	}

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -189,7 +189,10 @@ function parseUnmodifiedKittyPrintableCodepoint(sequence: string): number | unde
 	return codepoint >= 32 ? codepoint : undefined;
 }
 
-function extractCompleteSequences(buffer: string): { sequences: string[]; remainder: string } {
+function extractCompleteSequences(buffer: string): {
+	sequences: string[];
+	remainder: string;
+} {
 	const sequences: string[] = [];
 	let pos = 0;
 
@@ -222,9 +225,28 @@ function extractCompleteSequences(buffer: string): { sequences: string[]; remain
 				return { sequences, remainder: remaining };
 			}
 		} else {
-			// Not an escape sequence - take a single character
-			sequences.push(remaining[0]!);
-			pos++;
+			// Not an escape sequence - take a grapheme cluster (base char + combining marks)
+			// This prevents splitting NFD Vietnamese/french/german characters with
+			// combining diacritical marks into separate input events.
+			let end = 1;
+			while (pos + end < buffer.length) {
+				const next = buffer[pos + end];
+				if (next === "\x1b") break;
+				const cp = buffer.codePointAt(pos + end);
+				if (
+					(cp! >= 0x0300 && cp! <= 0x036f) || // Combining Diacritical Marks
+					(cp! >= 0x1ab0 && cp! <= 0x1aff) || // Combining Diacritical Marks Extended
+					(cp! >= 0x1dc0 && cp! <= 0x1dff) || // Combining Diacritical Marks Supplement
+					(cp! >= 0x20d0 && cp! <= 0x20ff) || // Combining Diacritical Marks for Symbols
+					(cp! >= 0xfe20 && cp! <= 0xfe2f) // Combining Half Marks
+				) {
+					end++;
+				} else {
+					break;
+				}
+			}
+			sequences.push(buffer.slice(pos, pos + end));
+			pos += end;
 		}
 	}
 

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -192,6 +192,18 @@ export class ProcessTerminal implements Terminal {
 	private queryAndEnableKittyProtocol(): void {
 		this.setupStdinBuffer();
 		process.stdin.on("data", this.stdinDataHandler!);
+
+		// VSCode's xterm.js Kitty protocol handling is broken for IME/dead key
+		// composition. When Kitty is active, dead keys are sent as literals and
+		// the following letter is sent only as a release event (which pi ignores),
+		// breaking accented characters entirely. Fall back to modifyOtherKeys mode 2.
+		const isVSCode = process.env.TERM_PROGRAM === "vscode";
+		if (isVSCode) {
+			process.stdout.write("\x1b[>4;2m");
+			this._modifyOtherKeysActive = true;
+			return;
+		}
+
 		process.stdout.write("\x1b[?u");
 		setTimeout(() => {
 			if (!this._kittyProtocolActive && !this._modifyOtherKeysActive) {


### PR DESCRIPTION
## Problem

### 1. Vietnamese / combining-mark languages broken in TUI (#2518)

Typing Vietnamese (or French, Spanish, German) in pi's TUI is slow/laggy because `StdinBuffer.extractCompleteSequences()` processes one UTF-16 code unit at a time. When the IME sends characters in NFD form, a single "ắ" arrives as 3 code points (a + ◌̆ + ◌́), each triggering a separate handleInput() call and re-render.

Additionally, normalizeText() and insertCharacter() in editor.ts and input.ts do not normalize to NFC, so decomposed text is stored as-is, causing cursor misalignment and rendering issues.

### 2. VSCode terminal breaks IME/dead key composition (#1973)

VSCode's xterm.js handles Kitty keyboard protocol incorrectly: dead keys / IME compositions are sent as separate events, with the following letter sent only as a release event (which pi ignores). Result: dead key + letter produces only the dead key character.

## Fix

4 changes across packages/tui/src/:

- **stdin-buffer.ts**: Group combining diacritical marks (U+0300-036F, U+1AB0-1AFF, U+1DC0-1DFF, U+20D0-20FF, U+FE20-FE2F) with their base character so NFD input arrives as single grapheme clusters
- **editor.ts (normalizeText)**: Add .normalize("NFC") to store text in composed form
- **editor.ts (insertCharacter)**: Normalize each inserted character to NFC
- **input.ts (insertCharacter)**: Normalize each inserted character to NFC
- **terminal.ts**: Skip Kitty protocol when TERM_PROGRAM=vscode. Fall back to modifyOtherKeys mode 2 which works correctly with IME/dead keys

## Verification

- npm run check: no new errors (pre-existing sandbox example errors only)
- ./test.sh: 568/568 tests pass, 0 fail

Closes #2518, closes #1973