### PR TITLE
chore: unset HF_TOKEN in pi-test.sh --no-env

### DIFF
--- a/pi-test.sh
+++ b/pi-test.sh
@@ -33,6 +33,7 @@ if [[ "$NO_ENV" == "true" ]]; then
   unset COPILOT_GITHUB_TOKEN
   unset GH_TOKEN
   unset GITHUB_TOKEN
+  unset HF_TOKEN
   unset GOOGLE_APPLICATION_CREDENTIALS
   unset GOOGLE_CLOUD_PROJECT
   unset GCLOUD_PROJECT


### PR DESCRIPTION
## Summary
- Add `unset HF_TOKEN` to the `--no-env` block in `pi-test.sh` so the Hugging Face token is also cleared alongside the other API keys.

## Test plan
- [ ] Run `./pi-test.sh --no-env` and confirm `HF_TOKEN` is unset in the resulting environment.