### PR TITLE
oauth: let consumers brand the localhost callback page

### DIFF
--- a/packages/ai/src/utils/oauth/anthropic.ts
+++ b/packages/ai/src/utils/oauth/anthropic.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Server } from "node:http";
-import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
+import { type OAuthPageBranding, oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
 import { generatePKCE } from "./pkce.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from "./types.js";
 
@@ -95,7 +95,7 @@ function formatErrorDetails(error: unknown): string {
 	return String(error);
 }
 
-async function startCallbackServer(expectedState: string): Promise<CallbackServerInfo> {
+async function startCallbackServer(expectedState: string, branding?: OAuthPageBranding): Promise<CallbackServerInfo> {
 	const { createServer } = await getNodeApis();
 
 	return new Promise((resolve, reject) => {
@@ -114,7 +114,7 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
 				const url = new URL(req.url || "", "http://localhost");
 				if (url.pathname !== CALLBACK_PATH) {
 					res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
-					res.end(oauthErrorHtml("Callback route not found."));
+					res.end(oauthErrorHtml("Callback route not found.", undefined, branding));
 					return;
 				}
 
@@ -124,24 +124,24 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
 
 				if (error) {
 					res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
-					res.end(oauthErrorHtml("Anthropic authentication did not complete.", `Error: ${error}`));
+					res.end(oauthErrorHtml("Anthropic authentication did not complete.", `Error: ${error}`, branding));
 					return;
 				}
 
 				if (!code || !state) {
 					res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
-					res.end(oauthErrorHtml("Missing code or state parameter."));
+					res.end(oauthErrorHtml("Missing code or state parameter.", undefined, branding));
 					return;
 				}
 
 				if (state !== expectedState) {
 					res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
-					res.end(oauthErrorHtml("State mismatch."));
+					res.end(oauthErrorHtml("State mismatch.", undefined, branding));
 					return;
 				}
 
 				res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-				res.end(oauthSuccessHtml("Anthropic authentication completed. You can close this window."));
+				res.end(oauthSuccessHtml("Anthropic authentication completed. You can close this window.", branding));
 				settleWait?.({ code, state });
 			} catch {
 				res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
@@ -226,15 +226,21 @@ async function exchangeAuthorizationCode(
 
 /**
  * Login with Anthropic OAuth (authorization code + PKCE)
+ *
+ * @param options.branding - Optional branding for the localhost callback success/error
+ *                           pages. Lets the consumer app swap the default Pi logo + page
+ *                           title for their own. Absence keeps historical Pi-branded
+ *                           behavior, preserving back-compat.
  */
 export async function loginAnthropic(options: {
 	onAuth: (info: { url: string; instructions?: string }) => void;
 	onPrompt: (prompt: OAuthPrompt) => Promise<string>;
 	onProgress?: (message: string) => void;
 	onManualCodeInput?: () => Promise<string>;
+	branding?: OAuthPageBranding;
 }): Promise<OAuthCredentials> {
 	const { verifier, challenge } = await generatePKCE();
-	const server = await startCallbackServer(verifier);
+	const server = await startCallbackServer(verifier, options.branding);
 
 	let code: string | undefined;
 	let state: string | undefined;

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -20,6 +20,12 @@ export {
 // OpenAI Codex (ChatGPT OAuth)
 export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.js";
 
+// Branding overrides for the localhost callback success/error pages.
+// Consumer apps can pass `branding: { logoSvg, appName }` to the login*
+// functions so the page that shows after the OAuth redirect carries their
+// brand instead of the default Pi logo. See oauth-page.ts for the shape.
+export { type OAuthPageBranding } from "./oauth-page.js";
+
 export * from "./types.js";
 
 // ============================================================================

--- a/packages/ai/src/utils/oauth/oauth-page.ts
+++ b/packages/ai/src/utils/oauth/oauth-page.ts
@@ -1,4 +1,29 @@
-const LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" aria-hidden="true"><path fill="#fff" fill-rule="evenodd" d="M165.29 165.29 H517.36 V400 H400 V517.36 H282.65 V634.72 H165.29 Z M282.65 282.65 V400 H400 V282.65 Z"/><path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/></svg>`;
+/**
+ * Branding options for the OAuth callback success/error pages. Each
+ * OAuth flow that runs a local callback server (openai-codex,
+ * anthropic, github-copilot, etc.) accepts these so consumer apps
+ * can swap the default Pi logo/title for their own brand.
+ *
+ * All fields are optional — absence falls back to the historical
+ * Pi-branded behavior, preserving back-compat.
+ */
+export interface OAuthPageBranding {
+	/**
+	 * Inline SVG markup rendered at the top of the page (above the
+	 * heading). Should be a complete `<svg>...</svg>` string sized
+	 * around 64-128 pixels — the page CSS scales it to a 72×72 box.
+	 * Absence falls back to the bundled Pi logo.
+	 */
+	logoSvg?: string;
+	/**
+	 * Application name appended to the document `<title>` so users
+	 * see e.g. "Authentication successful — Claudio Pipe" instead
+	 * of the generic default. Absence keeps the plain default.
+	 */
+	appName?: string;
+}
+
+const DEFAULT_LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" aria-hidden="true"><path fill="#fff" fill-rule="evenodd" d="M165.29 165.29 H517.36 V400 H400 V517.36 H282.65 V634.72 H165.29 Z M282.65 282.65 V400 H400 V282.65 Z"/><path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/></svg>`;
 
 function escapeHtml(value: string): string {
 	return value
@@ -9,11 +34,23 @@ function escapeHtml(value: string): string {
 		.replaceAll("'", "&#39;");
 }
 
-function renderPage(options: { title: string; heading: string; message: string; details?: string }): string {
-	const title = escapeHtml(options.title);
+function renderPage(options: {
+	title: string;
+	heading: string;
+	message: string;
+	details?: string;
+	branding?: OAuthPageBranding;
+}): string {
+	const appName = options.branding?.appName;
+	const fullTitle = appName ? `${options.title} — ${appName}` : options.title;
+	const title = escapeHtml(fullTitle);
 	const heading = escapeHtml(options.heading);
 	const message = escapeHtml(options.message);
 	const details = options.details ? escapeHtml(options.details) : undefined;
+	// `branding.logoSvg` is RAW SVG markup, intentionally NOT html-escaped
+	// — it's a trusted SVG string the consumer app supplied. Same handling
+	// the bundled DEFAULT_LOGO_SVG already gets.
+	const logoSvg = options.branding?.logoSvg ?? DEFAULT_LOGO_SVG;
 
 	return `<!doctype html>
 <html lang="en">
@@ -82,7 +119,7 @@ function renderPage(options: { title: string; heading: string; message: string; 
 </head>
 <body>
   <main>
-    <div class="logo">${LOGO_SVG}</div>
+    <div class="logo">${logoSvg}</div>
     <h1>${heading}</h1>
     <p>${message}</p>
     ${details ? `<div class="details">${details}</div>` : ""}
@@ -91,19 +128,21 @@ function renderPage(options: { title: string; heading: string; message: string; 
 </html>`;
 }
 
-export function oauthSuccessHtml(message: string): string {
+export function oauthSuccessHtml(message: string, branding?: OAuthPageBranding): string {
 	return renderPage({
 		title: "Authentication successful",
 		heading: "Authentication successful",
 		message,
+		...(branding ? { branding } : {}),
 	});
 }
 
-export function oauthErrorHtml(message: string, details?: string): string {
+export function oauthErrorHtml(message: string, details?: string, branding?: OAuthPageBranding): string {
 	return renderPage({
 		title: "Authentication failed",
 		heading: "Authentication failed",
 		message,
-		details,
+		...(details !== undefined ? { details } : {}),
+		...(branding ? { branding } : {}),
 	});
 }

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -17,7 +17,7 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
 	});
 }
 
-import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
+import { type OAuthPageBranding, oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
 import { generatePKCE } from "./pkce.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from "./types.js";
 
@@ -199,7 +199,7 @@ type OAuthServerInfo = {
 	waitForCode: () => Promise<{ code: string } | null>;
 };
 
-function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
+function startLocalOAuthServer(state: string, branding?: OAuthPageBranding): Promise<OAuthServerInfo> {
 	if (!_http) {
 		throw new Error("OpenAI Codex OAuth is only available in Node.js environments");
 	}
@@ -220,30 +220,30 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 			if (url.pathname !== "/auth/callback") {
 				res.statusCode = 404;
 				res.setHeader("Content-Type", "text/html; charset=utf-8");
-				res.end(oauthErrorHtml("Callback route not found."));
+				res.end(oauthErrorHtml("Callback route not found.", undefined, branding));
 				return;
 			}
 			if (url.searchParams.get("state") !== state) {
 				res.statusCode = 400;
 				res.setHeader("Content-Type", "text/html; charset=utf-8");
-				res.end(oauthErrorHtml("State mismatch."));
+				res.end(oauthErrorHtml("State mismatch.", undefined, branding));
 				return;
 			}
 			const code = url.searchParams.get("code");
 			if (!code) {
 				res.statusCode = 400;
 				res.setHeader("Content-Type", "text/html; charset=utf-8");
-				res.end(oauthErrorHtml("Missing authorization code."));
+				res.end(oauthErrorHtml("Missing authorization code.", undefined, branding));
 				return;
 			}
 			res.statusCode = 200;
 			res.setHeader("Content-Type", "text/html; charset=utf-8");
-			res.end(oauthSuccessHtml("OpenAI authentication completed. You can close this window."));
+			res.end(oauthSuccessHtml("OpenAI authentication completed. You can close this window.", branding));
 			settleWait?.({ code });
 		} catch {
 			res.statusCode = 500;
 			res.setHeader("Content-Type", "text/html; charset=utf-8");
-			res.end(oauthErrorHtml("Internal error while processing OAuth callback."));
+			res.end(oauthErrorHtml("Internal error while processing OAuth callback.", undefined, branding));
 		}
 	});
 
@@ -297,6 +297,10 @@ function getAccountId(accessToken: string): string | null {
  *                                    Races with browser callback - whichever completes first wins.
  *                                    Useful for showing paste input immediately alongside browser flow.
  * @param options.originator - OAuth originator parameter (defaults to "pi")
+ * @param options.branding - Optional branding for the localhost callback success/error
+ *                           pages. Lets the consumer app swap the default Pi logo +
+ *                           document title for their own. Absence keeps the historical
+ *                           Pi-branded behavior, preserving back-compat.
  */
 export async function loginOpenAICodex(options: {
 	onAuth: (info: { url: string; instructions?: string }) => void;
@@ -304,9 +308,10 @@ export async function loginOpenAICodex(options: {
 	onProgress?: (message: string) => void;
 	onManualCodeInput?: () => Promise<string>;
 	originator?: string;
+	branding?: OAuthPageBranding;
 }): Promise<OAuthCredentials> {
 	const { verifier, state, url } = await createAuthorizationFlow(options.originator);
-	const server = await startLocalOAuthServer(state);
+	const server = await startLocalOAuthServer(state, options.branding);
 
 	options.onAuth({ url, instructions: "A browser window should open. Complete login to finish." });
 


### PR DESCRIPTION
## Why

Pi-ai's OAuth flows (`loginAnthropic`, `loginOpenAICodex`) spin up a localhost callback server and serve a small HTML page after the redirect. Today that page hard-codes the bundled Pi logo and a generic title. When Pi is being used as a library inside another CLI, users see a Pi logo on the post-redirect page and reasonably wonder what just happened.

In our case ([Claudio Pipe](https://claudiopipe.com), a CLI that uses pi-ai for the ChatGPT subscription path), users complete the OAuth flow on `localhost:1455/auth/callback` and land on a page that reads "Authentication successful" with a Pi logo — not Claudio. Confusing for non-developer users.

## What

Adds an opt-in `branding?: OAuthPageBranding` parameter to the public login functions:

\`\`\`ts
await loginOpenAICodex({
  onAuth, onPrompt,
  branding: {
    logoSvg: '<svg xmlns=...>...</svg>',
    appName: 'Claudio Pipe',
  },
});
\`\`\`

Produces a callback page with the consumer's logo at the top, \`Authentication successful — Claudio Pipe\` in the document title, and otherwise identical structure / styling to today.

Both fields are optional. When \`branding\` is undefined, or any field is unset, the page falls back to the historical pi-branded behavior — every existing call site (and every other consumer of \`oauth-page.ts\`) keeps producing exactly the same HTML it does today. **Pure additive change.**

## Files touched

| File | Change |
|---|---|
| \`oauth-page.ts\` | New exported \`OAuthPageBranding\` type. \`renderPage\` accepts \`branding?\`. \`oauthSuccessHtml\` / \`oauthErrorHtml\` accept \`branding?\` as a trailing arg. |
| \`openai-codex.ts\` | \`loginOpenAICodex\` accepts \`branding?\`, threads through \`startLocalOAuthServer\` to all callback handlers (success + error variants). |
| \`anthropic.ts\` | Same shape — \`loginAnthropic\` accepts \`branding?\`, threads through \`startCallbackServer\`. |
| \`oauth/index.ts\` | Re-exports the new \`OAuthPageBranding\` type so consumers can import it without reaching into internals. |

## Security note

The supplied \`logoSvg\` is intentionally **not** html-escaped — same as the bundled \`DEFAULT_LOGO_SVG\`. Inline SVGs can't render through \`escapeHtml\`; consumers are trusted to supply their own SVG markup (it's their own brand asset compiled into their own binary). The other fields (\`title\`, \`heading\`, \`message\`, \`details\`) stay escaped via the existing \`escapeHtml\` helper. \`appName\` is escaped before interpolation into the document title.

## Tests

- Existing \`anthropic-oauth.test.ts\` + \`github-copilot-oauth.test.ts\` pass unchanged (back-compat preserved — branding defaults match the old hardcoded behavior byte-for-byte).
- \`npm run build\` clean in \`packages/ai\`.
- The 13 unrelated test failures in the full suite (abort + image-tool-result) require live API keys and fail at HEAD too.

## Back-compat

Every existing consumer of \`loginAnthropic\` / \`loginOpenAICodex\` / \`oauthSuccessHtml\` / \`oauthErrorHtml\` keeps working with no changes. Branding is opt-in. Default rendering is byte-for-byte identical.