### PR TITLE
feat(agent,coding-agent): add stopAfterTurn handoff control

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -95,6 +95,7 @@ export interface AgentOptions {
 	initialState?: Partial<Omit<AgentState, "pendingToolCalls" | "isStreaming" | "streamingMessage" | "errorMessage">>;
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+	shouldStopAfterTurn?: AgentLoopConfig["shouldStopAfterTurn"];
 	streamFn?: StreamFn;
 	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 	onPayload?: SimpleStreamOptions["onPayload"];
@@ -163,6 +164,7 @@ export class Agent {
 
 	public convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	public transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+	public shouldStopAfterTurn?: AgentLoopConfig["shouldStopAfterTurn"];
 	public streamFn: StreamFn;
 	public getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 	public onPayload?: SimpleStreamOptions["onPayload"];
@@ -176,6 +178,7 @@ export class Agent {
 		signal?: AbortSignal,
 	) => Promise<AfterToolCallResult | undefined>;
 	private activeRun?: ActiveRun;
+	private stopAfterTurnRequested = false;
 	/** Session identifier forwarded to providers for cache-aware backends. */
 	public sessionId?: string;
 	/** Optional per-level thinking token budgets forwarded to the stream function. */
@@ -191,6 +194,7 @@ export class Agent {
 		this._state = createMutableAgentState(options.initialState);
 		this.convertToLlm = options.convertToLlm ?? defaultConvertToLlm;
 		this.transformContext = options.transformContext;
+		this.shouldStopAfterTurn = options.shouldStopAfterTurn;
 		this.streamFn = options.streamFn ?? streamSimple;
 		this.getApiKey = options.getApiKey;
 		this.onPayload = options.onPayload;
@@ -287,6 +291,11 @@ export class Agent {
 	/** Abort the current run, if one is active. */
 	abort(): void {
 		this.activeRun?.abortController.abort();
+	}
+
+	/** Request that the current or next run stop after the active turn completes. */
+	stopAfterTurn(): void {
+		this.stopAfterTurnRequested = true;
 	}
 
 	/**
@@ -421,6 +430,13 @@ export class Agent {
 			toolExecution: this.toolExecution,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
+			shouldStopAfterTurn: async (context) => {
+				if (this.stopAfterTurnRequested) {
+					return true;
+				}
+
+				return (await this.shouldStopAfterTurn?.(context)) ?? false;
+			},
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
 			getApiKey: this.getApiKey,
@@ -483,6 +499,7 @@ export class Agent {
 		this._state.pendingToolCalls = new Set<string>();
 		this.activeRun?.resolve();
 		this.activeRun = undefined;
+		this.stopAfterTurnRequested = false;
 	}
 
 	/**

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -211,6 +211,41 @@ describe("Agent", () => {
 		expect(receivedSignal?.aborted).toBe(true);
 	});
 
+	it("should stop after the current turn and leave follow-ups queued", async () => {
+		let llmCalls = 0;
+		const agent = new Agent({
+			streamFn: () => {
+				llmCalls += 1;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage(`response-${llmCalls}`),
+					});
+				});
+				return stream;
+			},
+		});
+
+		agent.followUp({
+			role: "user",
+			content: "continue later",
+			timestamp: Date.now(),
+		});
+		agent.stopAfterTurn();
+
+		await agent.prompt("hello");
+
+		expect(llmCalls).toBe(1);
+		expect(agent.hasQueuedMessages()).toBe(true);
+
+		await agent.continue();
+
+		expect(llmCalls).toBe(2);
+		expect(agent.hasQueuedMessages()).toBe(false);
+	});
+
 	it("should update state with mutators", () => {
 		const agent = new Agent();
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1388,6 +1388,13 @@ export class AgentSession {
 		await this.agent.waitForIdle();
 	}
 
+	/**
+	 * Request that the current or next run stop after the active turn completes.
+	 */
+	stopAfterTurn(): void {
+		this.agent.stopAfterTurn();
+	}
+
 	// =========================================================================
 	// Model Management
 	// =========================================================================

--- a/packages/coding-agent/test/agent-session-stop-after-turn.test.ts
+++ b/packages/coding-agent/test/agent-session-stop-after-turn.test.ts
@@ -1,0 +1,98 @@
+import { Agent } from "@mariozechner/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { createTestResourceLoader } from "./utilities.js";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("AgentSession.stopAfterTurn", () => {
+	it("should stop the active run after the current turn and preserve follow-ups", async () => {
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		let llmCalls = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: "You are a helpful assistant.",
+				tools: [],
+				thinkingLevel: "off",
+			},
+			streamFn: () => {
+				llmCalls += 1;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage(`response-${llmCalls}`),
+					});
+				});
+				return stream;
+			},
+		});
+
+		const authStorage = AuthStorage.inMemory();
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settingsManager: SettingsManager.inMemory(),
+			cwd: process.cwd(),
+			modelRegistry: ModelRegistry.inMemory(authStorage),
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		try {
+			await session.followUp("continue later");
+			session.stopAfterTurn();
+
+			await session.prompt("hello");
+
+			expect(llmCalls).toBe(1);
+			expect(session.pendingMessageCount).toBeGreaterThan(0);
+
+			await session.agent.continue();
+
+			expect(llmCalls).toBe(2);
+			expect(session.pendingMessageCount).toBe(0);
+		} finally {
+			session.dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- add `agent.stopAfterTurn()` to request a graceful stop after the active turn completes
- wire the agent-level stop request into the existing low-level `shouldStopAfterTurn` loop boundary and clear it when the run finishes
- expose the same control as `session.stopAfterTurn()` in coding-agent

## Tests
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent.test.ts`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-session-stop-after-turn.test.ts`
- `npm run check`