### PR TITLE
test(ai,coding-agent): stabilize env-sensitive test cases

### DIFF
--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -242,7 +242,7 @@ describe("openai-codex streaming", () => {
 		};
 
 		const result = await Promise.race([
-			streamOpenAICodexResponses(model, context, { apiKey: token }).result(),
+			streamOpenAICodexResponses(model, context, { apiKey: token, transport: "sse" }).result(),
 			new Promise<never>((_, reject) => {
 				setTimeout(() => reject(new Error("Timed out waiting for completed SSE stream")), 1000);
 			}),
@@ -301,7 +301,7 @@ describe("openai-codex streaming", () => {
 		};
 
 		const result = await Promise.race([
-			streamOpenAICodexResponses(model, context, { apiKey: token }).result(),
+			streamOpenAICodexResponses(model, context, { apiKey: token, transport: "sse" }).result(),
 			new Promise<never>((_, reject) => {
 				setTimeout(() => reject(new Error("Timed out waiting for incomplete SSE stream")), 1000);
 			}),

--- a/packages/coding-agent/test/clipboard.test.ts
+++ b/packages/coding-agent/test/clipboard.test.ts
@@ -54,6 +54,9 @@ function osc52Writes(): string[] {
 
 beforeEach(() => {
 	vi.unstubAllEnvs();
+	vi.stubEnv("SSH_CONNECTION", "");
+	vi.stubEnv("SSH_CLIENT", "");
+	vi.stubEnv("MOSH_CONNECTION", "");
 	stdoutWrites = [];
 	nativeResolved = false;
 	mocks.clipboard.setText.mockReset();

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -160,60 +160,71 @@ Content`,
 		});
 
 		it("should resolve symlinked user and project resources once", async () => {
-			const sharedDir = join(tempDir, "shared-resources");
-			const sharedExtensionsDir = join(sharedDir, "extensions");
-			const sharedSkillsDir = join(sharedDir, "skills");
-			const sharedPromptsDir = join(sharedDir, "prompts");
-			const sharedThemesDir = join(sharedDir, "themes");
-			mkdirSync(sharedExtensionsDir, { recursive: true });
-			mkdirSync(sharedSkillsDir, { recursive: true });
-			mkdirSync(sharedPromptsDir, { recursive: true });
-			mkdirSync(sharedThemesDir, { recursive: true });
+			const previousHome = process.env.HOME;
+			process.env.HOME = tempDir;
 
-			writeFileSync(join(sharedExtensionsDir, "shared.ts"), "export default function() {}");
-			mkdirSync(join(sharedSkillsDir, "shared-skill"), { recursive: true });
-			writeFileSync(
-				join(sharedSkillsDir, "shared-skill", "SKILL.md"),
-				`---
+			try {
+				const sharedDir = join(tempDir, "shared-resources");
+				const sharedExtensionsDir = join(sharedDir, "extensions");
+				const sharedSkillsDir = join(sharedDir, "skills");
+				const sharedPromptsDir = join(sharedDir, "prompts");
+				const sharedThemesDir = join(sharedDir, "themes");
+				mkdirSync(sharedExtensionsDir, { recursive: true });
+				mkdirSync(sharedSkillsDir, { recursive: true });
+				mkdirSync(sharedPromptsDir, { recursive: true });
+				mkdirSync(sharedThemesDir, { recursive: true });
+
+				writeFileSync(join(sharedExtensionsDir, "shared.ts"), "export default function() {}");
+				mkdirSync(join(sharedSkillsDir, "shared-skill"), { recursive: true });
+				writeFileSync(
+					join(sharedSkillsDir, "shared-skill", "SKILL.md"),
+					`---
 name: shared-skill
 description: Shared skill
 ---
 Content`,
-			);
-			writeFileSync(join(sharedPromptsDir, "shared.md"), "Shared prompt");
-			writeFileSync(join(sharedThemesDir, "shared.json"), JSON.stringify({ name: "shared-theme" }));
+				);
+				writeFileSync(join(sharedPromptsDir, "shared.md"), "Shared prompt");
+				writeFileSync(join(sharedThemesDir, "shared.json"), JSON.stringify({ name: "shared-theme" }));
 
-			mkdirSync(join(agentDir), { recursive: true });
-			mkdirSync(join(tempDir, ".pi"), { recursive: true });
-			symlinkSync(sharedExtensionsDir, join(agentDir, "extensions"), "dir");
-			symlinkSync(sharedSkillsDir, join(agentDir, "skills"), "dir");
-			symlinkSync(sharedPromptsDir, join(agentDir, "prompts"), "dir");
-			symlinkSync(sharedThemesDir, join(agentDir, "themes"), "dir");
-			symlinkSync(sharedExtensionsDir, join(tempDir, ".pi", "extensions"), "dir");
-			symlinkSync(sharedSkillsDir, join(tempDir, ".pi", "skills"), "dir");
-			symlinkSync(sharedPromptsDir, join(tempDir, ".pi", "prompts"), "dir");
-			symlinkSync(sharedThemesDir, join(tempDir, ".pi", "themes"), "dir");
+				mkdirSync(join(agentDir), { recursive: true });
+				mkdirSync(join(tempDir, ".pi"), { recursive: true });
+				symlinkSync(sharedExtensionsDir, join(agentDir, "extensions"), "dir");
+				symlinkSync(sharedSkillsDir, join(agentDir, "skills"), "dir");
+				symlinkSync(sharedPromptsDir, join(agentDir, "prompts"), "dir");
+				symlinkSync(sharedThemesDir, join(agentDir, "themes"), "dir");
+				symlinkSync(sharedExtensionsDir, join(tempDir, ".pi", "extensions"), "dir");
+				symlinkSync(sharedSkillsDir, join(tempDir, ".pi", "skills"), "dir");
+				symlinkSync(sharedPromptsDir, join(tempDir, ".pi", "prompts"), "dir");
+				symlinkSync(sharedThemesDir, join(tempDir, ".pi", "themes"), "dir");
 
-			const result = await packageManager.resolve();
+				const result = await packageManager.resolve();
 
-			expect({
-				extensions: result.extensions.length,
-				skills: result.skills.length,
-				prompts: result.prompts.length,
-				themes: result.themes.length,
-			}).toEqual({
-				extensions: 1,
-				skills: 1,
-				prompts: 1,
-				themes: 1,
-			});
+				expect({
+					extensions: result.extensions.length,
+					skills: result.skills.length,
+					prompts: result.prompts.length,
+					themes: result.themes.length,
+				}).toEqual({
+					extensions: 1,
+					skills: 1,
+					prompts: 1,
+					themes: 1,
+				});
 
-			// Project auto-discovered has higher precedence than user auto-discovered,
-			// so the surviving entry should be scoped to project.
-			expect(result.extensions[0].metadata.scope).toBe("project");
-			expect(result.skills[0].metadata.scope).toBe("project");
-			expect(result.prompts[0].metadata.scope).toBe("project");
-			expect(result.themes[0].metadata.scope).toBe("project");
+				// Project auto-discovered has higher precedence than user auto-discovered,
+				// so the surviving entry should be scoped to project.
+				expect(result.extensions[0].metadata.scope).toBe("project");
+				expect(result.skills[0].metadata.scope).toBe("project");
+				expect(result.prompts[0].metadata.scope).toBe("project");
+				expect(result.themes[0].metadata.scope).toBe("project");
+			} finally {
+				if (previousHome === undefined) {
+					delete process.env.HOME;
+				} else {
+					process.env.HOME = previousHome;
+				}
+			}
 		});
 
 		it("should auto-discover project prompts with overrides", async () => {


### PR DESCRIPTION
## Summary

Stabilize three test cases that depended on local environment state.

## Changes

- force `transport: "sse"` in the two Codex SSE-specific tests
- clear SSH/MOSH env vars in clipboard local-session tests
- isolate `HOME` in the symlinked resource package-manager test

## Why

Before this change, the tests were sensitive to machine-specific state:

- the Codex SSE tests used default `auto` transport, which could try websocket before SSE and hit the test timeout
- the clipboard local-session tests behaved like remote-session tests when SSH env vars were present
- the package-manager symlink test could pick up real `~/.agents/skills` contents from the host machine

## Verification

- targeted test files pass
- `npm run check` passes