### PR TITLE
feat: add autocompleteNoIgnore setting to include git-ignored files in @ autocomplete

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -106,6 +106,7 @@ export interface Settings {
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
+	autocompleteNoIgnore?: boolean; // Include git-ignored files in @ autocomplete (default: false)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
 	warnings?: WarningSettings;
@@ -1049,6 +1050,10 @@ export class SettingsManager {
 		this.globalSettings.autocompleteMaxVisible = Math.max(3, Math.min(20, Math.floor(maxVisible)));
 		this.markModified("autocompleteMaxVisible");
 		this.save();
+	}
+
+	getAutocompleteNoIgnore(): boolean {
+		return this.settings.autocompleteNoIgnore ?? false;
 	}
 
 	getCodeBlockIndent(): string {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -510,6 +510,7 @@ export class InteractiveMode {
 			[...slashCommands, ...templateCommands, ...extensionCommands, ...skillCommandList],
 			this.sessionManager.getCwd(),
 			this.fdPath,
+			this.settingsManager.getAutocompleteNoIgnore(),
 		);
 	}
 

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -120,13 +120,14 @@ function buildCompletionValue(
 	return `${openQuote}${path}${closeQuote}`;
 }
 
-// Use fd to walk directory tree (fast, respects .gitignore)
+// Use fd to walk directory tree (fast, respects .gitignore by default)
 async function walkDirectoryWithFd(
 	baseDir: string,
 	fdPath: string,
 	query: string,
 	maxResults: number,
 	signal: AbortSignal,
+	noIgnore: boolean = false,
 ): Promise<Array<{ path: string; isDirectory: boolean }>> {
 	const args = [
 		"--base-directory",
@@ -146,6 +147,10 @@ async function walkDirectoryWithFd(
 		"--exclude",
 		".git/**",
 	];
+
+	if (noIgnore) {
+		args.push("--no-ignore");
+	}
 
 	if (toDisplayPath(query).includes("/")) {
 		args.push("--full-path");
@@ -271,11 +276,18 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	private commands: (SlashCommand | AutocompleteItem)[];
 	private basePath: string;
 	private fdPath: string | null;
+	private noIgnore: boolean;
 
-	constructor(commands: (SlashCommand | AutocompleteItem)[] = [], basePath: string, fdPath: string | null = null) {
+	constructor(
+		commands: (SlashCommand | AutocompleteItem)[] = [],
+		basePath: string,
+		fdPath: string | null = null,
+		noIgnore: boolean = false,
+	) {
 		this.commands = commands;
 		this.basePath = basePath;
 		this.fdPath = fdPath;
+		this.noIgnore = noIgnore;
 	}
 
 	async getSuggestions(
@@ -726,7 +738,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const scopedQuery = this.resolveScopedFuzzyQuery(query);
 			const fdBaseDir = scopedQuery?.baseDir ?? this.basePath;
 			const fdQuery = scopedQuery?.query ?? query;
-			const entries = await walkDirectoryWithFd(fdBaseDir, this.fdPath, fdQuery, 100, options.signal);
+			const entries = await walkDirectoryWithFd(fdBaseDir, this.fdPath, fdQuery, 100, options.signal, this.noIgnore);
 			if (options.signal.aborted) {
 				return [];
 			}


### PR DESCRIPTION
## Summary

Adds a new setting `autocompleteNoIgnore` (default: `false`) that passes `--no-ignore` to `fd` when searching for files in the `@` autocomplete.

## Motivation

Users who need to reference git-ignored files (e.g., build artifacts, generated files, local configs) currently can't find them via the `@` file picker and must type the full path manually.

## Usage

```json
{
  "autocompleteNoIgnore": true
}
```

Can be set globally (`~/.pi/agent/settings.json`) or per-project (`.pi/settings.json`).

## Changes

- **packages/tui**: Add `noIgnore` parameter to `walkDirectoryWithFd` and `CombinedAutocompleteProvider` constructor
- **packages/coding-agent**: Add `autocompleteNoIgnore` to `Settings` interface with getter, pass it through to the autocomplete provider

The setting is picked up dynamically — changing it and using `/reload` or `/settings` will take effect immediately without restarting pi.