### PR TITLE
/model - to toggle back to previously used model

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `/model -` toggles back to the previously used model ([#4135](https://github.com/badlogic/pi-mono/issues/4135))
+
 ### Changed
 
 - Changed `read` tool rendering to collapse Pi documentation, AGENTS/CLAUDE context files, and `SKILL.md` contents by default in interactive output.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -246,6 +246,7 @@ export class AgentSession {
 	readonly settingsManager: SettingsManager;
 
 	private _scopedModels: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>;
+	private _previousModel: Model<any> | undefined;
 
 	// Event subscription state
 	private _unsubscribeAgent?: () => void;
@@ -879,6 +880,11 @@ export class AgentSession {
 		return this._scopedModels;
 	}
 
+	/** Previously used model (for /model - toggle) */
+	get previousModel(): Model<any> | undefined {
+		return this._previousModel;
+	}
+
 	/** Update scoped models for cycling */
 	setScopedModels(scopedModels: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>): void {
 		this._scopedModels = scopedModels;
@@ -1417,6 +1423,7 @@ export class AgentSession {
 		}
 
 		const previousModel = this.model;
+		this._previousModel = previousModel;
 		const thinkingLevel = this._getThinkingLevelForModelSwitch();
 		this.agent.state.model = model;
 		this.sessionManager.appendModelChange(model.provider, model.id);
@@ -1446,6 +1453,7 @@ export class AgentSession {
 		if (scopedModels.length <= 1) return undefined;
 
 		const currentModel = this.model;
+		this._previousModel = currentModel;
 		let currentIndex = scopedModels.findIndex((sm) => modelsAreEqual(sm.model, currentModel));
 
 		if (currentIndex === -1) currentIndex = 0;
@@ -1475,6 +1483,7 @@ export class AgentSession {
 		if (availableModels.length <= 1) return undefined;
 
 		const currentModel = this.model;
+		this._previousModel = currentModel;
 		let currentIndex = availableModels.findIndex((m) => modelsAreEqual(m, currentModel));
 
 		if (currentIndex === -1) currentIndex = 0;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -441,25 +441,40 @@ export class InteractiveMode {
 						? this.session.scopedModels.map((s) => s.model)
 						: this.session.modelRegistry.getAvailable();
 
-				if (models.length === 0) return null;
+				const prevModel = this.session.previousModel;
 
-				// Create items with provider/id format
-				const items = models.map((m) => ({
-					id: m.id,
-					provider: m.provider,
-					label: `${m.provider}/${m.id}`,
-				}));
+				// Build items: previous-model dash toggle + available models
+				const items: Array<{ id: string; provider: string; label: string }> = [];
+
+				if (prevModel && (prefix === "" || prefix === "-")) {
+					items.push({ id: "-", provider: "previous", label: "-" });
+				}
+
+				for (const m of models) {
+					items.push({ id: m.id, provider: m.provider, label: `${m.provider}/${m.id}` });
+				}
+
+				if (items.length === 0) return null;
 
 				// Fuzzy filter by model ID + provider (allows "opus anthropic" to match)
 				const filtered = fuzzyFilter(items, prefix, (item) => `${item.id} ${item.provider}`);
 
 				if (filtered.length === 0) return null;
 
-				return filtered.map((item) => ({
-					value: item.label,
-					label: item.id,
-					description: item.provider,
-				}));
+				return filtered.map((item) => {
+					if (item.id === "-") {
+						return {
+							value: "-",
+							label: "-",
+							description: `previously: ${prevModel!.provider}/${prevModel!.id}`,
+						};
+					}
+					return {
+						value: item.label,
+						label: item.id,
+						description: item.provider,
+					};
+				});
 			};
 		}
 
@@ -3878,6 +3893,25 @@ export class InteractiveMode {
 	private async handleModelCommand(searchTerm?: string): Promise<void> {
 		if (!searchTerm) {
 			this.showModelSelector();
+			return;
+		}
+
+		if (searchTerm === "-") {
+			const prev = this.session.previousModel;
+			if (!prev) {
+				this.showStatus("No previously used model");
+				return;
+			}
+			try {
+				await this.session.setModel(prev);
+				this.footer.invalidate();
+				this.updateEditorBorderColor();
+				this.showStatus(`Model: ${prev.id}`);
+				void this.maybeWarnAboutAnthropicSubscriptionAuth(prev);
+				this.checkDaxnutsEasterEgg(prev);
+			} catch (error) {
+				this.showError(error instanceof Error ? error.message : String(error));
+			}
 			return;
 		}
 

--- a/packages/coding-agent/test/suite/regressions/4135-model-dash-previous.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4135-model-dash-previous.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.js";
+
+describe("/model - toggles to previously used model", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("previousModel is undefined before any model switch", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One" },
+				{ id: "faux-2", name: "Two" },
+			],
+		});
+		harnesses.push(harness);
+
+		expect(harness.session.previousModel).toBeUndefined();
+	});
+
+	it("previousModel tracks the old model after setModel", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One" },
+				{ id: "faux-2", name: "Two" },
+			],
+		});
+		harnesses.push(harness);
+
+		const initialModel = harness.session.model!;
+		const nextModel = harness.getModel("faux-2")!;
+
+		await harness.session.setModel(nextModel);
+
+		expect(harness.session.previousModel?.id).toBe(initialModel.id);
+		expect(harness.session.model?.id).toBe("faux-2");
+	});
+
+	it("previousModel updates after each model change", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One" },
+				{ id: "faux-2", name: "Two" },
+				{ id: "faux-3", name: "Three" },
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.setModel(harness.getModel("faux-2")!);
+		expect(harness.session.previousModel?.id).toBe("faux-1");
+
+		await harness.session.setModel(harness.getModel("faux-3")!);
+		expect(harness.session.previousModel?.id).toBe("faux-2");
+	});
+
+	it("switching back via setModel with previousModel works", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One" },
+				{ id: "faux-2", name: "Two" },
+			],
+		});
+		harnesses.push(harness);
+
+		const initialModel = harness.session.model!;
+		await harness.session.setModel(harness.getModel("faux-2")!);
+
+		// Go back to previous
+		await harness.session.setModel(harness.session.previousModel!);
+		expect(harness.session.model?.id).toBe(initialModel.id);
+	});
+
+	it("previousModel tracks the old model after cycleModel", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One" },
+				{ id: "faux-2", name: "Two" },
+			],
+		});
+		harnesses.push(harness);
+		harness.session.setScopedModels([{ model: harness.getModel("faux-1")! }, { model: harness.getModel("faux-2")! }]);
+
+		const initialModel = harness.session.model!;
+		await harness.session.cycleModel();
+
+		expect(harness.session.previousModel?.id).toBe(initialModel.id);
+		expect(harness.session.model?.id).toBe("faux-2");
+	});
+});


### PR DESCRIPTION
Add `-` semantics to `/model` so `/model -` toggles back to the previously used model, analogous to `cd -`.

- Tracks `_previousModel` on `AgentSession`, exposed via `previousModel` getter
- Updates on every `setModel` and `cycleModel` call
- `/model -` in interactive mode switches to the previous model
- Autocomplete shows `-` with description (`previously: <provider>/<id>`) when prefix is empty or `-`

Closes #4135
