### PR TITLE
Add extension tool unregister APIs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `pi.unregisterTool()` and `pi.replaceTools()` so extensions can remove or atomically replace their own registered tools at runtime without requiring `/reload`.
+
 ## [0.72.0] - 2026-05-01
 
 ### New Features

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1265,6 +1265,33 @@ pi.registerTool({
 });
 ```
 
+### pi.unregisterTool(name)
+
+Remove a custom tool previously registered by the current extension. Returns `true` when the tool existed and was removed, or `false` when the current extension had no tool with that name.
+
+`pi.unregisterTool()` works after startup as well as during extension load. When it removes a tool after startup, pi refreshes the current session registry immediately. Removed tools disappear from `pi.getAllTools()`, are dropped from the active tool set, and are no longer callable without requiring `/reload`.
+
+```typescript
+pi.registerCommand("disable-my-tool", {
+  handler: async () => {
+    pi.unregisterTool("my_tool");
+  },
+});
+```
+
+### pi.replaceTools(definitions)
+
+Replace all custom tools owned by the current extension in one refresh. This is useful for extensions that mirror an external tool catalog and need to hot-swap the whole set when that catalog changes.
+
+`pi.replaceTools()` only replaces tools registered by the current extension. It does not remove built-in tools, SDK custom tools, or tools registered by other extensions.
+
+```typescript
+pi.on("session_start", async () => {
+  const tools = await loadExternalToolCatalog();
+  pi.replaceTools(tools);
+});
+```
+
 ### pi.sendMessage(message, options?)
 
 Inject a custom message into the session.

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -208,6 +208,27 @@ function createExtensionAPI(
 			runtime.refreshTools();
 		},
 
+		unregisterTool(name: string): boolean {
+			runtime.assertActive();
+			const removed = extension.tools.delete(name);
+			if (removed) {
+				runtime.refreshTools();
+			}
+			return removed;
+		},
+
+		replaceTools(tools: readonly ToolDefinition[]): void {
+			runtime.assertActive();
+			extension.tools.clear();
+			for (const tool of tools) {
+				extension.tools.set(tool.name, {
+					definition: tool,
+					sourceInfo: extension.sourceInfo,
+				});
+			}
+			runtime.refreshTools();
+		},
+
 		registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">): void {
 			runtime.assertActive();
 			extension.commands.set(name, {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1134,6 +1134,12 @@ export interface ExtensionAPI {
 		tool: ToolDefinition<TParams, TDetails, TState>,
 	): void;
 
+	/** Unregister a tool previously registered by this extension. Returns true when a tool was removed. */
+	unregisterTool(name: string): boolean;
+
+	/** Replace all tools currently registered by this extension and refresh the active session registry once. */
+	replaceTools<TTools extends readonly ToolDefinition<any, any, any>[]>(tools: TTools): void;
+
 	// =========================================================================
 	// Command, Shortcut, Flag Registration
 	// =========================================================================

--- a/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
+++ b/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
@@ -91,6 +91,148 @@ describe("AgentSession dynamic tool registration", () => {
 		session.dispose();
 	});
 
+	it("unregisters dynamic tools and removes them from the active session registry", async () => {
+		let removed: boolean | undefined;
+		let removedAgain: boolean | undefined;
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const sessionManager = SessionManager.inMemory();
+
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: tempDir,
+			agentDir,
+			settingsManager,
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", () => {
+						pi.registerTool({
+							name: "dynamic_tool",
+							label: "Dynamic Tool",
+							description: "Tool registered from session_start",
+							promptSnippet: "Run dynamic test behavior",
+							promptGuidelines: ["Use dynamic_tool when the user asks for dynamic behavior tests."],
+							parameters: Type.Object({}),
+							execute: async () => ({
+								content: [{ type: "text", text: "ok" }],
+								details: {},
+							}),
+						});
+					});
+					pi.registerCommand("remove-dynamic-tool", {
+						handler: async () => {
+							removed = pi.unregisterTool("dynamic_tool");
+							removedAgain = pi.unregisterTool("dynamic_tool");
+						},
+					});
+				},
+			],
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir,
+			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+		});
+
+		await session.bindExtensions({});
+		expect(session.getAllTools().map((tool) => tool.name)).toContain("dynamic_tool");
+		expect(session.getActiveToolNames()).toContain("dynamic_tool");
+		expect(session.systemPrompt).toContain("- dynamic_tool: Run dynamic test behavior");
+
+		await session.extensionRunner
+			.getCommand("remove-dynamic-tool")
+			?.handler("", session.extensionRunner.createCommandContext());
+
+		expect(removed).toBe(true);
+		expect(removedAgain).toBe(false);
+		expect(session.getAllTools().map((tool) => tool.name)).not.toContain("dynamic_tool");
+		expect(session.getActiveToolNames()).not.toContain("dynamic_tool");
+		expect(session.systemPrompt).not.toContain("dynamic_tool");
+
+		session.dispose();
+	});
+
+	it("replaces dynamic tools and activates newly registered replacements", async () => {
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const sessionManager = SessionManager.inMemory();
+
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: tempDir,
+			agentDir,
+			settingsManager,
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", () => {
+						pi.registerTool({
+							name: "old_dynamic_tool",
+							label: "Old Dynamic Tool",
+							description: "Original dynamic tool",
+							promptSnippet: "Run old dynamic behavior",
+							promptGuidelines: ["Use old_dynamic_tool before the replacement is installed."],
+							parameters: Type.Object({}),
+							execute: async () => ({
+								content: [{ type: "text", text: "old" }],
+								details: {},
+							}),
+						});
+					});
+					pi.registerCommand("replace-dynamic-tools", {
+						handler: async () => {
+							pi.replaceTools([
+								{
+									name: "new_dynamic_tool",
+									label: "New Dynamic Tool",
+									description: "Replacement dynamic tool",
+									promptSnippet: "Run new dynamic behavior",
+									promptGuidelines: ["Use new_dynamic_tool after the replacement is installed."],
+									parameters: Type.Object({}),
+									execute: async () => ({
+										content: [{ type: "text", text: "new" }],
+										details: {},
+									}),
+								},
+							]);
+						},
+					});
+				},
+			],
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir,
+			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+		});
+
+		await session.bindExtensions({});
+		expect(session.getAllTools().map((tool) => tool.name)).toContain("old_dynamic_tool");
+		expect(session.getActiveToolNames()).toContain("old_dynamic_tool");
+		expect(session.systemPrompt).toContain("- old_dynamic_tool: Run old dynamic behavior");
+
+		await session.extensionRunner
+			.getCommand("replace-dynamic-tools")
+			?.handler("", session.extensionRunner.createCommandContext());
+
+		const allToolNames = session.getAllTools().map((tool) => tool.name);
+		expect(allToolNames).not.toContain("old_dynamic_tool");
+		expect(allToolNames).toContain("new_dynamic_tool");
+		expect(session.getActiveToolNames()).not.toContain("old_dynamic_tool");
+		expect(session.getActiveToolNames()).toContain("new_dynamic_tool");
+		expect(session.getActiveToolNames()).toContain("read");
+		expect(session.systemPrompt).not.toContain("old_dynamic_tool");
+		expect(session.systemPrompt).toContain("- new_dynamic_tool: Run new dynamic behavior");
+		expect(session.systemPrompt).toContain("Use new_dynamic_tool after the replacement is installed.");
+
+		session.dispose();
+	});
+
 	it("returns source metadata for SDK custom tools", async () => {
 		const settingsManager = SettingsManager.create(tempDir, agentDir);
 		const sessionManager = SessionManager.inMemory();


### PR DESCRIPTION
## Summary
- add pi.unregisterTool() so extensions can remove their own registered tools at runtime
- add pi.replaceTools() so extensions can atomically replace their owned tool catalog in a single refresh
- document the new APIs and cover active-tool/system-prompt refresh behavior in dynamic tool tests

## Testing
- npm --prefix packages/tui run build
- npm --prefix packages/ai run build
- npm --prefix packages/agent run build
- npm --prefix packages/coding-agent test -- agent-session-dynamic-tools.test.ts
- npm --prefix packages/coding-agent run build
- git diff --check
- npx biome check packages/coding-agent/src/core/extensions/types.ts packages/coding-agent/src/core/extensions/loader.ts packages/coding-agent/test/agent-session-dynamic-tools.test.ts packages/coding-agent/docs/extensions.md packages/coding-agent/CHANGELOG.md

## Known existing blockers
- npm --prefix packages/coding-agent test currently fails in test/package-manager.test.ts on managerWithInternals.shouldUseWindowsShell is not a function.
- The pre-commit hook's monorepo check also fails on the existing sandbox extension example due missing @anthropic-ai/sandbox-runtime and SandboxConfig fields.