### PR TITLE
Fix nested Codex stream error formatting

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -376,14 +376,19 @@ async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): 
 		if (!type) continue;
 
 		if (type === "error") {
-			const code = (event as { code?: string }).code || "";
-			const message = (event as { message?: string }).message || "";
-			throw new Error(`Codex error: ${message || code || JSON.stringify(event)}`);
+			throw new Error(formatCodexStreamError(event));
 		}
 
 		if (type === "response.failed") {
-			const msg = (event as { response?: { error?: { message?: string } } }).response?.error?.message;
-			throw new Error(msg || "Codex response failed");
+			const response = (event as { response?: { error?: CodexErrorPayload; request_id?: string } }).response;
+			throw new Error(
+				formatCodexErrorMessage({
+					code: response?.error?.code || response?.error?.type,
+					message: response?.error?.message,
+					requestId: response?.error?.request_id || response?.request_id || stringValue(event.request_id),
+					fallback: "Codex response failed",
+				}),
+			);
 		}
 
 		if (type === "response.done" || type === "response.completed" || type === "response.incomplete") {
@@ -821,6 +826,52 @@ async function processWebSocketStream(
 // ============================================================================
 // Error Handling
 // ============================================================================
+
+type CodexErrorPayload = {
+	type?: string;
+	code?: string;
+	message?: string;
+	request_id?: string;
+	requestId?: string;
+};
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function formatCodexErrorMessage({
+	code,
+	message,
+	requestId,
+	fallback = "Codex request failed",
+}: {
+	code?: string;
+	message?: string;
+	requestId?: string;
+	fallback?: string;
+}): string {
+	const text = `${code || ""} ${message || ""}`;
+	const transient = /server_error|rate_limit_exceeded|overloaded|service.?unavailable/i.test(text);
+	const parts = [transient ? "Codex transient error" : "Codex error"];
+	if (code) parts.push(`(${code})`);
+	parts.push(message || fallback);
+	if (requestId) parts.push(`Request ID: ${requestId}.`);
+	if (transient) {
+		parts.push("This is a server-side ChatGPT/Codex failure; retry the turn, or switch models if it persists.");
+	}
+	return parts.join(" ").trim();
+}
+
+function formatCodexStreamError(event: Record<string, unknown>): string {
+	const nested = event.error && typeof event.error === "object" ? (event.error as CodexErrorPayload) : undefined;
+	return formatCodexErrorMessage({
+		code: stringValue(event.code) || nested?.code || nested?.type,
+		message: stringValue(event.message) || nested?.message,
+		requestId:
+			stringValue(event.request_id) || stringValue(event.requestId) || nested?.request_id || nested?.requestId,
+		fallback: JSON.stringify(event),
+	});
+}
 
 async function parseErrorResponse(response: Response): Promise<{ message: string; friendlyMessage?: string }> {
 	const raw = await response.text();

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -185,6 +185,72 @@ describe("openai-codex streaming", () => {
 		expect(sawDone).toBe(true);
 	});
 
+	it("formats nested Codex stream errors with code and request ID", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const requestId = "4087f0ae-3153-4ef7-98b4-0415a5b1d7b3";
+		const sse = `data: ${JSON.stringify({
+			type: "error",
+			error: {
+				type: "server_error",
+				code: "server_error",
+				message: `An error occurred while processing your request. Please include the request ID ${requestId} in your message.`,
+				request_id: requestId,
+			},
+			sequence_number: 4,
+		})}\n\n`;
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const message = await streamOpenAICodexResponses(model, context, { apiKey: token }).result();
+
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("Codex transient error (server_error)");
+		expect(message.errorMessage).toContain(`Request ID: ${requestId}.`);
+		expect(message.errorMessage).toContain("retry the turn, or switch models");
+		expect(message.errorMessage).not.toContain('"sequence_number":4');
+	});
+
 	it("completes after response.completed even when the SSE body stays open", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
 		process.env.PI_CODING_AGENT_DIR = tempDir;


### PR DESCRIPTION
## Summary

Fixes #4092.

OpenAI Codex streamed `type: "error"` events can put their details under a nested `error` object. The previous handler only read top-level `event.code` and `event.message`, so nested server errors fell back to raw JSON.

This change:

- extracts nested `error.type`, `error.code`, `error.message`, and request IDs
- uses the same formatter for `response.failed`
- labels known transient failures as `Codex transient error`
- adds a focused regression test using the observed nested `server_error` event shape

## Validation

- `npx vitest --run packages/ai/test/openai-codex-stream.test.ts -t "formats nested Codex stream errors"` ✅
- `npx biome check packages/ai/src/providers/openai-codex-responses.ts packages/ai/test/openai-codex-stream.test.ts` ✅
- `npm run build --workspace @mariozechner/pi-ai` ✅

Note: the full `openai-codex-stream.test.ts` file currently has an unrelated timeout in `sets conversation_id/session_id headers and prompt_cache_key when sessionId is provided`, and the repo pre-commit `npm run check` fails in `packages/web-ui` because `@mariozechner/pi-agent-core` cannot be resolved. I did not change those areas.
