### PR TITLE
fix(ai): non-empty reasoning_content placeholder for Moonshot K2.6

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -859,7 +859,7 @@ export function convertMessages(
 				model.reasoning &&
 				(assistantMsg as { reasoning_content?: string }).reasoning_content === undefined
 			) {
-				(assistantMsg as { reasoning_content?: string }).reasoning_content = "";
+				(assistantMsg as { reasoning_content?: string }).reasoning_content = compat.reasoningContentFallback ?? "";
 			}
 			// Skip assistant messages that have no content and no tool calls.
 			// Some providers require "either content or tool_calls, but not none".
@@ -1069,7 +1069,8 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		requiresToolResultName: false,
 		requiresAssistantAfterToolResult: false,
 		requiresThinkingAsText: false,
-		requiresReasoningContentOnAssistantMessages: isDeepSeek,
+		requiresReasoningContentOnAssistantMessages: isDeepSeek || isMoonshot,
+		reasoningContentFallback: isMoonshot ? " " : "",
 		thinkingFormat: isDeepSeek
 			? "deepseek"
 			: isZai
@@ -1108,6 +1109,7 @@ function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletion
 		requiresReasoningContentOnAssistantMessages:
 			model.compat.requiresReasoningContentOnAssistantMessages ??
 			detected.requiresReasoningContentOnAssistantMessages,
+		reasoningContentFallback: model.compat.reasoningContentFallback ?? detected.reasoningContentFallback ?? "",
 		thinkingFormat: model.compat.thinkingFormat ?? detected.thinkingFormat,
 		openRouterRouting: model.compat.openRouterRouting ?? {},
 		vercelGatewayRouting: model.compat.vercelGatewayRouting ?? detected.vercelGatewayRouting,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -303,6 +303,11 @@ export interface OpenAICompletionsCompat {
 	requiresThinkingAsText?: boolean;
 	/** Whether all replayed assistant messages must include an empty reasoning_content field when reasoning is enabled. Default: auto-detected from URL. */
 	requiresReasoningContentOnAssistantMessages?: boolean;
+	/** Placeholder string used to fill `reasoning_content` on a replayed assistant message that
+	 * didn't carry one (only applies when `requiresReasoningContentOnAssistantMessages` is true).
+	 * Default: "" (empty string). Some providers (e.g. Moonshot K2.6) reject empty strings as
+	 * "missing" and require a non-empty placeholder like " ". */
+	reasoningContentFallback?: string;
 	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" uses thinking: { type } plus reasoning_effort, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
 	thinkingFormat?: "openai" | "openrouter" | "deepseek" | "zai" | "qwen" | "qwen-chat-template";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */

--- a/packages/ai/test/openai-completions-moonshot-replay.test.ts
+++ b/packages/ai/test/openai-completions-moonshot-replay.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages } from "../src/providers/openai-completions.js";
+import type { AssistantMessage, Context, Model, OpenAICompletionsCompat, Usage } from "../src/types.js";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const baseCompat = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresReasoningContentOnAssistantMessages: true,
+	reasoningContentFallback: "",
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	zaiToolStream: false,
+	supportsStrictMode: true,
+	cacheControlFormat: undefined,
+	sendSessionAffinityHeaders: false,
+	supportsLongCacheRetention: true,
+} satisfies Required<Omit<OpenAICompletionsCompat, "cacheControlFormat">> & {
+	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+};
+
+function buildModel(): Model<"openai-completions"> {
+	return {
+		id: "kimi-k2.6",
+		name: "Kimi K2.6",
+		api: "openai-completions",
+		provider: "moonshotai",
+		baseUrl: "https://api.moonshot.ai/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+		compat: {},
+	};
+}
+
+function buildAssistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-completions",
+		provider: "moonshotai",
+		model: "kimi-k2.6",
+		usage: emptyUsage,
+		stopReason: "stop",
+		timestamp: 2,
+	};
+}
+
+function buildContextWithToolCall(assistant: AssistantMessage): Context {
+	return {
+		messages: [
+			{ role: "user", content: "run a tool", timestamp: 1 },
+			assistant,
+			{
+				role: "toolResult",
+				toolCallId: "call_1",
+				toolName: "echo",
+				content: [{ type: "text", text: "hi" }],
+				isError: false,
+				timestamp: 3,
+			},
+			{ role: "user", content: "continue", timestamp: 4 },
+		],
+	};
+}
+
+function readReasoningContent(msg: unknown): string | undefined {
+	if (msg && typeof msg === "object" && "reasoning_content" in msg) {
+		const value = (msg as { reasoning_content?: unknown }).reasoning_content;
+		return typeof value === "string" ? value : undefined;
+	}
+	return undefined;
+}
+
+describe("openai-completions reasoning_content fallback on assistant tool-call replay", () => {
+	it("uses configured reasoningContentFallback when assistant has tool_calls but no thinking", () => {
+		const compat = { ...baseCompat, reasoningContentFallback: " " };
+		const messages = convertMessages(
+			buildModel(),
+			buildContextWithToolCall(
+				buildAssistant([{ type: "toolCall", id: "call_1", name: "echo", arguments: { text: "hi" } }]),
+			),
+			compat,
+		);
+		const assistantMsg = messages[1];
+		expect(assistantMsg?.role).toBe("assistant");
+		expect(readReasoningContent(assistantMsg)).toBe(" ");
+	});
+
+	it("defaults to empty string when reasoningContentFallback is not configured", () => {
+		const messages = convertMessages(
+			buildModel(),
+			buildContextWithToolCall(
+				buildAssistant([{ type: "toolCall", id: "call_1", name: "echo", arguments: { text: "hi" } }]),
+			),
+			baseCompat,
+		);
+		const assistantMsg = messages[1];
+		expect(assistantMsg?.role).toBe("assistant");
+		expect(readReasoningContent(assistantMsg)).toBe("");
+	});
+
+	it("does not overwrite reasoning_content when thinking blocks have set it via signature", () => {
+		const compat = { ...baseCompat, reasoningContentFallback: " " };
+		const messages = convertMessages(
+			buildModel(),
+			buildContextWithToolCall(
+				buildAssistant([
+					{ type: "thinking", thinking: "real reasoning", thinkingSignature: "reasoning_content" },
+					{ type: "toolCall", id: "call_1", name: "echo", arguments: { text: "hi" } },
+				]),
+			),
+			compat,
+		);
+		const assistantMsg = messages[1];
+		expect(assistantMsg?.role).toBe("assistant");
+		expect(readReasoningContent(assistantMsg)).toBe("real reasoning");
+	});
+
+	it("does not set reasoning_content when requiresReasoningContentOnAssistantMessages is false", () => {
+		const compat = {
+			...baseCompat,
+			requiresReasoningContentOnAssistantMessages: false,
+			reasoningContentFallback: " ",
+		};
+		const messages = convertMessages(
+			buildModel(),
+			buildContextWithToolCall(
+				buildAssistant([{ type: "toolCall", id: "call_1", name: "echo", arguments: { text: "hi" } }]),
+			),
+			compat,
+		);
+		const assistantMsg = messages[1];
+		expect(assistantMsg?.role).toBe("assistant");
+		expect(readReasoningContent(assistantMsg)).toBeUndefined();
+	});
+});

--- a/packages/ai/test/openai-completions-thinking-as-text.test.ts
+++ b/packages/ai/test/openai-completions-thinking-as-text.test.ts
@@ -31,6 +31,7 @@ const compat = {
 	requiresAssistantAfterToolResult: false,
 	requiresThinkingAsText: true,
 	requiresReasoningContentOnAssistantMessages: false,
+	reasoningContentFallback: "",
 	thinkingFormat: "openai",
 	openRouterRouting: {},
 	vercelGatewayRouting: {},

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -29,6 +29,7 @@ const compat: Required<OpenAICompletionsCompat> = {
 	requiresAssistantAfterToolResult: false,
 	requiresThinkingAsText: false,
 	requiresReasoningContentOnAssistantMessages: false,
+	reasoningContentFallback: "",
 	thinkingFormat: "openai",
 	openRouterRouting: {},
 	vercelGatewayRouting: {},


### PR DESCRIPTION
## Summary

Moonshot's API ([docs](https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model)) requires `reasoning_content` to be present on every assistant tool-call message replayed back to it when thinking is enabled, otherwise it returns:

```
400 thinking is enabled but reasoning_content is missing in assistant tool call message at index N
```

The fix in #4153 (v0.73.0) addresses the analogous contract for DeepSeek by setting `reasoning_content = ""` when undefined. **For Moonshot K2.6 specifically, an empty string is still treated as missing** — the validator returns the same 400 even with `reasoning_content: ""`. A non-empty placeholder satisfies the contract; empirically `" "` (single space) is the minimal value Moonshot accepts.

This PR:

1. Auto-enables `requiresReasoningContentOnAssistantMessages` for Moonshot (previously only DeepSeek).
2. Adds a per-provider `reasoningContentFallback?: string` to `OpenAICompletionsCompat`. Defaults to `""` — preserves existing behavior for DeepSeek and any provider that opts into the flag via `model.compat.requiresReasoningContentOnAssistantMessages`.
3. Sets `reasoningContentFallback: " "` for Moonshot in `detectCompat`.
4. Threads the field through `resolveCompat` so user overrides via `model.compat.reasoningContentFallback` work.
5. Replaces the hardcoded `""` in the assistant-message replay site with `compat.reasoningContentFallback ?? ""`.

## Verification

Verified locally against `moonshot/kimi-k2.6` with this exact logic backported into pi-ai 0.70.0 (running under OpenClaw 2026.4.23, which bundles that pi-ai version). Test sequence: agent turn → assistant tool-call → bash tool result → assistant continuation. The bug fires on the second turn's replay of the prior assistant tool-call message.

- Before: every multi-turn Kimi call 400'd with `reasoning_content is missing` and fell back to a different provider.
- With `reasoning_content: ""` (the v0.73.0 shape ported to Moonshot): same 400, Moonshot still rejects.
- With `reasoning_content: " "` (this PR): Moonshot returns success directly, no fallback, no errors.

## Refs

- Moonshot K2.6 docs: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
- LiteLLM hit the same Moonshot contract: https://github.com/BerriAI/litellm/issues/21672
- Related earlier fix: #4153

## Test plan

- [x] Existing tests under `packages/ai/test/` still pass (two tests using `Required<OpenAICompletionsCompat>` were updated to include the new `reasoningContentFallback` field — type-system change, no logic change)
- [x] `packages/ai/test/openai-completions-moonshot-replay.test.ts` added: covers four branches (configured fallback, default fallback, existing reasoning_content not overwritten, flag off)
- [x] Manual end-to-end against `moonshot/kimi-k2.6` with multi-turn tool calls — passes