### PR TITLE
Fix active tool updates during running agent sessions

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -64,7 +64,7 @@ type MutableAgentState = Omit<AgentState, "isStreaming" | "streamingMessage" | "
 function createMutableAgentState(
 	initialState?: Partial<Omit<AgentState, "pendingToolCalls" | "isStreaming" | "streamingMessage" | "errorMessage">>,
 ): MutableAgentState {
-	let tools = initialState?.tools?.slice() ?? [];
+	const tools = initialState?.tools?.slice() ?? [];
 	let messages = initialState?.messages?.slice() ?? [];
 
 	return {
@@ -75,7 +75,9 @@ function createMutableAgentState(
 			return tools;
 		},
 		set tools(nextTools: AgentTool<any>[]) {
-			tools = nextTools.slice();
+			if (tools === nextTools) return;
+			tools.length = 0;
+			tools.push(...nextTools);
 		},
 		get messages() {
 			return messages;
@@ -403,7 +405,7 @@ export class Agent {
 		return {
 			systemPrompt: this._state.systemPrompt,
 			messages: this._state.messages.slice(),
-			tools: this._state.tools.slice(),
+			tools: this._state.tools,
 		};
 	}
 

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1,6 +1,7 @@
 import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@mariozechner/pi-ai";
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
-import { Agent } from "../src/index.js";
+import { Agent, type AgentTool } from "../src/index.js";
 
 // Mock stream that mimics AssistantMessageEventStream
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
@@ -229,9 +230,14 @@ describe("Agent", () => {
 
 		// Test setTools
 		const tools = [{ name: "test", description: "test tool" } as any];
+		const previousTools = agent.state.tools;
 		agent.state.tools = tools;
 		expect(agent.state.tools).toEqual(tools);
 		expect(agent.state.tools).not.toBe(tools); // Should be a copy
+		expect(agent.state.tools).toBe(previousTools); // Existing references stay live
+		const sameTools = agent.state.tools;
+		agent.state.tools = sameTools;
+		expect(agent.state.tools).toEqual(tools); // Assigning the live array is a no-op
 
 		// Test replaceMessages
 		const messages = [{ role: "user" as const, content: "Hello", timestamp: Date.now() }];
@@ -248,6 +254,59 @@ describe("Agent", () => {
 		// Test clearMessages
 		agent.state.messages = [];
 		expect(agent.state.messages).toEqual([]);
+	});
+
+	it("should allow tools assigned during lifecycle events to affect the active run", async () => {
+		const schema = Type.Object({ value: Type.String() });
+		let executedValue: string | undefined;
+		const deferredTool: AgentTool<typeof schema, { value: string }> = {
+			name: "deferred",
+			label: "Deferred",
+			description: "Deferred tool",
+			parameters: schema,
+			async execute(_toolCallId, params) {
+				executedValue = params.value;
+				return {
+					content: [{ type: "text", text: `deferred: ${params.value}` }],
+					details: { value: params.value },
+					terminate: true,
+				};
+			},
+		};
+
+		let streamToolNames: string[] | undefined;
+		const agent = new Agent({
+			streamFn: (_model, context) => {
+				streamToolNames = context.tools?.map((tool) => tool.name);
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({
+						type: "done",
+						reason: "toolUse",
+						message: {
+							...createAssistantMessage(""),
+							content: [{ type: "toolCall", id: "tool-1", name: "deferred", arguments: { value: "ok" } }],
+							stopReason: "toolUse",
+						},
+					});
+				});
+				return stream;
+			},
+		});
+
+		agent.subscribe((event) => {
+			if (event.type === "agent_start") {
+				agent.state.tools = [deferredTool];
+			}
+		});
+
+		await agent.prompt("use the deferred tool");
+
+		expect(streamToolNames).toEqual(["deferred"]);
+		expect(executedValue).toBe("ok");
+		expect(
+			agent.state.messages.some((message) => message.role === "toolResult" && message.toolName === "deferred"),
+		).toBe(true);
 	});
 
 	it("should support steering message queue", async () => {


### PR DESCRIPTION
Fixes #4147

## Summary

Fixes setActiveTools() during an active agent run so tools added mid-session are visible to the current prompt cycle.

Previously, Agent.createContextSnapshot() copied state.tools, and assigning state.tools replaced the backing array. 
Any active loop held a stale tools snapshot, so tools enabled by extensions during tool execution could not be resolved later in the same run and failed with Tool <name> not found.

## Changes

- Keep the internal tools array identity stable by mutating it in place on assignment.
- Pass the live tools array into the agent loop context instead of a copied array.
- Add regression coverage for deferred tool activation during an active run.
- Preserve public API/types; agent.state.tools = [...] still copies the assigned array contents.

## Why

This enables deferred tools: an extension can discover or activate a tool during a running agent session, and the LLM can call that tool in the same prompt cycle.