### PR TITLE
fix(ai): preserve OpenRouter reasoning with Responses API

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -289,6 +289,10 @@ export async function processResponsesStream<TApi extends Api>(
 ): Promise<void> {
 	let currentItem: ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | null = null;
 	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
+	const blocksByOutputIndex = new Map<
+		number,
+		{ block: ThinkingContent | TextContent | (ToolCall & { partialJson: string }); contentIndex: number }
+	>();
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
 
@@ -301,11 +305,13 @@ export async function processResponsesStream<TApi extends Api>(
 				currentItem = item;
 				currentBlock = { type: "thinking", thinking: "" };
 				output.content.push(currentBlock);
+				blocksByOutputIndex.set(event.output_index, { block: currentBlock, contentIndex: blockIndex() });
 				stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
 			} else if (item.type === "message") {
 				currentItem = item;
 				currentBlock = { type: "text", text: "" };
 				output.content.push(currentBlock);
+				blocksByOutputIndex.set(event.output_index, { block: currentBlock, contentIndex: blockIndex() });
 				stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
 			} else if (item.type === "function_call") {
 				currentItem = item;
@@ -317,6 +323,7 @@ export async function processResponsesStream<TApi extends Api>(
 					partialJson: item.arguments || "",
 				};
 				output.content.push(currentBlock);
+				blocksByOutputIndex.set(event.output_index, { block: currentBlock, contentIndex: blockIndex() });
 				stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
 			}
 		} else if (event.type === "response.reasoning_summary_part.added") {
@@ -427,40 +434,41 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.output_item.done") {
 			const item = event.item;
+			const blockState = blocksByOutputIndex.get(event.output_index);
+			const completedBlock = blockState?.block;
+			const completedBlockIndex = blockState?.contentIndex ?? blockIndex();
 
-			if (item.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentBlock.thinking = item.summary?.map((s) => s.text).join("\n\n") || "";
-				currentBlock.thinkingSignature = JSON.stringify(item);
+			if (item.type === "reasoning" && completedBlock?.type === "thinking") {
+				completedBlock.thinking = item.summary?.map((s) => s.text).join("\n\n") || "";
+				completedBlock.thinkingSignature = JSON.stringify(item);
 				stream.push({
 					type: "thinking_end",
-					contentIndex: blockIndex(),
-					content: currentBlock.thinking,
+					contentIndex: completedBlockIndex,
+					content: completedBlock.thinking,
 					partial: output,
 				});
-				currentBlock = null;
-			} else if (item.type === "message" && currentBlock?.type === "text") {
-				currentBlock.text = item.content.map((c) => (c.type === "output_text" ? c.text : c.refusal)).join("");
-				currentBlock.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
+			} else if (item.type === "message" && completedBlock?.type === "text") {
+				completedBlock.text = item.content.map((c) => (c.type === "output_text" ? c.text : c.refusal)).join("");
+				completedBlock.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
 				stream.push({
 					type: "text_end",
-					contentIndex: blockIndex(),
-					content: currentBlock.text,
+					contentIndex: completedBlockIndex,
+					content: completedBlock.text,
 					partial: output,
 				});
-				currentBlock = null;
 			} else if (item.type === "function_call") {
 				const args =
-					currentBlock?.type === "toolCall" && currentBlock.partialJson
-						? parseStreamingJson(currentBlock.partialJson)
+					completedBlock?.type === "toolCall" && completedBlock.partialJson
+						? parseStreamingJson(completedBlock.partialJson)
 						: parseStreamingJson(item.arguments || "{}");
 
 				let toolCall: ToolCall;
-				if (currentBlock?.type === "toolCall") {
+				if (completedBlock?.type === "toolCall") {
 					// Finalize in-place and strip the scratch buffer so replay only
 					// carries parsed arguments.
-					currentBlock.arguments = args;
-					delete (currentBlock as { partialJson?: string }).partialJson;
-					toolCall = currentBlock;
+					completedBlock.arguments = args;
+					delete (completedBlock as { partialJson?: string }).partialJson;
+					toolCall = completedBlock;
 				} else {
 					toolCall = {
 						type: "toolCall",
@@ -470,9 +478,12 @@ export async function processResponsesStream<TApi extends Api>(
 					};
 				}
 
-				currentBlock = null;
-				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
+				stream.push({ type: "toolcall_end", contentIndex: completedBlockIndex, toolCall, partial: output });
 			}
+			if (currentBlock === completedBlock) {
+				currentBlock = null;
+			}
+			blocksByOutputIndex.delete(event.output_index);
 		} else if (event.type === "response.completed") {
 			const response = event.response;
 			if (response?.id) {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -280,6 +280,9 @@ export function convertResponsesTools(tools: Tool[], options?: ConvertResponsesT
 // Stream processing
 // =============================================================================
 
+type ResponsesContentBlock = ThinkingContent | TextContent | (ToolCall & { partialJson: string });
+type ResponsesContentBlockState = { block: ResponsesContentBlock; contentIndex: number };
+
 export async function processResponsesStream<TApi extends Api>(
 	openaiStream: AsyncIterable<ResponseStreamEvent>,
 	output: AssistantMessage,
@@ -288,11 +291,8 @@ export async function processResponsesStream<TApi extends Api>(
 	options?: OpenAIResponsesStreamOptions,
 ): Promise<void> {
 	let currentItem: ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | null = null;
-	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
-	const blocksByOutputIndex = new Map<
-		number,
-		{ block: ThinkingContent | TextContent | (ToolCall & { partialJson: string }); contentIndex: number }
-	>();
+	let currentBlock: ResponsesContentBlock | null = null;
+	const blocksByOutputIndex = new Map<number, ResponsesContentBlockState>();
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
 
@@ -301,18 +301,15 @@ export async function processResponsesStream<TApi extends Api>(
 			output.responseId = event.response.id;
 		} else if (event.type === "response.output_item.added") {
 			const item = event.item;
+			let startEventType: "thinking_start" | "text_start" | "toolcall_start" | undefined;
 			if (item.type === "reasoning") {
 				currentItem = item;
 				currentBlock = { type: "thinking", thinking: "" };
-				output.content.push(currentBlock);
-				blocksByOutputIndex.set(event.output_index, { block: currentBlock, contentIndex: blockIndex() });
-				stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+				startEventType = "thinking_start";
 			} else if (item.type === "message") {
 				currentItem = item;
 				currentBlock = { type: "text", text: "" };
-				output.content.push(currentBlock);
-				blocksByOutputIndex.set(event.output_index, { block: currentBlock, contentIndex: blockIndex() });
-				stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+				startEventType = "text_start";
 			} else if (item.type === "function_call") {
 				currentItem = item;
 				currentBlock = {
@@ -322,9 +319,14 @@ export async function processResponsesStream<TApi extends Api>(
 					arguments: {},
 					partialJson: item.arguments || "",
 				};
+				startEventType = "toolcall_start";
+			}
+
+			if (currentBlock && startEventType) {
 				output.content.push(currentBlock);
-				blocksByOutputIndex.set(event.output_index, { block: currentBlock, contentIndex: blockIndex() });
-				stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+				const contentIndex = blockIndex();
+				blocksByOutputIndex.set(event.output_index, { block: currentBlock, contentIndex });
+				stream.push({ type: startEventType, contentIndex, partial: output });
 			}
 		} else if (event.type === "response.reasoning_summary_part.added") {
 			if (currentItem && currentItem.type === "reasoning") {

--- a/packages/ai/test/openai-responses-interleaved-reasoning.test.ts
+++ b/packages/ai/test/openai-responses-interleaved-reasoning.test.ts
@@ -1,0 +1,115 @@
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import { describe, expect, it } from "vitest";
+import { processResponsesStream } from "../src/providers/openai-responses-shared.js";
+import type { AssistantMessage, Model } from "../src/types.js";
+import { AssistantMessageEventStream } from "../src/utils/event-stream.js";
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "gpt-5-mini",
+		name: "GPT-5 Mini",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+	};
+}
+
+function createOutput(model: Model<"openai-responses">): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+async function* createEvents(): AsyncIterable<ResponseStreamEvent> {
+	yield {
+		type: "response.output_item.added",
+		sequence_number: 1,
+		output_index: 0,
+		item: { id: "rs_1", type: "reasoning", status: "in_progress", summary: [] },
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.output_item.added",
+		sequence_number: 2,
+		output_index: 1,
+		item: {
+			id: "fc_1",
+			type: "function_call",
+			status: "in_progress",
+			call_id: "call_1",
+			name: "echo",
+			arguments: "",
+		},
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.output_item.done",
+		sequence_number: 3,
+		output_index: 1,
+		item: {
+			id: "fc_1",
+			type: "function_call",
+			status: "completed",
+			call_id: "call_1",
+			name: "echo",
+			arguments: '{"message":"hello"}',
+		},
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.output_item.done",
+		sequence_number: 4,
+		output_index: 0,
+		item: {
+			id: "rs_1",
+			type: "reasoning",
+			status: "completed",
+			summary: [{ type: "summary_text", text: "I should use the tool" }],
+			encrypted_content: "enc_1",
+			format: "openai-responses-v1",
+		},
+	} as ResponseStreamEvent;
+}
+
+describe("openai responses interleaved output items", () => {
+	it("preserves reasoning when another output item completes first", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+
+		await processResponsesStream(createEvents(), output, new AssistantMessageEventStream(), model);
+
+		expect(output.content).toHaveLength(2);
+		const thinkingBlock = output.content[0];
+		const toolCallBlock = output.content[1];
+		expect(thinkingBlock?.type).toBe("thinking");
+		expect(toolCallBlock?.type).toBe("toolCall");
+		if (thinkingBlock?.type !== "thinking" || toolCallBlock?.type !== "toolCall") {
+			throw new Error("Expected thinking and toolCall blocks");
+		}
+
+		expect(thinkingBlock.thinking).toBe("I should use the tool");
+		expect(JSON.parse(thinkingBlock.thinkingSignature ?? "{}")).toMatchObject({
+			id: "rs_1",
+			type: "reasoning",
+			encrypted_content: "enc_1",
+		});
+		expect(toolCallBlock.arguments).toEqual({ message: "hello" });
+		expect("partialJson" in toolCallBlock).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Fix OpenAI Responses stream handling for Responses-compatible providers such as OpenRouter when output item events complete out of order.

The issue was reproduced with OpenRouter using the `openai-responses` API and a custom provider config like:

```json
{
  "openrouter-example": {
    "baseUrl": "https://openrouter.ai/api/v1",
    "api": "openai-responses",
    "apiKey": "sk-xxxxx",
    "models": [
      {
        "id": "gpt-5.5",
        "reasoning": true,
        "input": ["text", "image"],
        "contextWindow": 272000
      }
    ]
  }
}
```

Example event order:

```text
sequence_number=2   output_index=0  response.output_item.added  reasoning      id=reasoning_1
sequence_number=81  output_index=1  response.output_item.added  function_call  id=function_call_1
sequence_number=89  output_index=1  response.output_item.done   function_call  name=bash arguments={"command":"ls"}
sequence_number=90  output_index=0  response.output_item.done   reasoning      includes encrypted_content
```

The previous implementation tracked only one `currentBlock`. After the reasoning item was added, `currentBlock` pointed at the reasoning block. When the function call item was added later, `currentBlock` was overwritten to point at the tool call block. Because the tool call `output_item.done` arrived before the reasoning `output_item.done`, the old code finalized the tool call and cleared `currentBlock`.

When the reasoning `output_item.done` arrived afterwards, the code no longer had the reasoning block, so it skipped setting `thinkingSignature`. Without `thinkingSignature`, the reasoning item, including its `encrypted_content`, is not replayed into the next Responses request. The next request then loses the model's previous reasoning state.

This fix stores each output block by `output_index` when `response.output_item.added` is received. Later, `response.output_item.done` uses the same `output_index` to finalize the correct block, so a tool call finishing first no longer causes the reasoning block to be dropped. The output-item start handling was also deduplicated so the tracking code stays small.
