### PR TITLE
Fix the wrong branch compaction diagram

### DIFF
--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -170,9 +170,9 @@ Entries to summarize: B, C, D
 
 After navigation with summary:
 
-         ┌─ B ─ C ─ D ─ [summary of B,C,D]
+         ┌─ B ─ C ─ D
     A ───┤
-         └─ E ─ F (new leaf)
+         └─ E ─ F ─ [summary of B,C,D] ─ (new leaf)
 ```
 
 ### Cumulative File Tracking


### PR DESCRIPTION
The original branch compaction diagram wrongly attach the compacted message to the old branch.