### PR TITLE
fix(ai): honor transport field in buildBaseOptions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `streamSimple()` provider option forwarding to preserve `transport`, allowing transport preferences such as WebSocket to reach provider implementations ([#4083](https://github.com/badlogic/pi-mono/issues/4083)).
+- Fixed `streamSimple()` provider option forwarding to preserve `transport`, allowing transport preferences such as WebSocket to reach provider implementations ([#4090](https://github.com/badlogic/pi-mono/pull/4090) by [@aadishv](https://github.com/aadishv)).
 
 ## [0.72.0] - 2026-05-01
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `streamSimple()` provider option forwarding to preserve `transport`, allowing transport preferences such as WebSocket to reach provider implementations ([#4083](https://github.com/badlogic/pi-mono/issues/4083)).
+
 ## [0.72.0] - 2026-05-01
 
 ### Breaking Changes

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -6,6 +6,7 @@ export function buildBaseOptions(model: Model<Api>, options?: SimpleStreamOption
 		maxTokens: options?.maxTokens ?? (model.maxTokens > 0 ? Math.min(model.maxTokens, 32000) : undefined),
 		signal: options?.signal,
 		apiKey: apiKey || options?.apiKey,
+		transport: options?.transport,
 		cacheRetention: options?.cacheRetention,
 		sessionId: options?.sessionId,
 		headers: options?.headers,


### PR DESCRIPTION
Resolves #4083.

Update `buildBaseOptions` to propagate the transport field, with corresponding changelog entry. Thank you @wtchangdm for the analysis!

Testing by sending "hi" to gpt-5.4 on the codex provider:
```bash
# with fix
2026-05-02T08:39:13.171Z [openai-codex-responses] transport_selected transport="websocket" sessionId="..." websocketUrl="wss://chatgpt.com/backend-api/codex/responses" sseUrl="https://chatgpt.com/backend-api/codex/responses"
2026-05-02T08:39:13.171Z [openai-codex-responses] websocket_attempt transport="websocket" sessionId="..." websocketUrl="wss://chatgpt.com/backend-api/codex/responses"
2026-05-02T08:39:13.172Z [openai-codex-responses] websocket_connecting websocketUrl="wss://chatgpt.com/backend-api/codex/responses" headerKeys=["authorization","chatgpt-account-id","openai-beta","originator","session_id","user-agent","x-client-request-id"]
2026-05-02T08:39:13.424Z [openai-codex-responses] websocket_open websocketUrl="wss://chatgpt.com/backend-api/codex/responses"
2026-05-02T08:39:13.424Z [openai-codex-responses] websocket_cache_created sessionId="..." websocketUrl="wss://chatgpt.com/backend-api/codex/responses"
2026-05-02T08:39:13.425Z [openai-codex-responses] websocket_started transport="websocket" sessionId="..." websocketUrl="wss://chatgpt.com/backend-api/codex/responses"
2026-05-02T08:39:14.110Z [openai-codex-responses] websocket_completed transport="websocket" sessionId="..." websocketUrl="wss://chatgpt.com/backend-api/codex/responses"

# w/o fix
2026-05-02T08:40:12.160Z [openai-codex-responses] transport_selected transport="sse" sessionId="..." websocketUrl="wss://chatgpt.com/backend-api/codex/responses" sseUrl="https://chatgpt.com/backend-api/codex/responses"
2026-05-02T08:40:12.160Z [openai-codex-responses] websocket_skipped reason="transport_forced_sse" sessionId="..." websocketUrl="wss://chatgpt.com/backend-api/codex/responses"
2026-05-02T08:40:12.160Z [openai-codex-responses] sse_attempt transport="sse" sessionId="..." sseUrl="https://chatgpt.com/backend-api/codex/responses" attempt=0
2026-05-02T08:40:12.597Z [openai-codex-responses] sse_response_ok transport="sse" sessionId="..." sseUrl="https://chatgpt.com/backend-api/codex/responses" attempt=0 status=200
```