### PR TITLE
fix(coding-agent): retry on transient HTTP 404/408 status responses

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2419,8 +2419,8 @@ export class AgentSession {
 		if (isContextOverflow(message, contextWindow)) return false;
 
 		const err = message.errorMessage;
-		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), WebSocket transport closes/errors, fetch failed, request ended without sending chunks, HTTP/2 closed before response, terminated, retry delay exceeded
-		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(
+		// Match: overloaded_error, provider returned error, rate limit, 404 (transient edge/CDN miss — observed bare-404 from Cerebras streaming endpoint), 408, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), WebSocket transport closes/errors, fetch failed, request ended without sending chunks, HTTP/2 closed before response, terminated, retry delay exceeded
+		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|404|408|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(
 			err,
 		);
 	}

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -228,6 +228,64 @@ describe("AgentSession retry", () => {
 		expect(events).toEqual(["start:1", "end:success=true"]);
 	});
 
+	it("retries bare 404 status responses (transient edge/CDN miss)", async () => {
+		const created = createSession({ failCount: 0 });
+		let callCount = 0;
+		const streamFn = () => {
+			callCount++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callCount === 1) {
+					const msg = createAssistantMessage("", {
+						stopReason: "error",
+						errorMessage: "404 status code (no body)",
+					});
+					stream.push({ type: "start", partial: msg });
+					stream.push({ type: "error", reason: "error", error: msg });
+					return;
+				}
+
+				const msg = createAssistantMessage("Recovered after retry");
+				stream.push({ type: "start", partial: msg });
+				stream.push({ type: "done", reason: "stop", message: msg });
+			});
+			return stream;
+		};
+		created.session.dispose();
+
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamFn,
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = ModelRegistry.create(authStorage, tempDir);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } });
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		const events: string[] = [];
+		session.subscribe((event) => {
+			if (event.type === "auto_retry_start") events.push(`start:${event.attempt}`);
+			if (event.type === "auto_retry_end") events.push(`end:success=${event.success}`);
+		});
+
+		await session.prompt("Test");
+
+		expect(callCount).toBe(2);
+		expect(events).toEqual(["start:1", "end:success=true"]);
+	});
+
 	it("prompt waits for full agent loop when retry produces tool calls", async () => {
 		// Regression: when auto-retry fires and the retry response includes tool_use,
 		// session.prompt() must wait for the entire tool loop to finish before returning.


### PR DESCRIPTION
## Summary

`_isRetryableError` previously matched 429 and 5xx but not 404 or 408, so a bare-404 from a provider edge/CDN surfaced as a hard error instead of triggering the existing exponential-backoff retry harness.

I observed this with Cerebras returning `"404 status code (no body)"` on the streaming `chat-completions` endpoint while `/v1/models` showed healthy — likely the model route was momentarily unreachable behind the edge.

## What this changes

- Adds `404` and `408` to the retryable-status alternation in `packages/coding-agent/src/core/agent-session.ts`.
- Adds a regression test (`agent-session-retry.test.ts`) mirroring the existing `network_error` retry test, using the exact `"404 status code (no body)"` message format the OpenAI Node SDK throws for bare-status errors.

## Why retry these

Both `404` and `408` are conventionally retryable in the same sense as `429`/`5xx`:

- **404 from an edge proxy** typically indicates the origin or model route is briefly unreachable rather than a permanent client error — observed on Cerebras and Groq edges during transient routing flaps.
- **408** is an explicit "request timeout — try again" signal.

The existing exponential backoff already handles the failure mode; this just lets the retry path receive these statuses.

## Test plan

- [x] `npm test` in `packages/coding-agent` — new test passes alongside existing `network_error` retry case.
- [x] Verified live in production routing harness: Cerebras transient 404s now recover automatically instead of surfacing as session-killing errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)