### PR TITLE
fix(coding-agent): disable provider session cache in print mode

### DIFF
--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -70,6 +70,9 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 
 	const rebindSession = async (): Promise<void> => {
 		session = runtimeHost.session;
+		// Print mode is single-shot: do not keep provider-side session caches
+		// such as cached WebSockets alive after the process has finished.
+		session.agent.sessionId = undefined;
 		await session.bindExtensions({
 			commandContextActions: {
 				waitForIdle: () => session.agent.waitForIdle(),

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -12,7 +12,7 @@ type FakeExtensionRunner = {
 
 type FakeSession = {
 	sessionManager: { getHeader: () => object | undefined };
-	agent: { waitForIdle: () => Promise<void> };
+	agent: { waitForIdle: () => Promise<void>; sessionId?: string };
 	state: { messages: AssistantMessage[] };
 	extensionRunner: FakeExtensionRunner;
 	bindExtensions: ReturnType<typeof vi.fn>;
@@ -65,7 +65,7 @@ function createRuntimeHost(assistantMessage: AssistantMessage): FakeRuntimeHost 
 
 	const session: FakeSession = {
 		sessionManager: { getHeader: () => undefined },
-		agent: { waitForIdle: async () => {} },
+		agent: { waitForIdle: async () => {}, sessionId: "test-session-id" },
 		state,
 		extensionRunner,
 		bindExtensions: vi.fn(async () => {}),
@@ -121,6 +121,18 @@ describe("runPrintMode", () => {
 		expect(session.prompt).toHaveBeenCalledWith("hello");
 		expect(session.extensionRunner.emit).toHaveBeenCalledTimes(1);
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
+	});
+
+	it("disables provider session caching in print mode", async () => {
+		const runtimeHost = createRuntimeHost(createAssistantMessage({ text: "done" }));
+		const { session } = runtimeHost;
+
+		await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+			messages: ["hello"],
+		});
+
+		expect(session.agent.sessionId).toBeUndefined();
 	});
 
 	it("emits session_shutdown and returns non-zero on assistant error", async () => {


### PR DESCRIPTION
## Summary

Print mode is documented as single-shot, but it still forwarded the agent session id to providers. Providers that keep session-scoped resources alive across requests, such as cached WebSockets, can therefore keep the Node process alive after print/json output has completed.

This change clears `session.agent.sessionId` in print mode before prompts run, so one-shot `pi -p` / `pi --mode json -p` executions do not enter provider-side session caches. Interactive and RPC sessions keep their session id and caching behavior unchanged.

## Why

This fixes cases where `openai-codex/*` with `transport: auto` emits the final output / `agent_end` but the print-mode process does not exit promptly because the provider cached a session-scoped WebSocket.

## Test plan

- [x] `node node_modules/vitest/vitest.mjs --run packages/coding-agent/test/print-mode.test.ts`
- [x] Live local check: `pi --no-session --no-extensions --no-tools --no-context-files --no-skills --no-prompt-templates --model openai-codex/gpt-5.3-codex-spark -p 'Say exactly: PATCH_A_TEXT_OK'` exits with rc 0
- [x] Live local check: same command with `--mode json` emits `agent_end` and exits with rc 0
